### PR TITLE
Java Client v4 - Added `MetadataUtils`

### DIFF
--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/common/utils/MetadataUtils.java
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/main/java/com/netflix/conductor/common/utils/MetadataUtils.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.common.utils;
+
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.Objects;
+
+import com.netflix.conductor.common.config.ObjectMapperProvider;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+
+public final class MetadataUtils {
+
+    private static final ObjectMapper objectMapper = new ObjectMapperProvider().getObjectMapper();
+
+    /**
+     * Returns true is both workflow definitions have matching checksums.
+     *
+     * @param def0
+     * @param def1
+     * @return
+     */
+    public static boolean areChecksumsEqual(WorkflowDef def0, WorkflowDef def1) {
+        String checksum1 = computeChecksum(def0);
+        String checksum2 = computeChecksum(def1);
+        return checksum2.equals(checksum1);
+    }
+
+    /**
+     * Returns the computed checksum for the workflowDefinition.
+     *
+     * @param workflowDef
+     * @return
+     */
+    @SneakyThrows
+    public static String computeChecksum(WorkflowDef workflowDef) {
+        Objects.requireNonNull(workflowDef, "WorkflowDef must not be null");
+        //TODO consider replacing this client-side implementation with a call to the server in MetadataClient.
+        WorkflowDef def = objectMapper.readValue(objectMapper.writeValueAsString(workflowDef), WorkflowDef.class);
+        def.setCreateTime(0L);
+        def.setUpdateTime(0L);
+        def.setOwnerEmail(null);
+        def.collectTasks().forEach(task -> {
+            if (task.getTaskDefinition() != null) {
+                task.getTaskDefinition().setCreateTime(0L);
+                task.getTaskDefinition().setUpdateTime(0L);
+                task.getTaskDefinition().setOwnerEmail("ignored@orkes.io");
+            }
+        });
+        byte[] bytes = objectMapper.writeValueAsBytes(def);
+        return encode(MessageDigest.getInstance("MD5").digest(bytes));
+    }
+
+    private static String encode(byte[] bytes) {
+        return Base64.getEncoder().encodeToString(bytes);
+    }
+}

--- a/conductor-clients/java/conductor-java-sdk/conductor-client/src/test/groovy/com/netflix/conductor/common/utils/MetadataUtilsSpec.groovy
+++ b/conductor-clients/java/conductor-java-sdk/conductor-client/src/test/groovy/com/netflix/conductor/common/utils/MetadataUtilsSpec.groovy
@@ -1,0 +1,68 @@
+package com.netflix.conductor.common.utils
+
+
+import com.netflix.conductor.common.metadata.tasks.TaskDef
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask
+import spock.lang.Specification
+
+class MetadataUtilsSpec extends Specification {
+
+    def "computed checksum matches"() {
+        given:
+          def wf0 = getWorkflowDef("someone@mail.com")
+          def wf1 = getWorkflowDef("someone_else@mail.com")
+
+        when:
+          def checksum0 = MetadataUtils.computeChecksum(wf0)
+          def checksum1 = MetadataUtils.computeChecksum(wf1)
+        then:
+          checksum0 != null
+          checksum0 == checksum1
+          MetadataUtils.areChecksumsEqual(wf0, wf1)
+    }
+
+    def "computed checksum does not match"() {
+        given:
+          def wf0 = getWorkflowDef("someone@mail.com")
+          def wf1 = getWorkflowDef("someone_else@mail.com")
+          wf1.setDescription("A change in the description")
+        when:
+          def checksum0 = MetadataUtils.computeChecksum(wf0)
+          def checksum1 = MetadataUtils.computeChecksum(wf1)
+        then:
+          checksum0 != null
+          checksum0 != checksum1
+          !MetadataUtils.areChecksumsEqual(wf0, wf1)
+    }
+
+    private static WorkflowDef getWorkflowDef(String owner) {
+        def wfDef = new WorkflowDef()
+        wfDef.setDescription("A sample workflow")
+        wfDef.setName("test_workflow")
+        wfDef.setVersion(1)
+        wfDef.setOwnerEmail(owner)
+        wfDef.setUpdateTime(System.currentTimeMillis())
+        wfDef.setCreateTime(System.currentTimeMillis())
+
+        var wfTask0 = new WorkflowTask()
+        wfTask0.setName("task0")
+        wfTask0.setTaskReferenceName("task0_ref")
+        wfTask0.setDescription("Task 0")
+        wfTask0.setType("SIMPLE")
+        var taskDef = new TaskDef();
+        taskDef.setName("task0")
+        taskDef.setUpdateTime(System.currentTimeMillis())
+        taskDef.setCreateTime(System.currentTimeMillis())
+        taskDef.setOwnerEmail(owner)
+
+        var wfTask1 = new WorkflowTask()
+        wfTask0.setName("task1")
+        wfTask0.setTaskReferenceName("task1_ref")
+        wfTask0.setDescription("Task 1")
+        wfTask0.setType("SIMPLE")
+
+        wfDef.setTasks([wfTask0, wfTask1])
+        return wfDef;
+    }
+}


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

Added `MetadataUtils` which provides utility methods to compute the checksum of workflow definitions.

This can be used to check (deep) equality of workflow definitions. The `equals` method of `WorkflowDef` does only an [identity based equality](https://github.com/conductor-oss/conductor/pull/194/files#diff-3c09838bf1a1aa802fb98802bb75bedbd7058684c6aee78a2645a9937b7b491d) in the Client and Backend.

