### PR TITLE
Add back `AfterburnerModule` to `ObjectMapperConfiguration`

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/config/ObjectMapperConfiguration.java
+++ b/common/src/main/java/com/netflix/conductor/common/config/ObjectMapperConfiguration.java
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import jakarta.annotation.PostConstruct;
 
 @Configuration
@@ -33,5 +34,6 @@ public class ObjectMapperConfiguration {
         objectMapper.setDefaultPropertyInclusion(
                 JsonInclude.Value.construct(
                         JsonInclude.Include.NON_NULL, JsonInclude.Include.ALWAYS));
+        objectMapper.registerModule(new AfterburnerModule());
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [x] Other (please describe):

Adds back Jackson's `AfterburnerModule`. 

It was removed in this recent [PR](https://github.com/conductor-oss/conductor/pull/194/files#r1662703108) from `ObjectMapperConfiguration` but it's still being used in `ObjectMapperProvider`. 

FYI, this instance is the one that Spring injects to its beans.

Changes in this PR
----

- Adds back `AfterburnerModule`.
