### PR TITLE
[BUG] PostgreQueueDAO.popMessage may pop messages from incorrect queues and return more messages than expected

### DIFF
--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresQueueDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresQueueDAO.java
@@ -449,12 +449,23 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
             }
         }
 
-        String POP_QUERY =
-                "UPDATE queue_message SET popped = true WHERE message_id IN ("
-                        + "SELECT message_id FROM queue_message WHERE queue_name = ? AND popped = false AND "
-                        + "deliver_on <= (current_timestamp + (1000 ||' microseconds')::interval) "
-                        + "ORDER BY priority DESC, deliver_on, created_on LIMIT ? FOR UPDATE SKIP LOCKED"
-                        + ") RETURNING message_id, priority, payload";
+        String POP_QUERY =  "WITH cte AS (" + 
+                            "    SELECT queue_name, message_id " + 
+                            "    FROM queue_message " + 
+                            "    WHERE queue_name = ? " + 
+                            "      AND popped = false " + 
+                            "      AND deliver_on <= (current_timestamp + (1000 || ' microseconds')::interval) " + 
+                            "    ORDER BY priority DESC, deliver_on, created_on " + 
+                            "    LIMIT ? " + 
+                            "    FOR UPDATE SKIP LOCKED " + 
+                            ") " + 
+                            "UPDATE queue_message " + 
+                            "   SET popped = true " + 
+                            "   FROM cte " + 
+                            "   WHERE queue_message.queue_name = cte.queue_name " + 
+                            "     AND queue_message.message_id = cte.message_id " + 
+                            "     AND queue_message.popped = false " + 
+                            "   RETURNING queue_message.message_id, queue_message.priority, queue_message.payload";
 
         return query(
                 connection,

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresQueueDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresQueueDAO.java
@@ -449,23 +449,24 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
             }
         }
 
-        String POP_QUERY =  "WITH cte AS (" + 
-                            "    SELECT queue_name, message_id " + 
-                            "    FROM queue_message " + 
-                            "    WHERE queue_name = ? " + 
-                            "      AND popped = false " + 
-                            "      AND deliver_on <= (current_timestamp + (1000 || ' microseconds')::interval) " + 
-                            "    ORDER BY priority DESC, deliver_on, created_on " + 
-                            "    LIMIT ? " + 
-                            "    FOR UPDATE SKIP LOCKED " + 
-                            ") " + 
-                            "UPDATE queue_message " + 
-                            "   SET popped = true " + 
-                            "   FROM cte " + 
-                            "   WHERE queue_message.queue_name = cte.queue_name " + 
-                            "     AND queue_message.message_id = cte.message_id " + 
-                            "     AND queue_message.popped = false " + 
-                            "   RETURNING queue_message.message_id, queue_message.priority, queue_message.payload";
+        String POP_QUERY =
+                "WITH cte AS ("
+                        + "    SELECT queue_name, message_id "
+                        + "    FROM queue_message "
+                        + "    WHERE queue_name = ? "
+                        + "      AND popped = false "
+                        + "      AND deliver_on <= (current_timestamp + (1000 || ' microseconds')::interval) "
+                        + "    ORDER BY priority DESC, deliver_on, created_on "
+                        + "    LIMIT ? "
+                        + "    FOR UPDATE SKIP LOCKED "
+                        + ") "
+                        + "UPDATE queue_message "
+                        + "   SET popped = true "
+                        + "   FROM cte "
+                        + "   WHERE queue_message.queue_name = cte.queue_name "
+                        + "     AND queue_message.message_id = cte.message_id "
+                        + "     AND queue_message.popped = false "
+                        + "   RETURNING queue_message.message_id, queue_message.priority, queue_message.payload";
 
         return query(
                 connection,

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresQueueDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresQueueDAOTest.java
@@ -221,6 +221,80 @@ public class PostgresQueueDAOTest {
         }
     }
 
+    /**
+     * Test fix for https://github.com/conductor-oss/conductor/issues/369
+     *
+     * <p>Confirms that the queue is taken into account when popping messages from the queue.
+     */
+    @Test
+    public void pollMessagesDuplicatePopsTest() throws InterruptedException {
+        final List<Message> messages = new ArrayList<>();
+        final String queueName1 = "issue369_testQueue_1";
+        final String queueName2 = "issue369_testQueue_2";
+        final int totalSize = 10;
+
+        for (int i = 0; i < totalSize; i++) {
+            String payload = "{\"id\": " + i + ", \"msg\":\"test " + i + "\"}";
+            Message m = new Message("testmsg-" + i, payload, "");
+            if (i % 2 == 0) {
+                // Set priority on message with pair id
+                m.setPriority(99 - i);
+            }
+            messages.add(m);
+        }
+
+        // Populate the queue with our test message batch
+        queueDAO.push(queueName1, ImmutableList.copyOf(messages));
+
+        // Add same messages for queue 2, to make sure that the message_id is duplicated across
+        // queues
+        queueDAO.push(queueName2, ImmutableList.copyOf(messages));
+
+        // Assert that all messages were persisted and no extras are in there
+        assertEquals("Queue size mismatch", totalSize, queueDAO.getSize(queueName1));
+        assertEquals("Queue size mismatch", totalSize, queueDAO.getSize(queueName2));
+
+        List<Message> zeroPoll = queueDAO.pollMessages(queueName1, 0, 10_000);
+        assertTrue("Zero poll should be empty", zeroPoll.isEmpty());
+
+        final int firstPollSize = 3;
+        List<Message> firstPoll = queueDAO.pollMessages(queueName1, firstPollSize, 10_000);
+        assertNotNull("First poll was null", firstPoll);
+        assertFalse("First poll was empty", firstPoll.isEmpty());
+        assertEquals("First poll size mismatch", firstPollSize, firstPoll.size());
+
+        final int secondPollSize = 4;
+        List<Message> secondPoll = queueDAO.pollMessages(queueName1, secondPollSize, 10_000);
+        assertNotNull("Second poll was null", secondPoll);
+        assertFalse("Second poll was empty", secondPoll.isEmpty());
+        assertEquals("Second poll size mismatch", secondPollSize, secondPoll.size());
+
+        // Assert that the total queue 1 size hasn't changed
+        assertEquals(
+                "Total queue 1 size should have remained the same",
+                totalSize,
+                queueDAO.getSize(queueName1));
+
+        // Assert that the total queue 2 size hasn't changed
+        assertEquals(
+                "Total queue 2 size should have remained the same",
+                totalSize,
+                queueDAO.getSize(queueName2));
+
+        // Assert that our un-popped messages match our expected size
+        final long expectedSize = totalSize - firstPollSize - secondPollSize;
+        try (Connection c = dataSource.getConnection()) {
+            String UNPOPPED =
+                    "SELECT COUNT(*) FROM queue_message WHERE queue_name = ? AND popped = false";
+            try (Query q = new Query(objectMapper, c, UNPOPPED)) {
+                long count = q.addParameter(queueName1).executeCount();
+                assertEquals("Remaining queue size mismatch", expectedSize, count);
+            }
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
     /** Test fix for https://github.com/Netflix/conductor/issues/1892 */
     @Test
     public void containsMessageTest() {

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresQueueDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresQueueDAOTest.java
@@ -288,7 +288,12 @@ public class PostgresQueueDAOTest {
                     "SELECT COUNT(*) FROM queue_message WHERE queue_name = ? AND popped = false";
             try (Query q = new Query(objectMapper, c, UNPOPPED)) {
                 long count = q.addParameter(queueName1).executeCount();
-                assertEquals("Remaining queue size mismatch", expectedSize, count);
+                assertEquals("Remaining queue 1 size mismatch", expectedSize, count);
+            }
+
+            try (Query q = new Query(objectMapper, c, UNPOPPED)) {
+                long count = q.addParameter(queueName2).executeCount();
+                assertEquals("Remaining queue 2 size mismatch", totalSize, count);
             }
         } catch (Exception ex) {
             fail(ex.getMessage());


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
This PR fixes a bug in the PostgreQueueDAO.popMessage() method, where the SQL query does not limit the update to the provided queue_name, which can result in unintentionally popping messages from other queues and returning too many rows.

The issue stems from the SQL used: it updates all messages matching the message_ids returned from a subquery, but does not check the associated queue_name. Since the table uses a composite primary key of (queue_name, message_id), both fields must be provided to uniquely identify a message.

To reproduce the bug:
1. Enable conductor.workflow-status-listener.type=queue_publisher but do not configure any event handlers to consume the events.
2. Run a few workflows that publish events to the queue, allowing it to fill with data.
3. Execute the original query (note that queue_name is only included in RETURNING for debugging):
```sql
BEGIN TRANSACTION;
UPDATE queue_message SET popped = true 
WHERE  message_id IN (SELECT message_id 
                    FROM queue_message 
                    WHERE queue_name = '_callbackFailureQueue' -- Only messages from the _callbackFailureQueue should be popped
                    AND popped = false 
                    AND deliver_on <= (current_timestamp + (1000 ||' microseconds')::interval) 
                    ORDER BY priority DESC, deliver_on, created_on 
                    LIMIT 2 -- Limiting to 2 results here
                    FOR UPDATE SKIP LOCKED) 
RETURNING queue_name, message_id, priority, payload
```
> [!NOTE]
> The `queue_name` name in the `RETURNING` is not part of the original query it was added in the sample here to show the issue.

This query may return rows like:
"queue_name"	                        "message_id"	                                                "priority"
"_callbackFinalizeQueue"	"98936225-c0d7-4963-a140-550d0ee4d57f"	0
"_callbackFailureQueue"	        "856b1b6f-e6ea-4dc7-bd91-6248e5ef4ae9"	0
"_callbackFinalizeQueue"	"856b1b6f-e6ea-4dc7-bd91-6248e5ef4ae9"	0
"_callbackFailureQueue"	        "98936225-c0d7-4963-a140-550d0ee4d57f"	0

We intended to pop messages only from _callbackFailureQueue, but ended up updating rows from multiple queues due to ambiguous use of message_id.

Fixed query (with CTE):
```sql
BEGIN TRANSACTION;
WITH cte AS (
    SELECT queue_name, message_id
    FROM queue_message
    WHERE 
        queue_name = '_callbackFailureQueue' 
        AND popped = false 
        AND deliver_on <= (current_timestamp + (1000 || ' microseconds')::interval)
    ORDER BY priority DESC, deliver_on, created_on
    LIMIT 2
    FOR UPDATE SKIP LOCKED
)
UPDATE queue_message
SET popped = true
FROM cte
WHERE 
    queue_message.queue_name = cte.queue_name 
    AND queue_message.message_id = cte.message_id
    AND queue_message.popped = false
RETURNING queue_message.queue_name, queue_message.message_id, queue_message.priority, queue_message.payload;
```

> [!NOTE]
> The `queue_name` name in the `RETURNING` is not part of the original query it was added in the sample here to show the issue is fixed.

This query correctly returns:
"queue_name"	                    "message_id"	                                                "priority"
"_callbackFailureQueue"     "856b1b6f-e6ea-4dc7-bd91-6248e5ef4ae9"	0
"_callbackFailureQueue"     "98936225-c0d7-4963-a140-550d0ee4d57f"	0

Only the intended messages in the specified queue are updated.

Another advantage of using the CTE is that it allows PostgreSQL to optimize the query plan more effectively as the dataset grows.

This new CTE-based approach also ensures that a message hasn't been popped by another process while the CTE was running, preventing unnecessary updates in high-concurrency scenarios.

Issue #369
