### PR TITLE
Reduce FORK/JOIN latency

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
@@ -241,11 +241,11 @@ public class ConductorProperties {
             200; // 10 seconds based on default systemTaskWorkerPollInterval of 50ms
 
     /**
-     * Timeout in milliseconds used by {@link
-     * com.netflix.conductor.core.execution.tasks.SystemTaskWorker} when polling, i.e.: call to
-     * {@link com.netflix.conductor.dao.QueueDAO#pop(String, int, int)}.
+     * Timeout used by {@link com.netflix.conductor.core.execution.tasks.SystemTaskWorker} when
+     * polling, i.e.: call to {@link com.netflix.conductor.dao.QueueDAO#pop(String, int, int)}.
      */
-    private int systemTaskQueuePopTimeout = 200;
+    @DurationUnit(ChronoUnit.MILLIS)
+    private Duration systemTaskQueuePopTimeout = Duration.ofMillis(100);
 
     public String getStack() {
         return stack;
@@ -597,11 +597,11 @@ public class ConductorProperties {
         return systemTaskPostponeThreshold;
     }
 
-    public int getSystemTaskQueuePopTimeout() {
+    public Duration getSystemTaskQueuePopTimeout() {
         return systemTaskQueuePopTimeout;
     }
 
-    public void setSystemTaskQueuePopTimeout(int systemTaskQueuePopTimeout) {
+    public void setSystemTaskQueuePopTimeout(Duration systemTaskQueuePopTimeout) {
         this.systemTaskQueuePopTimeout = systemTaskQueuePopTimeout;
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
@@ -229,16 +229,15 @@ public class ConductorProperties {
     private int taskExecLogSizeLimit = 10;
 
     /**
-     * This threshold defines the default number of executions after which SystemTasks implementing
-     * getEvaluationOffset should begin postponing execution.
+     * This property defines the number of poll counts (executions) after which SystemTasks
+     * implementing getEvaluationOffset should begin postponing the next execution.
      *
      * @see
      *     com.netflix.conductor.core.execution.tasks.WorkflowSystemTask#getEvaluationOffset(TaskModel,
      *     long)
      * @see com.netflix.conductor.core.execution.tasks.Join#getEvaluationOffset(TaskModel, long)
      */
-    private int systemTaskPostponeThreshold =
-            200; // 10 seconds based on default systemTaskWorkerPollInterval of 50ms
+    private int systemTaskPostponeThreshold = 200;
 
     /**
      * Timeout used by {@link com.netflix.conductor.core.execution.tasks.SystemTaskWorker} when

--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
@@ -24,6 +24,8 @@ import org.springframework.boot.convert.DurationUnit;
 import org.springframework.util.unit.DataSize;
 import org.springframework.util.unit.DataUnit;
 
+import com.netflix.conductor.model.TaskModel;
+
 @ConfigurationProperties("conductor.app")
 public class ConductorProperties {
 
@@ -225,6 +227,25 @@ public class ConductorProperties {
 
     /** Used to limit the size of task execution logs. */
     private int taskExecLogSizeLimit = 10;
+
+    /**
+     * This threshold defines the default number of executions after which SystemTasks implementing
+     * getEvaluationOffset should begin postponing execution.
+     *
+     * @see
+     *     com.netflix.conductor.core.execution.tasks.WorkflowSystemTask#getEvaluationOffset(TaskModel,
+     *     long)
+     * @see com.netflix.conductor.core.execution.tasks.Join#getEvaluationOffset(TaskModel, long)
+     */
+    private int systemTaskPostponeThreshold =
+            200; // 10 seconds based on default systemTaskWorkerPollInterval of 50ms
+
+    /**
+     * Timeout in milliseconds used by {@link
+     * com.netflix.conductor.core.execution.tasks.SystemTaskWorker} when polling, i.e.: call to
+     * {@link com.netflix.conductor.dao.QueueDAO#pop(String, int, int)}.
+     */
+    private int systemTaskQueuePopTimeout = 200;
 
     public String getStack() {
         return stack;
@@ -566,5 +587,21 @@ public class ConductorProperties {
         Properties props = System.getProperties();
         props.forEach((key, value) -> map.put(key.toString(), value));
         return map;
+    }
+
+    public void setSystemTaskPostponeThreshold(int systemTaskPostponeThreshold) {
+        this.systemTaskPostponeThreshold = systemTaskPostponeThreshold;
+    }
+
+    public int getSystemTaskPostponeThreshold() {
+        return systemTaskPostponeThreshold;
+    }
+
+    public int getSystemTaskQueuePopTimeout() {
+        return systemTaskQueuePopTimeout;
+    }
+
+    public void setSystemTaskQueuePopTimeout(int systemTaskQueuePopTimeout) {
+        this.systemTaskQueuePopTimeout = systemTaskQueuePopTimeout;
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorker.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorker.java
@@ -52,6 +52,7 @@ public class SystemTaskWorker extends LifecycleAwareComponent {
     private final AsyncSystemTaskExecutor asyncSystemTaskExecutor;
     private final ConductorProperties properties;
     private final ExecutionService executionService;
+    private final int queuePopTimeout;
 
     ConcurrentHashMap<String, ExecutionConfig> queueExecutionConfigMap = new ConcurrentHashMap<>();
 
@@ -67,6 +68,7 @@ public class SystemTaskWorker extends LifecycleAwareComponent {
         this.queueDAO = queueDAO;
         this.pollInterval = properties.getSystemTaskWorkerPollInterval().toMillis();
         this.executionService = executionService;
+        this.queuePopTimeout = (int) properties.getSystemTaskQueuePopTimeout().toMillis();
 
         LOGGER.info("SystemTaskWorker initialized with {} threads", threadCount);
     }
@@ -115,10 +117,7 @@ public class SystemTaskWorker extends LifecycleAwareComponent {
             LOGGER.debug("Polling queue: {} with {} slots acquired", queueName, messagesToAcquire);
 
             List<String> polledTaskIds =
-                    queueDAO.pop(
-                            queueName,
-                            messagesToAcquire,
-                            properties.getSystemTaskQueuePopTimeout());
+                    queueDAO.pop(queueName, messagesToAcquire, queuePopTimeout);
 
             Monitors.recordTaskPoll(queueName);
             LOGGER.debug("Polling queue:{}, got {} tasks", queueName, polledTaskIds.size());

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorker.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorker.java
@@ -114,7 +114,11 @@ public class SystemTaskWorker extends LifecycleAwareComponent {
 
             LOGGER.debug("Polling queue: {} with {} slots acquired", queueName, messagesToAcquire);
 
-            List<String> polledTaskIds = queueDAO.pop(queueName, messagesToAcquire, 200);
+            List<String> polledTaskIds =
+                    queueDAO.pop(
+                            queueName,
+                            messagesToAcquire,
+                            properties.getSystemTaskQueuePopTimeout());
 
             Monitors.recordTaskPoll(queueName);
             LOGGER.debug("Polling queue:{}, got {} tasks", queueName, polledTaskIds.size());

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/WorkflowSystemTask.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/WorkflowSystemTask.java
@@ -65,7 +65,19 @@ public abstract class WorkflowSystemTask {
      */
     public void cancel(WorkflowModel workflow, TaskModel task, WorkflowExecutor workflowExecutor) {}
 
-    public Optional<Long> getEvaluationOffset(TaskModel taskModel, long defaultOffset) {
+    /**
+     * Determines the time in seconds by which the next execution of a task will be postponed after
+     * an execution. By default, this method returns {@code Optional.empty()}.
+     *
+     * <p>WorkflowSystemTasks may override this method to define a custom evaluation offset based on
+     * the task's behavior or requirements.
+     *
+     * @param taskModel task model
+     * @param maxOffset the max recommended offset value to use
+     * @return an {@code Optional<Long>} specifying the evaluation offset in seconds, or {@code
+     *     Optional.empty()} if no postponement is required
+     */
+    public Optional<Long> getEvaluationOffset(TaskModel taskModel, long maxOffset) {
         return Optional.empty();
     }
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
@@ -128,7 +128,7 @@ public class TestDeciderOutcomes {
 
         @Bean(TASK_TYPE_JOIN)
         public Join join() {
-            return new Join();
+            return new Join(new ConductorProperties());
         }
 
         @Bean
@@ -595,7 +595,8 @@ public class TestDeciderOutcomes {
 
         assertEquals(TaskModel.Status.SCHEDULED, outcome.tasksToBeScheduled.get(0).getStatus());
         System.out.println(outcome.tasksToBeScheduled.get(0));
-        new Join().execute(workflow, outcome.tasksToBeScheduled.get(0), null);
+        new Join(new ConductorProperties())
+                .execute(workflow, outcome.tasksToBeScheduled.get(0), null);
         assertEquals(TaskModel.Status.COMPLETED, outcome.tasksToBeScheduled.get(0).getStatus());
     }
 


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

Currently, a JOIN execution is delayed exponentially up to a maximum of `30s` in the default configuration. This may cause a JOIN to complete with a significant delay compared to the actual completion of all forked tasks.

These changes introduce a configurable postpone calculation (with a less aggressive increase) and a configurable Queue Pop Timeout. By tweaking those values we can reduce the JOIN latency at the start and the end.

SEE also: https://github.com/orkes-io/orkes-queues/pull/19