### PR TITLE
Use environment variable to set ES6 support mode for Nashorn script evaluator

### DIFF
--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Javascript.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Javascript.java
@@ -22,6 +22,7 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 
+import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +50,8 @@ public class Javascript extends Task<Javascript> {
      * Javascript tasks are executed on the Conductor server without having to write worker code
      *
      * <p>Use {@link Javascript#validate()} method to validate the javascript to ensure the script
-     * is valid.
+     * is valid. Set environment variable CONDUCTOR_NASHORN_ES6_ENABLED=true for Nashorn ES6 support
+     * during validation.
      *
      * @param taskReferenceName
      * @param script script to execute
@@ -100,7 +102,13 @@ public class Javascript extends Task<Javascript> {
      * @return
      */
     public Javascript validate() {
-        ScriptEngine scriptEngine = new ScriptEngineManager().getEngineByName("Nashorn");
+        ScriptEngine scriptEngine;
+        if ("true".equalsIgnoreCase(System.getenv("CONDUCTOR_NASHORN_ES6_ENABLED"))) {
+            NashornScriptEngineFactory factory = new NashornScriptEngineFactory();
+            scriptEngine = factory.getScriptEngine("--language=es6");
+        } else {
+            scriptEngine = new ScriptEngineManager().getEngineByName("Nashorn");
+        }
         if (scriptEngine == null) {
             LOGGER.error("missing " + ENGINE + " engine.  Ensure you are running supported JVM");
             return this;
@@ -128,7 +136,13 @@ public class Javascript extends Task<Javascript> {
      */
     public Object test(Map<String, Object> input) {
 
-        ScriptEngine scriptEngine = new ScriptEngineManager().getEngineByName("Nashorn");
+        ScriptEngine scriptEngine;
+        if ("true".equalsIgnoreCase(System.getenv("CONDUCTOR_NASHORN_ES6_ENABLED"))) {
+            NashornScriptEngineFactory factory = new NashornScriptEngineFactory();
+            scriptEngine = factory.getScriptEngine("--language=es6");
+        } else {
+            scriptEngine = new ScriptEngineManager().getEngineByName("Nashorn");
+        }
         if (scriptEngine == null) {
             LOGGER.error("missing " + ENGINE + " engine.  Ensure you are running supported JVM");
             return this;


### PR DESCRIPTION
Pull Request type
----
- [x] Feature

Changes in this PR
----
If `CONDUCTOR_NASHORN_ES6_ENABLED` is set to `true`, invoke Nashorn with ES6 support argument.

Issue #86 

Alternatives considered
----

Separate Evaluator - we have decided the setting to be global.
