### PR TITLE
Unify environment variable usage

### DIFF
--- a/.github/workflows/java-client-v4-integration-tests.yml
+++ b/.github/workflows/java-client-v4-integration-tests.yml
@@ -33,8 +33,8 @@ jobs:
           ./gradlew -p tests test
         env:
           CONDUCTOR_SERVER_URL: ${{ secrets.CONDUCTOR_SERVER_URL }}
-          CONDUCTOR_SERVER_AUTH_KEY: ${{ secrets.CONDUCTOR_SERVER_AUTH_KEY }}
-          CONDUCTOR_SERVER_AUTH_SECRET: ${{ secrets.CONDUCTOR_SERVER_AUTH_SECRET }}
+          CONDUCTOR_AUTH_KEY: ${{ secrets.CONDUCTOR_AUTH_KEY }}
+          CONDUCTOR_AUTH_SECRET: ${{ secrets.CONDUCTOR_AUTH_SECRET }}
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3
         if: always()

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/http/ConductorClient.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/client/http/ConductorClient.java
@@ -452,6 +452,8 @@ public class ConductorClient {
         private Supplier<ObjectMapper> objectMapperSupplier = () -> new ObjectMapperProvider().getObjectMapper();
         private final List<HeaderSupplier> headerSuppliers = new ArrayList<>();
 
+        private boolean useEnvVariables = false;
+
         protected T self() {
             //noinspection unchecked
             return (T) this;
@@ -538,7 +540,19 @@ public class ConductorClient {
             return headerSuppliers;
         }
 
+        public T useEnvVariables(boolean useEnvVariables) {
+            this.useEnvVariables = useEnvVariables;
+            return self();
+        }
+
+        protected boolean isUseEnvVariables() {
+            return this.useEnvVariables;
+        }
+
         public ConductorClient build() {
+            if (useEnvVariables) {
+                applyEnvVariables();
+            }
             return new ConductorClient(this);
         }
 
@@ -549,6 +563,15 @@ public class ConductorClient {
 
             if (basePath.endsWith("/")) {
                 basePath = basePath.substring(0, basePath.length() - 1);
+            }
+        }
+
+        protected void applyEnvVariables() {
+            String conductorServerUrl = System.getenv("CONDUCTOR_SERVER_URL");
+            if (conductorServerUrl != null) {
+                this.basePath(conductorServerUrl);
+            } else {
+                throw new RuntimeException("env variable CONDUCTOR_SERVER_URL is not set");
             }
         }
     }

--- a/conductor-clients/java/conductor-java-sdk/examples/src/main/java/io/orkes/conductor/sdk/examples/util/ClientUtil.java
+++ b/conductor-clients/java/conductor-java-sdk/examples/src/main/java/io/orkes/conductor/sdk/examples/util/ClientUtil.java
@@ -14,44 +14,23 @@ package io.orkes.conductor.sdk.examples.util;
 
 import com.netflix.conductor.client.http.ConductorClient;
 
+import io.orkes.conductor.client.ApiClient;
 import io.orkes.conductor.client.OrkesClients;
-import io.orkes.conductor.client.http.OrkesAuthentication;
-
-import com.google.common.base.Preconditions;
-
-import static java.lang.System.getenv;
 
 public class ClientUtil {
-    private static final String ENV_ROOT_URI = "CONDUCTOR_SERVER_URL";
-    private static final String ENV_KEY_ID = "CONDUCTOR_SERVER_AUTH_KEY";
-    private static final String ENV_SECRET = "CONDUCTOR_SERVER_AUTH_SECRET";
-    private static final ConductorClient CLIENT = getClient();
+
+    private static final ConductorClient CLIENT = ApiClient.builder()
+            .useEnvVariables(true)
+            .readTimeout(10_000)
+            .connectTimeout(10_000)
+            .writeTimeout(10_000)
+            .build();;
 
     public static OrkesClients getOrkesClients() {
         return new OrkesClients(CLIENT);
     }
 
     public static ConductorClient getClient() {
-        if (CLIENT != null) {
-            return CLIENT;
-        }
-
-        var basePath = getenv(ENV_ROOT_URI);
-        Preconditions.checkNotNull(basePath, ENV_ROOT_URI + " env not set");
-
-        ConductorClient.Builder builder = ConductorClient.builder()
-                .basePath(basePath)
-                .readTimeout(10_000)
-                .connectTimeout(10_000)
-                .writeTimeout(10_000);
-
-        var keyId = getenv(ENV_KEY_ID);
-        var keySecret = getenv(ENV_SECRET);
-
-        if (keyId != null && keySecret != null) {
-            builder.addHeaderSupplier(new OrkesAuthentication(keyId, keySecret));
-        }
-
-        return builder.build();
+       return CLIENT;
     }
 }

--- a/conductor-clients/java/conductor-java-sdk/orkes-client/src/main/java/io/orkes/conductor/client/ApiClient.java
+++ b/conductor-clients/java/conductor-java-sdk/orkes-client/src/main/java/io/orkes/conductor/client/ApiClient.java
@@ -174,8 +174,17 @@ public final class ApiClient extends ConductorClient {
 
         protected void applyEnvVariables() {
             super.applyEnvVariables();
+
             String conductorAuthKey = System.getenv("CONDUCTOR_AUTH_KEY");
+            if (conductorAuthKey == null) {
+                conductorAuthKey = System.getenv("CONDUCTOR_SERVER_AUTH_KEY"); // for backwards compatibility
+            }
+
             String conductorAuthSecret = System.getenv("CONDUCTOR_AUTH_SECRET");
+            if (conductorAuthSecret == null) {
+                conductorAuthSecret = System.getenv("CONDUCTOR_SERVER_AUTH_SECRET"); // for backwards compatibility
+            }
+
             if (conductorAuthKey != null && conductorAuthSecret != null) {
                 this.credentials(conductorAuthKey, conductorAuthSecret);
             }

--- a/conductor-clients/java/conductor-java-sdk/orkes-client/src/main/java/io/orkes/conductor/client/ApiClient.java
+++ b/conductor-clients/java/conductor-java-sdk/orkes-client/src/main/java/io/orkes/conductor/client/ApiClient.java
@@ -52,6 +52,10 @@ public final class ApiClient extends ConductorClient {
         super(rootUri);
     }
 
+    public ApiClient() {
+        this(builder().useEnvVariables(true));
+    }
+
     private ApiClient(ApiClientBuilder builder) {
         super(builder);
     }
@@ -161,7 +165,20 @@ public final class ApiClient extends ConductorClient {
 
         @Override
         public ApiClient build() {
+            if (isUseEnvVariables()) {
+                applyEnvVariables();
+            }
+
             return new ApiClient(this);
+        }
+
+        protected void applyEnvVariables() {
+            super.applyEnvVariables();
+            String conductorAuthKey = System.getenv("CONDUCTOR_AUTH_KEY");
+            String conductorAuthSecret = System.getenv("CONDUCTOR_AUTH_SECRET");
+            if (conductorAuthKey != null && conductorAuthSecret != null) {
+                this.credentials(conductorAuthKey, conductorAuthSecret);
+            }
         }
     }
 

--- a/conductor-clients/java/conductor-java-sdk/tests/src/test/java/io/orkes/conductor/client/util/ClientTestUtil.java
+++ b/conductor-clients/java/conductor-java-sdk/tests/src/test/java/io/orkes/conductor/client/util/ClientTestUtil.java
@@ -12,45 +12,24 @@
  */
 package io.orkes.conductor.client.util;
 
-import org.junit.jupiter.api.Assertions;
-
 import com.netflix.conductor.client.http.ConductorClient;
 
 import io.orkes.conductor.client.ApiClient;
 import io.orkes.conductor.client.OrkesClients;
 
 public class ClientTestUtil {
-    private static final String ENV_ROOT_URI = "CONDUCTOR_SERVER_URL";
-    private static final String ENV_KEY_ID = "CONDUCTOR_SERVER_AUTH_KEY";
-    private static final String ENV_SECRET = "CONDUCTOR_SERVER_AUTH_SECRET";
-    private static final ConductorClient CLIENT = getClient();
+    private static final ConductorClient CLIENT = ApiClient.builder()
+            .useEnvVariables(true)
+            .readTimeout(30_000)
+            .connectTimeout(30_000)
+            .writeTimeout(30_000)
+            .build();
 
     public static OrkesClients getOrkesClients() {
         return new OrkesClients(CLIENT);
     }
 
     public static ConductorClient getClient() {
-        if (CLIENT != null) {
-            return CLIENT;
-        }
-
-        String basePath = getEnv(ENV_ROOT_URI);
-        Assertions.assertNotNull(basePath, ENV_ROOT_URI + " env not set");
-        String keyId = getEnv(ENV_KEY_ID);
-        Assertions.assertNotNull(keyId, ENV_KEY_ID + " env not set");
-        String keySecret = getEnv(ENV_SECRET);
-        Assertions.assertNotNull(keySecret, ENV_SECRET + " env not set");
-
-        return ApiClient.builder()
-                .basePath(basePath)
-                .credentials(keyId, keySecret)
-                .readTimeout(30_000)
-                .connectTimeout(30_000)
-                .writeTimeout(30_000)
-                .build();
-    }
-
-    private static String getEnv(String key) {
-        return System.getenv(key);
+        return CLIENT;
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

Added support for:

- `CONDUCTOR_SERVER_URL`
- `CONDUCTOR_AUTH_KEY`
- `CONDUCTOR_AUTH_SECRET`

Same env variables used in Python and Go SDK. Env variables are used when:

(1) Creating a new instance of `ApiClient` (Orkes Client) with its no-args constructor. E.g.:

```java
var client = new ApiClient();
```

(2) Creating a new instance of `ConductorClient` or `ApiClient` with `useEnvVariables(true)`. E.g.:

```java
var client = ConductorClient.builder()
            .useEnvVariables(true)
            .build()
```

