### PR TITLE
made changes to pass down the taskToDomain map to child workflow in case of events

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 
 import com.netflix.conductor.common.metadata.events.EventHandler.Action;
 import com.netflix.conductor.common.metadata.events.EventHandler.StartWorkflow;
@@ -32,7 +33,6 @@ import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.metrics.Monitors;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
-import org.springframework.util.CollectionUtils;
 
 /**
  * Action Processor subscribes to the Event Actions queue and processes the actions (e.g. start
@@ -198,17 +198,18 @@ public class SimpleActionProcessor implements ActionProcessor {
 
             Map<String, Object> paramsMap = new HashMap<>();
             // extracting taskToDomain map from the event payload
-            paramsMap.put("taskToDomain","${taskToDomain}");
+            paramsMap.put("taskToDomain", "${taskToDomain}");
             Optional.ofNullable(params.getCorrelationId())
                     .ifPresent(value -> paramsMap.put("correlationId", value));
             Map<String, Object> replaced = parametersUtils.replace(paramsMap, payload);
 
-            // if taskToDomain is absent from event handler definition, and taskDomain Map is passed as a part of payload
+            // if taskToDomain is absent from event handler definition, and taskDomain Map is passed
+            // as a part of payload
             // then assign payload taskToDomain map to the new workflow instance
-            final Map<String, String> taskToDomain = params.getTaskToDomain() != null ?
-                    params.getTaskToDomain() :
-                    (Map<String, String>) replaced.get("taskToDomain");
-
+            final Map<String, String> taskToDomain =
+                    params.getTaskToDomain() != null
+                            ? params.getTaskToDomain()
+                            : (Map<String, String>) replaced.get("taskToDomain");
 
             workflowInput.put("conductor.event.messageId", messageId);
             workflowInput.put("conductor.event.name", event);

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Event.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Event.java
@@ -62,6 +62,7 @@ public class Event extends WorkflowSystemTask {
         payload.put("workflowType", workflow.getWorkflowName());
         payload.put("workflowVersion", workflow.getWorkflowVersion());
         payload.put("correlationId", workflow.getCorrelationId());
+        payload.put("taskToDomain", workflow.getTaskToDomain());
 
         task.setStatus(TaskModel.Status.IN_PROGRESS);
         task.addOutput(payload);

--- a/core/src/test/java/com/netflix/conductor/core/events/TestSimpleActionProcessor.java
+++ b/core/src/test/java/com/netflix/conductor/core/events/TestSimpleActionProcessor.java
@@ -126,7 +126,8 @@ public class TestSimpleActionProcessor {
 
         Object payload =
                 objectMapper.readValue(
-                        "{ \"testId\": \"test_1\", \"taskToDomain\":{\"testTask\":\"testDomain\"} }", Object.class);
+                        "{ \"testId\": \"test_1\", \"taskToDomain\":{\"testTask\":\"testDomain\"} }",
+                        Object.class);
 
         Map<String, String> taskToDomain = new HashMap<>();
         taskToDomain.put("testTask", "testDomain");
@@ -155,7 +156,6 @@ public class TestSimpleActionProcessor {
                 "testMessage", capturedValue.getWorkflowInput().get("conductor.event.messageId"));
         assertEquals("testEvent", capturedValue.getWorkflowInput().get("conductor.event.name"));
     }
-
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test

--- a/core/src/test/java/com/netflix/conductor/core/events/TestSimpleActionProcessor.java
+++ b/core/src/test/java/com/netflix/conductor/core/events/TestSimpleActionProcessor.java
@@ -114,6 +114,49 @@ public class TestSimpleActionProcessor {
         assertEquals(taskToDomain, capturedValue.getTaskToDomain());
     }
 
+    @Test
+    public void testStartWorkflow_taskDomain() throws Exception {
+        StartWorkflow startWorkflow = new StartWorkflow();
+        startWorkflow.setName("testWorkflow");
+        startWorkflow.getInput().put("testInput", "${testId}");
+
+        Action action = new Action();
+        action.setAction(Type.start_workflow);
+        action.setStart_workflow(startWorkflow);
+
+        Object payload =
+                objectMapper.readValue(
+                        "{ \"testId\": \"test_1\", \"taskToDomain\":{\"testTask\":\"testDomain\"} }", Object.class);
+
+        Map<String, String> taskToDomain = new HashMap<>();
+        taskToDomain.put("testTask", "testDomain");
+
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setName("testWorkflow");
+        workflowDef.setVersion(1);
+
+        when(workflowExecutor.startWorkflow(any())).thenReturn("workflow_1");
+
+        Map<String, Object> output =
+                actionProcessor.execute(action, payload, "testEvent", "testMessage");
+
+        assertNotNull(output);
+        assertEquals("workflow_1", output.get("workflowId"));
+
+        ArgumentCaptor<StartWorkflowInput> startWorkflowInputArgumentCaptor =
+                ArgumentCaptor.forClass(StartWorkflowInput.class);
+
+        verify(workflowExecutor).startWorkflow(startWorkflowInputArgumentCaptor.capture());
+        StartWorkflowInput capturedValue = startWorkflowInputArgumentCaptor.getValue();
+
+        assertEquals("test_1", capturedValue.getWorkflowInput().get("testInput"));
+        assertEquals(taskToDomain, capturedValue.getTaskToDomain());
+        assertEquals(
+                "testMessage", capturedValue.getWorkflowInput().get("conductor.event.messageId"));
+        assertEquals("testEvent", capturedValue.getWorkflowInput().get("conductor.event.name"));
+    }
+
+
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
     public void testStartWorkflow() throws Exception {


### PR DESCRIPTION
This PR is to pass down taskToDomain map from parent workflow to child workflow in case EVENTS similar to what is already done for SUB_WORKFLOWS

Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
1. taskToDomain map is sent as a part of the event payload.
2. If no taskToDomain is mentioned in the event handler definition then a new workflow will be triggered with the parent tasktoDomain map.
3. Payload taskToDomain will be overwritten by the taskToDomain map coded as part of the event handler definition

_Describe the new behavior from this PR, and why it's needed_
Whenever an event is fired to trigger a workflow, the taskToDomain map of the parent workflow is not passed as a part of the event payload which leads to triggered child workflow not run in isolation. The only way to run the child workflow in isolation is not hard code the taskToDomain map in event handler definition.
This PR introduce then change where taskToDomain map is passed as part of event payload and if event handler definition does not have the taskToDomain map then the parent taskToDomain map is applied to child workflow. Similar change is already in place with subworkflows
Payload taskToDomain will be overwritten by the taskToDomain map coded as part of event handler definition.

Alternatives considered
----

_Describe alternative implementation you have considered_
