### PR TITLE
Add curl to standard Docker image

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -50,6 +50,7 @@ LABEL maintainer="Orkes OSS <oss@orkes.io>"
 
 RUN apk add openjdk17
 RUN apk add nginx
+RUN apk add curl
 
 # Make app folders
 RUN mkdir -p /app/config /app/logs /app/libs


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----
Added `curl` to standard Docker image. This is useful for health checks, e.g. when using the image with `docker compose`, where other services depend on it.
