### PR TITLE
[Feature] Adding support for Kafka in the Workflow Event Listener

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummaryExtended.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummaryExtended.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.common.run;
+
+import java.util.Map;
+
+import com.netflix.conductor.annotations.protogen.ProtoField;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Extended version of WorkflowSummary that retains input/output as Map */
+public class WorkflowSummaryExtended extends WorkflowSummary {
+
+    @ProtoField(id = 9) // Ensure Protobuf compatibility
+    @JsonIgnore
+    private Map<String, Object> inputMap;
+
+    @ProtoField(id = 10)
+    @JsonIgnore
+    private Map<String, Object> outputMap;
+
+    public WorkflowSummaryExtended(Workflow workflow) {
+        super(workflow);
+        if (workflow.getInput() != null) {
+            this.inputMap = workflow.getInput();
+        }
+        if (workflow.getOutput() != null) {
+            this.outputMap = workflow.getOutput();
+        }
+    }
+
+    /** New method for JSON serialization */
+    @JsonProperty("input")
+    public Map<String, Object> getInputMap() {
+        return inputMap;
+    }
+
+    /** New method for JSON serialization */
+    @JsonProperty("output")
+    public Map<String, Object> getOutputMap() {
+        return outputMap;
+    }
+
+    public void setInputMap(Map<String, Object> inputMap) {
+        this.inputMap = inputMap;
+    }
+
+    public void setOutputMap(Map<String, Object> outputMap) {
+        this.outputMap = outputMap;
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/listener/WorkflowStatusListener.java
+++ b/core/src/main/java/com/netflix/conductor/core/listener/WorkflowStatusListener.java
@@ -14,8 +14,28 @@ package com.netflix.conductor.core.listener;
 
 import com.netflix.conductor.model.WorkflowModel;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 /** Listener for the completed and terminated workflows */
 public interface WorkflowStatusListener {
+
+    enum WorkflowEventType {
+        STARTED,
+        RERAN,
+        RETRIED,
+        PAUSED,
+        RESUMED,
+        RESTARTED,
+        COMPLETED,
+        TERMINATED,
+        FINALIZED;
+
+        @JsonValue // Ensures correct JSON serialization
+        @Override
+        public String toString() {
+            return name().toLowerCase(); // Convert to lowercase for consistency
+        }
+    }
 
     default void onWorkflowCompletedIfEnabled(WorkflowModel workflow) {
         if (workflow.getWorkflowDefinition().isWorkflowStatusListenerEnabled()) {
@@ -35,9 +55,57 @@ public interface WorkflowStatusListener {
         }
     }
 
+    default void onWorkflowStartedIfEnabled(WorkflowModel workflow) {
+        if (workflow.getWorkflowDefinition().isWorkflowStatusListenerEnabled()) {
+            onWorkflowStarted(workflow);
+        }
+    }
+
+    default void onWorkflowRestartedIfEnabled(WorkflowModel workflow) {
+        if (workflow.getWorkflowDefinition().isWorkflowStatusListenerEnabled()) {
+            onWorkflowRestarted(workflow);
+        }
+    }
+
+    default void onWorkflowRerunIfEnabled(WorkflowModel workflow) {
+        if (workflow.getWorkflowDefinition().isWorkflowStatusListenerEnabled()) {
+            onWorkflowRerun(workflow);
+        }
+    }
+
+    default void onWorkflowRetriedIfEnabled(WorkflowModel workflow) {
+        if (workflow.getWorkflowDefinition().isWorkflowStatusListenerEnabled()) {
+            onWorkflowRetried(workflow);
+        }
+    }
+
+    default void onWorkflowPausedIfEnabled(WorkflowModel workflow) {
+        if (workflow.getWorkflowDefinition().isWorkflowStatusListenerEnabled()) {
+            onWorkflowPaused(workflow);
+        }
+    }
+
+    default void onWorkflowResumedIfEnabled(WorkflowModel workflow) {
+        if (workflow.getWorkflowDefinition().isWorkflowStatusListenerEnabled()) {
+            onWorkflowResumed(workflow);
+        }
+    }
+
     void onWorkflowCompleted(WorkflowModel workflow);
 
     void onWorkflowTerminated(WorkflowModel workflow);
 
     default void onWorkflowFinalized(WorkflowModel workflow) {}
+
+    default void onWorkflowStarted(WorkflowModel workflow) {}
+
+    default void onWorkflowRestarted(WorkflowModel workflow) {}
+
+    default void onWorkflowRerun(WorkflowModel workflow) {}
+
+    default void onWorkflowPaused(WorkflowModel workflow) {}
+
+    default void onWorkflowResumed(WorkflowModel workflow) {}
+
+    default void onWorkflowRetried(WorkflowModel workflow) {}
 }

--- a/workflow-event-listener/README.md
+++ b/workflow-event-listener/README.md
@@ -1,7 +1,8 @@
 # Workflow Event Listeners
 Workflow Event listeners can be configured for the purpose in Conductor:
-1. Remove and/or archive workflows from primary datasource (e.g. Redis) once the workflow reaches a terminal status
-2. Publish a message to a conductor queue as the workflows complete that can be used to trigger other workflows 
+1. Remove and/or archive workflows from primary datasource (e.g. Redis) once the workflow reaches a terminal status.
+2. Publish a message to a conductor queue as the workflows complete that can be used to trigger other workflows.
+3. Publish workflow status changes to Kafka as it moves along its lifecycle.
 
 ## Published Artifacts
 
@@ -46,4 +47,66 @@ conductor.workflow-status-listener.queue-publisher.failureQueue=_callbackFailure
 
 #Queue for terminal state workflows (success or failed)
 conductor.workflow-status-listener.queue-publisher.finalizeQueue=_callbackFinalizeQueue
+```
+
+### Kafka Publisher
+Publish a summary of workflow WorkflowSummary to a Kafka topic(s) as a workflow moves through its lifecycle.
+
+This publisher introduced some new events
+- STARTED
+- RERAN
+- RETRIED
+- PAUSED
+- RESUMED
+- RESTARTED
+- COMPLETED (supported by queue_publisher)
+- TERMINATED (supported by queue_publisher)
+- FINALIZED (supported by queue_publisher)
+
+Example of a default configuration:
+
+```properties
+conductor.workflow-status-listener.type=kafka
+
+# Kafka Producer Configurations
+conductor.workflow-status-listener.kafka.producer.bootstrap.servers=kafka:29092
+
+# Kafka Producer Configuration
+conductor.workflow-status-listener.kafka.producer.key.serializer=org.apache.kafka.common.serialization.StringSerializer
+conductor.workflow-status-listener.kafka.producer.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+
+# Reliability Settings
+conductor.workflow-status-listener.kafka.producer.acks=all
+conductor.workflow-status-listener.kafka.producer.enable.idempotence=true
+
+# Retry sending messages if failure
+conductor.workflow-status-listener.kafka.producer.retries=5
+conductor.workflow-status-listener.kafka.producer.retry.backoff.ms=100
+
+# Allow batching (default 0)
+conductor.workflow-status-listener.kafka.producer.linger.ms=10
+conductor.workflow-status-listener.kafka.producer.batch.size=65536
+conductor.workflow-status-listener.kafka.producer.buffer.memory=67108864
+# Reduce network load
+conductor.workflow-status-listener.kafka.producer.compression.type=zstd
+
+# Allow multiple in-flight messages (better throughput)
+conductor.workflow-status-listener.kafka.producer.max.in.flight.requests.per.connection=1
+
+# Default Topic for All Workflow Status Events
+conductor.workflow-status-listener.kafka.default-topic=workflow-status-events
+
+```
+
+For configuration it supports the Kafka Producer clients settings prefixed with `conductor.workflow-status-listener.kafka.producer`.
+
+`conductor.workflow-status-listener.kafka.default-topic`  defines the default topic to use for all events.
+Each event can also have its dedicated topic prefix the proeprty with `conductor.workflow-status-listener.kafka.event-topics.` followed by the event name in lowercase.
+
+Example of using specific topics for the events:
+```properties
+# Custom Topics for Specific Events
+conductor.workflow-status-listener.kafka.event-topics.completed=workflow-completed-events
+conductor.workflow-status-listener.kafka.event-topics.terminated=workflow-terminated-events
+conductor.workflow-status-listener.kafka.event-topics.started=workflow-started-events
 ```

--- a/workflow-event-listener/build.gradle
+++ b/workflow-event-listener/build.gradle
@@ -13,6 +13,10 @@ dependencies {
     implementation "org.apache.commons:commons-lang3:"
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.14'
     implementation "com.amazonaws:aws-java-sdk-s3:${revAwsSdk}"
+    implementation "org.apache.kafka:kafka-clients:${revKafka}"
+
+    implementation "com.fasterxml.jackson.core:jackson-databind"
+    implementation "com.fasterxml.jackson.core:jackson-core"
 
     compileOnly 'org.springframework.boot:spring-boot-starter'
     compileOnly 'org.springframework.boot:spring-boot-starter-web'
@@ -21,14 +25,15 @@ dependencies {
     testImplementation "org.apache.groovy:groovy-all:${revGroovy}"
     testImplementation "org.spockframework:spock-core:${revSpock}"
     testImplementation "org.spockframework:spock-spring:${revSpock}"
+
     implementation "org.springframework.boot:spring-boot-starter-log4j2"
     testImplementation 'org.springframework.retry:spring-retry'
     testImplementation 'org.springframework.boot:spring-boot-starter-web'
+
     testImplementation "com.netflix.dyno-queues:dyno-queues-redis:${revDynoQueues}"
     testImplementation project(':conductor-test-util').sourceSets.test.output
 
     //In memory
     implementation "org.rarefiedredis.redis:redis-java:${revRarefiedRedis}"
     testImplementation "redis.clients:jedis:${revJedis}"
-
 }

--- a/workflow-event-listener/src/main/java/com/netflix/conductor/contribs/listener/kafka/KafkaWorkflowStatusPublisher.java
+++ b/workflow-event-listener/src/main/java/com/netflix/conductor/contribs/listener/kafka/KafkaWorkflowStatusPublisher.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.listener.kafka;
+
+import java.time.Duration;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+
+import com.netflix.conductor.common.run.WorkflowSummary;
+import com.netflix.conductor.common.run.WorkflowSummaryExtended;
+import com.netflix.conductor.core.listener.WorkflowStatusListener;
+import com.netflix.conductor.model.WorkflowModel;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/** Kafka-based publisher for workflow status events. */
+public class KafkaWorkflowStatusPublisher implements WorkflowStatusListener, DisposableBean {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(KafkaWorkflowStatusPublisher.class);
+    private final KafkaProducer<String, String> producer;
+    private final Map<String, String> eventTopics;
+    private final String defaultTopic;
+    private final KafkaWorkflowStatusPublisherProperties properties;
+    private final ObjectMapper objectMapper;
+
+    public KafkaWorkflowStatusPublisher(
+            KafkaWorkflowStatusPublisherProperties properties, ObjectMapper objectMapper) {
+        this.eventTopics = properties.getEventTopics();
+        this.defaultTopic = properties.getDefaultTopic();
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+
+        // Configure Kafka Producer
+        Map<String, Object> producerConfig = properties.toProducerConfig();
+        this.producer = new KafkaProducer<>(producerConfig);
+    }
+
+    @Override
+    public void destroy() {
+        if (producer != null) {
+            try {
+                producer.close(Duration.ofSeconds(10)); // Allow graceful shutdown
+                LOGGER.info("Kafka producer shut down gracefully.");
+            } catch (Exception e) {
+                LOGGER.error("Error shutting down Kafka producer", e);
+            }
+        }
+    }
+
+    @Override
+    public void onWorkflowStarted(WorkflowModel workflow) {
+        publishEvent(WorkflowEventType.STARTED, workflow);
+    }
+
+    @Override
+    public void onWorkflowRestarted(WorkflowModel workflow) {
+        publishEvent(WorkflowEventType.RESTARTED, workflow);
+    }
+
+    @Override
+    public void onWorkflowRerun(WorkflowModel workflow) {
+        publishEvent(WorkflowEventType.RERAN, workflow);
+    }
+
+    @Override
+    public void onWorkflowCompleted(WorkflowModel workflow) {
+        publishEvent(WorkflowEventType.COMPLETED, workflow);
+    }
+
+    @Override
+    public void onWorkflowTerminated(WorkflowModel workflow) {
+        publishEvent(WorkflowEventType.TERMINATED, workflow);
+    }
+
+    @Override
+    public void onWorkflowFinalized(WorkflowModel workflow) {
+        publishEvent(WorkflowEventType.FINALIZED, workflow);
+    }
+
+    @Override
+    public void onWorkflowPaused(WorkflowModel workflow) {
+        publishEvent(WorkflowEventType.PAUSED, workflow);
+    }
+
+    @Override
+    public void onWorkflowResumed(WorkflowModel workflow) {
+        publishEvent(WorkflowEventType.RESUMED, workflow);
+    }
+
+    @Override
+    public void onWorkflowRetried(WorkflowModel workflow) {
+        publishEvent(WorkflowEventType.RETRIED, workflow);
+    }
+
+    private void publishEvent(WorkflowEventType eventType, WorkflowModel workflow) {
+        try {
+            // Determine the correct topic
+            String topic = eventTopics.getOrDefault(eventType.toString(), defaultTopic);
+            LOGGER.debug("Publish event {} to topic {}", eventType.toString(), topic);
+
+            // Convert workflow to summary
+            WorkflowSummary workflowSummary = new WorkflowSummaryExtended(workflow.toWorkflow());
+
+            // Construct JSON message
+            Map<String, Object> message =
+                    Map.of(
+                            "workflowName", workflow.getWorkflowName(),
+                            "eventType", eventType.toString(),
+                            "payload", workflowSummary);
+
+            String jsonMessage = objectMapper.writeValueAsString(message);
+
+            // Create Kafka record
+            ProducerRecord<String, String> record =
+                    new ProducerRecord<>(topic, workflow.getWorkflowId(), jsonMessage);
+
+            // Send message asynchronously
+            producer.send(
+                    record,
+                    (metadata, exception) -> {
+                        if (exception != null) {
+                            LOGGER.error(
+                                    "Failed to publish workflow event: {}", jsonMessage, exception);
+                        } else {
+                            LOGGER.debug(
+                                    "Published event: {}, Topic: {}, Partition: {}, Offset: {}",
+                                    eventType,
+                                    metadata.topic(),
+                                    metadata.partition(),
+                                    metadata.offset());
+                        }
+                    });
+
+        } catch (JsonProcessingException e) {
+            LOGGER.error(
+                    "Error serializing workflow event for {}: {}", eventType, e.getMessage(), e);
+        } catch (Exception e) {
+            LOGGER.error("Unexpected error publishing event {}: {}", eventType, e.getMessage(), e);
+        }
+    }
+}

--- a/workflow-event-listener/src/main/java/com/netflix/conductor/contribs/listener/kafka/KafkaWorkflowStatusPublisherConfiguration.java
+++ b/workflow-event-listener/src/main/java/com/netflix/conductor/contribs/listener/kafka/KafkaWorkflowStatusPublisherConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.listener.kafka;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.netflix.conductor.core.listener.WorkflowStatusListener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Configuration
+@EnableConfigurationProperties(KafkaWorkflowStatusPublisherProperties.class)
+@ConditionalOnProperty(name = "conductor.workflow-status-listener.type", havingValue = "kafka")
+public class KafkaWorkflowStatusPublisherConfiguration {
+
+    @Bean
+    public WorkflowStatusListener getWorkflowStatusListener(
+            KafkaWorkflowStatusPublisherProperties properties, ObjectMapper objectMapper) {
+        return new KafkaWorkflowStatusPublisher(properties, objectMapper);
+    }
+}

--- a/workflow-event-listener/src/main/java/com/netflix/conductor/contribs/listener/kafka/KafkaWorkflowStatusPublisherProperties.java
+++ b/workflow-event-listener/src/main/java/com/netflix/conductor/contribs/listener/kafka/KafkaWorkflowStatusPublisherProperties.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.listener.kafka;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "conductor.workflow-status-listener.kafka")
+public class KafkaWorkflowStatusPublisherProperties {
+
+    private Map<String, Object> producer = new HashMap<>();
+
+    /** Default Kafka topic where all workflow status events are published. */
+    private String defaultTopic = "workflow-status-events";
+
+    /**
+     * A map of event types to Kafka topics. If an event type has a specific topic, it will be
+     * published there instead of the default.
+     */
+    private Map<String, String> eventTopics = new HashMap<>();
+
+    public Map<String, Object> getProducer() {
+        return producer;
+    }
+
+    public void setProducer(Map<String, Object> producer) {
+        this.producer = producer;
+    }
+
+    public String getDefaultTopic() {
+        return defaultTopic;
+    }
+
+    public void setDefaultTopic(String defaultTopic) {
+        this.defaultTopic = defaultTopic;
+    }
+
+    public Map<String, String> getEventTopics() {
+        return eventTopics;
+    }
+
+    public void setEventTopics(Map<String, String> eventTopics) {
+        this.eventTopics = eventTopics;
+    }
+
+    /**
+     * Generates configuration properties for Kafka producers. Maps against `ProducerConfig` keys.
+     */
+    public Map<String, Object> toProducerConfig() {
+        return mapProperties(ProducerConfig.configNames(), producer);
+    }
+
+    /**
+     * Filters and maps properties based on the allowed keys for Kafka producer configuration.
+     *
+     * @param allowedKeys The allowed Kafka ProducerConfig keys.
+     * @param inputProperties The user-specified properties from application config.
+     * @return A filtered map containing only valid properties.
+     */
+    private Map<String, Object> mapProperties(
+            Iterable<String> allowedKeys, Map<String, Object> inputProperties) {
+        Map<String, Object> config = new HashMap<>();
+        for (String key : allowedKeys) {
+            if (inputProperties.containsKey(key)) {
+                config.put(key, inputProperties.get(key));
+            }
+        }
+
+        // Ensure bootstrapServers is always set
+        setDefaultIfNullOrEmpty(config, ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:29092");
+
+        // Set required default serializers
+        setDefaultIfNullOrEmpty(
+                config,
+                ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.StringSerializer");
+        setDefaultIfNullOrEmpty(
+                config,
+                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.StringSerializer");
+
+        // Set default client ID
+        setDefaultIfNullOrEmpty(
+                config, ProducerConfig.CLIENT_ID_CONFIG, "workflow-status-producer");
+
+        return config;
+    }
+
+    /** Sets a default value if the key is missing or empty. */
+    private void setDefaultIfNullOrEmpty(
+            Map<String, Object> config, String key, String defaultValue) {
+        Object value = config.get(key);
+        if (value == null || (value instanceof String && ((String) value).isBlank())) {
+            config.put(key, defaultValue);
+        }
+    }
+}

--- a/workflow-event-listener/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/workflow-event-listener/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -97,6 +97,10 @@
         {
           "value": "queue_publisher",
           "description": "Use the publisher implementation which publishes a message to the underlying queue implementation upon termination or completion as the workflow status listener."
+        },
+        {
+          "value": "kafka",
+          "description": "Use this publisher to publish workflow status changed to Kafka. The events published are the following Termination, Completion, Finalization, Started, Rearan, Retried, Paused, Resumed, Restarted, Finalized."
         }
       ]
     },


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
This PR adds the new Workflow Event Publisher `kafka`. It gives support to publish workflow events to Kafka. In addition to the existing events, Completed, Terminated and Finalized the following new events have been added:
- STARTED
- RERAN
- RETRIED
- PAUSED
- RESUMED
- RESTARTED
- COMPLETED (supported by queue_publisher)
- TERMINATED (supported by queue_publisher)
- FINALIZED (supported by queue_publisher)

That addition of these new events does not change the behavior of the existing publishers, they are unchanged.

A new type `WorkflowSummaryExtended` was added that extends the WorkflowSummary, it maintains input and output properties as objects when publishing objects to Kafka.

<strike>Moved rising of Workflow `FINALIZED` event from `cancelNonTerminalTasks` to `endExecution` in the `WorkflowExecutionOps.java`  to make sure it is only raised once. Currently when using a Terminate Task in a workflow it is razed twice.</strike>

To ensure that `FINALIZED` is raised to correct number of times, an overloaded `cancelNonTerminalTasks` was introduced to control if this event should be raised or not, by default it is raised. This is because the `cancelNonTerminalTasks` is called twice when `endExecution` is part of the flow. When `cancelNonTerminalTasks` is called from `endExecution` it should not raise the event again.

Issue #
