### PR TITLE
Feature/939208 fix persistence

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
@@ -60,6 +60,9 @@ public class ConductorProperties {
     /** Used to enable/disable the workflow execution lock. */
     private boolean workflowExecutionLockEnabled = false;
 
+    /** Used to enable/disable the duplicate message delivery persistence. */
+    private boolean eventExecutionPersistenceEnabled = true;
+
     /** The time (in milliseconds) for which the lock is leased for. */
     private Duration lockLeaseTime = Duration.ofMillis(60000);
 
@@ -297,6 +300,13 @@ public class ConductorProperties {
 
     public void setWorkflowExecutionLockEnabled(boolean workflowExecutionLockEnabled) {
         this.workflowExecutionLockEnabled = workflowExecutionLockEnabled;
+    }
+
+    public boolean isEventExecutionPersistenceEnabled() {
+        return eventExecutionPersistenceEnabled;
+    }
+    public void setEventExecutionPersistenceEnabled(boolean eventExecutionPersistenceEnabled) {
+        this.eventExecutionPersistenceEnabled = eventExecutionPersistenceEnabled;
     }
 
     public Duration getLockLeaseTime() {

--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
@@ -305,6 +305,7 @@ public class ConductorProperties {
     public boolean isEventExecutionPersistenceEnabled() {
         return eventExecutionPersistenceEnabled;
     }
+
     public void setEventExecutionPersistenceEnabled(boolean eventExecutionPersistenceEnabled) {
         this.eventExecutionPersistenceEnabled = eventExecutionPersistenceEnabled;
     }

--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -78,8 +78,7 @@ public class ExecutionService {
         this.queueTaskMessagePostponeSecs =
                 properties.getTaskExecutionPostponeDuration().getSeconds();
 
-        this.isEventExecutionPersistenceEnabled =
-                properties.isEventExecutionPersistenceEnabled();
+        this.isEventExecutionPersistenceEnabled = properties.isEventExecutionPersistenceEnabled();
 
         this.systemTaskRegistry = systemTaskRegistry;
         this.taskStatusListener = taskStatusListener;
@@ -581,23 +580,20 @@ public class ExecutionService {
     }
 
     public boolean addEventExecution(EventExecution eventExecution) {
-        if(isEventExecutionPersistenceEnabled)
-        {
+        if (isEventExecutionPersistenceEnabled) {
             return executionDAOFacade.addEventExecution(eventExecution);
         }
         return true;
     }
 
     public void removeEventExecution(EventExecution eventExecution) {
-        if(isEventExecutionPersistenceEnabled)
-        {
+        if (isEventExecutionPersistenceEnabled) {
             executionDAOFacade.removeEventExecution(eventExecution);
         }
     }
 
     public void updateEventExecution(EventExecution eventExecution) {
-        if(isEventExecutionPersistenceEnabled)
-        {
+        if (isEventExecutionPersistenceEnabled) {
             executionDAOFacade.updateEventExecution(eventExecution);
         }
     }

--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -56,6 +56,7 @@ public class ExecutionService {
     private final TaskStatusListener taskStatusListener;
 
     private final long queueTaskMessagePostponeSecs;
+    private final boolean isEventExecutionPersistenceEnabled;
 
     private static final int MAX_POLL_TIMEOUT_MS = 5000;
     private static final int POLL_COUNT_ONE = 1;
@@ -76,6 +77,10 @@ public class ExecutionService {
 
         this.queueTaskMessagePostponeSecs =
                 properties.getTaskExecutionPostponeDuration().getSeconds();
+
+        this.isEventExecutionPersistenceEnabled =
+                properties.isEventExecutionPersistenceEnabled();
+
         this.systemTaskRegistry = systemTaskRegistry;
         this.taskStatusListener = taskStatusListener;
     }
@@ -576,15 +581,25 @@ public class ExecutionService {
     }
 
     public boolean addEventExecution(EventExecution eventExecution) {
-        return executionDAOFacade.addEventExecution(eventExecution);
+        if(isEventExecutionPersistenceEnabled)
+        {
+            return executionDAOFacade.addEventExecution(eventExecution);
+        }
+        return true;
     }
 
     public void removeEventExecution(EventExecution eventExecution) {
-        executionDAOFacade.removeEventExecution(eventExecution);
+        if(isEventExecutionPersistenceEnabled)
+        {
+            executionDAOFacade.removeEventExecution(eventExecution);
+        }
     }
 
     public void updateEventExecution(EventExecution eventExecution) {
-        executionDAOFacade.updateEventExecution(eventExecution);
+        if(isEventExecutionPersistenceEnabled)
+        {
+            executionDAOFacade.updateEventExecution(eventExecution);
+        }
     }
 
     /**

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -73,6 +73,9 @@ conductor.default-event-queue.type=sqs
 conductor.app.workflow-execution-lock-enabled=false
 conductor.workflow-execution-lock.type=noop_lock
 
+#Used to enable/disable the duplicate message delivery persistence
+conductor.app.eventExecutionPersistenceEnabled=true
+
 #Redis cluster settings for locking module
 # conductor.redis-lock.serverType=single
 #Comma separated list of server nodes


### PR DESCRIPTION
Pull Request type: Bugfix

**Changes in this PR:** Improve Workflow Reliability during Gradual Restarts with Optional Redis Idempotence

**Description:** This PR addresses an issue encountered when Conductor is deployed across multiple machines, particularly during a gradual restart sequence. Previously, if a workflow event was consumed from RabbitMQ and saved to Redis but had not yet been processed when a machine shut down, the event would reappear in the RabbitMQ queue. At this point, another machine could re-consume the event, but since the original entry in Redis had not yet expired, Conductor would incorrectly assume that this event was already processed by another machine, resulting in an early acknowledgment to RabbitMQ. This led to the loss of events and untriggered workflows, impacting reliability and predictability.

**The Fix:** This update introduces a new property, eventExecutionPersistenceEnabled, which offers greater flexibility and control over event handling. When set to false, this property disables the Redis persistence mechanism for idempotence, delegating responsibility for deduplication and idempotence to business services. By default, eventExecutionPersistenceEnabled is set to true, preserving the current behavior for backward compatibility.

**Key Benefits:**

**Enhanced Reliability:** Prevents workflow event loss during machine restarts by allowing business services to handle idempotence directly.
**Backward Compatibility:** Maintains the existing Redis persistence behavior by default, ensuring seamless integration for existing deployments.
**Greater Control:** Empowers operators to manage idempotence in ways that best suit their distributed environments.
This update brings added robustness to distributed setups and ensures workflows are processed reliably, even during server transitions.
