### PR TITLE
Ignore `conductor-clients` changes in GitHub Action workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [ push, pull_request ]
+on:
+  push:
+    paths-ignore:
+      - 'conductor-clients/**'
+  pull_request:
+    paths-ignore:
+      - 'conductor-clients/**'
 
 jobs:
   build:

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'conductor-clients/**'
 
 permissions:
   contents: read

--- a/conductor-clients/README.md
+++ b/conductor-clients/README.md
@@ -1,1 +1,9 @@
 # Conductor Clients
+
+This directory serves as the central repository for various officially supported Conductor client projects.
+
+> **Note (2024-09-17):** 
+> 
+> Currently, it only contains the incubating Java client/SDK v3.
+> 
+> We are in the process of refactoring our clients/SDKs (see: [conductor-sdk](https://github.com/conductor-sdk)) and will be moving them here soon.


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [x] Other (please describe):


Changes in this PR
----

`conductor-clients` is going to be the home dir for our clients and sdks. 

These are standalone projects and should not trigger the existing GitHub Action workflows to build the root project (conductor server and its current clients)
