### PR TITLE
chore: add dep to support irsa role

### DIFF
--- a/awss3-storage/build.gradle
+++ b/awss3-storage/build.gradle
@@ -17,5 +17,6 @@ dependencies {
     compileOnly 'org.springframework.boot:spring-boot-starter'
 
     implementation "com.amazonaws:aws-java-sdk-s3:${revAwsSdk}"
+    implementation "com.amazonaws:aws-java-sdk-sts:${revAwsSdk}"
     implementation "org.apache.commons:commons-lang3"
 }


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

This change-set is required to support external payloads with AWS S3 and IRSA role credential provider. This is a common setup in kubernetes clusters. As described in [AWS documentation](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/WebIdentityTokenFileCredentialsProvider.html) to work with IRSA roles you need to include sts module in the class path.

<img width="1449" alt="image" src="https://github.com/user-attachments/assets/d50b73ea-f548-45d7-b8ed-6b4fa9b34dad" />



Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
