### PR TITLE
Implement removeWorkflow and removeTask for PostgresIndexDAO

### DIFF
--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresProperties.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresProperties.java
@@ -33,6 +33,12 @@ public class PostgresProperties {
 
     public boolean allowJsonQueries = true;
 
+    /** The maximum number of threads allowed in the async pool */
+    private int asyncMaxPoolSize = 12;
+
+    /** The size of the queue used for holding async indexing tasks */
+    private int asyncWorkerQueueSize = 100;
+
     public Duration getTaskDefCacheRefreshInterval() {
         return taskDefCacheRefreshInterval;
     }
@@ -71,5 +77,21 @@ public class PostgresProperties {
 
     public void setAllowJsonQueries(boolean allowJsonQueries) {
         this.allowJsonQueries = allowJsonQueries;
+    }
+
+    public int getAsyncWorkerQueueSize() {
+        return asyncWorkerQueueSize;
+    }
+
+    public void setAsyncWorkerQueueSize(int asyncWorkerQueueSize) {
+        this.asyncWorkerQueueSize = asyncWorkerQueueSize;
+    }
+
+    public int getAsyncMaxPoolSize() {
+        return asyncMaxPoolSize;
+    }
+
+    public void setAsyncMaxPoolSize(int asyncMaxPoolSize) {
+        this.asyncMaxPoolSize = asyncMaxPoolSize;
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [x] Feature

Changes in this PR
----
This PR implements `removeWorkflow` and `removeTask` in the `PostgresIndexDAO` class so that when you call `/api/workflow/{workflowId}/remove?archiveWorkflow=false` the workflow is removed from both the main workflow store as well as the index in postgres.

`archiveWorkflow=true` still has no effect because all this does when you're using ElasticSearch is to move the workflow data into the index, but there's no point doing this in Postgres since it's just moving from one place to another in the same database.
