### PR TITLE
Fix flaky tests in `HierarchicalForkJoinSubworkflowRerunSpec` & `HierarchicalForkJoinSubworkflowRestartSpec`

### DIFF
--- a/test-harness/build.gradle
+++ b/test-harness/build.gradle
@@ -40,4 +40,5 @@ dependencies {
     testImplementation "org.junit.vintage:junit-vintage-engine"
     testImplementation "jakarta.ws.rs:jakarta.ws.rs-api:${revJAXRS}"
     testImplementation "org.glassfish.jersey.core:jersey-common:${revJerseyCommon}"
+    testImplementation "org.awaitility:awaitility:${revAwaitility}"
 }

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/HierarchicalForkJoinSubworkflowRerunSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/HierarchicalForkJoinSubworkflowRerunSpec.groovy
@@ -12,6 +12,8 @@
  */
 package com.netflix.conductor.test.integration
 
+import java.util.concurrent.TimeUnit
+
 import org.springframework.beans.factory.annotation.Autowired
 
 import com.netflix.conductor.common.metadata.tasks.Task
@@ -29,6 +31,8 @@ import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_FOR
 import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_JOIN
 import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_SUB_WORKFLOW
 import static com.netflix.conductor.test.util.WorkflowTestUtil.verifyPolledAndAcknowledgedTask
+
+import static org.awaitility.Awaitility.await
 
 class HierarchicalForkJoinSubworkflowRerunSpec extends AbstractSpecification {
 
@@ -230,10 +234,23 @@ class HierarchicalForkJoinSubworkflowRerunSpec extends AbstractSpecification {
             tasks[3].status == Task.Status.IN_PROGRESS
         }
 
-        when: "poll and complete the integration_task_2 task in the root workflow"
+        when: "poll and complete integration_task_2 in root and mid level workflow"
         def rootJoinId = workflowExecutionService.getExecutionStatus(rootWorkflowId, true).getTaskByRefName("fanouttask_join").taskId
-        workflowTestUtil.pollAndCompleteTask('integration_task_2', 'task2.integration.worker', ['op': 'task2.done'])
         def newMidLevelWorkflowId = workflowExecutionService.getExecutionStatus(rootWorkflowId, true).getTasks().get(1).subWorkflowId
+        // The root workflow has an integration_task_2. Its subworkflow also has an integration_task_2.
+        // We have NO guarantees which will be polled and completed first, so the assertions done in previous versions of this test were wrong.
+        await().atMost(10, TimeUnit.SECONDS).until {
+            workflowTestUtil.pollAndCompleteTask('integration_task_2', 'task2.integration.worker', ['op': 'task2.done'])
+            def rootWf = workflowExecutionService.getExecutionStatus(rootWorkflowId, true)
+            def midWf = workflowExecutionService.getExecutionStatus(newMidLevelWorkflowId, true)
+
+            rootWf.status == Workflow.WorkflowStatus.RUNNING &&
+            rootWf.tasks[2].taskType == 'integration_task_2' &&
+            rootWf.tasks[2].status == Task.Status.COMPLETED &&
+            midWf.status == Workflow.WorkflowStatus.RUNNING &&
+            midWf.tasks[2].taskType == 'integration_task_2' &&
+            midWf.tasks[2].status == Task.Status.COMPLETED
+        }
 
         then: "verify that a new mid level workflow is created and is in RUNNING state"
         newMidLevelWorkflowId != midLevelWorkflowId
@@ -251,9 +268,8 @@ class HierarchicalForkJoinSubworkflowRerunSpec extends AbstractSpecification {
             tasks[3].status == Task.Status.IN_PROGRESS
         }
 
-        when: "poll and complete the integration_task_2 task in the root-level workflow"
+        when: "mid level workflow is in RUNNING state"
         def midJoinId = workflowExecutionService.getExecutionStatus(newMidLevelWorkflowId, true).getTaskByRefName("fanouttask_join").taskId
-        workflowTestUtil.pollAndCompleteTask('integration_task_2', 'task2.integration.worker', ['op': 'task2.done'])
         def newLeafWorkflowId = workflowExecutionService.getExecutionStatus(newMidLevelWorkflowId, true).getTasks().get(1).subWorkflowId
 
         then: "verify that a new leaf workflow is created and is in RUNNING state"


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

The assertions made by these tests were wrong causing them to be flaky. Example:

It failed in these recent runs:
- https://github.com/conductor-oss/conductor/actions/runs/10818411662/job/30015567619#step:7:907
- https://github.com/conductor-oss/conductor/actions/runs/10818411662/job/30013971034#step:7:907

And then passed:
- https://github.com/conductor-oss/conductor/actions/runs/10820181967/job/30019684474

The root cause of the issue is that a workflow forks a subworkflow task and an `integration_task_2` task. The subworkflow also has an `integration_task_2` task so there are NO guarantees on which `integration_task_2` will be polled and completed first. 

<img width="400" alt="Screenshot 2024-09-11 at 20 23 04" src="https://github.com/user-attachments/assets/de41cfb1-7c6a-4601-b986-171a4cd461a9">
