### PR TITLE
Feature/python inline task

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 
     implementation "org.openjdk.nashorn:nashorn-core:15.4"
 
+    //jython dependency
+    implementation "org.python:jython-standalone:2.7.4"
+
     // JAXB is not bundled with Java 11, dependencies added explicitly
     // These are needed by Apache BVAL
     implementation "jakarta.xml.bind:jakarta.xml.bind-api:${revJAXB}"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,8 +43,10 @@ dependencies {
 
     implementation "org.openjdk.nashorn:nashorn-core:15.4"
 
-    //jython dependency
-    implementation "org.python:jython-standalone:2.7.4"
+    //gralVm dependencies for executing python
+    implementation("org.graalvm.polyglot:polyglot:24.1.0")
+    implementation("org.graalvm.polyglot:python:24.1.0")
+    implementation "org.graalvm.sdk:graal-sdk:24.1.0"
 
     // JAXB is not bundled with Java 11, dependencies added explicitly
     // These are needed by Apache BVAL

--- a/core/src/main/java/com/netflix/conductor/core/execution/evaluators/PythonEvaluator.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/evaluators/PythonEvaluator.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.execution.evaluators;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Map;
+import java.util.Properties;
+
+import org.python.core.PyObject;
+import org.python.util.PythonInterpreter;
+import org.springframework.stereotype.Component;
+
+@Component(PythonEvaluator.NAME)
+public class PythonEvaluator implements Evaluator {
+    public static final String NAME = "python";
+
+    @Override
+    public Object evaluate(String expression, Object inputs) {
+
+        PythonInterpreter interpreter = null;
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        try {
+            Properties props = new Properties();
+            props.setProperty("python.import.site", "false");
+            PythonInterpreter.initialize(System.getProperties(), props, new String[] {});
+
+            interpreter = new PythonInterpreter();
+            interpreter.setOut(new PrintStream(outputStream));
+
+            if (inputs instanceof Map) {
+                Map<String, Object> input = (Map<String, Object>) inputs;
+
+                // Set variables in the interpreter
+                for (Map.Entry<String, Object> entry : input.entrySet()) {
+                    interpreter.set(entry.getKey(), entry.getValue());
+                }
+                // Build the global declaration dynamically
+                StringBuilder globalDeclaration = new StringBuilder("def evaluate():\n    global ");
+
+                for (Map.Entry<String, Object> entry : input.entrySet()) {
+                    globalDeclaration.append(entry.getKey()).append(", ");
+                }
+
+                // Remove the trailing comma and space, and add a newline
+                if (globalDeclaration.length() > 0) {
+                    globalDeclaration.setLength(globalDeclaration.length() - 2);
+                }
+                globalDeclaration.append("\n");
+
+                // Wrap the expression in a function to handle multi-line statements
+                String wrappedExpression =
+                        globalDeclaration.toString() // Add global declaration line
+                                + "    "
+                                + expression.replace(
+                                        "\n", "\n    ") // Indent the original expression
+                                + "\n"
+                                + "result = evaluate()";
+
+                // Execute the wrapped expression
+                interpreter.exec(wrappedExpression);
+
+                // Get the result
+                PyObject result = interpreter.get("result");
+                return result.__tojava__(Object.class);
+            } else {
+                return null;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        } finally {
+            if (interpreter != null) {
+                interpreter.close();
+            }
+        }
+    }
+}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -4,6 +4,7 @@ services:
   conductor-server:
     environment:
       - CONFIG_PROP=config-redis.properties
+      - JAVA_OPTS=-Dpolyglot.engine.WarnInterpreterOnly=false
     image: conductor:server
     container_name: conductor-server
     build:

--- a/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Python.java
+++ b/java-sdk/src/main/java/com/netflix/conductor/sdk/workflow/def/tasks/Python.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.sdk.workflow.def.tasks;
+
+import com.netflix.conductor.common.metadata.tasks.TaskType;
+
+public class Python extends Task<Python> {
+    public Python(String taskReferenceName, String script) {
+        super(taskReferenceName, TaskType.INLINE);
+        if (script == null || script.isEmpty()) {
+            throw new IllegalArgumentException("Python script cannot be null or empty");
+        }
+        super.input("evaluatorType", "python");
+        super.input("expression", script);
+    }
+}


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
This PR implements support for Python as a scripting language for inline tasks in Netflix Conductor, based on the roadmap outlined [here](https://github.com/conductor-oss/conductor/blob/main/ROADMAP.md).
The feature extends Conductor's usability by enabling lightweight Python code execution as inline tasks.
The Python environment used for executing scripts is Jython.
Key changes include:

-     Added a new inline task type that supports executing Python scripts (previously only JavaScript was supported).
-     Introduced a new dependency for Jython in the build.gradle file inside conductor/core.
-     Implemented a new Evaluator to execute Python scripts located in conductor/core/java/core/executions/evaluators.
-     Added a new task type Python in the Java SDK.


Issue #

Alternatives considered
----
One alternative approach is to use GraalVM's Python engine instead of Jython, which could offer improved performance and compatibility.
----
![Screenshot from 2024-10-03 15-04-33](https://github.com/user-attachments/assets/6a575836-bcc0-4b64-ab59-ae0e064d0d2f)

![Screenshot from 2024-10-03 15-02-08](https://github.com/user-attachments/assets/c705624c-1ced-44bd-aaaa-9074a187c372)
![Screenshot from 2024-10-03 15-01-14](https://github.com/user-attachments/assets/02ec7205-2185-43cf-b43b-5704cc819a84)
![Screenshot from 2024-10-03 15-00-14](https://github.com/user-attachments/assets/40350588-b3a1-4492-9c20-c3591b6ec95d)


_Describe alternative implementation you have considered_
