### PR TITLE
Handle duplicate event inserts gracefully when using Postgresql

### DIFF
--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresExecutionDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresExecutionDAO.java
@@ -903,7 +903,8 @@ public class PostgresExecutionDAO extends PostgresBaseDAO
 
         String INSERT_EVENT_EXECUTION =
                 "INSERT INTO event_execution (event_handler_name, event_name, message_id, execution_id, json_data) "
-                        + "VALUES (?, ?, ?, ?, ?)";
+                        + "VALUES (?, ?, ?, ?, ?) "
+                        + "ON CONFLICT DO NOTHING";
         int count =
                 query(
                         connection,


### PR DESCRIPTION
Pull Request type
----
- [X] Bugfix

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
This PR changed the behavior of the PostgresExecutionDAO `insertEventExecution` method to handle the insertion of duplicate event entries gracefully. This allows the proper application flow to continue.

Without this fix is not applied when exceptions will be thrown similar to this
```
com.netflix.conductor.core.exception.NonTransientException: Unable to add event execution 3e3ed625-d8a1-4e03-841c-4291b9da64f5_0
81496848 [event-queue-poll-scheduler-thread-1] ERROR com.netflix.conductor.core.events.DefaultEventProcessor [] - Error handling message: 3e3ed625-d8a1-4e03-841c-4291b9da64f5 on queue:_callbackFinalizeQueue
```
The number of exceptions will grow as the source `queue_message` table is not cleared of the of the bad entries because of the exception thrown when they are processed.


The new behavior matches that of the RedisExecutionDAO that skips adding events that have already been added. 

Issue #
