### PR TITLE
Fix Issue: Ensure proper locking in WorkflowSweeper to prevent race conditions

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -106,12 +106,6 @@ public interface WorkflowExecutor {
     WorkflowModel decide(String workflowId);
 
     /**
-     * @param workflow workflow to be evaluated
-     * @return updated workflow
-     */
-    WorkflowModel decideWithLock(WorkflowModel workflow);
-
-    /**
      * @param workflowId id of the workflow to be terminated
      * @param reason termination reason to be recorded
      */

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
@@ -1040,33 +1040,6 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
     }
 
     /**
-     * This method overloads the {@link #decide(String)}. It will acquire a lock and evaluate the
-     * state of the workflow.
-     *
-     * @param workflow the workflow to evaluate the state for
-     * @return the workflow
-     */
-    @Override
-    public WorkflowModel decideWithLock(WorkflowModel workflow) {
-        if (workflow == null) {
-            return null;
-        }
-        StopWatch watch = new StopWatch();
-        watch.start();
-        if (!executionLockService.acquireLock(workflow.getWorkflowId())) {
-            return null;
-        }
-        try {
-            return decide(workflow);
-
-        } finally {
-            executionLockService.releaseLock(workflow.getWorkflowId());
-            watch.stop();
-            Monitors.recordWorkflowDecisionTime(watch.getTime());
-        }
-    }
-
-    /**
      * @param workflow the workflow to evaluate the state for
      * @return true if the workflow has completed (success or failed), false otherwise. Note: This
      *     method does not acquire the lock on the workflow and should ony be called / overridden if

--- a/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowSweeper.java
+++ b/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowSweeper.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.commons.lang3.time.StopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
@@ -35,6 +36,7 @@ import com.netflix.conductor.metrics.Monitors;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.TaskModel.Status;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.ExecutionLockService;
 
 import static com.netflix.conductor.core.config.SchedulerConfiguration.SWEEPER_EXECUTOR_NAME;
 import static com.netflix.conductor.core.utils.Utils.DECIDER_QUEUE;
@@ -49,6 +51,7 @@ public class WorkflowSweeper {
     private final WorkflowRepairService workflowRepairService;
     private final QueueDAO queueDAO;
     private final ExecutionDAOFacade executionDAOFacade;
+    private final ExecutionLockService executionLockService;
 
     private static final String CLASS_NAME = WorkflowSweeper.class.getSimpleName();
 
@@ -57,12 +60,14 @@ public class WorkflowSweeper {
             Optional<WorkflowRepairService> workflowRepairService,
             ConductorProperties properties,
             QueueDAO queueDAO,
-            ExecutionDAOFacade executionDAOFacade) {
+            ExecutionDAOFacade executionDAOFacade,
+            ExecutionLockService executionLockService) {
         this.properties = properties;
         this.queueDAO = queueDAO;
         this.workflowExecutor = workflowExecutor;
         this.executionDAOFacade = executionDAOFacade;
         this.workflowRepairService = workflowRepairService.orElse(null);
+        this.executionLockService = executionLockService;
         LOGGER.info("WorkflowSweeper initialized.");
     }
 
@@ -78,20 +83,27 @@ public class WorkflowSweeper {
             WorkflowContext workflowContext = new WorkflowContext(properties.getAppId());
             WorkflowContext.set(workflowContext);
             LOGGER.debug("Running sweeper for workflow {}", workflowId);
-
+            if (!executionLockService.acquireLock(workflow.getWorkflowId())) {
+                return;
+            }
             workflow = executionDAOFacade.getWorkflowModel(workflowId, true);
-
             if (workflowRepairService != null) {
                 // Verify and repair tasks in the workflow.
                 workflowRepairService.verifyAndRepairWorkflowTasks(workflow);
             }
-
-            workflow = workflowExecutor.decideWithLock(workflow);
-            if (workflow != null && workflow.getStatus().isTerminal()) {
-                queueDAO.remove(DECIDER_QUEUE, workflowId);
-                return;
+            StopWatch watch = new StopWatch();
+            watch.start();
+            try {
+                workflow = workflowExecutor.decide(workflow);
+                if (workflow != null && workflow.getStatus().isTerminal()) {
+                    queueDAO.remove(DECIDER_QUEUE, workflowId);
+                    return;
+                }
+            } finally {
+                executionLockService.releaseLock(workflow.getWorkflowId());
+                watch.stop();
+                Monitors.recordWorkflowDecisionTime(watch.getTime());
             }
-
         } catch (NotFoundException nfe) {
             queueDAO.remove(DECIDER_QUEUE, workflowId);
             LOGGER.info(

--- a/core/src/test/java/com/netflix/conductor/core/reconciliation/TestWorkflowSweeper.java
+++ b/core/src/test/java/com/netflix/conductor/core/reconciliation/TestWorkflowSweeper.java
@@ -29,6 +29,7 @@ import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.TaskModel.Status;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.ExecutionLockService;
 
 import static com.netflix.conductor.core.utils.Utils.DECIDER_QUEUE;
 
@@ -45,6 +46,7 @@ public class TestWorkflowSweeper {
     private QueueDAO queueDAO;
     private ExecutionDAOFacade executionDAOFacade;
     private WorkflowSweeper workflowSweeper;
+    private ExecutionLockService executionLockService;
 
     private int defaultPostPoneOffSetSeconds = 1800;
 
@@ -55,13 +57,15 @@ public class TestWorkflowSweeper {
         queueDAO = mock(QueueDAO.class);
         workflowRepairService = mock(WorkflowRepairService.class);
         executionDAOFacade = mock(ExecutionDAOFacade.class);
+        executionLockService = mock(ExecutionLockService.class);
         workflowSweeper =
                 new WorkflowSweeper(
                         workflowExecutor,
                         Optional.of(workflowRepairService),
                         properties,
                         queueDAO,
-                        executionDAOFacade);
+                        executionDAOFacade,
+                        executionLockService);
     }
 
     @Test


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
[Issue:#213](https://github.com/conductor-oss/conductor/issues/213)
Correct locking mechanism in WorkflowSweeper to prevent race conditions

Previously, the WorkflowSweeper.class had a potential race condition due to the order of operations in the sweep method. The workflow was being fetched from the executionDaoFacade before acquiring the lock, followed by a verifyAndRepair operation that could mutate the state. This sequence allowed for a small window (~50µ to 100µ seconds) where a workflow could be in two different states across different threads, causing inconsistencies and failures in workflow listeners or completion checks.

Changes made:
- Removed the `decideWithLock` method.
- Moved the locking logic directly into the `sweep` method to ensure the workflow is locked before any operations are performed on it.
- Ensured the workflow lock is only released after it is removed from the queue to prevent race conditions.

Observed issues:
- Race conditions were observed at large scale (30 replicas in Kubernetes, Redis cluster with Redis lock, ~75-90 workflows/sec).
- Workflows could be in a "Running" state even after triggering the finish, leading to listener and completion check failures.

New implementation in `sweep` method:
- Acquire lock before fetching the workflow and performing any operations.
- Handle verify and repair within the lock.
- Ensure the workflow is locked throughout the decision process.
- Release the lock only after removing the workflow from the queue.

This fix ensures atomicity in operations on workflows, preventing the race conditions previously observed.