### PR TITLE
Updated Postgres indexer to handle out of order updates

### DIFF
--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresIndexDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresIndexDAO.java
@@ -82,14 +82,18 @@ public class PostgresIndexDAO extends PostgresBaseDAO implements IndexDAO {
     @Override
     public void indexWorkflow(WorkflowSummary workflow) {
         String INSERT_WORKFLOW_INDEX_SQL =
-                "INSERT INTO workflow_index (workflow_id, correlation_id, workflow_type, start_time, status, json_data)"
-                        + "VALUES (?, ?, ?, ?, ?, ?::JSONB) ON CONFLICT (workflow_id) \n"
+                "INSERT INTO workflow_index (workflow_id, correlation_id, workflow_type, start_time, update_time, status, json_data)"
+                        + "VALUES (?, ?, ?, ?, ?, ?, ?::JSONB) ON CONFLICT (workflow_id) \n"
                         + "DO UPDATE SET correlation_id = EXCLUDED.correlation_id, workflow_type = EXCLUDED.workflow_type, "
-                        + "start_time = EXCLUDED.start_time, status = EXCLUDED.status, json_data = EXCLUDED.json_data";
+                        + "start_time = EXCLUDED.start_time, status = EXCLUDED.status, json_data = EXCLUDED.json_data "
+                        + "WHERE EXCLUDED.update_time > workflow_index.update_time";
 
         if (onlyIndexOnStatusChange) {
-            INSERT_WORKFLOW_INDEX_SQL += " WHERE workflow_index.status != EXCLUDED.status";
+            INSERT_WORKFLOW_INDEX_SQL += " AND workflow_index.status != EXCLUDED.status";
         }
+
+        TemporalAccessor updateTa = DateTimeFormatter.ISO_INSTANT.parse(workflow.getUpdateTime());
+        Timestamp updateTime = Timestamp.from(Instant.from(updateTa));
 
         TemporalAccessor ta = DateTimeFormatter.ISO_INSTANT.parse(workflow.getStartTime());
         Timestamp startTime = Timestamp.from(Instant.from(ta));
@@ -102,6 +106,7 @@ public class PostgresIndexDAO extends PostgresBaseDAO implements IndexDAO {
                                         .addParameter(workflow.getCorrelationId())
                                         .addParameter(workflow.getWorkflowType())
                                         .addParameter(startTime)
+                                        .addParameter(updateTime)
                                         .addParameter(workflow.getStatus().toString())
                                         .addJsonParameter(workflow)
                                         .executeUpdate());
@@ -135,10 +140,11 @@ public class PostgresIndexDAO extends PostgresBaseDAO implements IndexDAO {
                 "INSERT INTO task_index (task_id, task_type, task_def_name, status, start_time, update_time, workflow_type, json_data)"
                         + "VALUES (?, ?, ?, ?, ?, ?, ?, ?::JSONB) ON CONFLICT (task_id) "
                         + "DO UPDATE SET task_type = EXCLUDED.task_type, task_def_name = EXCLUDED.task_def_name, "
-                        + "status = EXCLUDED.status, update_time = EXCLUDED.update_time, json_data = EXCLUDED.json_data";
+                        + "status = EXCLUDED.status, update_time = EXCLUDED.update_time, json_data = EXCLUDED.json_data "
+                        + "WHERE EXCLUDED.update_time > task_index.update_time";
 
         if (onlyIndexOnStatusChange) {
-            INSERT_TASK_INDEX_SQL += " WHERE task_index.status != EXCLUDED.status";
+            INSERT_TASK_INDEX_SQL += " AND task_index.status != EXCLUDED.status";
         }
 
         TemporalAccessor updateTa = DateTimeFormatter.ISO_INSTANT.parse(task.getUpdateTime());

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V13__workflow_index_columns.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V13__workflow_index_columns.sql
@@ -1,0 +1,8 @@
+ALTER TABLE workflow_index
+ADD update_time TIMESTAMP WITH TIME ZONE NULL;
+
+UPDATE workflow_index
+SET update_time = to_timestamp(json_data->>'updateTime', 'YYYY-MM-DDTHH24:MI:SSZ')::timestamp WITH time zone;
+
+ALTER TABLE workflow_index
+ALTER COLUMN update_time SET NOT NULL;

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresIndexDAOStatusChangeOnlyTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresIndexDAOStatusChangeOnlyTest.java
@@ -82,6 +82,7 @@ public class PostgresIndexDAOStatusChangeOnlyTest {
         wfs.setCorrelationId("correlation-id");
         wfs.setWorkflowType("workflow-type");
         wfs.setStartTime("2023-02-07T08:42:45Z");
+        wfs.setUpdateTime("2023-02-07T08:43:45Z");
         wfs.setStatus(Workflow.WorkflowStatus.RUNNING);
         return wfs;
     }
@@ -142,6 +143,7 @@ public class PostgresIndexDAOStatusChangeOnlyTest {
 
         // Change the record, but not the status, and re-index
         wfs.setCorrelationId("new-correlation-id");
+        wfs.setUpdateTime("2023-02-07T08:44:45Z");
         indexDAO.indexWorkflow(wfs);
 
         // retrieve the record, make sure it hasn't changed
@@ -149,6 +151,7 @@ public class PostgresIndexDAOStatusChangeOnlyTest {
 
         // Change the status and re-index
         wfs.setStatus(Workflow.WorkflowStatus.FAILED);
+        wfs.setUpdateTime("2023-02-07T08:45:45Z");
         indexDAO.indexWorkflow(wfs);
 
         // retrieve the record, make sure it has changed
@@ -172,9 +175,10 @@ public class PostgresIndexDAOStatusChangeOnlyTest {
 
         // Change the status and re-index
         ts.setStatus(Task.Status.FAILED);
+        ts.setUpdateTime("2023-02-07T10:43:45Z");
         indexDAO.indexTask(ts);
 
         // retrieve the record, make sure it has changed
-        checkTask("task-id", "FAILED", "2023-02-07 10:42:45.0");
+        checkTask("task-id", "FAILED", "2023-02-07 10:43:45.0");
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

Fixed issue affecting Postgres indexer receiving updates out of order.

**Additional Context**: There can be occasions when updates to a workflow or task a passed to the indexer out of order. Most situations this will resolve it's self. How ever, when the final update to a workflow is received before the prior updates this can leave the workflow showing as running in the indexed data. This PR addresses this for the Postgres Indexer.

