### PR TITLE
Adding redis username support for clusters

### DIFF
--- a/docs/documentation/advanced/redis.md
+++ b/docs/documentation/advanced/redis.md
@@ -1,9 +1,9 @@
 # Redis
 
 By default conductor runs with an in-memory Redis mock. However, you
-can change the configuration by setting the properties `conductor.db.type` and `conductor.redis.hosts`.
+can change the configuration by setting the properties mentioned below.
 
-## `conductor.db.type`
+## `conductor.db.type` and `conductor.queue.type`
 
 | Value                          | Description                                                                            |
 |--------------------------------|----------------------------------------------------------------------------------------|
@@ -13,8 +13,6 @@ can change the configuration by setting the properties `conductor.db.type` and `
 | redis_sentinel                 | Redis Sentinel configuration.                                                          |
 | redis_standalone               | Redis Standalone configuration.                                                        |
 
-
-
 ## `conductor.redis.hosts`
 
 Expected format is `host:port:rack` separated by semicolon, e.g.: 
@@ -23,16 +21,32 @@ Expected format is `host:port:rack` separated by semicolon, e.g.:
 conductor.redis.hosts=host0:6379:us-east-1c;host1:6379:us-east-1c;host2:6379:us-east-1c
 ```
 
-### Auth Support
+## `conductor.redis.database`
+Redis database value other than default of 0 is supported in sentinel and standalone configurations. 
+Redis cluster mode only uses database 0, and the configuration is ignored.
 
-Password authentication is supported. The password should be set as the 4th param of the first host `host:port:rack:password`, e.g.:
+```properties
+conductor.redis.database=1
+```
+
+
+## `conductor.redis.username`
+
+[Redis ACL](https://redis.io/docs/management/security/acl/) using username and password authentication is now supported. 
+
+The username property should be set as `conductor.redis.username`, e.g.:
+```properties
+conductor.redis.username=conductor
+```
+If not set, the client uses `default` as the username.
+
+The password should be set as the 4th param of the first host `host:port:rack:password`, e.g.:
 
 ```properties
 conductor.redis.hosts=host0:6379:us-east-1c:my_str0ng_pazz;host1:6379:us-east-1c;host2:6379:us-east-1c
 ```
 
-
 **Notes**
 
-- In a cluster, all nodes use the same password.
-- In a sentinel configuration, sentinels and redis nodes use the same password.
+- In a cluster, all nodes use the same username and password.
+- In a sentinel configuration, sentinels and redis nodes use the same database index, username, and password.

--- a/redis-persistence/src/main/java/com/netflix/conductor/redis/config/RedisClusterConfiguration.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/redis/config/RedisClusterConfiguration.java
@@ -55,7 +55,18 @@ public class RedisClusterConfiguration extends JedisCommandsConfigurer {
                         .collect(Collectors.toSet());
         String password = getPassword(hostSupplier.getHosts());
 
-        if (password != null) {
+        if (properties.getUsername() != null && password != null) {
+            log.info("Connecting to Redis Cluster with user AUTH");
+            return new JedisCluster(
+                    new redis.clients.jedis.JedisCluster(
+                            hosts,
+                            Protocol.DEFAULT_TIMEOUT,
+                            Protocol.DEFAULT_TIMEOUT,
+                            DEFAULT_MAX_ATTEMPTS,
+                            properties.getUsername(),
+                            password,
+                            genericObjectPoolConfig));
+        } else if (password != null) {
             log.info("Connecting to Redis Cluster with AUTH");
             return new JedisCluster(
                     new redis.clients.jedis.JedisCluster(


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Added ACL support and readme documentation for Redis ACL to Redis Cluster
This is follow up to Netflix/conductor#3847 extending support to Redis clusters.

Also updated the readme for redis in docs.