### PR TITLE
docs: Add custom logo link to Conductor documentation site

### DIFF
--- a/docs/overrides/partials/logo.html
+++ b/docs/overrides/partials/logo.html
@@ -1,0 +1,5 @@
+{% if config.theme.logo %}
+  <a href="https://conductor-oss.org/" class="md-header__button md-logo" aria-label="{{ config.site_name }}">
+    <img src="{{ config.theme.logo | url }}" alt="logo">
+  </a>
+{% endif %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,7 @@ nav:
 theme: 
   name: material
   logo: img/logo.svg
+  custom_dir: docs/overrides
   features:
     - navigation.tabs
     - navigation.tabs.sticky


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [x] Other (please describe): Documentation

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Description
----
This PR customizes the behavior of the documentation site logo by adding a custom template. When users click on the logo, they will be redirected to the [Conductor OSS website](https://conductor-oss.org/).



Changes in this PR
----
- Created custom logo template to override default MkDocs Material logo behavior
- Added custom template directory to `mkdocs.yml`
- Configured logo link to point to https://conductor-oss.org/

