### PR TITLE
Fix redundant taskDef in DB

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
@@ -24,6 +24,7 @@ import com.netflix.conductor.annotations.protogen.ProtoField;
 import com.netflix.conductor.annotations.protogen.ProtoMessage;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.protobuf.Any;
 import io.swagger.v3.oas.annotations.Hidden;
 
@@ -629,6 +630,7 @@ public class Task {
     /**
      * @return {@link Optional} containing the task definition if available
      */
+    @JsonIgnore
     public Optional<TaskDef> getTaskDefinition() {
         return Optional.ofNullable(this.getWorkflowTask()).map(WorkflowTask::getTaskDefinition);
     }

--- a/core/src/main/java/com/netflix/conductor/model/TaskModel.java
+++ b/core/src/main/java/com/netflix/conductor/model/TaskModel.java
@@ -571,6 +571,7 @@ public class TaskModel {
     /**
      * @return {@link Optional} containing the task definition if available
      */
+    @JsonIgnore
     public Optional<TaskDef> getTaskDefinition() {
         return Optional.ofNullable(this.getWorkflowTask()).map(WorkflowTask::getTaskDefinition);
     }


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

`./gradlew spotlessApply` is applied.

Changes in this PR
----
`taskDefinition` in `Task` and `TaskModel` are redundant in JSON ouput, esp. when persisting in DB, it is not necessary because the task definitions are retrieved via "WorkflowTask".

Alternatives considered
----

_Describe alternative implementation you have considered_
