### PR TITLE
Use UTC timestamp in PostgresQueueListenerTest

### DIFF
--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/util/PostgresQueueListenerTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/util/PostgresQueueListenerTest.java
@@ -99,7 +99,7 @@ public class PostgresQueueListenerTest {
             conn.setAutoCommit(true);
             PreparedStatement stmt =
                     conn.prepareStatement(
-                            "INSERT INTO queue_message (deliver_on, queue_name, message_id, priority, offset_time_seconds, payload) VALUES (current_timestamp, ?,?,?,?,?)");
+                            "INSERT INTO queue_message (deliver_on, queue_name, message_id, priority, offset_time_seconds, payload) VALUES (current_timestamp AT TIME ZONE 'UTC', ?,?,?,?,?)");
             stmt.setString(1, queue_name);
             stmt.setString(2, message_id);
             stmt.setInt(3, 0);


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

All timestamps generated in the DB are based on the current time (local time), while we use `System.currentTimeMillis()`, in the code to compare, which generates a UTC epoch ms offset. This change is needed for me to run this test successfully locally.

**It does have me a bit worried that current_timestamp  is used everywhere in the Conductor PG DAO code. While in the Java code, UTC epoch is used. Haven't seen this be a problem in practice, though. I guess most DBs are set to use UTC as its machine time anyways.**
