### PR TITLE
Added support to bind workflow instance id to parameter for worker task in SDK

### DIFF
--- a/conductor-clients/java/conductor-java-sdk/sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorker.java
+++ b/conductor-clients/java/conductor-java-sdk/sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorker.java
@@ -124,7 +124,7 @@ public class AnnotatedWorker implements Worker {
             Annotation[] paramAnnotation = parameterAnnotations[i];
             if(containsWorkflowInstanceIdInputParamAnnotation(paramAnnotation)) {
                 validateParameterForWorkflowInstanceId(parameters[i]);
-                values[i] = getWorkflowInstanceId(task, parameters[i]);
+                values[i] = task.getWorkflowInstanceId();
             } else if (paramAnnotation.length > 0) {
                 Type type = parameters[i].getParameterizedType();
                 Class<?> parameterType = parameterTypes[i];
@@ -144,18 +144,10 @@ public class AnnotatedWorker implements Worker {
     }
 
     private void validateParameterForWorkflowInstanceId(Parameter parameter) {
-        if(!parameter.getType().equals(String.class) && !parameter.getType().equals(UUID.class)) {
+        if(!parameter.getType().equals(String.class)) {
             throw new IllegalArgumentException(
                     "Parameter " + parameter + " is annotated with " + WorkflowInstanceIdInputParam.class.getSimpleName() +
-                            " but is not of type " + String.class.getSimpleName() + " or " + UUID.class.getSimpleName() + ".");
-        }
-    }
-
-    private Object getWorkflowInstanceId(final Task task, final Parameter parameter) {
-        if(parameter.getType().equals(String.class)) {
-            return task.getWorkflowInstanceId();
-        } else {
-            return UUID.fromString(task.getWorkflowInstanceId());
+                            " but is not of type " + String.class.getSimpleName() + ".");
         }
     }
 

--- a/conductor-clients/java/conductor-java-sdk/sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorker.java
+++ b/conductor-clients/java/conductor-java-sdk/sdk/src/main/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorker.java
@@ -18,11 +18,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import com.netflix.conductor.client.worker.Worker;
 import com.netflix.conductor.common.config.ObjectMapperProvider;
@@ -128,7 +124,7 @@ public class AnnotatedWorker implements Worker {
             Annotation[] paramAnnotation = parameterAnnotations[i];
             if(containsWorkflowInstanceIdInputParamAnnotation(paramAnnotation)) {
                 validateParameterForWorkflowInstanceId(parameters[i]);
-                values[i] = task.getWorkflowInstanceId();
+                values[i] = getWorkflowInstanceId(task, parameters[i]);
             } else if (paramAnnotation.length > 0) {
                 Type type = parameters[i].getParameterizedType();
                 Class<?> parameterType = parameterTypes[i];
@@ -148,10 +144,18 @@ public class AnnotatedWorker implements Worker {
     }
 
     private void validateParameterForWorkflowInstanceId(Parameter parameter) {
-        if(!parameter.getType().equals(String.class)){
+        if(!parameter.getType().equals(String.class) && !parameter.getType().equals(UUID.class)) {
             throw new IllegalArgumentException(
                     "Parameter " + parameter + " is annotated with " + WorkflowInstanceIdInputParam.class.getSimpleName() +
-                            " but is not of type " + String.class.getSimpleName() + ".");
+                            " but is not of type " + String.class.getSimpleName() + " or " + UUID.class.getSimpleName() + ".");
+        }
+    }
+
+    private Object getWorkflowInstanceId(final Task task, final Parameter parameter) {
+        if(parameter.getType().equals(String.class)) {
+            return task.getWorkflowInstanceId();
+        } else {
+            return UUID.fromString(task.getWorkflowInstanceId());
         }
     }
 

--- a/conductor-clients/java/conductor-java-sdk/sdk/src/main/java/com/netflix/conductor/sdk/workflow/task/WorkflowInstanceIdInputParam.java
+++ b/conductor-clients/java/conductor-java-sdk/sdk/src/main/java/com/netflix/conductor/sdk/workflow/task/WorkflowInstanceIdInputParam.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.sdk.workflow.task;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This can be used to access the workflow instance id of the initiating workflow in the worker task.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface WorkflowInstanceIdInputParam {
+}

--- a/conductor-clients/java/conductor-java-sdk/sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerTests.java
+++ b/conductor-clients/java/conductor-java-sdk/sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerTests.java
@@ -310,7 +310,7 @@ public class AnnotatedWorkerTests {
         assertEquals(2, taskThreadCount.get("test_2"));
     }
 
-    static class WorkflowInstanceIdInputParamWorker {
+    static class WorkflowInstanceIdInputParamAsStringWorker {
         @WorkerTask(value = "test_1", threadCount = 3, pollingInterval = 333)
         public Map<String, Object> doWork(
                 @WorkflowInstanceIdInputParam String workflowInstanceId) {
@@ -319,9 +319,9 @@ public class AnnotatedWorkerTests {
     }
 
     @Test
-    @DisplayName("it should handle workflowinstanceid input param")
-    void workflowInstanceIdInputParam() throws NoSuchMethodException {
-        var worker = new WorkflowInstanceIdInputParamWorker();
+    @DisplayName("it should handle workflow instance id input param for String parameter type")
+    void workflowInstanceIdInputParamAsString() throws NoSuchMethodException {
+        var worker = new WorkflowInstanceIdInputParamAsStringWorker();
         var annotatedWorker =
                 new AnnotatedWorker(
                         "test_1",
@@ -341,6 +341,37 @@ public class AnnotatedWorkerTests {
         assertEquals(workflowInstanceId, actual);
     }
 
+    static class WorkflowInstanceIdInputParamAsUuidWorker {
+        @WorkerTask(value = "test_1", threadCount = 3, pollingInterval = 333)
+        public Map<String, Object> doWork(
+                @WorkflowInstanceIdInputParam UUID workflowInstanceId) {
+            return Map.of("workflowInstanceId", workflowInstanceId);
+        }
+    }
+
+    @Test
+    @DisplayName("it should handle workflow instance id input param for UUID parameter type")
+    void workflowInstanceIdInputParamAsUuid() throws NoSuchMethodException {
+        var worker = new WorkflowInstanceIdInputParamAsUuidWorker();
+        var annotatedWorker =
+                new AnnotatedWorker(
+                        "test_1",
+                        worker.getClass().getMethod("doWork", UUID.class),
+                        worker);
+
+        var task = new Task();
+        var workflowInstanceId = UUID.randomUUID();
+        task.setWorkflowInstanceId(workflowInstanceId.toString());
+        task.setStatus(Task.Status.IN_PROGRESS);
+        task.setTaskId(UUID.randomUUID().toString());
+
+        var result0 = annotatedWorker.execute(task);
+        var outputData = result0.getOutputData();
+
+        var actual = (UUID) outputData.get("workflowInstanceId");
+        assertEquals(workflowInstanceId, actual);
+    }
+
     static class InvalidWorkflowInstanceIdInputParamWorker {
         @WorkerTask(value = "test_1", threadCount = 3, pollingInterval = 333)
         public Map<String, Object> doWork(
@@ -350,8 +381,8 @@ public class AnnotatedWorkerTests {
     }
 
     @Test
-    @DisplayName("it should handle workflowinstanceid input param")
-    void ionvalidWorkflowInstanceIdInputParam() throws NoSuchMethodException {
+    @DisplayName("it should throw exception if type of parameter is invalid for workflow instance id")
+    void invalidWorkflowInstanceIdInputParam() throws NoSuchMethodException {
         var worker = new InvalidWorkflowInstanceIdInputParamWorker();
         var annotatedWorker =
                 new AnnotatedWorker(

--- a/conductor-clients/java/conductor-java-sdk/sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerTests.java
+++ b/conductor-clients/java/conductor-java-sdk/sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerTests.java
@@ -341,37 +341,6 @@ public class AnnotatedWorkerTests {
         assertEquals(workflowInstanceId, actual);
     }
 
-    static class WorkflowInstanceIdInputParamAsUuidWorker {
-        @WorkerTask(value = "test_1", threadCount = 3, pollingInterval = 333)
-        public Map<String, Object> doWork(
-                @WorkflowInstanceIdInputParam UUID workflowInstanceId) {
-            return Map.of("workflowInstanceId", workflowInstanceId);
-        }
-    }
-
-    @Test
-    @DisplayName("it should handle workflow instance id input param for UUID parameter type")
-    void workflowInstanceIdInputParamAsUuid() throws NoSuchMethodException {
-        var worker = new WorkflowInstanceIdInputParamAsUuidWorker();
-        var annotatedWorker =
-                new AnnotatedWorker(
-                        "test_1",
-                        worker.getClass().getMethod("doWork", UUID.class),
-                        worker);
-
-        var task = new Task();
-        var workflowInstanceId = UUID.randomUUID();
-        task.setWorkflowInstanceId(workflowInstanceId.toString());
-        task.setStatus(Task.Status.IN_PROGRESS);
-        task.setTaskId(UUID.randomUUID().toString());
-
-        var result0 = annotatedWorker.execute(task);
-        var outputData = result0.getOutputData();
-
-        var actual = (UUID) outputData.get("workflowInstanceId");
-        assertEquals(workflowInstanceId, actual);
-    }
-
     static class InvalidWorkflowInstanceIdInputParamWorker {
         @WorkerTask(value = "test_1", threadCount = 3, pollingInterval = 333)
         public Map<String, Object> doWork(

--- a/conductor-clients/java/conductor-java-sdk/sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerTests.java
+++ b/conductor-clients/java/conductor-java-sdk/sdk/src/test/java/com/netflix/conductor/sdk/workflow/executor/task/AnnotatedWorkerTests.java
@@ -30,11 +30,10 @@ import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.sdk.workflow.task.InputParam;
 import com.netflix.conductor.sdk.workflow.task.OutputParam;
 import com.netflix.conductor.sdk.workflow.task.WorkerTask;
+import com.netflix.conductor.sdk.workflow.task.WorkflowInstanceIdInputParam;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.mock;
 
 public class AnnotatedWorkerTests {
@@ -309,5 +308,64 @@ public class AnnotatedWorkerTests {
         assertNotNull(taskThreadCount);
         assertEquals(3, taskThreadCount.get("test_1"));
         assertEquals(2, taskThreadCount.get("test_2"));
+    }
+
+    static class WorkflowInstanceIdInputParamWorker {
+        @WorkerTask(value = "test_1", threadCount = 3, pollingInterval = 333)
+        public Map<String, Object> doWork(
+                @WorkflowInstanceIdInputParam String workflowInstanceId) {
+            return Map.of("workflowInstanceId", workflowInstanceId);
+        }
+    }
+
+    @Test
+    @DisplayName("it should handle workflowinstanceid input param")
+    void workflowInstanceIdInputParam() throws NoSuchMethodException {
+        var worker = new WorkflowInstanceIdInputParamWorker();
+        var annotatedWorker =
+                new AnnotatedWorker(
+                        "test_1",
+                        worker.getClass().getMethod("doWork", String.class),
+                        worker);
+
+        var task = new Task();
+        var workflowInstanceId = UUID.randomUUID().toString();
+        task.setWorkflowInstanceId(workflowInstanceId);
+        task.setStatus(Task.Status.IN_PROGRESS);
+        task.setTaskId(UUID.randomUUID().toString());
+
+        var result0 = annotatedWorker.execute(task);
+        var outputData = result0.getOutputData();
+
+        var actual = (String) outputData.get("workflowInstanceId");
+        assertEquals(workflowInstanceId, actual);
+    }
+
+    static class InvalidWorkflowInstanceIdInputParamWorker {
+        @WorkerTask(value = "test_1", threadCount = 3, pollingInterval = 333)
+        public Map<String, Object> doWork(
+                @WorkflowInstanceIdInputParam int workflowInstanceId) {
+            return Map.of("workflowInstanceId", workflowInstanceId);
+        }
+    }
+
+    @Test
+    @DisplayName("it should handle workflowinstanceid input param")
+    void ionvalidWorkflowInstanceIdInputParam() throws NoSuchMethodException {
+        var worker = new InvalidWorkflowInstanceIdInputParamWorker();
+        var annotatedWorker =
+                new AnnotatedWorker(
+                        "test_1",
+                        worker.getClass().getMethod("doWork", int.class),
+                        worker);
+
+        var task = new Task();
+        var workflowInstanceId = UUID.randomUUID().toString();
+        task.setWorkflowInstanceId(workflowInstanceId);
+        task.setStatus(Task.Status.IN_PROGRESS);
+        task.setTaskId(UUID.randomUUID().toString());
+
+        final RuntimeException runtimeException = assertThrows(RuntimeException.class, () -> annotatedWorker.execute(task));
+        assertInstanceOf(IllegalArgumentException.class, runtimeException.getCause());
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

Added annotation WorkflowInstanceIdInputParam to the SDK. This can be used on a String parameter of a WorkerTask method. The parameter will be assigned the value of the workflowInstanceId if it is annotated with the WorkflowInstanceIdInputParam. 

The workflowInstanceId is useful for persisting with entities in a data store and for logging purposes. The alternative is to have a Task type parameter and get it from there, but it cannot be combined with the InputParam annotation. It's also more elegant to use an annotation.

Alternatives considered
----

_Describe alternative implementation you have considered_
