### PR TITLE
Fix: Wrap PGExecutionDAO createTasks in a single transaction

### DIFF
--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresExecutionDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresExecutionDAO.java
@@ -136,9 +136,10 @@ public class PostgresExecutionDAO extends PostgresBaseDAO
     public List<TaskModel> createTasks(List<TaskModel> tasks) {
         List<TaskModel> created = Lists.newArrayListWithCapacity(tasks.size());
 
-        for (TaskModel task : tasks) {
-            withTransaction(
-                    connection -> {
+        withTransaction(
+                connection -> {
+                    for (TaskModel task : tasks) {
+
                         validate(task);
 
                         task.setScheduledTime(System.currentTimeMillis());
@@ -155,7 +156,7 @@ public class PostgresExecutionDAO extends PostgresBaseDAO
                                             + task.getReferenceTaskName()
                                             + ", key="
                                             + taskKey);
-                            return;
+                            continue;
                         }
 
                         insertOrUpdateTaskData(connection, task);
@@ -164,8 +165,8 @@ public class PostgresExecutionDAO extends PostgresBaseDAO
                         updateTask(connection, task);
 
                         created.add(task);
-                    });
-        }
+                    }
+                });
 
         return created;
     }


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix

Changes in this PR
----
We’ve observed during load tests that forked tasks are sometimes partially not scheduled during high load peaks.

After debugging, we’ve identified that this may occur due to the createTasks routine in the PostgresExecutionDAO has a separate transaction per task that is getting inserted. If an error / crash occurs in the middle, all the tasks inserted before the crash will be picked up by the WorkflowReconciler and pushed into the queue, while the ones not pushed will never be scheduled. This potentially leads to a workflow hanging forever.

Wrapping the createTasks routine in a single transaction should resolve this issue.