### PR TITLE
Fix Issue: If status-listener throw exception, task not executed

### DIFF
--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -189,7 +189,18 @@ public class ExecutionService {
                 .map(executionDAOFacade::getTaskModel)
                 .filter(Objects::nonNull)
                 .filter(task -> TaskModel.Status.IN_PROGRESS.equals(task.getStatus()))
-                .forEach(taskStatusListener::onTaskInProgress);
+                .forEach(
+                        task -> {
+                            try {
+                                taskStatusListener.onTaskInProgress(task);
+                            } catch (Exception e) {
+                                String errorMsg =
+                                        String.format(
+                                                "Error while notifying TaskStatusListener: %s for workflow: %s",
+                                                task.getTaskId(), task.getWorkflowInstanceId());
+                                LOGGER.error(errorMsg, e);
+                            }
+                        });
         executionDAOFacade.updateTaskLastPoll(taskType, domain, workerId);
         Monitors.recordTaskPoll(queueName);
         tasks.forEach(this::ackTaskReceived);


### PR DESCRIPTION
Pull Request type
----
- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

_Describe the new behavior from this PR, and why it's needed_

https://github.com/conductor-oss/conductor/pull/58

If an exception occurs in taskStatusListener.onTaskInProgress(), the worker cannot poll, so conductor-server recognizes the task status as IN_PROGRESS.

<worker.log>
```
ERROR 27230 --- [pool-3-thread-7] c.n.c.client.automator.TaskRunner        : Error polling for taskType: sink-worker, error = 500 :
```

_Describe alternative implementation you have considered_
