### PR TITLE
Fix Persistence/IndexDAO config

### DIFF
--- a/docker/docker-compose-redis-os.yaml
+++ b/docker/docker-compose-redis-os.yaml
@@ -57,7 +57,7 @@ services:
       - cluster.initial_cluster_manager_nodes=conductor-opensearch # Nodes eligible to serve as cluster manager
       - OPENSEARCH_INITIAL_ADMIN_PASSWORD=P4zzW)rd>>123_
     volumes:
-      - esdata-conductor:/usr/share/opensearch/data
+      - osdata-conductor:/usr/share/opensearch/data
     networks:
       - internal
     ports:
@@ -74,7 +74,7 @@ services:
         max-file: "3"
 
 volumes:
-  esdata-conductor:
+  osdata-conductor:
     driver: local
 
 networks:

--- a/docker/docker-compose-redis-os.yaml
+++ b/docker/docker-compose-redis-os.yaml
@@ -55,6 +55,7 @@ services:
       - node.name=conductor-opensearch # Name the node that will run in this container
       - discovery.seed_hosts=conductor-opensearch # Nodes to look for when discovering the cluster
       - cluster.initial_cluster_manager_nodes=conductor-opensearch # Nodes eligible to serve as cluster manager
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=P4zzW)rd>>123_
     volumes:
       - esdata-conductor:/usr/share/opensearch/data
     networks:

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 
     //Indexing (note: Elasticsearch 6 is deprecated)
     implementation project(':conductor-os-persistence')
+    implementation project(':conductor-es7-persistence')
 
 
     implementation project(':conductor-redis-lock')


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

- Include back `conductor-es7-persistence` to fix issues with existing configs which are using es7 (like `docker/docker-compose.yaml`).

**NOTES** 

This is the cause of this error when running `docker compose -f docker/docker-compose.yaml up`

```
conductor-server           | ***************************
conductor-server           | APPLICATION FAILED TO START
conductor-server           | ***************************
conductor-server           | 
conductor-server           | Description:
conductor-server           | 
conductor-server           | Parameter 2 of constructor in com.netflix.conductor.core.dal.ExecutionDAOFacade required a bean of type 'com.netflix.conductor.dao.IndexDAO' that could not be found.
conductor-server           | 
conductor-server           | 
conductor-server           | Action:
conductor-server           | 
conductor-server           | Consider defining a bean of type 'com.netflix.conductor.dao.IndexDAO' in your configuration.
conductor-server           | 
```

indexing is enabled with es7 config but since was removed no `IndexDAO` implementation is loaded in the context.