### PR TITLE
Add an in-memory implementation of PollDataDAO

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/polldata/MemoryPollDataDAO.java
+++ b/core/src/main/java/com/netflix/conductor/core/polldata/MemoryPollDataDAO.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.index;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import com.netflix.conductor.common.metadata.tasks.PollData;
+import com.netflix.conductor.dao.PollDataDAO;
+
+/** In-memory implementation of {@link PollDataDAO} which keeps the poll data locally in memory */
+public class MemoryPollDataDAO implements PollDataDAO {
+
+    private ConcurrentHashMap<String, ConcurrentHashMap<String, PollData>> pollData =
+            new ConcurrentHashMap<String, ConcurrentHashMap<String, PollData>>();
+
+    @Override
+    public void updateLastPollData(String taskDefName, String domain, String workerId) {
+        ConcurrentHashMap<String, PollData> domainPollData = pollData.get(taskDefName);
+        if (domainPollData == null) {
+            domainPollData = new ConcurrentHashMap<String, PollData>();
+            pollData.put(taskDefName, domainPollData);
+        }
+        String domainKey = domain == null ? "DEFAULT" : domain;
+        domainPollData.put(
+                domainKey, new PollData(taskDefName, domain, workerId, System.currentTimeMillis()));
+    }
+
+    @Override
+    public PollData getPollData(String taskDefName, String domain) {
+        ConcurrentHashMap<String, PollData> domainPollData = pollData.get(taskDefName);
+        if (domainPollData == null) {
+            return null;
+        }
+        return domainPollData.get(domain == null ? "DEFAULT" : domain);
+    }
+
+    @Override
+    public List<PollData> getPollData(String taskDefName) {
+        ConcurrentHashMap<String, PollData> domainPollData = pollData.get(taskDefName);
+        if (domainPollData == null) {
+            return new ArrayList<PollData>();
+        }
+        return new ArrayList<PollData>(domainPollData.values());
+    }
+
+    @Override
+    public List<PollData> getAllPollData() {
+        return pollData.values().stream().map(m -> m.values()).collect(Collectors.toList()).stream()
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/polldata/MemoryPollDataDAOConfiguration.java
+++ b/core/src/main/java/com/netflix/conductor/core/polldata/MemoryPollDataDAOConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.index;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import com.netflix.conductor.dao.PollDataDAO;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(name = "conductor.polldata.type", havingValue = "memory")
+public class MemoryPollDataDAOConfiguration {
+
+    @Primary
+    @Bean
+    public PollDataDAO memoryPollDataDAO() {
+        return new MemoryPollDataDAO();
+    }
+}

--- a/core/src/test/java/com/netflix/conductor/core/polldata/TestMemoryPollDataDAO.java
+++ b/core/src/test/java/com/netflix/conductor/core/polldata/TestMemoryPollDataDAO.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2022 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.execution;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.netflix.conductor.common.metadata.tasks.PollData;
+import com.netflix.conductor.core.execution.mapper.*;
+import com.netflix.conductor.core.execution.tasks.*;
+import com.netflix.conductor.core.index.MemoryPollDataDAO;
+
+import static com.netflix.conductor.common.metadata.tasks.TaskType.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class TestMemoryPollDataDAO {
+    MemoryPollDataDAO pollDataDAO;
+
+    @Before
+    public void setup() {
+        pollDataDAO = new MemoryPollDataDAO();
+        pollDataDAO.updateLastPollData("test-task-one", "one", "worker-id1");
+        pollDataDAO.updateLastPollData("test-task-two", "one", "worker-id2");
+        pollDataDAO.updateLastPollData("test-task-one", "two", "worker-id3");
+        pollDataDAO.updateLastPollData("test-task-two", "two", "worker-id4");
+        pollDataDAO.updateLastPollData("test-task-one", null, "worker-id5");
+        pollDataDAO.updateLastPollData("test-task-two", null, "worker-id6");
+    }
+
+    @Test
+    public void testUpdateNewPollData() {
+        pollDataDAO.updateLastPollData("test-task-three", "three", "worker-id7");
+        PollData pollData = pollDataDAO.getPollData("test-task-three", "three");
+
+        assertNotNull(pollData);
+        assertTrue(pollData.getLastPollTime() > 0);
+        assertEquals("test-task-three", pollData.getQueueName());
+        assertEquals("three", pollData.getDomain());
+        assertEquals("worker-id7", pollData.getWorkerId());
+    }
+
+    @Test
+    public void testUpdateExistingPollData() {
+        PollData pollData = pollDataDAO.getPollData("test-task-one", "one");
+
+        assertNotNull(pollData);
+        assertEquals("worker-id1", pollData.getWorkerId());
+        assertTrue(pollData.getLastPollTime() > 0);
+        long previousLastPollTime = pollData.getLastPollTime();
+
+        try {
+            Thread.sleep(5);
+        } catch (InterruptedException e) {
+        }
+
+        pollDataDAO.updateLastPollData("test-task-one", "one", "worker-id8");
+
+        pollData = pollDataDAO.getPollData("test-task-one", "one");
+
+        assertNotNull(pollData);
+        assertTrue(pollData.getLastPollTime() > 0);
+        assertEquals("test-task-one", pollData.getQueueName());
+        assertEquals("worker-id8", pollData.getWorkerId());
+        assertTrue(pollData.getLastPollTime() > previousLastPollTime);
+    }
+
+    @Test
+    public void testGetPollDataByDomain() {
+        PollData pollData = pollDataDAO.getPollData("test-task-one", "one");
+
+        assertNotNull(pollData);
+        assertTrue(pollData.getLastPollTime() > 0);
+        assertEquals("test-task-one", pollData.getQueueName());
+        assertEquals("one", pollData.getDomain());
+        assertEquals("worker-id1", pollData.getWorkerId());
+
+        pollData = pollDataDAO.getPollData("test-task-two", "two");
+
+        assertNotNull(pollData);
+        assertTrue(pollData.getLastPollTime() > 0);
+        assertEquals("test-task-two", pollData.getQueueName());
+        assertEquals("two", pollData.getDomain());
+        assertEquals("worker-id4", pollData.getWorkerId());
+    }
+
+    @Test
+    public void testGetPollDataByDomainNoData() {
+        PollData pollData = pollDataDAO.getPollData("test-task-one", "three");
+
+        assertNull(pollData);
+    }
+
+    @Test
+    public void testGetPollDataWithNullDomain() {
+        PollData pollData = pollDataDAO.getPollData("test-task-one", null);
+
+        assertNotNull(pollData);
+        assertTrue(pollData.getLastPollTime() > 0);
+        assertEquals("test-task-one", pollData.getQueueName());
+        assertNull(pollData.getDomain());
+        assertEquals("worker-id5", pollData.getWorkerId());
+
+        pollData = pollDataDAO.getPollData("test-task-two", null);
+
+        assertNotNull(pollData);
+        assertTrue(pollData.getLastPollTime() > 0);
+        assertEquals("test-task-two", pollData.getQueueName());
+        assertNull(pollData.getDomain());
+        assertEquals("worker-id6", pollData.getWorkerId());
+    }
+
+    @Test
+    public void testGetAllPollDataForTask() {
+        List<PollData> pollData = pollDataDAO.getPollData("test-task-one");
+
+        assertNotNull(pollData);
+        assertEquals(3, pollData.size());
+
+        List<String> queueNames =
+                pollData.stream().map(x -> x.getQueueName()).collect(Collectors.toList());
+        assertEquals("test-task-one", queueNames.get(0));
+        assertEquals("test-task-one", queueNames.get(1));
+        assertEquals("test-task-one", queueNames.get(2));
+
+        List<String> domains =
+                pollData.stream().map(x -> x.getDomain()).collect(Collectors.toList());
+        assertTrue(domains.contains("one"));
+        assertTrue(domains.contains("two"));
+        assertTrue(domains.contains(null));
+
+        List<String> workerIds =
+                pollData.stream().map(x -> x.getWorkerId()).collect(Collectors.toList());
+        assertTrue(workerIds.contains("worker-id1"));
+        assertTrue(workerIds.contains("worker-id3"));
+        assertTrue(workerIds.contains("worker-id5"));
+    }
+
+    @Test
+    public void testGetPollDatForTaskNoData() {
+        List<PollData> pollData = pollDataDAO.getPollData("test-task-three");
+
+        assertEquals(0, pollData.size());
+    }
+
+    @Test
+    public void testGetAllPollData() {
+        List<PollData> pollData = pollDataDAO.getAllPollData();
+
+        assertNotNull(pollData);
+        assertEquals(6, pollData.size());
+
+        List<String> queueNames =
+                pollData.stream().map(x -> x.getQueueName()).collect(Collectors.toList());
+        assertEquals(3, Collections.frequency(queueNames, "test-task-one"));
+        assertEquals(3, Collections.frequency(queueNames, "test-task-two"));
+
+        List<String> domains =
+                pollData.stream().map(x -> x.getDomain()).collect(Collectors.toList());
+        assertEquals(2, Collections.frequency(domains, "one"));
+        assertEquals(2, Collections.frequency(domains, "two"));
+        assertEquals(2, Collections.frequency(domains, null));
+
+        List<String> workerIds =
+                pollData.stream().map(x -> x.getWorkerId()).collect(Collectors.toList());
+        assertTrue(workerIds.contains("worker-id1"));
+        assertTrue(workerIds.contains("worker-id2"));
+        assertTrue(workerIds.contains("worker-id3"));
+        assertTrue(workerIds.contains("worker-id4"));
+        assertTrue(workerIds.contains("worker-id5"));
+        assertTrue(workerIds.contains("worker-id6"));
+    }
+
+
+    @Test
+    public void testGetAllPollDataNoData() {
+        pollDataDAO = new MemoryPollDataDAO();
+
+        List<PollData> pollData = pollDataDAO.getAllPollData();
+
+        assertEquals(0, pollData.size());
+    }
+}

--- a/docs/documentation/advanced/in-memory-poll-data.md
+++ b/docs/documentation/advanced/in-memory-poll-data.md
@@ -1,0 +1,13 @@
+# In-memory Poll Data Storage
+
+Conductor stores records of the last time it was polled for data by the task workers and uses this to calculate which domains to assign to tasks. When using Redis as a data store this is fine as updates are cheap, however when using PostgreSQL as the datestore this can result in a lot of updates to the same records, causing resource contention and locking.
+
+If you are not using domains it is also possible to store this data in-memory on each Conductor instance. Whilst this has the downside that when querying the API for this data you are only getting the data for the server serving your request, it has the benefit of not causing any more database writes. In practice, if you have many workers polling for tasks, this data changes hundreds of times per second, so only having a slice of that data has little impact.
+
+Setting the following property will use the in-memory implementation:
+
+```
+conductor.polldata.type=memory
+```
+
+**WARNING**: If you are using domains for your task workers then you should avoid using this module as it can negatively impact the domain allocation for workers.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
       - documentation/advanced/azureblob-storage.md
       - documentation/advanced/externalpayloadstorage.md
       - documentation/advanced/redis.md
+      - documentation/advanced/in-memory-poll-data.md
     - Client SDKs:
       - documentation/clientsdks/index.md
       - documentation/clientsdks/java-sdk.md


### PR DESCRIPTION
Pull Request type
----
- [x] Feature

Changes in this PR
----

This PR adds a simple in-memory PollDataDAO implementation.

Why?
-----

When using Postgres as a backend, persisting this to the database results in hundreds of updates per second depending on the number of workers you have. Given this data is only used to provide basic info on when a queue was polled, using an in-memory implementation is much more efficient. The downside is that you only get the data stored in memory on the Conductor instance your API request routes to, however with many workers querying multiple times per second this makes very little tangible difference.