### PR TITLE
Fix an issue with the postgres indices as they weren't being used properly

### DIFF
--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
@@ -13,6 +13,7 @@
 package com.netflix.conductor.postgres.config;
 
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Optional;
 
 import javax.sql.DataSource;
@@ -59,6 +60,7 @@ public class PostgresConfiguration {
     public Flyway flywayForPrimaryDb() {
         return Flyway.configure()
                 .locations("classpath:db/migration_postgres")
+                .configuration(Map.of("flyway.postgresql.transactional.lock", "false"))
                 .schemas(properties.getSchema())
                 .dataSource(dataSource)
                 .outOfOrder(true)

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilder.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilder.java
@@ -44,7 +44,7 @@ public class PostgresIndexQueryBuilder {
         "task_def_name",
         "update_time",
         "json_data",
-        "to_tsvector(json_data::text)"
+        "jsonb_to_tsvector('english', json_data, '[\"all\"]')"
     };
 
     private static final String[] VALID_SORT_ORDER = {"ASC", "DESC"};
@@ -186,7 +186,7 @@ public class PostgresIndexQueryBuilder {
                 conditions.add(cond);
             } else {
                 Condition cond = new Condition();
-                cond.setAttribute("to_tsvector(json_data::text)");
+                cond.setAttribute("jsonb_to_tsvector('english', json_data, '[\"all\"]')");
                 cond.setOperator("@@");
                 String[] values = {freeText};
                 cond.setValues(Arrays.asList(values));

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V9__indexing_index_fix.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V9__indexing_index_fix.sql
@@ -1,0 +1,12 @@
+-- Drop the unused text index on the json_data column
+DROP INDEX CONCURRENTLY IF EXISTS workflow_index_json_data_text_idx;
+-- Create a new index to enable querying the json by attribute and value
+CREATE INDEX CONCURRENTLY IF NOT EXISTS workflow_index_json_data_gin_idx ON workflow_index USING GIN (json_data jsonb_path_ops);
+
+-- Drop the incorrectly created indices on the workflow_index that should be on the task_index table
+DROP INDEX CONCURRENTLY IF EXISTS task_index_json_data_json_idx;
+DROP INDEX CONCURRENTLY IF EXISTS task_index_json_data_text_idx;
+-- Create the full text index on the json_data column of the task_index table
+CREATE INDEX CONCURRENTLY IF NOT EXISTS task_index_json_data_json_idx ON task_index USING GIN (jsonb_to_tsvector('english', json_data, '["all"]'));
+-- Create a new index to enable querying the json by attribute and value
+CREATE INDEX CONCURRENTLY IF NOT EXISTS task_index_json_data_gin_idx ON task_index USING GIN (json_data jsonb_path_ops);

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilderTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilderTest.java
@@ -268,7 +268,7 @@ public class PostgresIndexQueryBuilderTest {
                 new PostgresIndexQueryBuilder(
                         "table_name", "", freeText, 0, 15, Arrays.asList(query));
         String expectedQuery =
-                "SELECT json_data::TEXT FROM table_name WHERE to_tsvector(json_data::text) @@ to_tsquery(?) LIMIT ? OFFSET ?";
+                "SELECT json_data::TEXT FROM table_name WHERE jsonb_to_tsvector('english', json_data, '[\"all\"]') @@ to_tsquery(?) LIMIT ? OFFSET ?";
         assertEquals(expectedQuery, builder.getQuery());
     }
 


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix

Changes in this PR
----
There were some issues with the existing indexing of the Postgres index tables:
 - The two indexes on the task_index table were incorrectly created on the workflow_index table
 - The query we were making for fulltext search wasn't hitting the index properly
 - The query for JSON searching wasn't actually working as expected

This PR:
 - Removes the unnecessary indexes
 - Recreates the fulltext index on the task_index table
 - Creates new `gin` indexes on both tables to allow json queries to work properly
 - Updates the Java query generator to generate a query that will use the full text index properly

All creation and removal of the indices uses `CONCURRENTLY` to avoid any database locks. All statements also use `IF / IF NOT EXISTS` so that you can run the statements yourself manually and the migration will still work (see warning)

Note: This sets the flyway property `flyway.postgresql.transactional.lock=false` ([docs](https://documentation.red-gate.com/fd/postgresql-transactional-lock-224919738.html)) as there is an incompatibility with using `CONCURRENTLY` when creating indices (which should _always_ be used unless you like downtime during migrations) - see thread [here](https://github.com/flyway/flyway/issues/3491)

**Warning** If you already have lots of data in Postgres, these indexes can take some time to generate - you should run the statements manually at a time that is suitable for you to avoid them running whenever you deploy as Conductor may appear to hang while they are running.