### PR TITLE
Add Jackson Kotlin module to ObjectMapper instances

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-core:${revFasterXml}"
     // https://github.com/FasterXML/jackson-modules-base/tree/master/afterburner
     implementation "com.fasterxml.jackson.module:jackson-module-afterburner:${revFasterXml}"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:${revFasterXml}"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${revSpringDoc}"
@@ -53,4 +54,3 @@ task protogen(dependsOn: jar, type: JavaExec) {
             "com.netflix.conductor.common",
     )
 }
-

--- a/common/src/main/java/com/netflix/conductor/common/config/ObjectMapperProvider.java
+++ b/common/src/main/java/com/netflix/conductor/common/config/ObjectMapperProvider.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
+import com.fasterxml.jackson.module.kotlin.KotlinModule;
 
 /**
  * A Factory class for creating a customized {@link ObjectMapper}. This is only used by the
@@ -58,6 +59,7 @@ public class ObjectMapperProvider {
         objectMapper.registerModule(new JsonProtoModule());
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.registerModule(new AfterburnerModule());
+        objectMapper.registerModule(new KotlinModule.Builder().build());
         return objectMapper;
     }
 }

--- a/java-sdk/build.gradle
+++ b/java-sdk/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation project(':conductor-client')
 
     implementation "com.fasterxml.jackson.core:jackson-databind:${revFasterXml}"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:${revFasterXml}"
     implementation "com.google.guava:guava:${revGuava}"
     implementation "cglib:cglib:3.3.0"
     implementation "com.sun.jersey:jersey-client:${revJersey}"
@@ -30,4 +31,3 @@ test {
     }
 }
 sourceSets.main.java.srcDirs += ['example/java', 'example/resources']
-

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/utils/ObjectMapperProvider.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/utils/ObjectMapperProvider.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.module.kotlin.KotlinModule;
 
 public class ObjectMapperProvider {
 
@@ -35,6 +36,7 @@ public class ObjectMapperProvider {
         // objectMapper.setSerializationInclusion(JsonInclude.Include.);
 
         objectMapper.registerModule(new JsonProtoModule());
+        objectMapper.registerModule(new KotlinModule.Builder().build());
         return objectMapper;
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----
Added Jackson Kotlin Module to the `ObjectMapper` instances created for serialization/deserialization.

This makes it easier to implement workflows and task workers using DTOs written as Kotlin `data` classes.

