### PR TITLE
classifier is deprecated since gradle 5.1(replaced by archiveClassifier) and removed in 8

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -88,7 +88,7 @@ jar {
 
 bootJar {
     mainClass = 'com.netflix.conductor.Conductor'
-    classifier = 'boot'
+    archiveClassifier = 'boot'
 }
 
 // https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/#integrating-with-actuator.build-info


### PR DESCRIPTION
This change is transitive.  It removes one issue when moving to Gradle 8.

Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

One of the necessary updates toward Gradle 8. Replace deprecated attribute (that will be removed in Gradle 8 API)

eg: https://github.com/spring-projects/spring-boot/pull/29611/files
Alternatives considered

See also:

deprecated since 5.1 - https://github.com/spring-projects/spring-boot/issues/29610
will be removed in 8 - https://docs.gradle.org/current/userguide/upgrading_version_7.html where classifier is listed to be removed (replaced by archiveClassifier)
The deprecated appendix, archiveName, archivePath, baseName, classifier, destinationDir, extension and version properties of the AbstractArchiveTask task type have been removed. Use the archiveAppendix, archiveFileName , archiveFile, archiveBaseName, archiveClassifier, destinationDirectory, archiveExtension and archiveVersion properties instead.
from gradle src: https://github.com/gradle/gradle/pull/22107/files#diff-1c2c4263cffdda364f17c6f3dee6540bbe13d53a38a2814bcb2723fa7c1b3821
----

