### PR TITLE
Adding event_queue_depth metric

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/events/DefaultEventQueueManager.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/DefaultEventQueueManager.java
@@ -164,6 +164,13 @@ public class DefaultEventQueueManager extends LifecycleAwareComponent implements
                         }
                     });
 
+            Map<String, Map<String, Long>> eventToQueueSize = getQueueSizes();
+            eventToQueueSize.forEach(
+                    (event, queueMap) -> {
+                        Map.Entry<String, Long> queueSize = queueMap.entrySet().iterator().next();
+                        Monitors.recordEventQueueDepth(queueSize.getKey(), queueSize.getValue());
+                    });
+
             LOGGER.debug("Event queues: {}", eventToQueueMap.keySet());
             LOGGER.debug("Stored queue: {}", events);
             LOGGER.debug("Removed queue: {}", removed);

--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -235,6 +235,10 @@ public class Monitors {
                 StringUtils.defaultIfBlank(ownerApp, "unknown"));
     }
 
+    public static void recordEventQueueDepth(String queueType, long size) {
+        gauge(classQualifier, "event_queue_depth", size, "queueType", queueType);
+    }
+
     public static void recordTaskInProgress(String taskType, long size, String ownerApp) {
         gauge(
                 classQualifier,


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
Currently, we don't have any metric that can tell us the event queue size.
In this pull request, I am introducing a new metric called event_queue_depth, similar to the existing task_queue_depth metric. This new metric will indicate the number of events currently in the queue. It will be emitted each time the event queues are refreshed.

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
