### PR TITLE
Redis Health Indicator for Spring Actuator

### DIFF
--- a/docker/server/config/config-redis-os.properties
+++ b/docker/server/config/config-redis-os.properties
@@ -28,7 +28,10 @@ conductor.elasticsearch.clusterHealthColor=green
 
 # Additional modules for metrics collection exposed to Prometheus (optional)
 conductor.metrics-prometheus.enabled=true
-management.endpoints.web.exposure.include=prometheus
+management.endpoints.web.exposure.include=health,prometheus
+
+# Redis health indicator
+management.health.redis.enabled=true
 
 # Load sample kitchen sink workflow
 loadSample=true

--- a/docker/server/config/config-redis.properties
+++ b/docker/server/config/config-redis.properties
@@ -25,7 +25,10 @@ conductor.elasticsearch.clusterHealthColor=yellow
 
 # Additional modules for metrics collection exposed to Prometheus (optional)
 conductor.metrics-prometheus.enabled=true
-management.endpoints.web.exposure.include=prometheus
+management.endpoints.web.exposure.include=health,prometheus
+
+# Redis health indicator
+management.health.redis.enabled=true
 
 # Load sample kitchen sink workflow
 loadSample=true

--- a/redis-lock/build.gradle
+++ b/redis-lock/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 
     implementation "org.apache.commons:commons-lang3"
     implementation "org.redisson:redisson:${revRedisson}"
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     testImplementation "org.testcontainers:testcontainers:${revTestContainer}"
 }

--- a/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisHealthIndicator.java
+++ b/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisHealthIndicator.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.redislock.config;
+
+import org.redisson.api.RedissonClient;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.redisson.api.redisnode.RedisNodes.*;
+
+@Component
+@ConditionalOnProperty(name = "management.health.redis.enabled", havingValue = "true")
+public class RedisHealthIndicator implements HealthIndicator {
+    private final RedissonClient redisClient;
+    private final RedisLockProperties redisProperties;
+
+    public RedisHealthIndicator(RedissonClient redisClient, RedisLockProperties redisProperties) {
+        this.redisClient = redisClient;
+        this.redisProperties = redisProperties;
+    }
+
+    @Override
+    public Health health() {
+        return isHealth() ? Health.up().build() : Health.down().build();
+    }
+
+    private boolean isHealth() {
+        switch (redisProperties.getServerType()) {
+            case SINGLE -> {
+                return redisClient.getRedisNodes(SINGLE).pingAll(5, SECONDS);
+            }
+
+            case CLUSTER -> {
+                return redisClient.getRedisNodes(CLUSTER).pingAll(5, SECONDS);
+            }
+
+            case SENTINEL -> {
+                return redisClient.getRedisNodes(SENTINEL_MASTER_SLAVE).pingAll(5, SECONDS);
+            }
+
+            default -> {
+                return false;
+            }
+        }
+    }
+}

--- a/redis-lock/src/test/java/com/netflix/conductor/redislock/config/RedisHealthIndicatorTest.java
+++ b/redis-lock/src/test/java/com/netflix/conductor/redislock/config/RedisHealthIndicatorTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.redislock.config;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.redisson.api.RedissonClient;
+import org.redisson.redisnode.RedissonClusterNodes;
+import org.redisson.redisnode.RedissonSentinelMasterSlaveNodes;
+import org.redisson.redisnode.RedissonSingleNode;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static com.netflix.conductor.redislock.config.RedisLockProperties.REDIS_SERVER_TYPE.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringRunner.class)
+public class RedisHealthIndicatorTest {
+
+    @Mock private RedissonClient redissonClient;
+
+    @Test
+    public void shouldReturnAsHealthWhenServerTypeIsSingle() {
+        // Given a Redisson client
+        var redisProperties = new RedisLockProperties();
+        redisProperties.setServerType(SINGLE);
+
+        // And its mocks
+        var redisNode = Mockito.mock(RedissonSingleNode.class);
+        when(redissonClient.getRedisNodes(any())).thenReturn(redisNode);
+        when(redisNode.pingAll(anyLong(), any(TimeUnit.class))).thenReturn(true);
+
+        // When execute a health indicator
+        var actualHealth = new RedisHealthIndicator(redissonClient, redisProperties);
+
+        // Then should return as health
+        assertThat(actualHealth.health()).isEqualTo(Health.up().build());
+    }
+
+    @Test
+    public void shouldReturnAsHealthWhenServerTypeIsCluster() {
+        // Given a Redisson client
+        var redisProperties = new RedisLockProperties();
+        redisProperties.setServerType(CLUSTER);
+
+        // And its mocks
+        var redisNode = Mockito.mock(RedissonClusterNodes.class);
+        when(redissonClient.getRedisNodes(any())).thenReturn(redisNode);
+        when(redisNode.pingAll(anyLong(), any(TimeUnit.class))).thenReturn(true);
+
+        // When execute a health indicator
+        var actualHealth = new RedisHealthIndicator(redissonClient, redisProperties);
+
+        // Then should return as health
+        assertThat(actualHealth.health()).isEqualTo(Health.up().build());
+    }
+
+    @Test
+    public void shouldReturnAsHealthWhenServerTypeIsSentinel() {
+        // Given a Redisson client
+        var redisProperties = new RedisLockProperties();
+        redisProperties.setServerType(SENTINEL);
+
+        // And its mocks
+        var redisNode = Mockito.mock(RedissonSentinelMasterSlaveNodes.class);
+        when(redissonClient.getRedisNodes(any())).thenReturn(redisNode);
+        when(redisNode.pingAll(anyLong(), any(TimeUnit.class))).thenReturn(true);
+
+        // When execute a health indicator
+        var actualHealth = new RedisHealthIndicator(redissonClient, redisProperties);
+
+        // Then should return as health
+        assertThat(actualHealth.health()).isEqualTo(Health.up().build());
+    }
+
+    @Test
+    public void shouldReturnAsUnhealthyWhenAnyServerIsDown() {
+        // Given a Redisson client
+        var redisProperties = new RedisLockProperties();
+        redisProperties.setServerType(SINGLE);
+
+        // And its mocks
+        var redisNode = Mockito.mock(RedissonSingleNode.class);
+        when(redissonClient.getRedisNodes(any())).thenReturn(redisNode);
+        when(redisNode.pingAll(anyLong(), any(TimeUnit.class))).thenReturn(false);
+
+        // When execute a health indicator
+        var actualHealth = new RedisHealthIndicator(redissonClient, redisProperties);
+
+        // Then should return as unhealthy
+        assertThat(actualHealth.health()).isEqualTo(Health.down().build());
+    }
+}


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

- Adds a  _Health Indicator_ component for **Redis**, allowing it to be part of _Spring Actuator_ monitoring ecosystem.


Illustrations
---

```
curl --location 'http://localhost:8080/actuator/health/'
```
![Actuator Health](https://github.com/user-attachments/assets/f5c21b22-be11-4b84-9604-3eda85a4b5ce)

```
curl --location 'http://localhost:8080/actuator/health/redis'
```
![Actuator Redis Health](https://github.com/user-attachments/assets/c6cdb5c6-3c1f-41cf-8661-4aeea4190c86)


