### PR TITLE
Fix sweeper locking: expose both a decide with lock and without lock

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -194,7 +194,7 @@ public class AsyncSystemTaskExecutor {
             }
             // if the current task execution has completed, then the workflow needs to be evaluated
             if (hasTaskExecutionCompleted) {
-                workflowExecutor.decide(workflowId);
+                workflowExecutor.decideWithLock(workflowId);
             }
         }
     }

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -103,7 +103,13 @@ public interface WorkflowExecutor {
      * @param workflowId id of the workflow to be evaluated
      * @return updated workflow
      */
-    WorkflowModel decide(String workflowId);
+    WorkflowModel decideWithLock(String workflowId);
+
+    /**
+     * @param workflowId id of the workflow to be evaluated
+     * @return updated workflow
+     */
+    WorkflowModel decideWithoutLock(String workflowId);
 
     /**
      * @param workflowId id of the workflow to be terminated

--- a/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowSweeper.java
+++ b/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowSweeper.java
@@ -91,7 +91,7 @@ public class WorkflowSweeper {
                 workflowRepairService.verifyAndRepairWorkflowTasks(workflow);
             }
             long decideStartTime = System.currentTimeMillis();
-            workflow = workflowExecutor.decide(workflow.getWorkflowId());
+            workflow = workflowExecutor.decideWithoutLock(workflow.getWorkflowId());
             Monitors.recordWorkflowDecisionTime(System.currentTimeMillis() - decideStartTime);
             if (workflow != null && workflow.getStatus().isTerminal()) {
                 queueDAO.remove(DECIDER_QUEUE, workflowId);

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowServiceImpl.java
@@ -238,7 +238,7 @@ public class WorkflowServiceImpl implements WorkflowService {
      * @param workflowId WorkflowId of the workflow.
      */
     public void decideWorkflow(String workflowId) {
-        workflowExecutor.decide(workflowId);
+        workflowExecutor.decideWithLock(workflowId);
     }
 
     /**

--- a/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
@@ -248,7 +248,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         1 * queueDAO.postpone(queueName, taskId, task.workflowPriority, properties.systemTaskWorkerCallbackDuration.seconds)
         1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.IN_PROGRESS }
 
-        0 * workflowExecutor.decide(workflowId) // verify that workflow is NOT decided
+        0 * workflowExecutor.decideWithLock(workflowId) // verify that workflow is NOT decided
 
         task.status == TaskModel.Status.IN_PROGRESS
         task.startTime != 0 // verify that startTime is set
@@ -276,7 +276,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
 
         1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.COMPLETED }
         1 * queueDAO.remove(queueName, taskId)
-        1 * workflowExecutor.decide(workflowId) // verify that workflow is decided
+        1 * workflowExecutor.decideWithLock(workflowId) // verify that workflow is decided
 
         task.status == TaskModel.Status.COMPLETED
         task.startTime != 0 // verify that startTime is set
@@ -307,7 +307,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
             throw new RuntimeException("unknown system task failure")
         }
 
-        0 * workflowExecutor.decide(workflowId) // verify that workflow is NOT decided
+        0 * workflowExecutor.decideWithLock(workflowId) // verify that workflow is NOT decided
 
         task.status == TaskModel.Status.IN_PROGRESS
         task.startTime != 0 // verify that startTime is set
@@ -336,7 +336,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.IN_PROGRESS }
         1 * queueDAO.remove(queueName, taskId)
 
-        1 * workflowExecutor.decide(workflowId) // verify that workflow is decided
+        1 * workflowExecutor.decideWithLock(workflowId) // verify that workflow is decided
 
         task.status == TaskModel.Status.IN_PROGRESS
         task.startTime != 0 // verify that startTime is set

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -2091,7 +2091,7 @@ public class TestWorkflowExecutor {
                 .thenReturn(workflow);
         when(executionLockService.acquireLock(anyString())).thenReturn(true);
 
-        workflowExecutor.decide(workflow.getWorkflowId());
+        workflowExecutor.decideWithLock(workflow.getWorkflowId());
 
         assertEquals(WorkflowModel.Status.FAILED, workflow.getStatus());
         assertTrue(workflow.getOutput().containsKey("conductor.failure_workflow"));

--- a/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/WorkflowServiceTest.java
@@ -271,7 +271,7 @@ public class WorkflowServiceTest {
     @Test
     public void testDecideWorkflow() {
         workflowService.decideWorkflow("test");
-        verify(workflowExecutor, times(1)).decide(anyString());
+        verify(workflowExecutor, times(1)).decideWithLock(anyString());
     }
 
     @Test

--- a/kafka/src/test/groovy/com/netflix/conductor/test/integration/KafkaPublishTaskSpec.groovy
+++ b/kafka/src/test/groovy/com/netflix/conductor/test/integration/KafkaPublishTaskSpec.groovy
@@ -70,7 +70,7 @@ class KafkaPublishTaskSpec extends AbstractSpecification {
         workflowExecutionService.updateTask(taskResult)
 
         and: "Then run a decide to move the workflow forward"
-        workflowExecutor.decide(workflowInstanceId)
+        workflowExecutor.decideWithLock(workflowInstanceId)
 
         and: "Get the updated workflow after the task result has been updated"
         def updatedWorkflow = workflowExecutionService.getExecutionStatus(workflowInstanceId, true)
@@ -115,7 +115,7 @@ class KafkaPublishTaskSpec extends AbstractSpecification {
         workflowExecutionService.updateTask(taskResult)
 
         and: "Then run a decide to move the workflow forward"
-        workflowExecutor.decide(workflowInstanceId)
+        workflowExecutor.decideWithLock(workflowInstanceId)
 
         and: "Get the updated workflow after the task result has been updated"
         def updatedWorkflow = workflowExecutionService.getExecutionStatus(workflowInstanceId, true)

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/HierarchicalForkJoinSubworkflowRerunSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/HierarchicalForkJoinSubworkflowRerunSpec.groovy
@@ -85,7 +85,7 @@ class HierarchicalForkJoinSubworkflowRerunSpec extends AbstractSpecification {
                 correlationId, input, null)
 
         then: "verify that the workflow is in a RUNNING state"
-        workflowExecutor.decide(rootWorkflowId)
+        workflowExecutor.decideWithLock(rootWorkflowId)
         with(workflowExecutionService.getExecutionStatus(rootWorkflowId, true)) {
             status == Workflow.WorkflowStatus.RUNNING
             tasks.size() == 4
@@ -120,7 +120,7 @@ class HierarchicalForkJoinSubworkflowRerunSpec extends AbstractSpecification {
 
         and: "verify that the mid-level workflow is RUNNING, and first task is in SCHEDULED state"
         midLevelWorkflowId = rootWorkflowInstance.tasks[1].subWorkflowId
-        workflowExecutor.decide(midLevelWorkflowId)
+        workflowExecutor.decideWithLock(midLevelWorkflowId)
         with(workflowExecutionService.getExecutionStatus(midLevelWorkflowId, true)) {
             status == Workflow.WorkflowStatus.RUNNING
             tasks.size() == 4
@@ -254,7 +254,7 @@ class HierarchicalForkJoinSubworkflowRerunSpec extends AbstractSpecification {
 
         then: "verify that a new mid level workflow is created and is in RUNNING state"
         newMidLevelWorkflowId != midLevelWorkflowId
-        workflowExecutor.decide(newMidLevelWorkflowId)
+        workflowExecutor.decideWithLock(newMidLevelWorkflowId)
         with(workflowExecutionService.getExecutionStatus(newMidLevelWorkflowId, true)) {
             status == Workflow.WorkflowStatus.RUNNING
             tasks.size() == 4

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/SimpleWorkflowSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/SimpleWorkflowSpec.groovy
@@ -265,7 +265,7 @@ class SimpleWorkflowSpec extends AbstractSpecification {
 
         when: "The processing of the polled task takes more time than the response time out"
         Thread.sleep(10000)
-        workflowExecutor.decide(workflowInstanceId)
+        workflowExecutor.decideWithLock(workflowInstanceId)
 
         then: "Expect a new task to be added to the queue in place of the timed out task"
         queueDAO.getSize('task_rt') == 1
@@ -297,7 +297,7 @@ class SimpleWorkflowSpec extends AbstractSpecification {
         queueDAO.processUnacks(polledTaskRtTry2.taskDefName)
 
         and: "run the decide process on the workflow"
-        workflowExecutor.decide(workflowInstanceId)
+        workflowExecutor.decideWithLock(workflowInstanceId)
 
         and: "poll for the task and then complete the task 'task_rt' "
         def pollAndCompleteTaskTry3 = workflowTestUtil.pollAndCompleteTask('task_rt', 'task1.integration.worker.testTimeout', ['op': 'task1.done'])

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/WorkflowAndTaskConfigurationSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/WorkflowAndTaskConfigurationSpec.groovy
@@ -13,10 +13,8 @@
 package com.netflix.conductor.test.integration
 
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.TestPropertySource
 
-import com.netflix.conductor.ConductorTestApp
 import com.netflix.conductor.common.metadata.tasks.Task
 import com.netflix.conductor.common.metadata.tasks.TaskDef
 import com.netflix.conductor.common.metadata.tasks.TaskResult
@@ -106,7 +104,7 @@ class WorkflowAndTaskConfigurationSpec extends AbstractSpecification {
         verifyPolledAndAcknowledgedTask(polledAndFailedTaskTry1)
 
         when: "A decide is executed on the workflow"
-        workflowExecutor.decide(workflowInstanceId)
+        workflowExecutor.decideWithLock(workflowInstanceId)
 
         then: "verify that the workflow is still running and the first optional task has failed and the retry has kicked in"
         with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
@@ -121,7 +119,7 @@ class WorkflowAndTaskConfigurationSpec extends AbstractSpecification {
         when: "Poll the optional task again and do not complete it and run decide"
         workflowExecutionService.poll('task_optional', 'task1.integration.worker')
         Thread.sleep(5000)
-        workflowExecutor.decide(workflowInstanceId)
+        workflowExecutor.decideWithLock(workflowInstanceId)
 
         then: "Ensure that the workflow is updated"
         with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
@@ -178,7 +176,7 @@ class WorkflowAndTaskConfigurationSpec extends AbstractSpecification {
         verifyPolledAndAcknowledgedTask(polledAndFailedTaskTry1)
 
         when: "A decide is executed on the workflow"
-        workflowExecutor.decide(workflowInstanceId)
+        workflowExecutor.decideWithLock(workflowInstanceId)
 
         then: "verify that the workflow is still running and the first permissive task has failed and the retry has kicked in"
         with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
@@ -197,7 +195,7 @@ class WorkflowAndTaskConfigurationSpec extends AbstractSpecification {
         then: "Verify that the task_permissive was polled and acknowledged"
         verifyPolledAndAcknowledgedTask(polledAndFailedTaskTry2)
 
-        workflowExecutor.decide(workflowInstanceId)
+        workflowExecutor.decideWithLock(workflowInstanceId)
 
         then: "Ensure that the workflow is updated"
         with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
@@ -255,7 +253,7 @@ class WorkflowAndTaskConfigurationSpec extends AbstractSpecification {
         verifyPolledAndAcknowledgedTask(polledAndFailedTaskTry1)
 
         when: "A decide is executed on the workflow"
-        workflowExecutor.decide(workflowInstanceId)
+        workflowExecutor.decideWithLock(workflowInstanceId)
 
         then: "verify that the workflow is still running and the first permissive optional task has failed and the retry has kicked in"
         with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
@@ -270,7 +268,7 @@ class WorkflowAndTaskConfigurationSpec extends AbstractSpecification {
         when: "Poll the permissive optional task again and do not complete it and run decide"
         workflowExecutionService.poll('task_optional', 'task1.integration.worker')
         Thread.sleep(5000)
-        workflowExecutor.decide(workflowInstanceId)
+        workflowExecutor.decideWithLock(workflowInstanceId)
 
         then: "Ensure that the workflow is updated"
         with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
@@ -308,7 +306,7 @@ class WorkflowAndTaskConfigurationSpec extends AbstractSpecification {
         def workflowInstanceId = startWorkflow(TEMPLATED_LINEAR_WORKFLOW, 1,
                 correlationId, workflowInput,
                 null)
-        workflowExecutor.decide(workflowInstanceId)
+        workflowExecutor.decideWithLock(workflowInstanceId)
         def pollAndCompleteTask1Try1 = workflowTestUtil.pollAndCompleteTask('integration_task_1', 'task1.integration.worker', ['op': 'task1.done'])
 
         then: "Verify that input template is processed"
@@ -831,7 +829,7 @@ class WorkflowAndTaskConfigurationSpec extends AbstractSpecification {
         !task2Try1
 
         when: "A decide is run explicitly"
-        workflowExecutor.decide(workflowInstanceId)
+        workflowExecutor.decideWithLock(workflowInstanceId)
 
         and: "The next task is polled again"
         def task2Try2 = workflowExecutionService.poll('integration_task_2', 'task2.integration.worker')
@@ -885,7 +883,7 @@ class WorkflowAndTaskConfigurationSpec extends AbstractSpecification {
         Thread.sleep(3000)
 
         and: "A decide is executed on the workflow"
-        workflowExecutor.decide(workflowInstanceId)
+        workflowExecutor.decideWithLock(workflowInstanceId)
 
         then: "verify that the workflow is in running state and a replacement task has been scheduled due to time out"
         with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/resiliency/TaskResiliencySpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/resiliency/TaskResiliencySpec.groovy
@@ -90,7 +90,7 @@ class TaskResiliencySpec extends AbstractResiliencySpecification {
 
         when: "Running a repair and decide on the workflow"
         workflowRepairService.verifyAndRepairWorkflow(workflowInstanceId, true)
-        workflowExecutor.decide(workflowInstanceId)
+        workflowExecutor.decideWithLock(workflowInstanceId)
         workflowTestUtil.pollAndCompleteTask('integration_task_2', 'task2.integration.worker')
 
         then: "verify that the next scheduled task can be polled and executed successfully"


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix


Changes in this PR
----
HELP NEEDED: where should I best add a test for this fix?

Currently the `WorkflowSweeper` is a no-op, This issues causes workflows not to advance in case of an incomplete `updateTask` or when using subworkflows.

The current `sweeper` implementation takes a lock on the workflow level before calling `decide`. Within the decide method, another lock is attempted on the same key, which is then already taken, and the method returns without doing anything. 

In this PR, another method  `decideWithoutLock` is added to the `WorkflowExecutor`. The sweeper uses this new method, all other old callers use the decide with explicit locking.
