### PR TITLE
Address missing time part for task log entries

### DIFF
--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresIndexDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresIndexDAO.java
@@ -233,7 +233,7 @@ public class PostgresIndexDAO extends PostgresBaseDAO implements IndexDAO {
                                                 log.setLog(rs.getString("log"));
                                                 log.setTaskId(rs.getString("task_id"));
                                                 log.setCreatedTime(
-                                                        rs.getDate("created_time").getTime());
+                                                        rs.getTimestamp("created_time").getTime());
                                                 result.add(log);
                                             }
                                             return result;


### PR DESCRIPTION
(cherry picked from commit c84b5f4bd94cf4a1afb32d2e3e7996849c0b0728)

Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

Issue #

When using Postgres as persistence storage for Conductor, and one adds Log entries to a task with a date time timestamp. The `/api/tasks/{taskId}/log` endpoint truncates the time part and only returns the date.

In this PR I have updated the `PostgresIndexDAO.java` to return the full datetime value.