### PR TITLE
Fix issue: Return 404 instead of 2xx codes for methods handling non-existent tasks#38

### DIFF
--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
@@ -73,7 +73,7 @@ public class TaskResource {
         // for backwards compatibility with 2.x client which expects a 204 when no Task is found
         return Optional.ofNullable(
                         taskService.batchPoll(taskType, workerId, domain, count, timeout))
-                .filter(logs -> !logs.isEmpty())
+                .filter(tasks -> !tasks.isEmpty())
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }

--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import com.netflix.conductor.core.exception.NotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -108,7 +109,7 @@ public class TaskResource {
         return Optional.ofNullable(taskService.getTaskLogs(taskId))
                 .filter(logs -> !logs.isEmpty())
                 .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+                .orElseThrow(() -> new NotFoundException("Task logs not found for taskId: %s", taskId));
     }
 
     @GetMapping("/{taskId}")

--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
@@ -60,7 +60,7 @@ public class TaskResource {
         // for backwards compatibility with 2.x client which expects a 204 when no Task is found
         return Optional.ofNullable(taskService.poll(taskType, workerId, domain))
                 .map(ResponseEntity::ok)
-                .orElseThrow(() -> new NotFoundException("Poll not found for Task Type: %s", taskType));
+                .orElse(ResponseEntity.noContent().build());
     }
 
     @GetMapping("/poll/batch/{tasktype}")
@@ -72,11 +72,10 @@ public class TaskResource {
             @RequestParam(value = "count", defaultValue = "1") int count,
             @RequestParam(value = "timeout", defaultValue = "100") int timeout) {
         // for backwards compatibility with 2.x client which expects a 204 when no Task is found
-        return Optional.ofNullable(
-                        taskService.batchPoll(taskType, workerId, domain, count, timeout))
+        return Optional.ofNullable(taskService.batchPoll(taskType, workerId, domain, count, timeout))
                 .filter(tasks -> !tasks.isEmpty())
                 .map(ResponseEntity::ok)
-                .orElseThrow(() -> new NotFoundException("Batch Poll not found for Task Type: %s", taskType));
+                .orElse(ResponseEntity.noContent().build());
     }
 
     @PostMapping(produces = TEXT_PLAIN_VALUE)

--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
@@ -73,6 +73,7 @@ public class TaskResource {
         // for backwards compatibility with 2.x client which expects a 204 when no Task is found
         return Optional.ofNullable(
                         taskService.batchPoll(taskType, workerId, domain, count, timeout))
+                .filter(logs -> !logs.isEmpty())
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }

--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
@@ -59,7 +59,7 @@ public class TaskResource {
         // for backwards compatibility with 2.x client which expects a 204 when no Task is found
         return Optional.ofNullable(taskService.poll(taskType, workerId, domain))
                 .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.noContent().build());
+                .orElse(ResponseEntity.notFound().build());
     }
 
     @GetMapping("/poll/batch/{tasktype}")
@@ -74,7 +74,7 @@ public class TaskResource {
         return Optional.ofNullable(
                         taskService.batchPoll(taskType, workerId, domain, count, timeout))
                 .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.noContent().build());
+                .orElse(ResponseEntity.notFound().build());
     }
 
     @PostMapping(produces = TEXT_PLAIN_VALUE)
@@ -103,8 +103,11 @@ public class TaskResource {
 
     @GetMapping("/{taskId}/log")
     @Operation(summary = "Get Task Execution Logs")
-    public List<TaskExecLog> getTaskLogs(@PathVariable("taskId") String taskId) {
-        return taskService.getTaskLogs(taskId);
+    public ResponseEntity<List<TaskExecLog>> getTaskLogs(@PathVariable("taskId") String taskId) {
+        return Optional.ofNullable(taskService.getTaskLogs(taskId))
+                .filter(logs -> !logs.isEmpty())
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
     }
 
     @GetMapping("/{taskId}")
@@ -113,7 +116,7 @@ public class TaskResource {
         // for backwards compatibility with 2.x client which expects a 204 when no Task is found
         return Optional.ofNullable(taskService.getTask(taskId))
                 .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.noContent().build());
+                .orElse(ResponseEntity.notFound().build());
     }
 
     @GetMapping("/queue/sizes")

--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
@@ -60,7 +60,7 @@ public class TaskResource {
         // for backwards compatibility with 2.x client which expects a 204 when no Task is found
         return Optional.ofNullable(taskService.poll(taskType, workerId, domain))
                 .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+                .orElseThrow(() -> new NotFoundException("Poll not found for Task Type: %s", taskType));
     }
 
     @GetMapping("/poll/batch/{tasktype}")
@@ -76,7 +76,7 @@ public class TaskResource {
                         taskService.batchPoll(taskType, workerId, domain, count, timeout))
                 .filter(tasks -> !tasks.isEmpty())
                 .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+                .orElseThrow(() -> new NotFoundException("Batch Poll not found for Task Type: %s", taskType));
     }
 
     @PostMapping(produces = TEXT_PLAIN_VALUE)
@@ -118,7 +118,7 @@ public class TaskResource {
         // for backwards compatibility with 2.x client which expects a 204 when no Task is found
         return Optional.ofNullable(taskService.getTask(taskId))
                 .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+                .orElseThrow(() -> new NotFoundException("Task not found for taskId: %s", taskId));
     }
 
     @GetMapping("/queue/sizes")


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Describe the new behavior from this PR, and why it's needed
![Screenshot 2024-02-11 at 1 17 54 AM](https://github.com/conductor-oss/conductor/assets/47558150/0d40d1c3-0db6-4bb8-aa66-d88cfdb0bbc4)
![Screenshot 2024-02-11 at 1 18 33 AM](https://github.com/conductor-oss/conductor/assets/47558150/97cb0b08-f754-46e1-8194-8e7c4b931e18)
![Screenshot 2024-02-11 at 1 21 25 AM](https://github.com/conductor-oss/conductor/assets/47558150/4146df52-824b-496c-bb59-1ec90b8f8f74)
![Screenshot 2024-02-11 at 1 25 28 AM](https://github.com/conductor-oss/conductor/assets/47558150/9628479a-558b-497a-8093-381e41f75d52)


Issue #

Alternatives considered
----

Describe alternative implementation you have considered