### PR TITLE
fix: latter task cannot be executed because taskResult.getLogs() can return null and decide(workflowId) will not be invoked

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
@@ -869,10 +869,13 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
                             task.getTaskId(), workflowId);
             LOGGER.error(errorMsg, e);
         }
-
-        taskResult.getLogs().forEach(taskExecLog -> taskExecLog.setTaskId(task.getTaskId()));
-        executionDAOFacade.addTaskExecLog(taskResult.getLogs());
-
+        List<TaskExecLog> taskLogs = taskResult.getLogs();
+        Optional.ofNullable(taskLogs)
+          .ifPresent(
+                  logs -> {
+                      logs.forEach(taskExecLog -> taskExecLog.setTaskId(task.getTaskId()));
+                      executionDAOFacade.addTaskExecLog(taskLogs);
+                  });
         if (task.getStatus().isTerminal()) {
             long duration = getTaskDuration(0, task);
             long lastDuration = task.getEndTime() - task.getStartTime();


### PR DESCRIPTION
…return null and decide(workflowId) will not be invoked

Pull Request type
----
- [x ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
Added null check for return value taskResult.getLogs before saving task execution log when update task.

