### PR TITLE
Fix Issue: notify cancelled task 

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -742,6 +742,17 @@ public class WorkflowExecutor {
         if (task.getStatus().isTerminal()) {
             // Task was already updated....
             queueDAO.remove(taskQueueName, taskResult.getTaskId());
+            if (task.getStatus().equals(CANCELED)) {
+                try {
+                    notifyTaskStatusListener(task);
+                } catch (Exception e) {
+                    String errorMsg =
+                            String.format(
+                                    "Error while notifying TaskStatusListener: %s for workflow: %s",
+                                    task.getTaskId(), task.getWorkflowInstanceId());
+                    LOGGER.error(errorMsg, e);
+                }
+            }
             LOGGER.info(
                     "Task: {} has already finished execution with status: {} within workflow: {}. Removed task from queue: {}",
                     task.getTaskId(),

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -742,17 +742,6 @@ public class WorkflowExecutor {
         if (task.getStatus().isTerminal()) {
             // Task was already updated....
             queueDAO.remove(taskQueueName, taskResult.getTaskId());
-            if (task.getStatus().equals(CANCELED)) {
-                try {
-                    notifyTaskStatusListener(task);
-                } catch (Exception e) {
-                    String errorMsg =
-                            String.format(
-                                    "Error while notifying TaskStatusListener: %s for workflow: %s",
-                                    task.getTaskId(), task.getWorkflowInstanceId());
-                    LOGGER.error(errorMsg, e);
-                }
-            }
             LOGGER.info(
                     "Task: {} has already finished execution with status: {} within workflow: {}. Removed task from queue: {}",
                     task.getTaskId(),
@@ -1214,6 +1203,15 @@ public class WorkflowExecutor {
             if (!task.getStatus().isTerminal()) {
                 // Cancel the ones which are not completed yet....
                 task.setStatus(CANCELED);
+                try {
+                    notifyTaskStatusListener(task);
+                } catch (Exception e) {
+                    String errorMsg =
+                            String.format(
+                                    "Error while notifying TaskStatusListener: %s for workflow: %s",
+                                    task.getTaskId(), task.getWorkflowInstanceId());
+                    LOGGER.error(errorMsg, e);
+                }
                 if (systemTaskRegistry.isSystemTask(task.getTaskType())) {
                     WorkflowSystemTask workflowSystemTask =
                             systemTaskRegistry.get(task.getTaskType());


### PR DESCRIPTION
Pull Request type
----
- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_

If a failure occurs inside the Fork-Join Task and other tasks change to the `CANCLED` state, a CANCLED notification is required when the `CANCLED` task calls the update task from the worker.

Alternatives considered
----

_Describe alternative implementation you have considered_
