### PR TITLE
Add running workflow to deciderQueue reconciliation

### DIFF
--- a/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
@@ -153,6 +153,14 @@ public interface ExecutionDAO {
     List<String> getRunningWorkflowIds(String workflowName, int version);
 
     /**
+     * @return List of workflow ids which are running
+     */
+    default List<String> getRunningWorkflowIds() {
+        throw new UnsupportedOperationException(
+                getClass() + " does not support getRunningWorkflowIds");
+    }
+
+    /**
      * @param workflowName Name of the workflow
      * @param version the workflow version
      * @return List of workflows that are running

--- a/core/src/main/java/com/netflix/conductor/dao/QueueDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/QueueDAO.java
@@ -164,4 +164,13 @@ public interface QueueDAO {
         throw new UnsupportedOperationException(
                 "Please ensure your provided Queue implementation overrides and implements this method.");
     }
+
+    /**
+     * @param queueName name of the queue
+     * @return List of messages in the queue
+     */
+    default List<Message> getMessages(String queueName) {
+        throw new UnsupportedOperationException(
+                "Please ensure your provided Queue implementation overrides and implements this method.");
+    }
 }

--- a/core/src/test/java/com/netflix/conductor/core/reconciliation/TestWorkflowReconciler.java
+++ b/core/src/test/java/com/netflix/conductor/core/reconciliation/TestWorkflowReconciler.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.reconciliation;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.core.events.queue.Message;
+import com.netflix.conductor.dao.ExecutionDAO;
+import com.netflix.conductor.dao.QueueDAO;
+
+import static com.netflix.conductor.core.utils.Utils.DECIDER_QUEUE;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class TestWorkflowReconciler {
+
+    @InjectMocks private WorkflowReconciler workflowReconciler;
+
+    @Mock private QueueDAO queueDAO;
+
+    @Mock private ExecutionDAO executionDAO;
+
+    @Mock private ConductorProperties conductorProperties;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(conductorProperties.getSweeperThreadCount()).thenReturn(5);
+        when(conductorProperties.getSweeperWorkflowPollTimeout())
+                .thenReturn(java.time.Duration.ofMillis(1000));
+        workflowReconciler.start();
+    }
+
+    @Test
+    public void testReconcilePendingWorkflows_NoWorkflowsRunning() {
+        when(executionDAO.getRunningWorkflowIds()).thenReturn(Collections.emptyList());
+        workflowReconciler.reconcileRunningWorkflowsAndDeciderQueue();
+        verify(queueDAO, never()).push(anyString(), anyList());
+    }
+
+    @Test
+    public void testReconcilePendingWorkflows_AllWorkflowsInQueue() {
+        List<String> runningWorkflowIds = Arrays.asList("wf1", "wf2");
+        Set<String> workflowIdsInQueue = new HashSet<>(Arrays.asList("wf1", "wf2"));
+
+        when(executionDAO.getRunningWorkflowIds()).thenReturn(runningWorkflowIds);
+        when(queueDAO.getMessages(DECIDER_QUEUE))
+                .thenReturn(
+                        workflowIdsInQueue.stream()
+                                .map(id -> new Message(id, null, null, 0))
+                                .collect(Collectors.toList()));
+
+        workflowReconciler.reconcileRunningWorkflowsAndDeciderQueue();
+        verify(queueDAO, never()).push(eq(DECIDER_QUEUE), anyList());
+    }
+
+    @Test
+    public void testReconcilePendingWorkflows_WorkflowsMissingFromQueue() {
+        List<String> runningWorkflowIds = Arrays.asList("wf1", "wf2", "wf3");
+        Set<String> workflowIdsInQueue = new HashSet<>(Arrays.asList("wf1", "wf3"));
+
+        when(executionDAO.getRunningWorkflowIds()).thenReturn(runningWorkflowIds);
+        when(queueDAO.getMessages(DECIDER_QUEUE))
+                .thenReturn(
+                        workflowIdsInQueue.stream()
+                                .map(id -> new Message(id, null, null, 0))
+                                .collect(Collectors.toList()));
+
+        workflowReconciler.reconcileRunningWorkflowsAndDeciderQueue();
+
+        ArgumentCaptor<List<Message>> argumentCaptor = ArgumentCaptor.forClass(List.class);
+        verify(queueDAO).push(eq(DECIDER_QUEUE), argumentCaptor.capture());
+        List<Message> capturedMessages = argumentCaptor.getValue();
+        assertEquals(
+                "Expected to push missing workflow back into queue", 1, capturedMessages.size());
+        assertEquals("wf2", capturedMessages.get(0).getId());
+    }
+}

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresExecutionDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresExecutionDAO.java
@@ -392,6 +392,18 @@ public class PostgresExecutionDAO extends PostgresBaseDAO
     }
 
     /**
+     * @return list of workflow ids that are in RUNNING state
+     */
+    @Override
+    public List<String> getRunningWorkflowIds() {
+        String GET_PENDING_WORKFLOW_IDS =
+                "SELECT workflow_id FROM workflow WHERE (json_data::jsonb)->>'status' = 'RUNNING'";
+
+        return queryWithTransaction(
+                GET_PENDING_WORKFLOW_IDS, q -> q.executeScalarList(String.class));
+    }
+
+    /**
      * @param workflowName Name of the workflow
      * @param version the workflow version
      * @return list of workflows that are in RUNNING state

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V13__workflow_table_index_running.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V13__workflow_table_index_running.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS workflow_status_running_idx
+ON workflow (json_data) WHERE (json_data::jsonb ->> 'status') = 'RUNNING';

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresQueueDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresQueueDAOTest.java
@@ -415,4 +415,19 @@ public class PostgresQueueDAOTest {
         assertNotNull(size);
         assertEquals(size.longValue(), count - unackedCount);
     }
+
+    @Test
+    public void getMessagesTest() {
+        String queueName = "testQueue";
+        for (int i = 0; i < 4; i++) {
+            String messageId = "msg" + i;
+            queueDAO.push(queueName, messageId, 5);
+        }
+        queueDAO.pop(queueName, 1, 10_000);
+
+        List<Message> messages = queueDAO.getMessages(queueName);
+
+        assertNotNull(messages);
+        assertEquals(3, messages.size());
+    }
 }


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix

Changes in this PR
----
_PROBLEM_
This PR addresses the following issues when using Postgres as an execution and queuing backend:
1. A workflow gets stuck in a RUNNING state while all tasks are terminal.
2. A workflow has tasks that are in a SCHEDULED state but are never polled again.

In both cases, we've observed that the task is marked as RUNNING in the executionDAO, but is missing from the deciderQueue. The deciderQueue being in sync with the executionDAO is critical, as the workflowSweeper only operates on workflows that can be popped from the deciderQueue.

 The workflowSweeper is responsible for two things:
- Periodically trying to advance the progression of a workflow, by checking which tasks can be run next, or marking the workflow as terminal if all tasks are terminal, which is important for solving symptom 1.
- running the workflowRepairService on the workflow on every sweep, during which tasks that are marked as SCHEDULED are reconciled with the task queue, which is important for solving symptom 2.

_SOLUTION_
Periodically push all RUNNING workflows present in the executionDAO into the deciderQueue if they are not present.

Two DAO methods are added to enable this:
1. getMessages on the queueDAO, which retrieves all messages for a certain queue.
2. getRunningWorkflows(), which retrieves all workflows in a `RUNNING` state from the executionDAO

To enable this, an index identifying the RUNNING workflows is added to the postgres `workflow` table (i.e., the table used by the executionDAO). We choose to query this directly from the executionDAO instead of the indexDAO (which already contains a similar index) as the executionDAO and indexDAO could be out of sync themselves: the executionDAO should always be the source of truth. 

We have not been able to identify the root cause of the mismatch between the DAOs due to the complexity of workflow progression and the lack of transactions spanning the executionDAO and queueDAO.

Remaining work
---
- This solution will only work if using Postgres for queuing and execution, as the PR does not contain overrides for the new required DAO operations for other backends. This should be addressed.
- Add a toggle for enabling this reconciliation and a possibility to override the reconciliation period.
- Address a known race condition between the PG unack routine and the reconciliation. Can potentially be fixed by also including messages that are popped in the queue in the `getMessages` method on the `queueDAO`.
- Fix failing test.




