### PR TITLE
Redisson DNS Monitoring Interval

### DIFF
--- a/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockConfiguration.java
+++ b/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockConfiguration.java
@@ -65,7 +65,8 @@ public class RedisLockConfiguration {
                         .useSingleServer()
                         .setAddress(redisServerAddress)
                         .setPassword(redisServerPassword)
-                        .setTimeout(connectionTimeout);
+                        .setTimeout(connectionTimeout)
+                        .setDnsMonitoringInterval(properties.getDnsMonitoringInterval());
                 break;
             case CLUSTER:
                 LOGGER.info("Setting up Redis Cluster for RedisLockConfiguration");
@@ -82,7 +83,8 @@ public class RedisLockConfiguration {
                         .setMasterConnectionMinimumIdleSize(
                                 properties.getClusterPrimaryConnectionMinIdleSize())
                         .setMasterConnectionPoolSize(
-                                properties.getClusterPrimaryConnectionPoolSize());
+                                properties.getClusterPrimaryConnectionPoolSize())
+                        .setDnsMonitoringInterval(properties.getDnsMonitoringInterval());
                 break;
             case SENTINEL:
                 LOGGER.info("Setting up Redis Sentinel Servers for RedisLockConfiguration");
@@ -92,7 +94,8 @@ public class RedisLockConfiguration {
                         .setMasterName(masterName)
                         .addSentinelAddress(redisServerAddress)
                         .setPassword(redisServerPassword)
-                        .setTimeout(connectionTimeout);
+                        .setTimeout(connectionTimeout)
+                        .setDnsMonitoringInterval(properties.getDnsMonitoringInterval());
                 break;
         }
 

--- a/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockProperties.java
+++ b/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockProperties.java
@@ -53,6 +53,9 @@ public class RedisLockProperties {
      */
     private boolean ignoreLockingExceptions = false;
 
+    /** Interval in milliseconds to check the endpoint's DNS (Set -1 to disable). */
+    private long dnsMonitoringInterval = 5000L;
+
     public REDIS_SERVER_TYPE getServerType() {
         return serverType;
     }
@@ -141,6 +144,14 @@ public class RedisLockProperties {
 
     public void setClusterPrimaryConnectionPoolSize(Integer clusterPrimaryConnectionPoolSize) {
         this.clusterPrimaryConnectionPoolSize = clusterPrimaryConnectionPoolSize;
+    }
+
+    public long getDnsMonitoringInterval() {
+        return dnsMonitoringInterval;
+    }
+
+    public void setDnsMonitoringInterval(long dnsMonitoringInterval) {
+        this.dnsMonitoringInterval = dnsMonitoringInterval;
     }
 
     public enum REDIS_SERVER_TYPE {


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

- Add _property_ to override the default _DNS Monitoring Interval_ setting from `Redisson` (5s), allowing it to be increased or even disabled.

🔗  Reference
---

- [Redisson DNS Monitoring Interval Javadoc](https://javadoc.io/doc/org.redisson/redisson/3.13.3/org/redisson/config/SingleServerConfig.html#setDnsMonitoringInterval-long-)

![Redisson Javadoc](https://github.com/user-attachments/assets/8adc3df6-78c1-4ba2-ab1d-4edbf157388f)

