### PR TITLE
Feature: Use TaskStatusListener.onTaskInProgress() 

### DIFF
--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -187,6 +187,7 @@ public class ExecutionService {
         }
         taskIds.stream()
                 .map(executionDAOFacade::getTaskModel)
+                .filter(Objects::nonNull)
                 .filter(task -> TaskModel.Status.IN_PROGRESS.equals(task.getStatus()))
                 .forEach(taskStatusListener::onTaskInProgress);
         executionDAOFacade.updateTaskLastPoll(taskType, domain, workerId);

--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -35,6 +35,7 @@ import com.netflix.conductor.core.events.queue.Message;
 import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.core.execution.tasks.SystemTaskRegistry;
+import com.netflix.conductor.core.listener.TaskStatusListener;
 import com.netflix.conductor.core.utils.QueueUtils;
 import com.netflix.conductor.core.utils.Utils;
 import com.netflix.conductor.dao.QueueDAO;
@@ -52,6 +53,7 @@ public class ExecutionService {
     private final QueueDAO queueDAO;
     private final ExternalPayloadStorage externalPayloadStorage;
     private final SystemTaskRegistry systemTaskRegistry;
+    private final TaskStatusListener taskStatusListener;
 
     private final long queueTaskMessagePostponeSecs;
 
@@ -65,7 +67,8 @@ public class ExecutionService {
             QueueDAO queueDAO,
             ConductorProperties properties,
             ExternalPayloadStorage externalPayloadStorage,
-            SystemTaskRegistry systemTaskRegistry) {
+            SystemTaskRegistry systemTaskRegistry,
+            TaskStatusListener taskStatusListener) {
         this.workflowExecutor = workflowExecutor;
         this.executionDAOFacade = executionDAOFacade;
         this.queueDAO = queueDAO;
@@ -74,6 +77,7 @@ public class ExecutionService {
         this.queueTaskMessagePostponeSecs =
                 properties.getTaskExecutionPostponeDuration().getSeconds();
         this.systemTaskRegistry = systemTaskRegistry;
+        this.taskStatusListener = taskStatusListener;
     }
 
     public Task poll(String taskType, String workerId) {
@@ -181,6 +185,10 @@ public class ExecutionService {
                 queueDAO.postpone(queueName, taskId, 0, queueTaskMessagePostponeSecs);
             }
         }
+        taskIds.stream()
+                .map(executionDAOFacade::getTaskModel)
+                .filter(task -> TaskModel.Status.IN_PROGRESS.equals(task.getStatus()))
+                .forEach(taskStatusListener::onTaskInProgress);
         executionDAOFacade.updateTaskLastPoll(taskType, domain, workerId);
         Monitors.recordTaskPoll(queueName);
         tasks.forEach(this::ackTaskReceived);

--- a/core/src/test/java/com/netflix/conductor/service/ExecutionServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/ExecutionServiceTest.java
@@ -34,6 +34,7 @@ import com.netflix.conductor.core.config.ConductorProperties;
 import com.netflix.conductor.core.dal.ExecutionDAOFacade;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.core.execution.tasks.SystemTaskRegistry;
+import com.netflix.conductor.core.listener.TaskStatusListener;
 import com.netflix.conductor.dao.QueueDAO;
 
 import static junit.framework.TestCase.assertEquals;
@@ -48,6 +49,7 @@ public class ExecutionServiceTest {
     @Mock private ConductorProperties conductorProperties;
     @Mock private ExternalPayloadStorage externalPayloadStorage;
     @Mock private SystemTaskRegistry systemTaskRegistry;
+    @Mock private TaskStatusListener taskStatusListener;
 
     private ExecutionService executionService;
 
@@ -68,7 +70,8 @@ public class ExecutionServiceTest {
                         queueDAO,
                         conductorProperties,
                         externalPayloadStorage,
-                        systemTaskRegistry);
+                        systemTaskRegistry,
+                        taskStatusListener);
         WorkflowDef workflowDef = new WorkflowDef();
         workflow1 = new Workflow();
         workflow1.setWorkflowId("wf1");


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Hi all. I'm implementing `TaskStatusListener` and using it. However, if it changes to `SCHEDULED` -> `IN_PROGRESS` (i.e. if the worker polls the task), the `TaskStatusListener.onTaskInProgress` method will not be called. So I changed the code so that I could call it.

![conductor-polling](https://github.com/conductor-oss/conductor/assets/68694844/f4563746-65d8-4a49-a72b-e2d73811ced6)

I tried to implement the code as below. However, it was not updated in DB, so when I called `taskClient.getTaskDetails(taskId)` somewhere else, the task was in `SCHEDULE` state.

```
public List<Task> poll(
        String taskType, String workerId, String domain, int count, int timeoutInMilliSecond) {
   ...
        for (String taskId : taskIds) {
            try {
                      taskModel.setStatus(TaskModel.Status.IN_PROGRESS);
                      taskStatusListener.onTaskInProgress(taskModel);
            }
   ...
}


```


Alternatives considered
----

_Describe alternative implementation you have considered_
