### PR TITLE
[Java Client v4] Added ZoneId to SaveScheduleRequest

### DIFF
--- a/conductor-clients/java/conductor-java-sdk/orkes-client/src/main/java/io/orkes/conductor/client/model/SaveScheduleRequest.java
+++ b/conductor-clients/java/conductor-java-sdk/orkes-client/src/main/java/io/orkes/conductor/client/model/SaveScheduleRequest.java
@@ -213,4 +213,9 @@ public class SaveScheduleRequest {
     public void setZoneId(String zoneId) {
         this.zoneId = zoneId;
     }
+
+    public SaveScheduleRequest zoneId(String zoneId) {
+        this.zoneId = zoneId;
+        return this;
+    }
 }

--- a/conductor-clients/java/conductor-java-sdk/orkes-client/src/main/java/io/orkes/conductor/client/model/WorkflowSchedule.java
+++ b/conductor-clients/java/conductor-java-sdk/orkes-client/src/main/java/io/orkes/conductor/client/model/WorkflowSchedule.java
@@ -43,6 +43,8 @@ public class WorkflowSchedule {
 
     private Long updatedTime = null;
 
+    private String zoneId;
+
     public WorkflowSchedule createTime(Long createTime) {
         this.createTime = createTime;
         return this;
@@ -184,5 +186,18 @@ public class WorkflowSchedule {
 
     public void setUpdatedTime(Long updatedTime) {
         this.updatedTime = updatedTime;
+    }
+
+    public String getZoneId() {
+        return zoneId;
+    }
+
+    public void setZoneId(String zoneId) {
+        this.zoneId = zoneId;
+    }
+
+    public WorkflowSchedule zoneId(String zoneId) {
+        this.zoneId = zoneId;
+        return this;
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

Added `ZoneId` to `SaveScheduleRequest`. FYI, this was added to [Orkes Conductor Client v2.1.6](https://github.com/orkes-io/orkes-conductor-client/releases/tag/v2.1.6) but v4 was forked before that.

