### PR TITLE
Optimise the postgres queries for popping messages

### DIFF
--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresQueueDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresQueueDAO.java
@@ -422,17 +422,19 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
                 q -> q.addParameter(queueName).addParameter(messageId).executeDelete());
     }
 
-    private List<Message> peekMessages(Connection connection, String queueName, int count) {
-        if (count < 1) {
-            return Collections.emptyList();
-        }
+    private List<Message> popMessages(
+            Connection connection, String queueName, int count, int timeout) {
 
-        final String PEEK_MESSAGES =
-                "SELECT message_id, priority, payload FROM queue_message WHERE queue_name = ? AND popped = false AND deliver_on <= (current_timestamp + (1000 ||' microseconds')::interval) ORDER BY priority DESC, deliver_on, created_on LIMIT ? FOR UPDATE SKIP LOCKED";
+        String POP_QUERY =
+                "UPDATE queue_message SET popped = true WHERE message_id IN ("
+                        + "SELECT message_id FROM queue_message WHERE queue_name = ? AND popped = false AND "
+                        + "deliver_on <= (current_timestamp + (1000 ||' microseconds')::interval) "
+                        + "ORDER BY priority DESC, deliver_on, created_on LIMIT ? FOR UPDATE SKIP LOCKED"
+                        + ") RETURNING message_id, priority, payload";
 
         return query(
                 connection,
-                PEEK_MESSAGES,
+                POP_QUERY,
                 p ->
                         p.addParameter(queueName)
                                 .addParameter(count)
@@ -448,34 +450,6 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
                                             }
                                             return results;
                                         }));
-    }
-
-    private List<Message> popMessages(
-            Connection connection, String queueName, int count, int timeout) {
-        List<Message> messages = peekMessages(connection, queueName, count);
-
-        if (messages.isEmpty()) {
-            return messages;
-        }
-
-        List<Message> poppedMessages = new ArrayList<>();
-        for (Message message : messages) {
-            final String POP_MESSAGE =
-                    "UPDATE queue_message SET popped = true WHERE queue_name = ? AND message_id = ? AND popped = false";
-            int result =
-                    query(
-                            connection,
-                            POP_MESSAGE,
-                            q ->
-                                    q.addParameter(queueName)
-                                            .addParameter(message.getId())
-                                            .executeUpdate());
-
-            if (result == 1) {
-                poppedMessages.add(message);
-            }
-        }
-        return poppedMessages;
     }
 
     @Override


### PR DESCRIPTION
Pull Request type
----
- [x] Refactoring (no functional changes, no api changes)

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
The previous behaviour for popping messages off a queue when using Postgres was:
- SELECT potential messages using `peekMessages` while locking them for update
- Loop through those messages in Conductor and update them to pop them

This means that Postgres is holding open a transaction and lock over the course of multiple queries

The new behaviour is to do the exact same thing but in a single statement so that at worst it will half the number of queries made when popping a message and reduce the amount of time a lock is held on records.

It doesn't change the behaviour at all.