### PR TITLE
fix: logging of connection failures due to bad evaluation of a string…

### DIFF
--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/util/PostgresQueueListener.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/util/PostgresQueueListener.java
@@ -166,7 +166,7 @@ public class PostgresQueueListener {
                 conn.setAutoCommit(previousAutoCommitMode);
             }
         } catch (SQLException e) {
-            if (!e.getSQLState().equals("08003")) {
+            if (!isSQLExceptionConnectionDoesNotExists(e)) {
                 logger.error("Error fetching notifications {}", e.getSQLState());
             }
             connect();
@@ -187,7 +187,7 @@ public class PostgresQueueListener {
             }
             processPayload(notifications[notifications.length - 1].getParameter());
         } catch (SQLException e) {
-            if (e.getSQLState() != "08003") {
+            if (!isSQLExceptionConnectionDoesNotExists(e)) {
                 logger.error("Error fetching notifications {}", e.getSQLState());
             }
             connect();
@@ -222,5 +222,9 @@ public class PostgresQueueListener {
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static boolean isSQLExceptionConnectionDoesNotExists(SQLException e) {
+        return "08003".equals(e.getSQLState());
     }
 }


### PR DESCRIPTION
… comparison

Pull Request type
----
- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
The previous code was failing in evaluating a string comparison because of not using equals method.
I also gave a name to the magic constant 08003 using the information from documentation
https://www.postgresql.org/docs/9.0/errcodes-appendix.html 

Alternatives considered
----

_Describe alternative implementation you have considered_
