### PR TITLE
Feature/keepLastN

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
@@ -112,12 +112,15 @@ public class DoWhile extends WorkflowSystemTask {
         }
         doWhileTaskModel.addOutput(String.valueOf(doWhileTaskModel.getIteration()), output);
 
-        Optional<Integer> keepLastN = Optional.ofNullable(doWhileTaskModel.getWorkflowTask().getInputParameters())
-                .map(parameters -> parameters.get("keepLastN"))
-                .map(value -> (Integer) value);
-        if(keepLastN.isPresent() && doWhileTaskModel.getIteration() > keepLastN.get()) {
+        Optional<Integer> keepLastN =
+                Optional.ofNullable(doWhileTaskModel.getWorkflowTask().getInputParameters())
+                        .map(parameters -> parameters.get("keepLastN"))
+                        .map(value -> (Integer) value);
+        if (keepLastN.isPresent() && doWhileTaskModel.getIteration() > keepLastN.get()) {
             Integer iteration = doWhileTaskModel.getIteration();
-            IntStream.range(0, iteration - keepLastN.get()).mapToObj(Integer::toString).forEach(doWhileTaskModel::removeOutput);
+            IntStream.range(0, iteration - keepLastN.get())
+                    .mapToObj(Integer::toString)
+                    .forEach(doWhileTaskModel::removeOutput);
         }
 
         if (hasFailures) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
@@ -118,7 +118,7 @@ public class DoWhile extends WorkflowSystemTask {
                         .map(value -> (Integer) value);
         if (keepLastN.isPresent() && doWhileTaskModel.getIteration() > keepLastN.get()) {
             Integer iteration = doWhileTaskModel.getIteration();
-            IntStream.range(0, iteration - keepLastN.get())
+            IntStream.range(0, iteration - keepLastN.get() - 1)
                     .mapToObj(Integer::toString)
                     .forEach(doWhileTaskModel::removeOutput);
         }

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
@@ -275,10 +275,4 @@ public class DoWhile extends WorkflowSystemTask {
         }
         return result;
     }
-
-    Optional<Integer> getKeepLastN(TaskModel task) {
-        return Optional.ofNullable(task.getWorkflowTask().getInputParameters())
-                .map(parameters -> parameters.get("keepLastN"))
-                .map(value -> (Integer) value);
-    }
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
@@ -46,10 +46,6 @@ public class DoWhile extends WorkflowSystemTask {
         this.parametersUtils = parametersUtils;
     }
 
-    private static Integer apply(Object a) {
-        return (Integer) a;
-    }
-
     @Override
     public void cancel(WorkflowModel workflow, TaskModel task, WorkflowExecutor executor) {
         task.setStatus(TaskModel.Status.CANCELED);

--- a/core/src/main/java/com/netflix/conductor/model/TaskModel.java
+++ b/core/src/main/java/com/netflix/conductor/model/TaskModel.java
@@ -874,6 +874,10 @@ public class TaskModel {
         this.outputData.put(key, value);
     }
 
+    public void removeOutput(String key) {
+        this.outputData.remove(key);
+    }
+
     public void addOutput(Map<String, Object> outputData) {
         if (outputData != null) {
             this.outputData.putAll(outputData);


### PR DESCRIPTION
Pull Request type
----
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
If `keepLastN` is passed as part of input parameters of a DO_WHILE task, then the old / stale iterations' output data shall be removed while executing the DO_WHILE task. 

_Describe the new behavior from this PR, and why it's needed_
Issue # [134](https://github.com/conductor-oss/conductor/discussions/134)

Alternatives considered
----

_Describe alternative implementation you have considered_
