### PR TITLE
Enable finer-grained control over the postgres indexing and searching

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
@@ -81,6 +81,9 @@ public class ConductorProperties {
     @DurationUnit(ChronoUnit.SECONDS)
     private Duration taskExecutionPostponeDuration = Duration.ofSeconds(60);
 
+    /** Used to enable/disable the indexing of tasks. */
+    private boolean taskIndexingEnabled = true;
+
     /** Used to enable/disable the indexing of task execution logs. */
     private boolean taskExecLogIndexingEnabled = true;
 
@@ -331,6 +334,14 @@ public class ConductorProperties {
 
     public void setTaskExecLogIndexingEnabled(boolean taskExecLogIndexingEnabled) {
         this.taskExecLogIndexingEnabled = taskExecLogIndexingEnabled;
+    }
+
+    public boolean isTaskIndexingEnabled() {
+        return taskIndexingEnabled;
+    }
+
+    public void setTaskIndexingEnabled(boolean taskIndexingEnabled) {
+        this.taskIndexingEnabled = taskIndexingEnabled;
     }
 
     public boolean isAsyncIndexingEnabled() {

--- a/core/src/main/java/com/netflix/conductor/core/dal/ExecutionDAOFacade.java
+++ b/core/src/main/java/com/netflix/conductor/core/dal/ExecutionDAOFacade.java
@@ -513,7 +513,7 @@ public class ExecutionDAOFacade {
              * of tasks on a system failure. So only index for each update if async indexing is not enabled.
              * If it *is* enabled, tasks will be indexed only when a workflow is in terminal state.
              */
-            if (!properties.isAsyncIndexingEnabled()) {
+            if (!properties.isAsyncIndexingEnabled() && properties.isTaskIndexingEnabled()) {
                 indexDAO.indexTask(new TaskSummary(taskModel.toTask()));
             }
         } catch (TerminateWorkflowException e) {

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
@@ -96,8 +96,9 @@ public class PostgresConfiguration {
     @ConditionalOnProperty(name = "conductor.indexing.type", havingValue = "postgres")
     public PostgresIndexDAO postgresIndexDAO(
             @Qualifier("postgresRetryTemplate") RetryTemplate retryTemplate,
-            ObjectMapper objectMapper) {
-        return new PostgresIndexDAO(retryTemplate, objectMapper, dataSource);
+            ObjectMapper objectMapper,
+            PostgresProperties properties) {
+        return new PostgresIndexDAO(retryTemplate, objectMapper, dataSource, properties);
     }
 
     @Bean

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresProperties.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresProperties.java
@@ -29,6 +29,10 @@ public class PostgresProperties {
 
     public String schema = "public";
 
+    public boolean allowFullTextQueries = true;
+
+    public boolean allowJsonQueries = true;
+
     public Duration getTaskDefCacheRefreshInterval() {
         return taskDefCacheRefreshInterval;
     }
@@ -51,5 +55,21 @@ public class PostgresProperties {
 
     public void setSchema(String schema) {
         this.schema = schema;
+    }
+
+    public boolean getAllowFullTextQueries() {
+        return allowFullTextQueries;
+    }
+
+    public void setAllowFullTextQueries(boolean allowFullTextQueries) {
+        this.allowFullTextQueries = allowFullTextQueries;
+    }
+
+    public boolean getAllowJsonQueries() {
+        return allowJsonQueries;
+    }
+
+    public void setAllowJsonQueries(boolean allowJsonQueries) {
+        this.allowJsonQueries = allowJsonQueries;
     }
 }

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresIndexDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresIndexDAO.java
@@ -30,15 +30,22 @@ import com.netflix.conductor.common.run.TaskSummary;
 import com.netflix.conductor.common.run.WorkflowSummary;
 import com.netflix.conductor.core.events.queue.Message;
 import com.netflix.conductor.dao.IndexDAO;
+import com.netflix.conductor.postgres.config.PostgresProperties;
 import com.netflix.conductor.postgres.util.PostgresIndexQueryBuilder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class PostgresIndexDAO extends PostgresBaseDAO implements IndexDAO {
 
+    private final PostgresProperties properties;
+
     public PostgresIndexDAO(
-            RetryTemplate retryTemplate, ObjectMapper objectMapper, DataSource dataSource) {
+            RetryTemplate retryTemplate,
+            ObjectMapper objectMapper,
+            DataSource dataSource,
+            PostgresProperties properties) {
         super(retryTemplate, objectMapper, dataSource);
+        this.properties = properties;
     }
 
     @Override
@@ -69,7 +76,7 @@ public class PostgresIndexDAO extends PostgresBaseDAO implements IndexDAO {
             String query, String freeText, int start, int count, List<String> sort) {
         PostgresIndexQueryBuilder queryBuilder =
                 new PostgresIndexQueryBuilder(
-                        "workflow_index", query, freeText, start, count, sort);
+                        "workflow_index", query, freeText, start, count, sort, properties);
 
         List<WorkflowSummary> results =
                 queryWithTransaction(
@@ -117,7 +124,8 @@ public class PostgresIndexDAO extends PostgresBaseDAO implements IndexDAO {
     public SearchResult<TaskSummary> searchTaskSummary(
             String query, String freeText, int start, int count, List<String> sort) {
         PostgresIndexQueryBuilder queryBuilder =
-                new PostgresIndexQueryBuilder("task_index", query, freeText, start, count, sort);
+                new PostgresIndexQueryBuilder(
+                        "task_index", query, freeText, start, count, sort, properties);
 
         List<TaskSummary> results =
                 queryWithTransaction(

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilder.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilder.java
@@ -24,6 +24,8 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.netflix.conductor.postgres.config.PostgresProperties;
+
 public class PostgresIndexQueryBuilder {
 
     private final String table;
@@ -32,6 +34,10 @@ public class PostgresIndexQueryBuilder {
     private final int count;
     private final List<String> sort;
     private final List<Condition> conditions = new ArrayList<>();
+
+    private boolean allowJsonQueries;
+
+    private boolean allowFullTextQueries;
 
     private static final String[] VALID_FIELDS = {
         "workflow_id",
@@ -128,12 +134,20 @@ public class PostgresIndexQueryBuilder {
     }
 
     public PostgresIndexQueryBuilder(
-            String table, String query, String freeText, int start, int count, List<String> sort) {
+            String table,
+            String query,
+            String freeText,
+            int start,
+            int count,
+            List<String> sort,
+            PostgresProperties properties) {
         this.table = table;
         this.freeText = freeText;
         this.start = start;
         this.count = count;
         this.sort = sort;
+        this.allowFullTextQueries = properties.getAllowFullTextQueries();
+        this.allowJsonQueries = properties.getAllowJsonQueries();
         this.parseQuery(query);
         this.parseFreeText(freeText);
     }
@@ -177,14 +191,14 @@ public class PostgresIndexQueryBuilder {
 
     private void parseFreeText(String freeText) {
         if (!StringUtils.isEmpty(freeText) && !freeText.equals("*")) {
-            if (freeText.startsWith("{") && freeText.endsWith("}")) {
+            if (allowJsonQueries && freeText.startsWith("{") && freeText.endsWith("}")) {
                 Condition cond = new Condition();
                 cond.setAttribute("json_data");
                 cond.setOperator("@>");
                 String[] values = {freeText};
                 cond.setValues(Arrays.asList(values));
                 conditions.add(cond);
-            } else {
+            } else if (allowFullTextQueries) {
                 Condition cond = new Condition();
                 cond.setAttribute("to_tsvector(json_data::text)");
                 cond.setOperator("@@");

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilderTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilderTest.java
@@ -21,16 +21,21 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
+import com.netflix.conductor.postgres.config.PostgresProperties;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 public class PostgresIndexQueryBuilderTest {
+
+    private PostgresProperties properties = new PostgresProperties();
+
     @Test
     void shouldGenerateQueryForEmptyString() throws SQLException {
         String inputQuery = "";
         PostgresIndexQueryBuilder builder =
                 new PostgresIndexQueryBuilder(
-                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
         String generatedQuery = builder.getQuery();
         assertEquals("SELECT json_data::TEXT FROM table_name LIMIT ? OFFSET ?", generatedQuery);
         Query mockQuery = mock(Query.class);
@@ -46,7 +51,7 @@ public class PostgresIndexQueryBuilderTest {
         String inputQuery = null;
         PostgresIndexQueryBuilder builder =
                 new PostgresIndexQueryBuilder(
-                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
         String generatedQuery = builder.getQuery();
         assertEquals("SELECT json_data::TEXT FROM table_name LIMIT ? OFFSET ?", generatedQuery);
         Query mockQuery = mock(Query.class);
@@ -62,7 +67,7 @@ public class PostgresIndexQueryBuilderTest {
         String inputQuery = "workflowId=\"abc123\"";
         PostgresIndexQueryBuilder builder =
                 new PostgresIndexQueryBuilder(
-                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
         String generatedQuery = builder.getQuery();
         assertEquals(
                 "SELECT json_data::TEXT FROM table_name WHERE workflow_id = ? LIMIT ? OFFSET ?",
@@ -81,7 +86,7 @@ public class PostgresIndexQueryBuilderTest {
         String inputQuery = "status IN (COMPLETED,RUNNING)";
         PostgresIndexQueryBuilder builder =
                 new PostgresIndexQueryBuilder(
-                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
         String generatedQuery = builder.getQuery();
         assertEquals(
                 "SELECT json_data::TEXT FROM table_name WHERE status = ANY(?) LIMIT ? OFFSET ?",
@@ -100,7 +105,7 @@ public class PostgresIndexQueryBuilderTest {
         String inputQuery = "status IN (COMPLETED)";
         PostgresIndexQueryBuilder builder =
                 new PostgresIndexQueryBuilder(
-                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
         String generatedQuery = builder.getQuery();
         assertEquals(
                 "SELECT json_data::TEXT FROM table_name WHERE status = ? LIMIT ? OFFSET ?",
@@ -119,7 +124,7 @@ public class PostgresIndexQueryBuilderTest {
         String inputQuery = "startTime>1675702498000";
         PostgresIndexQueryBuilder builder =
                 new PostgresIndexQueryBuilder(
-                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
         String generatedQuery = builder.getQuery();
         assertEquals(
                 "SELECT json_data::TEXT FROM table_name WHERE start_time > ?::TIMESTAMPTZ LIMIT ? OFFSET ?",
@@ -138,7 +143,7 @@ public class PostgresIndexQueryBuilderTest {
         String inputQuery = "startTime<1675702498000";
         PostgresIndexQueryBuilder builder =
                 new PostgresIndexQueryBuilder(
-                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
         String generatedQuery = builder.getQuery();
         assertEquals(
                 "SELECT json_data::TEXT FROM table_name WHERE start_time < ?::TIMESTAMPTZ LIMIT ? OFFSET ?",
@@ -157,7 +162,7 @@ public class PostgresIndexQueryBuilderTest {
         String inputQuery = "updateTime>1675702498000";
         PostgresIndexQueryBuilder builder =
                 new PostgresIndexQueryBuilder(
-                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
         String generatedQuery = builder.getQuery();
         assertEquals(
                 "SELECT json_data::TEXT FROM table_name WHERE update_time > ?::TIMESTAMPTZ LIMIT ? OFFSET ?",
@@ -176,7 +181,7 @@ public class PostgresIndexQueryBuilderTest {
         String inputQuery = "updateTime<1675702498000";
         PostgresIndexQueryBuilder builder =
                 new PostgresIndexQueryBuilder(
-                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
         String generatedQuery = builder.getQuery();
         assertEquals(
                 "SELECT json_data::TEXT FROM table_name WHERE update_time < ?::TIMESTAMPTZ LIMIT ? OFFSET ?",
@@ -196,7 +201,7 @@ public class PostgresIndexQueryBuilderTest {
                 "workflowId=\"abc123\" AND workflowType IN (one,two) AND status IN (COMPLETED,RUNNING) AND startTime>1675701498000 AND startTime<1675702498000";
         PostgresIndexQueryBuilder builder =
                 new PostgresIndexQueryBuilder(
-                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
         String generatedQuery = builder.getQuery();
         assertEquals(
                 "SELECT json_data::TEXT FROM table_name WHERE start_time < ?::TIMESTAMPTZ AND start_time > ?::TIMESTAMPTZ AND status = ANY(?) AND workflow_id = ? AND workflow_type = ANY(?) LIMIT ? OFFSET ?",
@@ -220,7 +225,7 @@ public class PostgresIndexQueryBuilderTest {
         String[] query = {"updateTime:DESC"};
         PostgresIndexQueryBuilder builder =
                 new PostgresIndexQueryBuilder(
-                        "table_name", inputQuery, "", 0, 15, Arrays.asList(query));
+                        "table_name", inputQuery, "", 0, 15, Arrays.asList(query), properties);
         String expectedQuery =
                 "SELECT json_data::TEXT FROM table_name WHERE update_time < ?::TIMESTAMPTZ ORDER BY update_time DESC LIMIT ? OFFSET ?";
         assertEquals(expectedQuery, builder.getQuery());
@@ -232,7 +237,7 @@ public class PostgresIndexQueryBuilderTest {
         String[] query = {"updateTime:DESC", "correlationId:ASC"};
         PostgresIndexQueryBuilder builder =
                 new PostgresIndexQueryBuilder(
-                        "table_name", inputQuery, "", 0, 15, Arrays.asList(query));
+                        "table_name", inputQuery, "", 0, 15, Arrays.asList(query), properties);
         String expectedQuery =
                 "SELECT json_data::TEXT FROM table_name WHERE update_time < ?::TIMESTAMPTZ ORDER BY update_time DESC, correlation_id ASC LIMIT ? OFFSET ?";
         assertEquals(expectedQuery, builder.getQuery());
@@ -243,7 +248,7 @@ public class PostgresIndexQueryBuilderTest {
         String inputQuery = "sqlInjection<1675702498000";
         PostgresIndexQueryBuilder builder =
                 new PostgresIndexQueryBuilder(
-                        "table_name", inputQuery, "", 0, 15, new ArrayList<>());
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
         String expectedQuery = "SELECT json_data::TEXT FROM table_name LIMIT ? OFFSET ?";
         assertEquals(expectedQuery, builder.getQuery());
     }
@@ -254,7 +259,7 @@ public class PostgresIndexQueryBuilderTest {
         String[] query = {"sqlInjection:DESC"};
         PostgresIndexQueryBuilder builder =
                 new PostgresIndexQueryBuilder(
-                        "table_name", inputQuery, "", 0, 15, Arrays.asList(query));
+                        "table_name", inputQuery, "", 0, 15, Arrays.asList(query), properties);
         String expectedQuery =
                 "SELECT json_data::TEXT FROM table_name WHERE update_time < ?::TIMESTAMPTZ LIMIT ? OFFSET ?";
         assertEquals(expectedQuery, builder.getQuery());
@@ -266,7 +271,7 @@ public class PostgresIndexQueryBuilderTest {
         String[] query = {"sqlInjection:DESC"};
         PostgresIndexQueryBuilder builder =
                 new PostgresIndexQueryBuilder(
-                        "table_name", "", freeText, 0, 15, Arrays.asList(query));
+                        "table_name", "", freeText, 0, 15, Arrays.asList(query), properties);
         String expectedQuery =
                 "SELECT json_data::TEXT FROM table_name WHERE to_tsvector(json_data::text) @@ to_tsquery(?) LIMIT ? OFFSET ?";
         assertEquals(expectedQuery, builder.getQuery());
@@ -278,7 +283,7 @@ public class PostgresIndexQueryBuilderTest {
         String[] query = {"sqlInjection:DESC"};
         PostgresIndexQueryBuilder builder =
                 new PostgresIndexQueryBuilder(
-                        "table_name", "", freeText, 0, 15, Arrays.asList(query));
+                        "table_name", "", freeText, 0, 15, Arrays.asList(query), properties);
         String expectedQuery =
                 "SELECT json_data::TEXT FROM table_name WHERE json_data @> ?::JSONB LIMIT ? OFFSET ?";
         assertEquals(expectedQuery, builder.getQuery());


### PR DESCRIPTION
Pull Request type
----
- [x] Feature

Changes in this PR
----

Depending on your needs, you may not require all of the indexing features. This PR adds a parameter to control the indexing of Tasks. It default to true, so the existing behaviour is unchanged by default. As the indexing puts additional load on the database, being able to configure this for your needs is quite useful. The indexing parameters are:

```
conductor.app.taskIndexingEnabled=(true|false)
```

There are two indexes on the json_data in the index tables for both workflows and tasks. These are quite computationally intensive to generate but if you removed them then you are at risk of a query doing a full scan of the database table and reducing performance of the service.

These two config parameters allow you to individually disable full text searches and json searches so that if you find you don't need them for your specific use case you could safely drop the indexes to improve performance. You can enable and disable these queries using the following parameters:


```
conductor.postgres.allowFullTextQueries=(true|false)
conductor.postgres.allowJsonQueries=(true|false)
```
