### PR TITLE
YARN_OPTS for Dockerfile

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -72,7 +72,7 @@ This can happen, even if the network resources `yarn` tries to use are available
 
 For passing arguments to `yarn`, in [this Dockerfile](server/Dockerfile) the build arg `YARN_OPTS` has been added. This argument will be added to each `yarn` call. It is not compulsory to set this argument.
 
-When using one of the `docker-compose-*` files, you can set this via the eponymous environment variable `YARN_OPTS`, e.g.:
+When using one of the `docker-compose-*` files, you can set this via the environment variable `YARN_OPTS`, e.g.:
 
 ```
 YARN_OPTS='--network-timeout 10000000' docker compose -f docker-compose.yaml up

--- a/docker/README.md
+++ b/docker/README.md
@@ -68,9 +68,9 @@ It has been observed, that the UI build may fail with an error message like
 953.6 info There appears to be trouble with your network connection. Retrying...
 ```
 
-This can happen, even if the network resources `yarn` tries to use are available, but there is too much network latency. `yarn` accepts the option `--network-timeout` to set a custom timeout in milliseconds.
+This does not necessarily mean, that the network is unavailable, but can be caused by too high latency, as well. `yarn` accepts the option `--network-timeout <#ms>` to set a custom timeout in milliseconds.
 
-For passing arguments to `yarn`, in [this Dockerfile](server/Dockerfile) the build arg `YARN_OPTS` has been added. This argument will be added to each `yarn` call. It is not compulsory to set this argument.
+For passing arguments to `yarn`, in [this Dockerfile](server/Dockerfile) the _optional_ build arg `YARN_OPTS` has been added. This argument will be added to each `yarn` call.
 
 When using one of the `docker-compose-*` files, you can set this via the environment variable `YARN_OPTS`, e.g.:
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -49,3 +49,35 @@ TODO: Link to the helm charts
 | [docker-compose.yaml](docker-compose.yaml)                   | Redis + Elasticsearch 7    |
 | [docker-compose-postgres.yaml](docker-compose-postgres.yaml) | Postgres + Elasticsearch 7 |
 | [docker-compose-mysql.yaml](docker-compose-mysql.yaml)    | Mysql + Elasticsearch 7    |
+
+### Network errors during UI build with yarn
+
+It has been observed, that the UI build may fail with an error message like
+
+```
+> [linux/arm64 ui-builder 5/7] RUN yarn install && cp -r node_modules/monaco-editor public/ && yarn build:
+269.9     at Object.onceWrapper (node:events:633:28)
+269.9     at TLSSocket.emit (node:events:531:35)
+269.9     at Socket._onTimeout (node:net:590:8)
+269.9     at listOnTimeout (node:internal/timers:573:17)
+269.9     at process.processTimers (node:internal/timers:514:7)
+269.9 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
+281.2 info There appears to be trouble with your network connection. Retrying...
+313.5 info There appears to be trouble with your network connection. Retrying...
+920.3 info There appears to be trouble with your network connection. Retrying...
+953.6 info There appears to be trouble with your network connection. Retrying...
+```
+
+This can happen, even if the network resources `yarn` tries to use are available, but there is too much network latency. `yarn` accepts the option `--network-timeout` to set a custom timeout in milliseconds.
+
+For passing arguments to `yarn`, in [this Dockerfile](server/Dockerfile) the build arg `YARN_OPTS` has been added. This argument will be added to each `yarn` call. When using one of the `docker-compose-*` files, you can set this via the eponymous environment variable `YARN_OPTS`, e.g.:
+
+```
+YARN_OPTS='--network-timeout 10000000' docker compose -f docker-compose.yaml up
+```
+
+When building a Docker image using `docker`, you must call it like e.g.
+
+```
+docker build --build-arg='YARN_OPTS=--network-timeout 10000000' .. -f server/Dockerfile -t oss-conductor:v3.21.4
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -70,7 +70,9 @@ It has been observed, that the UI build may fail with an error message like
 
 This can happen, even if the network resources `yarn` tries to use are available, but there is too much network latency. `yarn` accepts the option `--network-timeout` to set a custom timeout in milliseconds.
 
-For passing arguments to `yarn`, in [this Dockerfile](server/Dockerfile) the build arg `YARN_OPTS` has been added. This argument will be added to each `yarn` call. When using one of the `docker-compose-*` files, you can set this via the eponymous environment variable `YARN_OPTS`, e.g.:
+For passing arguments to `yarn`, in [this Dockerfile](server/Dockerfile) the build arg `YARN_OPTS` has been added. This argument will be added to each `yarn` call. It is not compulsory to set this argument.
+
+When using one of the `docker-compose-*` files, you can set this via the eponymous environment variable `YARN_OPTS`, e.g.:
 
 ```
 YARN_OPTS='--network-timeout 10000000' docker compose -f docker-compose.yaml up

--- a/docker/docker-compose-mysql.yaml
+++ b/docker/docker-compose-mysql.yaml
@@ -10,6 +10,8 @@ services:
     build:
       context: ../
       dockerfile: docker/server/Dockerfile
+      args:
+        YARN_OPTS: ${YARN_OPTS}
     networks:
       - internal
     ports:

--- a/docker/docker-compose-postgres-es7.yaml
+++ b/docker/docker-compose-postgres-es7.yaml
@@ -9,6 +9,8 @@ services:
     build:
       context: ../
       dockerfile: docker/server/Dockerfile
+      args:
+        YARN_OPTS: ${YARN_OPTS}
     networks:
       - internal
     ports:

--- a/docker/docker-compose-postgres.yaml
+++ b/docker/docker-compose-postgres.yaml
@@ -9,6 +9,8 @@ services:
     build:
       context: ../
       dockerfile: docker/server/Dockerfile
+      args:
+        YARN_OPTS: ${YARN_OPTS}
     networks:
       - internal
     ports:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -9,6 +9,8 @@ services:
     build:
       context: ../
       dockerfile: docker/server/Dockerfile
+      args:
+        YARN_OPTS: ${YARN_OPTS}
     networks:
       - internal
     ports:

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -25,6 +25,7 @@ RUN ls -ltr
 # 1. Builder stage 2
 # ===========================================================================================================
 FROM alpine:3.20 AS ui-builder
+ARG YARN_OPTS
 
 LABEL maintainer="Orkes OSS <oss@orkes.io>"
 
@@ -36,7 +37,7 @@ WORKDIR /conductor/ui
 
 # Include monaco sources into bundle (instead of using CDN)
 ENV REACT_APP_MONACO_EDITOR_USING_CDN=false
-RUN yarn install && cp -r node_modules/monaco-editor public/ && yarn build
+RUN yarn ${YARN_OPTS} install && cp -r node_modules/monaco-editor public/ && yarn ${YARN_OPTS} build
 RUN ls -ltr
 RUN echo "Done building UI"
 


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

The build arg `YARN_OPTS` allows us to pass custom arguments to `yarn` during the Docker build. More specifically, it can be used to avoid timeout errors during the UI build by increasing `yarn`'s network timeout by setting the option `--network-timeout=<timeout in ms>`
