### PR TITLE
Add support for configurable MetricsCollector in Spring client

### DIFF
--- a/conductor-clients/java/conductor-java-sdk/gradle.properties
+++ b/conductor-clients/java/conductor-java-sdk/gradle.properties
@@ -1,1 +1,1 @@
-version=4.0.2-beta
+version=4.0.4


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

This PR introduces the ability to configure a `MetricsCollector`. If a `MetricsCollector` bean is registered in the Spring context it will be used.