### PR TITLE
Add beans and deserializers to @WorkerTask methods.

### DIFF
--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/WorkflowExecutor.java
@@ -36,6 +36,7 @@ import com.netflix.conductor.sdk.workflow.executor.task.AnnotatedWorkerExecutor;
 import com.netflix.conductor.sdk.workflow.utils.ObjectMapperProvider;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.jersey.api.client.ClientHandler;
 import com.sun.jersey.api.client.config.DefaultClientConfig;
@@ -240,5 +241,13 @@ public class WorkflowExecutor {
 
     public WorkflowClient getWorkflowClient() {
         return workflowClient;
+    }
+
+    public void addBean(Object bean) {
+        annotatedWorkerExecutor.addBean(bean);
+    }
+
+    public void registerModule(Module module) {
+        annotatedWorkerExecutor.registerModule(module);
     }
 }

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorker.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorker.java
@@ -27,6 +27,7 @@ import com.netflix.conductor.sdk.workflow.task.OutputParam;
 import com.netflix.conductor.sdk.workflow.utils.ObjectMapperProvider;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class AnnotatedWorker implements Worker {
@@ -49,6 +50,10 @@ public class AnnotatedWorker implements Worker {
         this.workerMethod = workerMethod;
         this.obj = obj;
         om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    void registerModule(Module module) {
+        om.registerModule(module);
     }
 
     @Override

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerExecutor.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerExecutor.java
@@ -23,6 +23,7 @@ import com.netflix.conductor.client.http.TaskClient;
 import com.netflix.conductor.client.worker.Worker;
 import com.netflix.conductor.sdk.workflow.task.WorkerTask;
 
+import com.fasterxml.jackson.databind.Module;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.reflect.ClassPath;
@@ -50,6 +51,8 @@ public class AnnotatedWorkerExecutor {
     private static Set<String> scannedPackages = new HashSet<>();
 
     private WorkerConfiguration workerConfiguration;
+
+    private Set<Module> modules = new HashSet<>();
 
     public AnnotatedWorkerExecutor(TaskClient taskClient) {
         this.taskClient = taskClient;
@@ -189,6 +192,9 @@ public class AnnotatedWorkerExecutor {
                 (taskName, method) -> {
                     Object obj = workerClassObjs.get(taskName);
                     AnnotatedWorker executor = new AnnotatedWorker(taskName, method, obj);
+                    for (Module module : modules) {
+                        executor.registerModule(module);
+                    }
                     executor.setPollingInterval(workerToPollingInterval.get(taskName));
                     executors.add(executor);
                 });
@@ -217,5 +223,9 @@ public class AnnotatedWorkerExecutor {
     @VisibleForTesting
     TaskRunnerConfigurer getTaskRunner() {
         return taskRunner;
+    }
+
+    public void registerModule(Module module) {
+        modules.add(module);
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
@WorkerTask methods were not aware of spring beans and the ObjectMapper could not be configured with new deserializers.  These changes permit both.

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
The alternate implementation is to abandon @WorkerTask as there is an alternative API to implement workers.
