### PR TITLE
bugfix: wrong unit used in SetVariable error message

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SetVariable.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SetVariable.java
@@ -66,7 +66,7 @@ public class SetVariable extends WorkflowSystemTask {
             if (payloadSize > maxThreshold * 1024) {
                 String errorMsg =
                         String.format(
-                                "The variables payload size: %d of workflow: %s is greater than the permissible limit: %d bytes",
+                                "The variables payload size: %d of workflow: %s is greater than the permissible limit: %d kilobytes",
                                 payloadSize, workflowId, maxThreshold);
                 LOGGER.error(errorMsg);
                 task.setReasonForIncompletion(errorMsg);

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/SetVariableTaskSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/SetVariableTaskSpec.groovy
@@ -62,7 +62,7 @@ class SetVariableTaskSpec extends AbstractSpecification {
         def EXTRA_HASHMAP_SIZE = 17
         def expectedErrorMessage =
                 String.format(
-                        "The variables payload size: %d of workflow: %s is greater than the permissible limit: %d bytes",
+                        "The variables payload size: %d of workflow: %s is greater than the permissible limit: %d kilobytes",
                         EXTRA_HASHMAP_SIZE + maxThreshold * 1024 + 1, workflowInstanceId, maxThreshold)
 
         then: "verify that the task is completed and variables were set"


### PR DESCRIPTION
wrong unit used in SetVariable error message on payloadSize > maxThreshold.
So far was mentioning bytes while it was in fact kilobytes.

Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
SetVariable error mention bytes while the configuration usage provides kilobytes.
Users of the engine complained about the misleading information when providing variables bigger than the configured limit.

Alternatives considered
----

_Describe alternative implementation you have considered_
