### PR TITLE
Initial GitHub Action workflows to build Java client v4

### DIFF
--- a/.github/workflows/java-client-v4-build.yml
+++ b/.github/workflows/java-client-v4-build.yml
@@ -1,0 +1,37 @@
+name: Java Client v4 Build
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'conductor-clients/java/conductor-java-sdk/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'conductor-clients/java/conductor-java-sdk/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Java Client v4 Build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Zulu JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: "zulu"
+          java-version: "17"
+      - name: Build
+        run: |
+          cd conductor-clients/java/conductor-java-sdk
+          ./gradlew clean build -x :tests:build
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: 'conductor-clients/java/**/build/test-results/test/TEST-*.xml'
+

--- a/.github/workflows/java-client-v4-integration-tests.yml
+++ b/.github/workflows/java-client-v4-integration-tests.yml
@@ -1,0 +1,70 @@
+name: Java Client v4 Integration Tests
+
+on:
+  workflow_run:
+    workflows: ["Java Client v4 Build"]
+    types:
+      - completed
+
+jobs:
+  integrations-tests:
+    runs-on: ubuntu-latest
+    environment: integration-tests
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    name: Java Client v4 Integration test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          repository: ${{ github.event.workflow_run.repository.full_name }}
+      - name: Set up Zulu JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: "zulu"
+          java-version: "17"
+      - name: Run Integration tests
+        run: |
+          cd conductor-clients/java/conductor-java-sdk
+          ./gradlew -p tests test
+        env:
+          CONDUCTOR_SERVER_URL: ${{ secrets.CONDUCTOR_SERVER_URL }}
+          CONDUCTOR_SERVER_AUTH_KEY: ${{ secrets.CONDUCTOR_SERVER_AUTH_KEY }}
+          CONDUCTOR_SERVER_AUTH_SECRET: ${{ secrets.CONDUCTOR_SERVER_AUTH_SECRET }}
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: 'conductor-clients/java/**/build/test-results/test/TEST-*.xml'
+      - name: Set PR Status to Failure
+        if: ${{ failure() }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.payload.workflow_run.head_sha;
+            await github.rest.repos.createCommitStatus({
+              owner: owner,
+              repo: repo,
+              sha: sha,
+              state: 'failure',
+              context: 'Java Client v4 Integration Tests',
+              description: 'Integration tests failed.',
+            });
+      - name: Set PR Status to Success
+        if: ${{ success() }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.payload.workflow_run.head_sha;
+            await github.rest.repos.createCommitStatus({
+              owner: owner,
+              repo: repo,
+              sha: sha,
+              state: 'success',
+              context: 'Java Client v4 Integration Tests',
+              description: 'Integration tests succeeded.',
+            });
+
+

--- a/.github/workflows/java-client-v4-publish-release.yml
+++ b/.github/workflows/java-client-v4-publish-release.yml
@@ -1,0 +1,43 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Publish Java Client v4 to Maven Central
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., v1.0.0)'
+        required: true
+      maven_central:
+        description: 'Publish to Maven Central'
+        required: true
+        default: 'true'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: prod
+    name: Gradle Build and Publish
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Set up Zulu JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+      - name: Publish
+        run: |
+          export VERSION="${{ github.event.inputs.version }}"
+          export CONDUCTOR_CLIENT_VERSION=`echo ${VERSION:1}`
+          echo Publishing version $CONDUCTOR_CLIENT_VERSION
+          cd conductor-clients/java/conductor-java-sdk
+          ./gradlew publish -Pversion=$CONDUCTOR_CLIENT_VERSION -PmavenCentral=${{ github.event.inputs.maven_central }} -Pusername=${{ secrets.SONATYPE_USERNAME }} -Ppassword=${{ secrets.SONATYPE_PASSWORD }}
+    env:
+      ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
+      ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+      ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+

--- a/conductor-clients/java/conductor-java-sdk/gradle.properties
+++ b/conductor-clients/java/conductor-java-sdk/gradle.properties
@@ -1,1 +1,1 @@
-version=3.0.0-alpha16-SNAPSHOT
+version=4.0.0-alpha-SNAPSHOT


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

Initial GitHub Action workflows to build Java client v3.

- `Java Client v4 Build` should be triggered on changes to `conductor-clients/java/**`.
-  `Java Client v4 Integration Tests` should be triggered after a successful `Java Client v4 Build`.
- `Publish Java Client v4 to Maven Central` is intentionally manual at the moment. It won't be triggered by a GitHub release.