### PR TITLE
Update JDK Version in Prerequisites

### DIFF
--- a/docs/devguide/running/source.md
+++ b/docs/devguide/running/source.md
@@ -5,7 +5,7 @@ In this article we will explore how you can set up Conductor on your local machi
 features.
 
 ### Prerequisites
-1. JDK 11 or greater
+1. JDK 17 or greater
 2. (Optional) Docker if you want to run tests.  You can install docker from [here](https://www.docker.com/get-started/).
 3. Node for building and running UI.  Instructions at [https://nodejs.org](https://nodejs.org).
 4. Yarn for building and running UI.  Instructions at [https://classic.yarnpkg.com/en/docs/install](https://classic.yarnpkg.com/en/docs/install).


### PR DESCRIPTION
Conductor requires JDK 17 for building from source code. Updated the required JDK version in the docs.

Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [X] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
---- Updated the Required JDK version in docs/devguide/running.md from 11 to 17

_Describe the new behavior from this PR, and why it's needed_
As mentioned in the docs I was trying to use JDK 11, but it requires JDK 17, this is a mistake or maybe older documentation. It should be updated.
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
