### PR TITLE
Feat: Added isolation groups for commonly used internal tasks

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/InlineTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/InlineTaskMapper.java
@@ -75,6 +75,9 @@ public class InlineTaskMapper implements TaskMapper {
         inlineTask.setTaskType(TaskType.TASK_TYPE_INLINE);
         inlineTask.setStartTime(System.currentTimeMillis());
         inlineTask.setInputData(taskInput);
+        if (taskMapperContext.getTaskDefinition().getIsolationGroupId() != null) {
+            inlineTask.setIsolationGroupId(taskMapperContext.getTaskDefinition().getIsolationGroupId());
+        }
         inlineTask.setStatus(TaskModel.Status.IN_PROGRESS);
 
         return List.of(inlineTask);

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/InlineTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/InlineTaskMapper.java
@@ -76,7 +76,8 @@ public class InlineTaskMapper implements TaskMapper {
         inlineTask.setStartTime(System.currentTimeMillis());
         inlineTask.setInputData(taskInput);
         if (taskMapperContext.getTaskDefinition().getIsolationGroupId() != null) {
-            inlineTask.setIsolationGroupId(taskMapperContext.getTaskDefinition().getIsolationGroupId());
+            inlineTask.setIsolationGroupId(
+                    taskMapperContext.getTaskDefinition().getIsolationGroupId());
         }
         inlineTask.setStatus(TaskModel.Status.IN_PROGRESS);
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/InlineTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/InlineTaskMapper.java
@@ -14,6 +14,7 @@ package com.netflix.conductor.core.execution.mapper;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.slf4j.Logger;
@@ -75,7 +76,7 @@ public class InlineTaskMapper implements TaskMapper {
         inlineTask.setTaskType(TaskType.TASK_TYPE_INLINE);
         inlineTask.setStartTime(System.currentTimeMillis());
         inlineTask.setInputData(taskInput);
-        if (taskMapperContext.getTaskDefinition().getIsolationGroupId() != null) {
+        if (Objects.nonNull(taskMapperContext.getTaskDefinition())) {
             inlineTask.setIsolationGroupId(
                     taskMapperContext.getTaskDefinition().getIsolationGroupId());
         }

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapper.java
@@ -65,6 +65,9 @@ public class JsonJQTransformTaskMapper implements TaskMapper {
         TaskModel jsonJQTransformTask = taskMapperContext.createTaskModel();
         jsonJQTransformTask.setStartTime(System.currentTimeMillis());
         jsonJQTransformTask.setInputData(taskInput);
+        if (taskMapperContext.getTaskDefinition().getIsolationGroupId() != null) {
+            jsonJQTransformTask.setIsolationGroupId(taskMapperContext.getTaskDefinition().getIsolationGroupId());
+        }
         jsonJQTransformTask.setStatus(TaskModel.Status.IN_PROGRESS);
 
         return List.of(jsonJQTransformTask);

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapper.java
@@ -66,7 +66,8 @@ public class JsonJQTransformTaskMapper implements TaskMapper {
         jsonJQTransformTask.setStartTime(System.currentTimeMillis());
         jsonJQTransformTask.setInputData(taskInput);
         if (taskMapperContext.getTaskDefinition().getIsolationGroupId() != null) {
-            jsonJQTransformTask.setIsolationGroupId(taskMapperContext.getTaskDefinition().getIsolationGroupId());
+            jsonJQTransformTask.setIsolationGroupId(
+                    taskMapperContext.getTaskDefinition().getIsolationGroupId());
         }
         jsonJQTransformTask.setStatus(TaskModel.Status.IN_PROGRESS);
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapper.java
@@ -14,6 +14,7 @@ package com.netflix.conductor.core.execution.mapper;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.slf4j.Logger;
@@ -65,7 +66,7 @@ public class JsonJQTransformTaskMapper implements TaskMapper {
         TaskModel jsonJQTransformTask = taskMapperContext.createTaskModel();
         jsonJQTransformTask.setStartTime(System.currentTimeMillis());
         jsonJQTransformTask.setInputData(taskInput);
-        if (taskMapperContext.getTaskDefinition().getIsolationGroupId() != null) {
+        if (Objects.nonNull(taskMapperContext.getTaskDefinition())) {
             jsonJQTransformTask.setIsolationGroupId(
                     taskMapperContext.getTaskDefinition().getIsolationGroupId());
         }

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/WaitTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/WaitTaskMapper.java
@@ -79,6 +79,9 @@ public class WaitTaskMapper implements TaskMapper {
         waitTask.setInputData(waitTaskInput);
         waitTask.setStartTime(System.currentTimeMillis());
         waitTask.setStatus(TaskModel.Status.IN_PROGRESS);
+        if (taskMapperContext.getTaskDefinition().getIsolationGroupId() != null) {
+            waitTask.setIsolationGroupId(taskMapperContext.getTaskDefinition().getIsolationGroupId());
+        }
         setCallbackAfter(waitTask);
         return List.of(waitTask);
     }

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/WaitTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/WaitTaskMapper.java
@@ -14,10 +14,7 @@ package com.netflix.conductor.core.execution.mapper;
 
 import java.text.ParseException;
 import java.time.Duration;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -79,7 +76,7 @@ public class WaitTaskMapper implements TaskMapper {
         waitTask.setInputData(waitTaskInput);
         waitTask.setStartTime(System.currentTimeMillis());
         waitTask.setStatus(TaskModel.Status.IN_PROGRESS);
-        if (taskMapperContext.getTaskDefinition().getIsolationGroupId() != null) {
+        if (Objects.nonNull(taskMapperContext.getTaskDefinition())) {
             waitTask.setIsolationGroupId(
                     taskMapperContext.getTaskDefinition().getIsolationGroupId());
         }

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/WaitTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/WaitTaskMapper.java
@@ -80,7 +80,8 @@ public class WaitTaskMapper implements TaskMapper {
         waitTask.setStartTime(System.currentTimeMillis());
         waitTask.setStatus(TaskModel.Status.IN_PROGRESS);
         if (taskMapperContext.getTaskDefinition().getIsolationGroupId() != null) {
-            waitTask.setIsolationGroupId(taskMapperContext.getTaskDefinition().getIsolationGroupId());
+            waitTask.setIsolationGroupId(
+                    taskMapperContext.getTaskDefinition().getIsolationGroupId());
         }
         setCallbackAfter(waitTask);
         return List.of(waitTask);

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Wait.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Wait.java
@@ -32,6 +32,11 @@ public class Wait extends WorkflowSystemTask {
     }
 
     @Override
+    public void start(WorkflowModel workflow, TaskModel task, WorkflowExecutor executor) {
+        task.setStatus(TaskModel.Status.IN_PROGRESS);
+    }
+
+    @Override
     public void cancel(WorkflowModel workflow, TaskModel task, WorkflowExecutor workflowExecutor) {
         task.setStatus(TaskModel.Status.CANCELED);
     }


### PR DESCRIPTION
Pull Request type
----
- [X] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):



Changes in this PR
Added isolation groups to : 

- Inline Tasks
- JQ Tasks
- Wait Tasks

_Describe the new behavior from this PR, and why it's needed_
This will allow isolationGroups for commonly used internal Tasks end result is to break out the name spacing in queues so each can be distributed for workflows with high usage of a internal tasks. 

- There is a small bug fix in here for the wait tasks , that in the event it does not start , the call to the start method will insert this in the correct state to be evaluated for the next sweep/decider run.
