### PR TITLE
Ignore WorkflowExecutionLock in terminate workflow

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutor.java
@@ -117,7 +117,8 @@ public interface WorkflowExecutor {
      * @param failureWorkflow the failure workflow (if any) to be triggered as a result of this
      *     termination
      */
-    WorkflowModel terminateWorkflow(WorkflowModel workflow, String reason, String failureWorkflow);
+    WorkflowModel terminateWorkflow(
+            WorkflowModel workflow, String reason, String failureWorkflow, boolean lockAcquired);
 
     /**
      * @param workflowId

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SubWorkflow.java
@@ -141,7 +141,7 @@ public class SubWorkflow extends WorkflowSystemTask {
                         ? "Parent workflow has been terminated with status " + workflow.getStatus()
                         : "Parent workflow has been terminated with reason: "
                                 + workflow.getReasonForIncompletion();
-        workflowExecutor.terminateWorkflow(subWorkflow, reason, null);
+        workflowExecutor.terminateWorkflow(subWorkflow, reason, null, false);
     }
 
     /**


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
- Add param lockAcquired in terminateWorkflow to avoid 2nd lock to be held in same thread

_Describe the new behavior from this PR, and why it's needed_
Issue #
[https://github.com/conductor-oss/conductor/issues/295]
Conductor Properties:
```
conductor.app.workflowExecutionLockEnabled=true
conductor.app.workflowOffsetTimeout=3600
```
- Workflow status update delayed by 60 seconds due to dual locks when task is failed with lock enabled
When the same thread tries to lock the same workflow in subsequent operations (decide and termination), workflow termination is delayed by `lockLeaseTime`. Thread is hanging there until lockLeaseTime is completed.

Alternatives considered
----

_Describe alternative implementation you have considered_
