### PR TITLE
[Java Client v4] External storage support + Event refactoring

### DIFF
--- a/conductor-clients/java/conductor-java-sdk/conductor-client-metrics/src/main/java/com/netflix/conductor/client/metrics/prometheus/PrometheusMetricsCollector.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client-metrics/src/main/java/com/netflix/conductor/client/metrics/prometheus/PrometheusMetricsCollector.java
@@ -15,12 +15,17 @@ package com.netflix.conductor.client.metrics.prometheus;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
-import com.netflix.conductor.client.automator.events.PollCompleted;
-import com.netflix.conductor.client.automator.events.PollFailure;
-import com.netflix.conductor.client.automator.events.PollStarted;
-import com.netflix.conductor.client.automator.events.TaskExecutionCompleted;
-import com.netflix.conductor.client.automator.events.TaskExecutionFailure;
-import com.netflix.conductor.client.automator.events.TaskExecutionStarted;
+import com.netflix.conductor.client.events.task.TaskPayloadUsedEvent;
+import com.netflix.conductor.client.events.task.TaskResultPayloadSizeEvent;
+import com.netflix.conductor.client.events.taskrunner.PollCompleted;
+import com.netflix.conductor.client.events.taskrunner.PollFailure;
+import com.netflix.conductor.client.events.taskrunner.PollStarted;
+import com.netflix.conductor.client.events.taskrunner.TaskExecutionCompleted;
+import com.netflix.conductor.client.events.taskrunner.TaskExecutionFailure;
+import com.netflix.conductor.client.events.taskrunner.TaskExecutionStarted;
+import com.netflix.conductor.client.events.workflow.WorkflowInputPayloadSizeEvent;
+import com.netflix.conductor.client.events.workflow.WorkflowPayloadUsedEvent;
+import com.netflix.conductor.client.events.workflow.WorkflowStartedEvent;
 import com.netflix.conductor.client.metrics.MetricsCollector;
 
 import com.sun.net.httpserver.HttpServer;
@@ -31,8 +36,12 @@ public class PrometheusMetricsCollector implements MetricsCollector {
 
     private static final PrometheusMeterRegistry prometheusRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
 
+    private static final int DEFAULT_PORT = 9991;
+
+    private static final String DEFAULT_ENDPOINT = "/metrics";
+
     public  void startServer() throws IOException {
-        startServer(9991, "/metrics");
+        startServer(DEFAULT_PORT, DEFAULT_ENDPOINT);
     }
 
     public void startServer(int port, String endpoint) throws IOException {
@@ -82,5 +91,30 @@ public class PrometheusMetricsCollector implements MetricsCollector {
     public void consume(TaskExecutionFailure e) {
         var timer = prometheusRegistry.timer("task_execution_failure", "type", e.getTaskType());
         timer.record(e.getDuration());
+    }
+
+    @Override
+    public void consume(TaskPayloadUsedEvent e) {
+        //TODO implement
+    }
+
+    @Override
+    public void consume(TaskResultPayloadSizeEvent e) {
+        //TODO implement
+    }
+
+    @Override
+    public void consume(WorkflowPayloadUsedEvent event) {
+        //TODO implement
+    }
+
+    @Override
+    public void consume(WorkflowInputPayloadSizeEvent event) {
+        //TODO implement
+    }
+
+    @Override
+    public void consume(WorkflowStartedEvent event) {
+        //TODO implement
     }
 }

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/config/ConductorClientConfiguration.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/config/ConductorClientConfiguration.java
@@ -47,4 +47,11 @@ public interface ConductorClientConfiguration {
      *     and the task/workflow execution fails.
      */
     boolean isExternalPayloadStorageEnabled();
+
+    /**
+     * @return the flag which controls whether to enforce or not the barriers on the size
+     * of workflow and task payloads for both input and output.
+     * SEE: <a href="https://conductor-oss.github.io/conductor/documentation/advanced/externalpayloadstorage.html">External Payload Storage</a>
+     */
+    boolean isEnforceThresholds();
 }

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/config/DefaultConductorClientConfiguration.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/config/DefaultConductorClientConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.client.config;
+
+/**
+ * A default implementation of {@link ConductorClientConfiguration} where external payload barriers
+ * is disabled. SEE: SEE: <a href="https://conductor-oss.github.io/conductor/documentation/advanced/externalpayloadstorage.html">External Payload Storage</a>
+ */
+public class DefaultConductorClientConfiguration implements ConductorClientConfiguration {
+
+    @Override
+    public int getWorkflowInputPayloadThresholdKB() {
+        return 5120;
+    }
+
+    @Override
+    public int getWorkflowInputMaxPayloadThresholdKB() {
+        return 10240;
+    }
+
+    @Override
+    public int getTaskOutputPayloadThresholdKB() {
+        return 3072;
+    }
+
+    @Override
+    public int getTaskOutputMaxPayloadThresholdKB() {
+        return 10240;
+    }
+
+    @Override
+    public boolean isExternalPayloadStorageEnabled() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnforceThresholds() {
+        return false;
+    }
+}

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/ConductorClientEvent.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/ConductorClientEvent.java
@@ -10,12 +10,15 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.client.metrics;
+package com.netflix.conductor.client.events;
 
-import com.netflix.conductor.client.events.listeners.TaskClientListener;
-import com.netflix.conductor.client.events.listeners.TaskRunnerEventsListener;
-import com.netflix.conductor.client.events.listeners.WorkflowClientListener;
+import java.time.Instant;
 
-public interface MetricsCollector extends TaskRunnerEventsListener, WorkflowClientListener, TaskClientListener {
+import lombok.Getter;
+import lombok.ToString;
 
+@Getter
+@ToString
+public abstract class ConductorClientEvent {
+    private final Instant time = Instant.now();
 }

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/dispatcher/EventDispatcher.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/dispatcher/EventDispatcher.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.client.events.dispatcher;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.netflix.conductor.client.events.ConductorClientEvent;
+
+public class EventDispatcher<T extends ConductorClientEvent> {
+
+    private final Map<Class<? extends T>, List<Consumer<? extends T>>> listeners;
+
+    public EventDispatcher() {
+        this.listeners = new ConcurrentHashMap<>();
+    }
+
+    public <U extends T> void register(Class<U> clazz, Consumer<U> listener) {
+        //  CopyOnWriteArrayList is thread-safe. It's particularly useful in scenarios where
+        //  reads are far more frequent than writes (typical for event listeners).
+        listeners.computeIfAbsent(clazz, k -> new CopyOnWriteArrayList<>()).add(listener);
+    }
+
+    public <U extends T> void unregister(Class<U> clazz, Consumer<U> listener) {
+        List<Consumer<? extends T>> consumers = listeners.get(clazz);
+        if (consumers != null) {
+            consumers.remove(listener);
+            if (consumers.isEmpty()) {
+                listeners.remove(clazz);
+            }
+        }
+    }
+
+    public void publish(T event) {
+        if (noListeners(event)) {
+            return;
+        }
+
+        CompletableFuture.runAsync(() -> {
+            List<Consumer<? extends T>> eventListeners = getEventListeners(event);
+            for (Consumer<? extends T> listener : eventListeners) {
+                ((Consumer<T>) listener).accept(event);
+            }
+        });
+    }
+
+    private boolean noListeners(T event) {
+        if (listeners.isEmpty()) {
+            return true;
+        }
+
+        var specificEventListeners = listeners.get(event.getClass());
+        var promiscuousListeners = listeners.get(ConductorClientEvent.class);
+
+        return (specificEventListeners == null || specificEventListeners.isEmpty())
+                && (promiscuousListeners == null || promiscuousListeners.isEmpty());
+    }
+
+    private List<Consumer<? extends T>> getEventListeners(T event) {
+        var specificEventListeners = listeners.get(event.getClass());
+        var promiscuousListeners = listeners.get(ConductorClientEvent.class);
+        if (promiscuousListeners == null || promiscuousListeners.isEmpty()) {
+            return specificEventListeners;
+        }
+
+        if (specificEventListeners == null || specificEventListeners.isEmpty()) {
+            return promiscuousListeners;
+        }
+
+        return Stream.concat(specificEventListeners.stream(), promiscuousListeners.stream())
+                .collect(Collectors.toList());
+    }
+
+}

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/listeners/ListenerRegister.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/listeners/ListenerRegister.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.client.events.listeners;
+
+import com.netflix.conductor.client.events.dispatcher.EventDispatcher;
+import com.netflix.conductor.client.events.task.TaskClientEvent;
+import com.netflix.conductor.client.events.task.TaskPayloadUsedEvent;
+import com.netflix.conductor.client.events.task.TaskResultPayloadSizeEvent;
+import com.netflix.conductor.client.events.taskrunner.PollCompleted;
+import com.netflix.conductor.client.events.taskrunner.PollFailure;
+import com.netflix.conductor.client.events.taskrunner.PollStarted;
+import com.netflix.conductor.client.events.taskrunner.TaskExecutionCompleted;
+import com.netflix.conductor.client.events.taskrunner.TaskExecutionFailure;
+import com.netflix.conductor.client.events.taskrunner.TaskExecutionStarted;
+import com.netflix.conductor.client.events.taskrunner.TaskRunnerEvent;
+import com.netflix.conductor.client.events.workflow.WorkflowClientEvent;
+import com.netflix.conductor.client.events.workflow.WorkflowInputPayloadSizeEvent;
+import com.netflix.conductor.client.events.workflow.WorkflowPayloadUsedEvent;
+import com.netflix.conductor.client.events.workflow.WorkflowStartedEvent;
+
+public class ListenerRegister {
+
+    public static void register(TaskRunnerEventsListener listener, EventDispatcher<TaskRunnerEvent> dispatcher) {
+        dispatcher.register(PollFailure.class, listener::consume);
+        dispatcher.register(PollCompleted.class, listener::consume);
+        dispatcher.register(PollStarted.class, listener::consume);
+        dispatcher.register(TaskExecutionStarted.class, listener::consume);
+        dispatcher.register(TaskExecutionCompleted.class, listener::consume);
+        dispatcher.register(TaskExecutionFailure.class, listener::consume);
+    }
+
+    public static void register(TaskClientListener listener, EventDispatcher<TaskClientEvent> dispatcher) {
+        dispatcher.register(TaskResultPayloadSizeEvent.class, listener::consume);
+        dispatcher.register(TaskPayloadUsedEvent.class, listener::consume);
+    }
+
+    public static void register(WorkflowClientListener listener, EventDispatcher<WorkflowClientEvent> dispatcher) {
+        dispatcher.register(WorkflowStartedEvent.class, listener::consume);
+        dispatcher.register(WorkflowInputPayloadSizeEvent.class, listener::consume);
+        dispatcher.register(WorkflowPayloadUsedEvent.class, listener::consume);
+    }
+}

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/listeners/TaskClientListener.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/listeners/TaskClientListener.java
@@ -10,12 +10,18 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.client.metrics;
+package com.netflix.conductor.client.events.listeners;
 
-import com.netflix.conductor.client.events.listeners.TaskClientListener;
-import com.netflix.conductor.client.events.listeners.TaskRunnerEventsListener;
-import com.netflix.conductor.client.events.listeners.WorkflowClientListener;
+import com.netflix.conductor.client.events.task.TaskPayloadUsedEvent;
+import com.netflix.conductor.client.events.task.TaskResultPayloadSizeEvent;
 
-public interface MetricsCollector extends TaskRunnerEventsListener, WorkflowClientListener, TaskClientListener {
+/**
+ * TaskPayloadUsedEvent and TaskRecordPayloadSizeEvent are only published when
+ * conductorClientConfiguration.isEnforceThresholds == true.
+ */
+public interface TaskClientListener {
 
+    void consume(TaskPayloadUsedEvent e);
+
+    void consume(TaskResultPayloadSizeEvent e);
 }

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/listeners/TaskRunnerEventsListener.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/listeners/TaskRunnerEventsListener.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.client.events.listeners;
+
+import com.netflix.conductor.client.events.taskrunner.PollCompleted;
+import com.netflix.conductor.client.events.taskrunner.PollFailure;
+import com.netflix.conductor.client.events.taskrunner.PollStarted;
+import com.netflix.conductor.client.events.taskrunner.TaskExecutionCompleted;
+import com.netflix.conductor.client.events.taskrunner.TaskExecutionFailure;
+import com.netflix.conductor.client.events.taskrunner.TaskExecutionStarted;
+
+public interface TaskRunnerEventsListener {
+
+    void consume(PollFailure e);
+
+    void consume(PollCompleted e);
+
+    void consume(PollStarted e);
+
+    void consume(TaskExecutionStarted e);
+
+    void consume(TaskExecutionCompleted e);
+
+    void consume(TaskExecutionFailure e);
+
+}

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/listeners/WorkflowClientListener.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/listeners/WorkflowClientListener.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.client.events.listeners;
+
+import com.netflix.conductor.client.events.workflow.WorkflowInputPayloadSizeEvent;
+import com.netflix.conductor.client.events.workflow.WorkflowPayloadUsedEvent;
+import com.netflix.conductor.client.events.workflow.WorkflowStartedEvent;
+
+/**
+ * WorkflowPayloadUsedEvent and WorkflowRecordPayloadSizeEvent are only published when
+ * conductorClientConfiguration.isEnforceThresholds == true.
+ */
+public interface WorkflowClientListener {
+
+    void consume(WorkflowPayloadUsedEvent event);
+    void consume(WorkflowInputPayloadSizeEvent event);
+    void consume(WorkflowStartedEvent event);
+}

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/task/TaskClientEvent.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/task/TaskClientEvent.java
@@ -10,22 +10,17 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.client.automator.events;
+package com.netflix.conductor.client.events.task;
 
-import java.time.Duration;
+import com.netflix.conductor.client.events.ConductorClientEvent;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 
+@AllArgsConstructor
 @Getter
 @ToString
-public final class PollFailure extends TaskRunnerEvent {
-    private final Duration duration;
-    private final Throwable cause;
-
-    public PollFailure(String taskType, long durationInMillis, Throwable cause) {
-        super(taskType);
-        this.duration = Duration.ofMillis(durationInMillis);
-        this.cause = cause;
-    }
+public abstract class TaskClientEvent extends ConductorClientEvent {
+    private final String taskType;
 }

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/task/TaskPayloadUsedEvent.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/task/TaskPayloadUsedEvent.java
@@ -10,26 +10,19 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.client.automator.events;
-
-import java.time.Duration;
+package com.netflix.conductor.client.events.task;
 
 import lombok.Getter;
-import lombok.ToString;
 
 @Getter
-@ToString
-public final class TaskExecutionFailure extends TaskRunnerEvent {
-    public final String taskId;
-    public final String workerId;
-    private final Duration duration;
-    private final Throwable cause;
+public class TaskPayloadUsedEvent extends TaskClientEvent {
 
-    public TaskExecutionFailure(String taskType, String taskId, String workerId, Throwable cause, long durationInMillis) {
+    private final String operation;
+    private final String payloadType;
+
+    public TaskPayloadUsedEvent(String taskType, String operation, String payloadType) {
         super(taskType);
-        this.cause = cause;
-        this.taskId = taskId;
-        this.workerId = workerId;
-        this.duration = Duration.ofMillis(durationInMillis);
+        this.operation = operation;
+        this.payloadType = payloadType;
     }
 }

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/task/TaskResultPayloadSizeEvent.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/task/TaskResultPayloadSizeEvent.java
@@ -10,12 +10,16 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.client.metrics;
+package com.netflix.conductor.client.events.task;
 
-import com.netflix.conductor.client.events.listeners.TaskClientListener;
-import com.netflix.conductor.client.events.listeners.TaskRunnerEventsListener;
-import com.netflix.conductor.client.events.listeners.WorkflowClientListener;
+import lombok.Getter;
 
-public interface MetricsCollector extends TaskRunnerEventsListener, WorkflowClientListener, TaskClientListener {
+@Getter
+public class TaskResultPayloadSizeEvent extends TaskClientEvent {
+    private final long size;
 
+    public TaskResultPayloadSizeEvent(String taskType, long size) {
+        super(taskType);
+        this.size = size;
+    }
 }

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/taskrunner/PollCompleted.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/taskrunner/PollCompleted.java
@@ -10,20 +10,20 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.client.automator.events;
+package com.netflix.conductor.client.events.taskrunner;
+
+import java.time.Duration;
 
 import lombok.Getter;
 import lombok.ToString;
 
 @Getter
 @ToString
-public final class TaskExecutionStarted extends TaskRunnerEvent {
-    public final String taskId;
-    public final String workerId;
+public final class PollCompleted extends TaskRunnerEvent {
+    private final Duration duration;
 
-    public TaskExecutionStarted(String taskType, String taskId, String workerId) {
+    public PollCompleted(String taskType, long durationInMillis) {
         super(taskType);
-        this.taskId = taskId;
-        this.workerId = workerId;
+        this.duration = Duration.ofMillis(durationInMillis);
     }
 }

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/taskrunner/PollFailure.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/taskrunner/PollFailure.java
@@ -10,14 +10,22 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.client.automator.events;
+package com.netflix.conductor.client.events.taskrunner;
 
+import java.time.Duration;
+
+import lombok.Getter;
 import lombok.ToString;
 
+@Getter
 @ToString
-public final class PollStarted extends TaskRunnerEvent {
+public final class PollFailure extends TaskRunnerEvent {
+    private final Duration duration;
+    private final Throwable cause;
 
-    public PollStarted(String taskType) {
+    public PollFailure(String taskType, long durationInMillis, Throwable cause) {
         super(taskType);
+        this.duration = Duration.ofMillis(durationInMillis);
+        this.cause = cause;
     }
 }

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/taskrunner/PollStarted.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/taskrunner/PollStarted.java
@@ -10,12 +10,14 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.client.metrics;
+package com.netflix.conductor.client.events.taskrunner;
 
-import com.netflix.conductor.client.events.listeners.TaskClientListener;
-import com.netflix.conductor.client.events.listeners.TaskRunnerEventsListener;
-import com.netflix.conductor.client.events.listeners.WorkflowClientListener;
+import lombok.ToString;
 
-public interface MetricsCollector extends TaskRunnerEventsListener, WorkflowClientListener, TaskClientListener {
+@ToString
+public final class PollStarted extends TaskRunnerEvent {
 
+    public PollStarted(String taskType) {
+        super(taskType);
+    }
 }

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/taskrunner/TaskExecutionCompleted.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/taskrunner/TaskExecutionCompleted.java
@@ -10,18 +10,24 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.client.automator.events;
+package com.netflix.conductor.client.events.taskrunner;
 
-import java.time.Instant;
+import java.time.Duration;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 
-@AllArgsConstructor
 @Getter
 @ToString
-public abstract class TaskRunnerEvent {
-    private final Instant time = Instant.now();
-    private final String taskType;
+public final class TaskExecutionCompleted extends TaskRunnerEvent {
+    public final String taskId;
+    public final String workerId;
+    private final Duration duration;
+
+    public TaskExecutionCompleted(String taskType, String taskId, String workerId, long durationInMillis) {
+        super(taskType);
+        this.taskId = taskId;
+        this.workerId = workerId;
+        this.duration = Duration.ofMillis(durationInMillis);
+    }
 }

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/taskrunner/TaskExecutionFailure.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/taskrunner/TaskExecutionFailure.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.client.events.taskrunner;
+
+import java.time.Duration;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public final class TaskExecutionFailure extends TaskRunnerEvent {
+    public final String taskId;
+    public final String workerId;
+    private final Duration duration;
+    private final Throwable cause;
+
+    public TaskExecutionFailure(String taskType, String taskId, String workerId, Throwable cause, long durationInMillis) {
+        super(taskType);
+        this.cause = cause;
+        this.taskId = taskId;
+        this.workerId = workerId;
+        this.duration = Duration.ofMillis(durationInMillis);
+    }
+}

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/taskrunner/TaskExecutionStarted.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/taskrunner/TaskExecutionStarted.java
@@ -10,12 +10,20 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.client.metrics;
+package com.netflix.conductor.client.events.taskrunner;
 
-import com.netflix.conductor.client.events.listeners.TaskClientListener;
-import com.netflix.conductor.client.events.listeners.TaskRunnerEventsListener;
-import com.netflix.conductor.client.events.listeners.WorkflowClientListener;
+import lombok.Getter;
+import lombok.ToString;
 
-public interface MetricsCollector extends TaskRunnerEventsListener, WorkflowClientListener, TaskClientListener {
+@Getter
+@ToString
+public final class TaskExecutionStarted extends TaskRunnerEvent {
+    public final String taskId;
+    public final String workerId;
 
+    public TaskExecutionStarted(String taskType, String taskId, String workerId) {
+        super(taskType);
+        this.taskId = taskId;
+        this.workerId = workerId;
+    }
 }

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/taskrunner/TaskRunnerEvent.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/taskrunner/TaskRunnerEvent.java
@@ -10,12 +10,17 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.client.metrics;
+package com.netflix.conductor.client.events.taskrunner;
 
-import com.netflix.conductor.client.events.listeners.TaskClientListener;
-import com.netflix.conductor.client.events.listeners.TaskRunnerEventsListener;
-import com.netflix.conductor.client.events.listeners.WorkflowClientListener;
+import com.netflix.conductor.client.events.ConductorClientEvent;
 
-public interface MetricsCollector extends TaskRunnerEventsListener, WorkflowClientListener, TaskClientListener {
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
 
+@AllArgsConstructor
+@Getter
+@ToString
+public abstract class TaskRunnerEvent extends ConductorClientEvent {
+    private final String taskType;
 }

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/workflow/WorkflowClientEvent.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/workflow/WorkflowClientEvent.java
@@ -10,12 +10,18 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.client.metrics;
+package com.netflix.conductor.client.events.workflow;
 
-import com.netflix.conductor.client.events.listeners.TaskClientListener;
-import com.netflix.conductor.client.events.listeners.TaskRunnerEventsListener;
-import com.netflix.conductor.client.events.listeners.WorkflowClientListener;
+import com.netflix.conductor.client.events.ConductorClientEvent;
 
-public interface MetricsCollector extends TaskRunnerEventsListener, WorkflowClientListener, TaskClientListener {
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
 
+@AllArgsConstructor
+@Getter
+@ToString
+public abstract class WorkflowClientEvent extends ConductorClientEvent {
+    private final String name;
+    private final Integer version;
 }

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/workflow/WorkflowInputPayloadSizeEvent.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/workflow/WorkflowInputPayloadSizeEvent.java
@@ -10,20 +10,17 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.client.automator.events;
-
-import java.time.Duration;
+package com.netflix.conductor.client.events.workflow;
 
 import lombok.Getter;
-import lombok.ToString;
 
 @Getter
-@ToString
-public final class PollCompleted extends TaskRunnerEvent {
-    private final Duration duration;
+public class WorkflowInputPayloadSizeEvent extends WorkflowClientEvent {
 
-    public PollCompleted(String taskType, long durationInMillis) {
-        super(taskType);
-        this.duration = Duration.ofMillis(durationInMillis);
+    private final long size;
+
+    public WorkflowInputPayloadSizeEvent(String name, Integer version, long size) {
+        super(name, version);
+        this.size = size;
     }
 }

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/workflow/WorkflowPayloadUsedEvent.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/workflow/WorkflowPayloadUsedEvent.java
@@ -10,12 +10,19 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.client.metrics;
+package com.netflix.conductor.client.events.workflow;
 
-import com.netflix.conductor.client.events.listeners.TaskClientListener;
-import com.netflix.conductor.client.events.listeners.TaskRunnerEventsListener;
-import com.netflix.conductor.client.events.listeners.WorkflowClientListener;
+import lombok.Getter;
 
-public interface MetricsCollector extends TaskRunnerEventsListener, WorkflowClientListener, TaskClientListener {
+@Getter
+public class WorkflowPayloadUsedEvent extends WorkflowClientEvent {
 
+    private final String operation;
+    private final String payloadType;
+
+    public WorkflowPayloadUsedEvent(String name, Integer version, String operation, String payloadType) {
+        super(name, version);
+        this.operation = operation;
+        this.payloadType = payloadType;
+    }
 }

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/workflow/WorkflowStartedEvent.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/events/workflow/WorkflowStartedEvent.java
@@ -10,24 +10,24 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.client.automator.events;
-
-import java.time.Duration;
+package com.netflix.conductor.client.events.workflow;
 
 import lombok.Getter;
-import lombok.ToString;
 
 @Getter
-@ToString
-public final class TaskExecutionCompleted extends TaskRunnerEvent {
-    public final String taskId;
-    public final String workerId;
-    private final Duration duration;
+public class WorkflowStartedEvent extends WorkflowClientEvent {
 
-    public TaskExecutionCompleted(String taskType, String taskId, String workerId, long durationInMillis) {
-        super(taskType);
-        this.taskId = taskId;
-        this.workerId = workerId;
-        this.duration = Duration.ofMillis(durationInMillis);
+    private final boolean success;
+
+    private final Throwable throwable;
+
+    public WorkflowStartedEvent(String name, Integer version) {
+        this(name, version, true, null);
+    }
+
+    public WorkflowStartedEvent(String name, Integer version, boolean success, Throwable t) {
+        super(name, version);
+        this.success = success;
+        this.throwable = t;
     }
 }

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/http/PayloadStorage.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/http/PayloadStorage.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.client.http;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.netflix.conductor.client.exception.ConductorClientException;
+import com.netflix.conductor.common.run.ExternalStorageLocation;
+import com.netflix.conductor.common.utils.ExternalPayloadStorage;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.extern.slf4j.Slf4j;
+
+/** An implementation of {@link ExternalPayloadStorage} for storing large JSON payload data. */
+@Slf4j
+class PayloadStorage implements ExternalPayloadStorage {
+
+    private static final int BUFFER_SIZE = 1024 * 32;
+
+    private final ConductorClient client;
+
+    PayloadStorage(ConductorClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public ExternalStorageLocation getLocation(Operation operation, PayloadType payloadType, String path) {
+        ConductorClientRequest request = ConductorClientRequest.builder()
+                .method(ConductorClientRequest.Method.GET)
+                .path("/{resource}/externalstoragelocation")
+                .addPathParam("resource", getResource(operation, payloadType))
+                .addQueryParam("path", path)
+                .addQueryParam("operation", operation.toString())
+                .addQueryParam("payloadType", payloadType.toString())
+                .build();
+
+        ConductorClientResponse<ExternalStorageLocation> resp = client.execute(request, new TypeReference<>() {
+        });
+
+        return resp.getData();
+    }
+
+    @NotNull
+    private String getResource(Operation operation, PayloadType payloadType) {
+        switch (payloadType) {
+            case WORKFLOW_INPUT:
+            case WORKFLOW_OUTPUT:
+                return "workflow";
+            case TASK_INPUT:
+            case TASK_OUTPUT:
+                return "tasks";
+        }
+
+        throw new ConductorClientException(String.format("Invalid payload type: %s for operation: %s",
+                payloadType, operation));
+    }
+
+    /**
+     * Uploads the payload to the uri specified.
+     *
+     * @param uri the location to which the object is to be uploaded
+     * @param payload an {@link InputStream} containing the json payload which is to be uploaded
+     * @param payloadSize the size of the json payload in bytes
+     * @throws ConductorClientException if the upload fails due to an invalid path or an error from
+     *     external storage
+     */
+    @Override
+    public void upload(String uri, InputStream payload, long payloadSize) {
+        HttpURLConnection connection = null;
+        try {
+            URL url = new URI(uri).toURL();
+
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setDoOutput(true);
+            connection.setRequestMethod("PUT");
+
+            try (BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(connection.getOutputStream())) {
+                byte[] buffer = new byte[BUFFER_SIZE];
+                int bytesRead;
+                long totalBytes = 0;
+                while ((bytesRead = payload.read(buffer)) != -1) {
+                    bufferedOutputStream.write(buffer, 0, bytesRead);
+                    totalBytes += bytesRead;
+                }
+                bufferedOutputStream.flush();
+
+                int responseCode = connection.getResponseCode();
+                if (!isSuccessful(responseCode)) {
+                    String errorMsg = String.format("Unable to upload. Response code: %d", responseCode);
+                    log.error(errorMsg);
+                    throw new ConductorClientException(errorMsg);
+                }
+                log.debug("Uploaded {} bytes to uri: {}, with HTTP response code: {}", totalBytes, uri, responseCode);
+            }
+        } catch (URISyntaxException | MalformedURLException e) {
+            String errorMsg = String.format("Invalid path specified: %s", uri);
+            log.error(errorMsg, e);
+            throw new ConductorClientException(e);
+        } catch (IOException e) {
+            String errorMsg = String.format("Error uploading to path: %s", uri);
+            log.error(errorMsg, e);
+            throw new ConductorClientException(e);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+            try {
+                if (payload != null) {
+                    payload.close();
+                }
+            } catch (IOException e) {
+                log.warn("Unable to close input stream when uploading to uri: {}", uri);
+            }
+        }
+    }
+
+    /**
+     * Downloads the payload from the given uri.
+     *
+     * @param uri the location from where the object is to be downloaded
+     * @return an inputstream of the payload in the external storage
+     * @throws ConductorClientException if the download fails due to an invalid path or an error
+     *     from external storage
+     */
+    @Override
+    public InputStream download(String uri) {
+        try {
+            URL url = new URI(uri).toURL();
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setDoOutput(false);
+
+            int responseCode = connection.getResponseCode();
+            if (responseCode == HttpURLConnection.HTTP_OK) {
+                log.debug("Download completed with HTTP response code: {}", connection.getResponseCode());
+                return new BufferedInputStream(connection.getInputStream());
+            }
+            String errorMsg = String.format("Unable to download. Response code: %d", responseCode);
+            log.error(errorMsg);
+            throw new ConductorClientException(errorMsg);
+        } catch (URISyntaxException | MalformedURLException e) {
+            String errorMsg = String.format("Invalid uri specified: %s", uri);
+            log.error(errorMsg, e);
+            throw new ConductorClientException(e);
+        } catch (IOException e) {
+            String errorMsg = String.format("Error downloading from uri: %s", uri);
+            log.error(errorMsg, e);
+            throw new ConductorClientException(e);
+        }
+    }
+
+    private boolean isSuccessful(int responseCode) {
+        return responseCode >= 200 && responseCode < 300;
+    }
+}

--- a/conductor-clients/java/conductor-java-sdk/examples/src/main/java/com/netflix/conductor/sdk/examples/events/EventListenerExample.java
+++ b/conductor-clients/java/conductor-java-sdk/examples/src/main/java/com/netflix/conductor/sdk/examples/events/EventListenerExample.java
@@ -17,9 +17,9 @@ import java.net.InetSocketAddress;
 import java.util.List;
 
 import com.netflix.conductor.client.automator.TaskRunnerConfigurer;
-import com.netflix.conductor.client.automator.events.PollCompleted;
-import com.netflix.conductor.client.automator.events.PollFailure;
-import com.netflix.conductor.client.automator.events.TaskExecutionFailure;
+import com.netflix.conductor.client.events.taskrunner.PollCompleted;
+import com.netflix.conductor.client.events.taskrunner.PollFailure;
+import com.netflix.conductor.client.events.taskrunner.TaskExecutionFailure;
 import com.netflix.conductor.client.http.TaskClient;
 import com.netflix.conductor.client.worker.Worker;
 import com.netflix.conductor.common.metadata.tasks.Task;

--- a/conductor-clients/java/conductor-java-sdk/orkes-client/src/main/java/io/orkes/conductor/client/http/OrkesTaskClient.java
+++ b/conductor-clients/java/conductor-java-sdk/orkes-client/src/main/java/io/orkes/conductor/client/http/OrkesTaskClient.java
@@ -17,7 +17,6 @@ import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.apache.commons.lang3.Validate;
 
@@ -151,10 +150,6 @@ public class OrkesTaskClient {
 
     public void updateTask(TaskResult taskResult) {
         taskClient.updateTask(taskResult);
-    }
-
-    public Optional<String> evaluateAndUploadLargePayload(Map<String, Object> taskOutputData, String taskType) {
-        return taskClient.evaluateAndUploadLargePayload(taskOutputData, taskType);
     }
 
     public void logMessageForTask(String taskId, String logMessage) {


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

1. Adds support for External Payload Storage (as supported in OSS Conductor Client v3). SEE: `TaskClient.evaluateAndUploadLargePayload` and `WorkflowClient.checkAndUploadToExternalStorage`
2. Event refactoring
  2.1 Moved Events out of automator package to `com.netflix.conductor.client.events`.
  2.2 Extracted logic from `TaskRunner` to `EventDispatcher`- Events are not only published by `TaskRunner`.
  2.3 `TaskClient` and `WorkflowClient` publish events related to external storage payload and workflow start.

**TODO**
- Use the events from `TaskClient` and `WorkflowClient` in PrometheusMetricsCollector.
