### PR TITLE
Fix task def name npe

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
@@ -530,10 +530,10 @@ public class WorkflowTask {
     }
 
     /**
-     * Sets the TaskDef for this instance. If the passed TaskDef does not have a name,
-     * this method will set it to the name of the current instance.
+     * Sets the TaskDef for this instance. If the passed TaskDef does not have a name, this method
+     * will set it to the name of the current instance.
      *
-     * NOTE: This method mutates the passed TaskDef object.
+     * <p>NOTE: This method mutates the passed TaskDef object.
      *
      * @param taskDefinition The TaskDef to set. It may be modified by this method.
      */

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
@@ -533,6 +533,9 @@ public class WorkflowTask {
      * @param taskDefinition Task definition
      */
     public void setTaskDefinition(TaskDef taskDefinition) {
+        if (taskDefinition != null && taskDefinition.getName() == null) {
+            taskDefinition.setName(this.name);
+        }
         this.taskDefinition = taskDefinition;
     }
 

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
@@ -538,7 +538,7 @@ public class WorkflowTask {
      * @param taskDefinition The TaskDef to set. It may be modified by this method.
      */
     public void setTaskDefinition(TaskDef taskDefinition) {
-        if (taskDefinition != null) {
+        if (taskDefinition != null && taskDefinition.getName() == null) {
             taskDefinition.setName(this.name);
         }
         this.taskDefinition = taskDefinition;

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
@@ -530,10 +530,15 @@ public class WorkflowTask {
     }
 
     /**
-     * @param taskDefinition Task definition
+     * Sets the TaskDef for this instance. If the passed TaskDef does not have a name,
+     * this method will set it to the name of the current instance.
+     *
+     * NOTE: This method mutates the passed TaskDef object.
+     *
+     * @param taskDefinition The TaskDef to set. It may be modified by this method.
      */
     public void setTaskDefinition(TaskDef taskDefinition) {
-        if (taskDefinition != null && taskDefinition.getName() == null) {
+        if (taskDefinition != null) {
             taskDefinition.setName(this.name);
         }
         this.taskDefinition = taskDefinition;

--- a/common/src/test/java/com/netflix/conductor/common/workflow/WorkflowTaskTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/workflow/WorkflowTaskTest.java
@@ -16,9 +16,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import org.junit.Test;
 
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 

--- a/common/src/test/java/com/netflix/conductor/common/workflow/WorkflowTaskTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/workflow/WorkflowTaskTest.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import org.junit.Test;
 
 import com.netflix.conductor.common.metadata.tasks.TaskType;
@@ -29,6 +30,7 @@ import jakarta.validation.ValidatorFactory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class WorkflowTaskTest {
@@ -75,5 +77,25 @@ public class WorkflowTaskTest {
         assertTrue(
                 validationErrors.contains(
                         "WorkflowTask taskReferenceName name cannot be empty or null"));
+    }
+
+    @Test
+    public void testSetTaskDefinition() {
+        WorkflowTask workflowTask = new WorkflowTask();
+        TaskDef taskDef = new TaskDef();
+
+        // Case 1: taskDefinition is not null and taskDefinition.getName() is null
+        taskDef.setName(null);
+        workflowTask.setTaskDefinition(taskDef);
+        assertEquals(workflowTask.getName(), taskDef.getName());
+
+        // Case 2: taskDefinition is not null and taskDefinition.getName() is not null
+        taskDef.setName("existingName");
+        workflowTask.setTaskDefinition(taskDef);
+        assertEquals("existingName", taskDef.getName());
+
+        // Case 3: taskDefinition is null
+        workflowTask.setTaskDefinition(null);
+        assertNull(workflowTask.getTaskDefinition());
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
About the taskDef npe exception for http tasks!
When task definition is not provided and we are trying to use inputSchema in task, then during deserialisation, name will be set to null.  We never checked for taskDef name before so never faced issue.

Fix:
----
Check if taskdef.getName() is null then set taskName.

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
