### PR TITLE
Add missing createdBy field to fix workflow search endpoint

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
@@ -133,6 +133,7 @@ public class WorkflowSummary {
         if (StringUtils.isNotBlank(workflow.getExternalOutputPayloadStoragePath())) {
             this.externalOutputPayloadStoragePath = workflow.getExternalOutputPayloadStoragePath();
         }
+        this.createdBy = workflow.getCreatedBy();
     }
 
     /**


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----
The `createdBy` field is lost when `Workflow` gets wrapped into `WorkflowSummary`, leading to null `createdBy` fields in the workflow search endpoint