### PR TITLE
Fix PostgresIndexQueryBuilder null pointer exception

### DIFF
--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilder.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilder.java
@@ -75,6 +75,8 @@ public class PostgresIndexQueryBuilder {
                 if (this.attribute.endsWith("_time")) {
                     values.set(0, millisToUtc(values.get(0)));
                 }
+            } else {
+                throw new IllegalArgumentException("Incorrectly formatted query string: " + query);
             }
         }
 

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilderTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilderTest.java
@@ -24,6 +24,7 @@ import org.mockito.Mockito;
 import com.netflix.conductor.postgres.config.PostgresProperties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 public class PostgresIndexQueryBuilderTest {
@@ -287,5 +288,20 @@ public class PostgresIndexQueryBuilderTest {
         String expectedQuery =
                 "SELECT json_data::TEXT FROM table_name WHERE json_data @> ?::JSONB LIMIT ? OFFSET ?";
         assertEquals(expectedQuery, builder.getQuery());
+    }
+
+    @Test()
+    void shouldThrowIllegalArgumentExceptionWhenQueryStringIsInvalid() {
+        String inputQuery =
+                "workflowType IN (one,two) AND status IN (COMPLETED,RUNNING) AND startTime>1675701498000 AND xyz";
+
+        try {
+            new PostgresIndexQueryBuilder(
+                    "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+
+            fail("should have failed since xyz does not conform to expected format");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Incorrectly formatted query string: xyz", e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----
`PostgresIndexQueryBuilder` throws an NPE when a `Condition` object is created from a query string which doesn't conform to the regex provided. In this PR, if the string doesn't match the regex we throw a `IllegalArgumentException` instead so that the error is handled properly. 

Alternatives considered
----

