### PR TITLE
Added a class to abstract time to a centralised place to improve testing.

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/dal/ExecutionDAOFacade.java
+++ b/core/src/main/java/com/netflix/conductor/core/dal/ExecutionDAOFacade.java
@@ -47,6 +47,7 @@ import com.netflix.conductor.dao.*;
 import com.netflix.conductor.metrics.Monitors;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.TimeService;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -285,9 +286,9 @@ public class ExecutionDAOFacade {
      * @return the id of the updated workflow
      */
     public String updateWorkflow(WorkflowModel workflowModel) {
-        workflowModel.setUpdatedTime(System.currentTimeMillis());
+        workflowModel.setUpdatedTime(TimeService.currentTimeMillis());
         if (workflowModel.getStatus().isTerminal()) {
-            workflowModel.setEndTime(System.currentTimeMillis());
+            workflowModel.setEndTime(TimeService.currentTimeMillis());
         }
         externalizeWorkflowData(workflowModel);
         executionDAO.updateWorkflow(workflowModel);
@@ -498,10 +499,10 @@ public class ExecutionDAOFacade {
         if (taskModel.getStatus() != null) {
             if (!taskModel.getStatus().isTerminal()
                     || (taskModel.getStatus().isTerminal() && taskModel.getUpdateTime() == 0)) {
-                taskModel.setUpdateTime(System.currentTimeMillis());
+                taskModel.setUpdateTime(TimeService.currentTimeMillis());
             }
             if (taskModel.getStatus().isTerminal() && taskModel.getEndTime() == 0) {
-                taskModel.setEndTime(System.currentTimeMillis());
+                taskModel.setEndTime(TimeService.currentTimeMillis());
             }
         }
         externalizeTaskData(taskModel);
@@ -561,7 +562,7 @@ public class ExecutionDAOFacade {
     }
 
     public void extendLease(TaskModel taskModel) {
-        taskModel.setUpdateTime(System.currentTimeMillis());
+        taskModel.setUpdateTime(TimeService.currentTimeMillis());
         executionDAO.updateTask(taskModel);
     }
 

--- a/core/src/main/java/com/netflix/conductor/core/events/DefaultEventProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/DefaultEventProcessor.java
@@ -44,6 +44,7 @@ import com.netflix.conductor.core.utils.JsonUtils;
 import com.netflix.conductor.metrics.Monitors;
 import com.netflix.conductor.service.ExecutionService;
 import com.netflix.conductor.service.MetadataService;
+import com.netflix.conductor.service.TimeService;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spotify.futures.CompletableFutures;
@@ -181,7 +182,7 @@ public class DefaultEventProcessor {
             if (!success) {
                 String id = msg.getId() + "_" + 0;
                 EventExecution eventExecution = new EventExecution(id, msg.getId());
-                eventExecution.setCreated(System.currentTimeMillis());
+                eventExecution.setCreated(TimeService.currentTimeMillis());
                 eventExecution.setEvent(eventHandler.getEvent());
                 eventExecution.setName(eventHandler.getName());
                 eventExecution.setStatus(Status.SKIPPED);
@@ -240,7 +241,7 @@ public class DefaultEventProcessor {
         for (Action action : eventHandler.getActions()) {
             String id = msg.getId() + "_" + i++;
             EventExecution eventExecution = new EventExecution(id, msg.getId());
-            eventExecution.setCreated(System.currentTimeMillis());
+            eventExecution.setCreated(TimeService.currentTimeMillis());
             eventExecution.setEvent(eventHandler.getEvent());
             eventExecution.setName(eventHandler.getName());
             eventExecution.setAction(action.getAction());

--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -25,6 +25,7 @@ import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.metrics.Monitors;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.TimeService;
 
 @Component
 public class AsyncSystemTaskExecutor {
@@ -147,7 +148,7 @@ public class AsyncSystemTaskExecutor {
             }
 
             if (task.getStatus() == TaskModel.Status.SCHEDULED) {
-                task.setStartTime(System.currentTimeMillis());
+                task.setStartTime(TimeService.currentTimeMillis());
                 Monitors.recordQueueWaitTime(task.getTaskType(), task.getQueueWaitTime());
                 systemTask.start(workflow, task, workflowExecutor);
             } else if (task.getStatus() == TaskModel.Status.IN_PROGRESS) {
@@ -160,7 +161,7 @@ public class AsyncSystemTaskExecutor {
                 shouldRemoveTaskFromQueue = true;
                 hasTaskExecutionCompleted = true;
             } else if (task.getStatus().isTerminal()) {
-                task.setEndTime(System.currentTimeMillis());
+                task.setEndTime(TimeService.currentTimeMillis());
                 shouldRemoveTaskFromQueue = true;
                 hasTaskExecutionCompleted = true;
             } else {

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
@@ -52,6 +52,7 @@ import com.netflix.conductor.metrics.Monitors;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
 import com.netflix.conductor.service.ExecutionLockService;
+import com.netflix.conductor.service.TimeService;
 
 import static com.netflix.conductor.core.utils.Utils.DECIDER_QUEUE;
 import static com.netflix.conductor.model.TaskModel.Status.*;
@@ -87,7 +88,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
     private final Predicate<PollData> validateLastPolledTime =
             pollData ->
                     pollData.getLastPollTime()
-                            > System.currentTimeMillis() - activeWorkerLastPollMs;
+                            > TimeService.currentTimeMillis() - activeWorkerLastPollMs;
 
     public WorkflowExecutorOps(
             DeciderService deciderService,
@@ -227,7 +228,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
         workflow.getTasks().clear();
         workflow.setReasonForIncompletion(null);
         workflow.setFailedTaskId(null);
-        workflow.setCreateTime(System.currentTimeMillis());
+        workflow.setCreateTime(TimeService.currentTimeMillis());
         workflow.setEndTime(0);
         workflow.setLastRetriedTime(0);
         // Change the status to running
@@ -320,7 +321,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
             WorkflowModel parentWorkflow =
                     executionDAOFacade.getWorkflowModel(parentWorkflowId, true);
             parentWorkflow.setStatus(WorkflowModel.Status.RUNNING);
-            parentWorkflow.setLastRetriedTime(System.currentTimeMillis());
+            parentWorkflow.setLastRetriedTime(TimeService.currentTimeMillis());
             executionDAOFacade.updateWorkflow(parentWorkflow);
 
             try {
@@ -394,7 +395,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
         // Update Workflow with new status.
         // This should load Workflow from archive, if archived.
         workflow.setStatus(WorkflowModel.Status.RUNNING);
-        workflow.setLastRetriedTime(System.currentTimeMillis());
+        workflow.setLastRetriedTime(TimeService.currentTimeMillis());
         String lastReasonForIncompletion = workflow.getReasonForIncompletion();
         workflow.setReasonForIncompletion(null);
         // Add to decider queue
@@ -816,7 +817,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
         }
 
         if (task.getStatus().isTerminal()) {
-            task.setEndTime(System.currentTimeMillis());
+            task.setEndTime(TimeService.currentTimeMillis());
         }
 
         // Update message in Task queue based on Task status
@@ -1327,7 +1328,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
                             + workflow.getStatus().name());
         }
         workflow.setStatus(WorkflowModel.Status.RUNNING);
-        workflow.setLastRetriedTime(System.currentTimeMillis());
+        workflow.setLastRetriedTime(TimeService.currentTimeMillis());
         // Add to decider queue
         queueDAO.push(
                 DECIDER_QUEUE,
@@ -1392,7 +1393,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
         taskToBeSkipped.setWorkflowInstanceId(workflowId);
         taskToBeSkipped.setWorkflowPriority(workflow.getPriority());
         taskToBeSkipped.setStatus(SKIPPED);
-        taskToBeSkipped.setEndTime(System.currentTimeMillis());
+        taskToBeSkipped.setEndTime(TimeService.currentTimeMillis());
         taskToBeSkipped.setTaskType(workflowTask.getName());
         taskToBeSkipped.setCorrelationId(workflow.getCorrelationId());
         if (skipTaskRequest != null) {
@@ -1552,7 +1553,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
                 if (task.getStatus() != null
                         && !task.getStatus().isTerminal()
                         && task.getStartTime() == 0) {
-                    task.setStartTime(System.currentTimeMillis());
+                    task.setStartTime(TimeService.currentTimeMillis());
                 }
                 if (!workflowSystemTask.isAsync()) {
                     try {
@@ -1754,7 +1755,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
             }
             workflow.setTasks(filteredTasks);
             // reset fields before restarting the task
-            rerunFromTask.setScheduledTime(System.currentTimeMillis());
+            rerunFromTask.setScheduledTime(TimeService.currentTimeMillis());
             rerunFromTask.setStartTime(0);
             rerunFromTask.setUpdateTime(0);
             rerunFromTask.setEndTime(0);
@@ -1764,7 +1765,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
             if (rerunFromTask.getTaskType().equalsIgnoreCase(TaskType.TASK_TYPE_SUB_WORKFLOW)) {
                 // if task is sub workflow set task as IN_PROGRESS and reset start time
                 rerunFromTask.setStatus(IN_PROGRESS);
-                rerunFromTask.setStartTime(System.currentTimeMillis());
+                rerunFromTask.setStartTime(TimeService.currentTimeMillis());
             } else {
                 if (taskInput != null) {
                     rerunFromTask.setInputData(taskInput);
@@ -1902,7 +1903,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
         workflow.setParentWorkflowId(input.getParentWorkflowId());
         workflow.setParentWorkflowTaskId(input.getParentWorkflowTaskId());
         workflow.setOwnerApp(WorkflowContext.get().getClientApp());
-        workflow.setCreateTime(System.currentTimeMillis());
+        workflow.setCreateTime(TimeService.currentTimeMillis());
         workflow.setUpdatedBy(null);
         workflow.setUpdatedTime(null);
         workflow.setEvent(input.getEvent());

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/DecisionTaskMapper.java
@@ -32,6 +32,7 @@ import com.netflix.conductor.core.events.ScriptEvaluator;
 import com.netflix.conductor.core.exception.TerminateWorkflowException;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.TimeService;
 
 /**
  * An implementation of {@link TaskMapper} to map a {@link WorkflowTask} of type {@link
@@ -88,7 +89,7 @@ public class DecisionTaskMapper implements TaskMapper {
         decisionTask.setTaskDefName(TaskType.TASK_TYPE_DECISION);
         decisionTask.addInput("case", caseValue);
         decisionTask.addOutput("caseOutput", Collections.singletonList(caseValue));
-        decisionTask.setStartTime(System.currentTimeMillis());
+        decisionTask.setStartTime(TimeService.currentTimeMillis());
         decisionTask.setStatus(TaskModel.Status.IN_PROGRESS);
         tasksToBeScheduled.add(decisionTask);
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/DoWhileTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/DoWhileTaskMapper.java
@@ -28,6 +28,7 @@ import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.TimeService;
 
 /**
  * An implementation of {@link TaskMapper} to map a {@link WorkflowTask} of type {@link
@@ -85,7 +86,7 @@ public class DoWhileTaskMapper implements TaskMapper {
         TaskModel doWhileTask = taskMapperContext.createTaskModel();
         doWhileTask.setTaskType(TaskType.TASK_TYPE_DO_WHILE);
         doWhileTask.setStatus(TaskModel.Status.IN_PROGRESS);
-        doWhileTask.setStartTime(System.currentTimeMillis());
+        doWhileTask.setStartTime(TimeService.currentTimeMillis());
         doWhileTask.setRateLimitPerFrequency(taskDefinition.getRateLimitPerFrequency());
         doWhileTask.setRateLimitFrequencyInSeconds(taskDefinition.getRateLimitFrequencyInSeconds());
         doWhileTask.setRetryCount(taskMapperContext.getRetryCount());

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/ExclusiveJoinTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/ExclusiveJoinTaskMapper.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Component;
 import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.model.TaskModel;
+import com.netflix.conductor.service.TimeService;
 
 @Component
 public class ExclusiveJoinTaskMapper implements TaskMapper {
@@ -51,7 +52,7 @@ public class ExclusiveJoinTaskMapper implements TaskMapper {
         TaskModel joinTask = taskMapperContext.createTaskModel();
         joinTask.setTaskType(TaskType.TASK_TYPE_EXCLUSIVE_JOIN);
         joinTask.setTaskDefName(TaskType.TASK_TYPE_EXCLUSIVE_JOIN);
-        joinTask.setStartTime(System.currentTimeMillis());
+        joinTask.setStartTime(TimeService.currentTimeMillis());
         joinTask.setInputData(joinInput);
         joinTask.setStatus(TaskModel.Status.IN_PROGRESS);
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinDynamicTaskMapper.java
@@ -40,6 +40,7 @@ import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.TimeService;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -289,8 +290,8 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
         TaskModel forkDynamicTask = taskMapperContext.createTaskModel();
         forkDynamicTask.setTaskType(TaskType.TASK_TYPE_FORK);
         forkDynamicTask.setTaskDefName(TaskType.TASK_TYPE_FORK);
-        forkDynamicTask.setStartTime(System.currentTimeMillis());
-        forkDynamicTask.setEndTime(System.currentTimeMillis());
+        forkDynamicTask.setStartTime(TimeService.currentTimeMillis());
+        forkDynamicTask.setEndTime(TimeService.currentTimeMillis());
         List<String> forkedTaskNames =
                 dynForkTasks.stream()
                         .map(WorkflowTask::getTaskReferenceName)
@@ -329,8 +330,8 @@ public class ForkJoinDynamicTaskMapper implements TaskMapper {
         joinTask.setWorkflowInstanceId(workflowModel.getWorkflowId());
         joinTask.setWorkflowType(workflowModel.getWorkflowName());
         joinTask.setCorrelationId(workflowModel.getCorrelationId());
-        joinTask.setScheduledTime(System.currentTimeMillis());
-        joinTask.setStartTime(System.currentTimeMillis());
+        joinTask.setScheduledTime(TimeService.currentTimeMillis());
+        joinTask.setStartTime(TimeService.currentTimeMillis());
         joinTask.setInputData(joinInput);
         joinTask.setTaskId(idGenerator.generate());
         joinTask.setStatus(TaskModel.Status.IN_PROGRESS);

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/ForkJoinTaskMapper.java
@@ -27,6 +27,7 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.core.exception.TerminateWorkflowException;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.TimeService;
 
 /**
  * An implementation of {@link TaskMapper} to map a {@link WorkflowTask} of type {@link
@@ -74,7 +75,7 @@ public class ForkJoinTaskMapper implements TaskMapper {
         TaskModel forkTask = taskMapperContext.createTaskModel();
         forkTask.setTaskType(TaskType.TASK_TYPE_FORK);
         forkTask.setTaskDefName(TaskType.TASK_TYPE_FORK);
-        long epochMillis = System.currentTimeMillis();
+        long epochMillis = TimeService.currentTimeMillis();
         forkTask.setStartTime(epochMillis);
         forkTask.setEndTime(epochMillis);
         forkTask.setInputData(taskInput);

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/HumanTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/HumanTaskMapper.java
@@ -25,6 +25,7 @@ import com.netflix.conductor.core.execution.tasks.Human;
 import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.TimeService;
 
 import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_HUMAN;
 
@@ -66,7 +67,7 @@ public class HumanTaskMapper implements TaskMapper {
         TaskModel humanTask = taskMapperContext.createTaskModel();
         humanTask.setTaskType(TASK_TYPE_HUMAN);
         humanTask.setInputData(humanTaskInput);
-        humanTask.setStartTime(System.currentTimeMillis());
+        humanTask.setStartTime(TimeService.currentTimeMillis());
         humanTask.setStatus(TaskModel.Status.IN_PROGRESS);
         return List.of(humanTask);
     }

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/InlineTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/InlineTaskMapper.java
@@ -28,6 +28,7 @@ import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.TimeService;
 
 /**
  * An implementation of {@link TaskMapper} to map a {@link WorkflowTask} of type {@link
@@ -74,7 +75,7 @@ public class InlineTaskMapper implements TaskMapper {
 
         TaskModel inlineTask = taskMapperContext.createTaskModel();
         inlineTask.setTaskType(TaskType.TASK_TYPE_INLINE);
-        inlineTask.setStartTime(System.currentTimeMillis());
+        inlineTask.setStartTime(TimeService.currentTimeMillis());
         inlineTask.setInputData(taskInput);
         if (Objects.nonNull(taskMapperContext.getTaskDefinition())) {
             inlineTask.setIsolationGroupId(

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/JoinTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/JoinTaskMapper.java
@@ -26,6 +26,7 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.TimeService;
 
 /**
  * An implementation of {@link TaskMapper} to map a {@link WorkflowTask} of type {@link
@@ -63,7 +64,7 @@ public class JoinTaskMapper implements TaskMapper {
         TaskModel joinTask = taskMapperContext.createTaskModel();
         joinTask.setTaskType(TaskType.TASK_TYPE_JOIN);
         joinTask.setTaskDefName(TaskType.TASK_TYPE_JOIN);
-        joinTask.setStartTime(System.currentTimeMillis());
+        joinTask.setStartTime(TimeService.currentTimeMillis());
         joinTask.setInputData(joinInput);
         joinTask.setStatus(TaskModel.Status.IN_PROGRESS);
         if (Objects.nonNull(taskMapperContext.getTaskDefinition())) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/JsonJQTransformTaskMapper.java
@@ -28,6 +28,7 @@ import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.TimeService;
 
 @Component
 public class JsonJQTransformTaskMapper implements TaskMapper {
@@ -64,7 +65,7 @@ public class JsonJQTransformTaskMapper implements TaskMapper {
                         workflowTask.getInputParameters(), workflowModel, taskId, taskDefinition);
 
         TaskModel jsonJQTransformTask = taskMapperContext.createTaskModel();
-        jsonJQTransformTask.setStartTime(System.currentTimeMillis());
+        jsonJQTransformTask.setStartTime(TimeService.currentTimeMillis());
         jsonJQTransformTask.setInputData(taskInput);
         if (Objects.nonNull(taskMapperContext.getTaskDefinition())) {
             jsonJQTransformTask.setIsolationGroupId(

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/LambdaTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/LambdaTaskMapper.java
@@ -27,6 +27,7 @@ import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.TimeService;
 
 /**
  * @author x-ultra
@@ -74,7 +75,7 @@ public class LambdaTaskMapper implements TaskMapper {
 
         TaskModel lambdaTask = taskMapperContext.createTaskModel();
         lambdaTask.setTaskType(TaskType.TASK_TYPE_LAMBDA);
-        lambdaTask.setStartTime(System.currentTimeMillis());
+        lambdaTask.setStartTime(TimeService.currentTimeMillis());
         lambdaTask.setInputData(taskInput);
         lambdaTask.setStatus(TaskModel.Status.IN_PROGRESS);
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/NoopTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/NoopTaskMapper.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Component;
 
 import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.model.TaskModel;
+import com.netflix.conductor.service.TimeService;
 
 import static com.netflix.conductor.common.metadata.tasks.TaskType.*;
 
@@ -39,7 +40,7 @@ public class NoopTaskMapper implements TaskMapper {
 
         TaskModel task = taskMapperContext.createTaskModel();
         task.setTaskType(TASK_TYPE_NOOP);
-        task.setStartTime(System.currentTimeMillis());
+        task.setStartTime(TimeService.currentTimeMillis());
         task.setStatus(TaskModel.Status.IN_PROGRESS);
         return List.of(task);
     }

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SetVariableTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SetVariableTaskMapper.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Component;
 import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.core.exception.TerminateWorkflowException;
 import com.netflix.conductor.model.TaskModel;
+import com.netflix.conductor.service.TimeService;
 
 @Component
 public class SetVariableTaskMapper implements TaskMapper {
@@ -38,7 +39,7 @@ public class SetVariableTaskMapper implements TaskMapper {
         LOGGER.debug("TaskMapperContext {} in SetVariableMapper", taskMapperContext);
 
         TaskModel varTask = taskMapperContext.createTaskModel();
-        varTask.setStartTime(System.currentTimeMillis());
+        varTask.setStartTime(TimeService.currentTimeMillis());
         varTask.setInputData(taskMapperContext.getTaskInput());
         varTask.setStatus(TaskModel.Status.IN_PROGRESS);
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SwitchTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SwitchTaskMapper.java
@@ -27,6 +27,7 @@ import com.netflix.conductor.core.exception.TerminateWorkflowException;
 import com.netflix.conductor.core.execution.evaluators.Evaluator;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.TimeService;
 
 /**
  * An implementation of {@link TaskMapper} to map a {@link WorkflowTask} of type {@link
@@ -93,7 +94,7 @@ public class SwitchTaskMapper implements TaskMapper {
             switchTask.setTaskType(TaskType.TASK_TYPE_SWITCH);
             switchTask.setTaskDefName(TaskType.TASK_TYPE_SWITCH);
             switchTask.getInputData().putAll(taskInput);
-            switchTask.setStartTime(System.currentTimeMillis());
+            switchTask.setStartTime(TimeService.currentTimeMillis());
             switchTask.setStatus(TaskModel.Status.FAILED);
             switchTask.setReasonForIncompletion(exception.getMessage());
             tasksToBeScheduled.add(switchTask);
@@ -109,7 +110,7 @@ public class SwitchTaskMapper implements TaskMapper {
         switchTask.getInputData().put("case", evalResult);
         switchTask.addOutput("evaluationResult", List.of(evalResult));
         switchTask.addOutput("selectedCase", evalResult);
-        switchTask.setStartTime(System.currentTimeMillis());
+        switchTask.setStartTime(TimeService.currentTimeMillis());
         switchTask.setStatus(TaskModel.Status.IN_PROGRESS);
         tasksToBeScheduled.add(switchTask);
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/TaskMapperContext.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/TaskMapperContext.java
@@ -20,6 +20,7 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.core.execution.DeciderService;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.TimeService;
 
 /** Business Object class used for interaction between the DeciderService and Different Mappers */
 public class TaskMapperContext {
@@ -103,7 +104,7 @@ public class TaskMapperContext {
         taskModel.setWorkflowInstanceId(workflowModel.getWorkflowId());
         taskModel.setWorkflowType(workflowModel.getWorkflowName());
         taskModel.setCorrelationId(workflowModel.getCorrelationId());
-        taskModel.setScheduledTime(System.currentTimeMillis());
+        taskModel.setScheduledTime(TimeService.currentTimeMillis());
 
         taskModel.setTaskId(taskId);
         taskModel.setWorkflowTask(workflowTask);

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/TerminateTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/TerminateTaskMapper.java
@@ -23,6 +23,7 @@ import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.TimeService;
 
 import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_TERMINATE;
 
@@ -58,7 +59,7 @@ public class TerminateTaskMapper implements TaskMapper {
 
         TaskModel task = taskMapperContext.createTaskModel();
         task.setTaskType(TASK_TYPE_TERMINATE);
-        task.setStartTime(System.currentTimeMillis());
+        task.setStartTime(TimeService.currentTimeMillis());
         task.setInputData(taskInput);
         task.setStatus(TaskModel.Status.IN_PROGRESS);
         return List.of(task);

--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/WaitTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/WaitTaskMapper.java
@@ -27,6 +27,7 @@ import com.netflix.conductor.core.execution.tasks.Wait;
 import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.TimeService;
 
 import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_WAIT;
 import static com.netflix.conductor.core.execution.tasks.Wait.DURATION_INPUT;
@@ -74,7 +75,7 @@ public class WaitTaskMapper implements TaskMapper {
         TaskModel waitTask = taskMapperContext.createTaskModel();
         waitTask.setTaskType(TASK_TYPE_WAIT);
         waitTask.setInputData(waitTaskInput);
-        waitTask.setStartTime(System.currentTimeMillis());
+        waitTask.setStartTime(TimeService.currentTimeMillis());
         waitTask.setStatus(TaskModel.Status.IN_PROGRESS);
         if (Objects.nonNull(taskMapperContext.getTaskDefinition())) {
             waitTask.setIsolationGroupId(
@@ -100,7 +101,7 @@ public class WaitTaskMapper implements TaskMapper {
         if (StringUtils.isNotBlank(duration)) {
 
             Duration timeDuration = parseDuration(duration);
-            long waitTimeout = System.currentTimeMillis() + (timeDuration.getSeconds() * 1000);
+            long waitTimeout = TimeService.currentTimeMillis() + (timeDuration.getSeconds() * 1000);
             task.setWaitTimeout(waitTimeout);
             long seconds = timeDuration.getSeconds();
             task.setCallbackAfterSeconds(seconds);
@@ -110,7 +111,7 @@ public class WaitTaskMapper implements TaskMapper {
 
                 Date expiryDate = parseDate(until);
                 long timeInMS = expiryDate.getTime();
-                long now = System.currentTimeMillis();
+                long now = TimeService.currentTimeMillis();
                 long seconds = ((timeInMS - now) / 1000);
                 if (seconds < 0) {
                     seconds = 0;

--- a/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowSweeper.java
+++ b/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowSweeper.java
@@ -36,6 +36,7 @@ import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.TaskModel.Status;
 import com.netflix.conductor.model.WorkflowModel;
 import com.netflix.conductor.service.ExecutionLockService;
+import com.netflix.conductor.service.TimeService;
 
 import static com.netflix.conductor.core.config.SchedulerConfiguration.SWEEPER_EXECUTOR_NAME;
 import static com.netflix.conductor.core.utils.Utils.DECIDER_QUEUE;
@@ -90,9 +91,9 @@ public class WorkflowSweeper {
                 // Verify and repair tasks in the workflow.
                 workflowRepairService.verifyAndRepairWorkflowTasks(workflow);
             }
-            long decideStartTime = System.currentTimeMillis();
+            long decideStartTime = TimeService.currentTimeMillis();
             workflow = workflowExecutor.decide(workflow.getWorkflowId());
-            Monitors.recordWorkflowDecisionTime(System.currentTimeMillis() - decideStartTime);
+            Monitors.recordWorkflowDecisionTime(TimeService.currentTimeMillis() - decideStartTime);
             if (workflow != null && workflow.getStatus().isTerminal()) {
                 queueDAO.remove(DECIDER_QUEUE, workflowId);
                 return;
@@ -133,7 +134,8 @@ public class WorkflowSweeper {
                         postponeDurationSeconds = workflowOffsetTimeout;
                     } else {
                         long deltaInSeconds =
-                                (taskModel.getWaitTimeout() - System.currentTimeMillis()) / 1000;
+                                (taskModel.getWaitTimeout() - TimeService.currentTimeMillis())
+                                        / 1000;
                         postponeDurationSeconds = (deltaInSeconds > 0) ? deltaInSeconds : 0;
                     }
                 } else if (taskModel.getTaskType().equals(TaskType.TASK_TYPE_HUMAN)) {

--- a/core/src/main/java/com/netflix/conductor/model/TaskModel.java
+++ b/core/src/main/java/com/netflix/conductor/model/TaskModel.java
@@ -23,6 +23,7 @@ import org.springframework.beans.BeanUtils;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.service.TimeService;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -598,7 +599,7 @@ public class TaskModel {
         if (this.startTime > 0 && this.scheduledTime > 0) {
             if (this.updateTime > 0 && getCallbackAfterSeconds() > 0) {
                 long waitTime =
-                        System.currentTimeMillis()
+                        TimeService.currentTimeMillis()
                                 - (this.updateTime + (getCallbackAfterSeconds() * 1000));
                 return waitTime > 0 ? waitTime : 0;
             } else {

--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -167,7 +167,7 @@ public class ExecutionService {
 
                 taskModel.setStatus(TaskModel.Status.IN_PROGRESS);
                 if (taskModel.getStartTime() == 0) {
-                    taskModel.setStartTime(System.currentTimeMillis());
+                    taskModel.setStartTime(TimeService.currentTimeMillis());
                     Monitors.recordQueueWaitTime(
                             taskModel.getTaskDefName(), taskModel.getQueueWaitTime());
                 }
@@ -365,7 +365,7 @@ public class ExecutionService {
             callback = 0;
         }
         queueDAO.remove(QueueUtils.getQueueName(pending), pending.getTaskId());
-        long now = System.currentTimeMillis();
+        long now = TimeService.currentTimeMillis();
         callback = callback - ((now - pending.getUpdateTime()) / 1000);
         if (callback < 0) {
             callback = 0;
@@ -605,7 +605,7 @@ public class ExecutionService {
         TaskExecLog executionLog = new TaskExecLog();
         executionLog.setTaskId(taskId);
         executionLog.setLog(log);
-        executionLog.setCreatedTime(System.currentTimeMillis());
+        executionLog.setCreatedTime(TimeService.currentTimeMillis());
         executionDAOFacade.addTaskExecLog(Collections.singletonList(executionLog));
     }
 

--- a/core/src/main/java/com/netflix/conductor/service/MetadataServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/MetadataServiceImpl.java
@@ -59,7 +59,7 @@ public class MetadataServiceImpl implements MetadataService {
     public void registerTaskDef(List<TaskDef> taskDefinitions) {
         for (TaskDef taskDefinition : taskDefinitions) {
             taskDefinition.setCreatedBy(WorkflowContext.get().getClientApp());
-            taskDefinition.setCreateTime(System.currentTimeMillis());
+            taskDefinition.setCreateTime(TimeService.currentTimeMillis());
             taskDefinition.setUpdatedBy(null);
             taskDefinition.setUpdateTime(null);
 
@@ -81,7 +81,7 @@ public class MetadataServiceImpl implements MetadataService {
             throw new NotFoundException("No such task by name %s", taskDefinition.getName());
         }
         taskDefinition.setUpdatedBy(WorkflowContext.get().getClientApp());
-        taskDefinition.setUpdateTime(System.currentTimeMillis());
+        taskDefinition.setUpdateTime(TimeService.currentTimeMillis());
         taskDefinition.setCreateTime(existing.getCreateTime());
         taskDefinition.setCreatedBy(existing.getCreatedBy());
         metadataDAO.updateTaskDef(taskDefinition);
@@ -117,7 +117,7 @@ public class MetadataServiceImpl implements MetadataService {
      * @param workflowDef Workflow definition to be updated
      */
     public void updateWorkflowDef(WorkflowDef workflowDef) {
-        workflowDef.setUpdateTime(System.currentTimeMillis());
+        workflowDef.setUpdateTime(TimeService.currentTimeMillis());
         metadataDAO.updateWorkflowDef(workflowDef);
     }
 
@@ -170,7 +170,7 @@ public class MetadataServiceImpl implements MetadataService {
     }
 
     public void registerWorkflowDef(WorkflowDef workflowDef) {
-        workflowDef.setCreateTime(System.currentTimeMillis());
+        workflowDef.setCreateTime(TimeService.currentTimeMillis());
         metadataDAO.createWorkflowDef(workflowDef);
     }
 

--- a/core/src/main/java/com/netflix/conductor/service/TimeService.java
+++ b/core/src/main/java/com/netflix/conductor/service/TimeService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.service;
+
+import java.time.Clock;
+
+/**
+ * Centralised time service to get the current time. This is aimed to abstract the time source and
+ * allow for interacting with time during testing.
+ */
+public class TimeService {
+    public static boolean useCustomClockForTests = false;
+    public static Clock customClockForTests = Clock.systemDefaultZone();
+
+    public static long currentTimeMillis() {
+        if (!useCustomClockForTests) {
+            return TimeService.currentTimeMillis();
+        } else {
+            return customClockForTests.millis();
+        }
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/service/WorkflowTestService.java
+++ b/core/src/main/java/com/netflix/conductor/service/WorkflowTestService.java
@@ -123,11 +123,11 @@ public class WorkflowTestService {
                             if (task.getExecutionTime() > 0 || task.getQueueWaitTime() > 0) {
                                 TaskModel existing = executionDAO.getTask(running.getTaskId());
                                 existing.setScheduledTime(
-                                        System.currentTimeMillis()
+                                        TimeService.currentTimeMillis()
                                                 - (task.getExecutionTime()
                                                         + task.getQueueWaitTime()));
                                 existing.setStartTime(
-                                        System.currentTimeMillis() - task.getExecutionTime());
+                                        TimeService.currentTimeMillis() - task.getExecutionTime());
                                 existing.setStatus(
                                         TaskModel.Status.valueOf(task.getStatus().name()));
                                 existing.getOutputData().putAll(task.getOutput());

--- a/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
@@ -25,6 +25,7 @@ import com.netflix.conductor.dao.MetadataDAO
 import com.netflix.conductor.dao.QueueDAO
 import com.netflix.conductor.model.TaskModel
 import com.netflix.conductor.model.WorkflowModel
+import com.netflix.conductor.service.TimeService
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import spock.lang.Specification
@@ -73,7 +74,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         task1.setTaskType(SUB_WORKFLOW.name())
         task1.setReferenceTaskName("waitTask")
         task1.setWorkflowInstanceId(workflowId)
-        task1.setScheduledTime(System.currentTimeMillis())
+        task1.setScheduledTime(TimeService.currentTimeMillis())
         task1.setTaskId(task1Id)
         task1.getInputData().put("asyncComplete", true)
         task1.getInputData().put("subWorkflowName", "junit1")

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderOutcomes.java
@@ -67,6 +67,7 @@ import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.TimeService;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -263,7 +264,7 @@ public class TestDeciderOutcomes {
         WorkflowModel workflow = new WorkflowModel();
         workflow.setWorkflowDefinition(def);
         workflow.getInput().put("requestId", 123);
-        workflow.setCreateTime(System.currentTimeMillis());
+        workflow.setCreateTime(TimeService.currentTimeMillis());
         DeciderOutcome outcome = deciderService.decide(workflow);
         assertNotNull(outcome);
 
@@ -330,7 +331,7 @@ public class TestDeciderOutcomes {
         workflow = new WorkflowModel();
         workflow.setWorkflowDefinition(def);
         workflow.getInput().put("requestId", 123);
-        workflow.setCreateTime(System.currentTimeMillis());
+        workflow.setCreateTime(TimeService.currentTimeMillis());
 
         workflow.getInput().put("forks", forks);
         workflow.getInput().put("forkedInputs", forkedInputs);
@@ -349,7 +350,7 @@ public class TestDeciderOutcomes {
 
         outcome.tasksToBeScheduled.get(1).setStatus(TaskModel.Status.FAILED);
         for (TaskModel taskToBeScheduled : outcome.tasksToBeScheduled) {
-            taskToBeScheduled.setUpdateTime(System.currentTimeMillis());
+            taskToBeScheduled.setUpdateTime(TimeService.currentTimeMillis());
         }
         workflow.getTasks().addAll(outcome.tasksToBeScheduled);
 
@@ -396,7 +397,7 @@ public class TestDeciderOutcomes {
 
         WorkflowModel workflow = new WorkflowModel();
         workflow.setWorkflowDefinition(def);
-        workflow.setCreateTime(System.currentTimeMillis());
+        workflow.setCreateTime(TimeService.currentTimeMillis());
         DeciderOutcome outcome = deciderService.decide(workflow);
         assertNotNull(outcome);
         assertEquals(1, outcome.tasksToBeScheduled.size());
@@ -470,7 +471,7 @@ public class TestDeciderOutcomes {
 
         WorkflowModel workflow = new WorkflowModel();
         workflow.setWorkflowDefinition(def);
-        workflow.setCreateTime(System.currentTimeMillis());
+        workflow.setCreateTime(TimeService.currentTimeMillis());
         DeciderOutcome outcome = deciderService.decide(workflow);
         assertNotNull(outcome);
         assertEquals(1, outcome.tasksToBeScheduled.size());
@@ -562,7 +563,7 @@ public class TestDeciderOutcomes {
         workflow.getInput().put("forks", forks);
         workflow.getInput().put("forkedInputs", forkedInputs);
 
-        workflow.setCreateTime(System.currentTimeMillis());
+        workflow.setCreateTime(TimeService.currentTimeMillis());
         DeciderOutcome outcome = deciderService.decide(workflow);
         assertNotNull(outcome);
         assertEquals(5, outcome.tasksToBeScheduled.size());
@@ -580,7 +581,7 @@ public class TestDeciderOutcomes {
                     taskToBeScheduled.setStatus(TaskModel.Status.FAILED);
                 }
 
-                taskToBeScheduled.setUpdateTime(System.currentTimeMillis());
+                taskToBeScheduled.setUpdateTime(TimeService.currentTimeMillis());
             }
             workflow.getTasks().addAll(outcome.tasksToBeScheduled);
             outcome = deciderService.decide(workflow);
@@ -641,7 +642,7 @@ public class TestDeciderOutcomes {
 
         WorkflowModel workflow = new WorkflowModel();
         workflow.setWorkflowDefinition(def);
-        workflow.setCreateTime(System.currentTimeMillis());
+        workflow.setCreateTime(TimeService.currentTimeMillis());
         DeciderOutcome outcome = deciderService.decide(workflow);
         assertNotNull(outcome);
         assertEquals(2, outcome.tasksToBeScheduled.size());

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -57,6 +57,7 @@ import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.TimeService;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Registry;
@@ -501,7 +502,7 @@ public class TestDeciderService {
 
         TaskModel task = new TaskModel();
         task.setTaskType(taskType.getName());
-        task.setStartTime(System.currentTimeMillis() - 2_000); // 2 seconds ago!
+        task.setStartTime(TimeService.currentTimeMillis() - 2_000); // 2 seconds ago!
         task.setStatus(TaskModel.Status.IN_PROGRESS);
         deciderService.checkTaskTimeout(taskType, task);
 
@@ -558,7 +559,7 @@ public class TestDeciderService {
 
         TaskModel task = new TaskModel();
         task.setTaskType(taskType.getName());
-        task.setScheduledTime(System.currentTimeMillis() - 2_000);
+        task.setScheduledTime(TimeService.currentTimeMillis() - 2_000);
         task.setStatus(TaskModel.Status.SCHEDULED);
         deciderService.checkTaskPollTimeout(taskType, task);
 
@@ -566,7 +567,7 @@ public class TestDeciderService {
         assertEquals(TaskModel.Status.TIMED_OUT, task.getStatus());
         assertNotNull(task.getReasonForIncompletion());
 
-        task.setScheduledTime(System.currentTimeMillis());
+        task.setScheduledTime(TimeService.currentTimeMillis());
         task.setReasonForIncompletion(null);
         task.setStatus(TaskModel.Status.SCHEDULED);
         deciderService.checkTaskPollTimeout(taskType, task);
@@ -994,7 +995,7 @@ public class TestDeciderService {
         task.setStatus(TaskModel.Status.IN_PROGRESS);
         task.setTaskId("aa");
         task.setTaskType(TaskType.TASK_TYPE_SIMPLE);
-        task.setUpdateTime(System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(11));
+        task.setUpdateTime(TimeService.currentTimeMillis() - TimeUnit.SECONDS.toMillis(11));
 
         assertTrue(deciderService.isResponseTimedOut(taskDef, task));
 
@@ -1155,7 +1156,7 @@ public class TestDeciderService {
         workflowDef.setName("test");
         WorkflowModel workflow = new WorkflowModel();
         workflow.setOwnerApp("junit");
-        workflow.setCreateTime(System.currentTimeMillis() - 10_000);
+        workflow.setCreateTime(TimeService.currentTimeMillis() - 10_000);
         workflow.setWorkflowId("workflow_id");
 
         // no-op
@@ -1183,7 +1184,7 @@ public class TestDeciderService {
         }
 
         // for a retried workflow
-        workflow.setLastRetriedTime(System.currentTimeMillis() - 5_000);
+        workflow.setLastRetriedTime(TimeService.currentTimeMillis() - 5_000);
         try {
             deciderService.checkWorkflowTimeout(workflow);
         } catch (TerminateWorkflowException twe) {

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -58,6 +58,7 @@ import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
 import com.netflix.conductor.service.ExecutionLockService;
+import com.netflix.conductor.service.TimeService;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -254,7 +255,7 @@ public class TestWorkflowExecutor {
         task1.setReferenceTaskName(taskToSchedule.getTaskReferenceName());
         task1.setWorkflowInstanceId(workflow.getWorkflowId());
         task1.setCorrelationId(workflow.getCorrelationId());
-        task1.setScheduledTime(System.currentTimeMillis());
+        task1.setScheduledTime(TimeService.currentTimeMillis());
         task1.setTaskId(idGenerator.generate());
         task1.setInputData(new HashMap<>());
         task1.setStatus(TaskModel.Status.SCHEDULED);
@@ -268,7 +269,7 @@ public class TestWorkflowExecutor {
         task2.setReferenceTaskName(taskToSchedule.getTaskReferenceName());
         task2.setWorkflowInstanceId(workflow.getWorkflowId());
         task2.setCorrelationId(workflow.getCorrelationId());
-        task2.setScheduledTime(System.currentTimeMillis());
+        task2.setScheduledTime(TimeService.currentTimeMillis());
         task2.setInputData(new HashMap<>());
         task2.setTaskId(idGenerator.generate());
         task2.setStatus(TaskModel.Status.IN_PROGRESS);
@@ -280,7 +281,7 @@ public class TestWorkflowExecutor {
         task3.setReferenceTaskName(taskToSchedule.getTaskReferenceName());
         task3.setWorkflowInstanceId(workflow.getWorkflowId());
         task3.setCorrelationId(workflow.getCorrelationId());
-        task3.setScheduledTime(System.currentTimeMillis());
+        task3.setScheduledTime(TimeService.currentTimeMillis());
         task3.setTaskId(idGenerator.generate());
         task3.setInputData(new HashMap<>());
         task3.setStatus(TaskModel.Status.SCHEDULED);
@@ -1108,7 +1109,7 @@ public class TestWorkflowExecutor {
         task.setTaskDefName("task");
         task.setReferenceTaskName("task_ref");
         task.setWorkflowInstanceId(workflowInstanceId);
-        task.setScheduledTime(System.currentTimeMillis());
+        task.setScheduledTime(TimeService.currentTimeMillis());
         task.setTaskId(idGenerator.generate());
         task.setStatus(TaskModel.Status.COMPLETED);
         task.setRetryCount(0);
@@ -1122,7 +1123,7 @@ public class TestWorkflowExecutor {
         task1.setTaskDefName("task1");
         task1.setReferenceTaskName("task1_ref");
         task1.setWorkflowInstanceId(workflowInstanceId);
-        task1.setScheduledTime(System.currentTimeMillis());
+        task1.setScheduledTime(TimeService.currentTimeMillis());
         task1.setTaskId(idGenerator.generate());
         task1.setStatus(TaskModel.Status.FAILED);
         task1.setRetryCount(0);
@@ -1143,7 +1144,7 @@ public class TestWorkflowExecutor {
 
         TaskModel task2 = new TaskModel();
         task2.setWorkflowInstanceId(subWorkflow.getWorkflowId());
-        task2.setScheduledTime(System.currentTimeMillis());
+        task2.setScheduledTime(TimeService.currentTimeMillis());
         task2.setTaskId(idGenerator.generate());
         task2.setStatus(TaskModel.Status.FAILED);
         task2.setRetryCount(0);
@@ -1351,7 +1352,7 @@ public class TestWorkflowExecutor {
         task1.setTaskDefName("task1");
         task1.setReferenceTaskName("task1_ref");
         task1.setWorkflowInstanceId(subWorkflowId);
-        task1.setScheduledTime(System.currentTimeMillis());
+        task1.setScheduledTime(TimeService.currentTimeMillis());
         task1.setTaskId(idGenerator.generate());
         task1.setStatus(TaskModel.Status.COMPLETED);
         task1.setWorkflowTask(new WorkflowTask());
@@ -1362,7 +1363,7 @@ public class TestWorkflowExecutor {
         task2.setTaskDefName("task2");
         task2.setReferenceTaskName("task2_ref");
         task2.setWorkflowInstanceId(subWorkflowId);
-        task2.setScheduledTime(System.currentTimeMillis());
+        task2.setScheduledTime(TimeService.currentTimeMillis());
         task2.setTaskId(idGenerator.generate());
         task2.setStatus(TaskModel.Status.COMPLETED);
         task2.setWorkflowTask(new WorkflowTask());
@@ -1382,7 +1383,7 @@ public class TestWorkflowExecutor {
         // parent workflow setup
         TaskModel task = new TaskModel();
         task.setWorkflowInstanceId(parentWorkflowId);
-        task.setScheduledTime(System.currentTimeMillis());
+        task.setScheduledTime(TimeService.currentTimeMillis());
         task.setTaskId(idGenerator.generate());
         task.setStatus(TaskModel.Status.COMPLETED);
         task.setOutputData(new HashMap<>());
@@ -1505,7 +1506,7 @@ public class TestWorkflowExecutor {
         task1.setTaskDefName("task1");
         task1.setReferenceTaskName("task1_ref");
         task1.setWorkflowInstanceId(workflowId);
-        task1.setScheduledTime(System.currentTimeMillis());
+        task1.setScheduledTime(TimeService.currentTimeMillis());
         task1.setTaskId(idGenerator.generate());
         task1.setStatus(TaskModel.Status.COMPLETED);
         task1.setWorkflowTask(new WorkflowTask());
@@ -1515,7 +1516,7 @@ public class TestWorkflowExecutor {
         task2.setTaskType(TaskType.JSON_JQ_TRANSFORM.name());
         task2.setReferenceTaskName("task2_ref");
         task2.setWorkflowInstanceId(workflowId);
-        task2.setScheduledTime(System.currentTimeMillis());
+        task2.setScheduledTime(TimeService.currentTimeMillis());
         task2.setTaskId("system-task-id");
         task2.setStatus(TaskModel.Status.FAILED);
 
@@ -1574,7 +1575,7 @@ public class TestWorkflowExecutor {
         task1.setTaskDefName("task1");
         task1.setReferenceTaskName("task1_ref");
         task1.setWorkflowInstanceId(subWorkflowId);
-        task1.setScheduledTime(System.currentTimeMillis());
+        task1.setScheduledTime(TimeService.currentTimeMillis());
         task1.setTaskId(idGenerator.generate());
         task1.setStatus(TaskModel.Status.COMPLETED);
         task1.setWorkflowTask(new WorkflowTask());
@@ -1585,7 +1586,7 @@ public class TestWorkflowExecutor {
         task2.setTaskDefName("task2");
         task2.setReferenceTaskName("task2_ref");
         task2.setWorkflowInstanceId(subWorkflowId);
-        task2.setScheduledTime(System.currentTimeMillis());
+        task2.setScheduledTime(TimeService.currentTimeMillis());
         task2.setTaskId(idGenerator.generate());
         task2.setStatus(TaskModel.Status.COMPLETED);
         task2.setWorkflowTask(new WorkflowTask());
@@ -1605,7 +1606,7 @@ public class TestWorkflowExecutor {
         // parent workflow setup
         TaskModel task = new TaskModel();
         task.setWorkflowInstanceId(parentWorkflowId);
-        task.setScheduledTime(System.currentTimeMillis());
+        task.setScheduledTime(TimeService.currentTimeMillis());
         task.setTaskId(idGenerator.generate());
         task.setStatus(TaskModel.Status.COMPLETED);
         task.setOutputData(new HashMap<>());
@@ -1655,7 +1656,10 @@ public class TestWorkflowExecutor {
 
         PollData pollData1 =
                 new PollData(
-                        "queue1", domains[0], "worker1", System.currentTimeMillis() - 99 * 1000);
+                        "queue1",
+                        domains[0],
+                        "worker1",
+                        TimeService.currentTimeMillis() - 99 * 1000);
         when(executionDAOFacade.getTaskPollDataByDomain(taskType, domains[0]))
                 .thenReturn(pollData1);
         String activeDomain = workflowExecutor.getActiveDomain(taskType, domains);
@@ -1664,7 +1668,10 @@ public class TestWorkflowExecutor {
 
         PollData pollData2 =
                 new PollData(
-                        "queue2", domains[1], "worker2", System.currentTimeMillis() - 99 * 1000);
+                        "queue2",
+                        domains[1],
+                        "worker2",
+                        TimeService.currentTimeMillis() - 99 * 1000);
         when(executionDAOFacade.getTaskPollDataByDomain(taskType, domains[1]))
                 .thenReturn(pollData2);
         activeDomain = workflowExecutor.getActiveDomain(taskType, domains);
@@ -1701,7 +1708,10 @@ public class TestWorkflowExecutor {
 
         PollData pollData1 =
                 new PollData(
-                        "queue1", domains[0], "worker1", System.currentTimeMillis() - 99 * 10000);
+                        "queue1",
+                        domains[0],
+                        "worker1",
+                        TimeService.currentTimeMillis() - 99 * 10000);
         when(executionDAOFacade.getTaskPollDataByDomain(taskType, domains[0]))
                 .thenReturn(pollData1);
         when(executionDAOFacade.getTaskPollDataByDomain(taskType, domains[1])).thenReturn(null);
@@ -1716,7 +1726,10 @@ public class TestWorkflowExecutor {
 
         PollData pollData1 =
                 new PollData(
-                        "queue1", domains[0], "worker1", System.currentTimeMillis() - 99 * 10000);
+                        "queue1",
+                        domains[0],
+                        "worker1",
+                        TimeService.currentTimeMillis() - 99 * 10000);
         when(executionDAOFacade.getTaskPollDataByDomain(taskType, domains[0]))
                 .thenReturn(pollData1);
         when(executionDAOFacade.getTaskPollDataByDomain(taskType, domains[1])).thenReturn(null);
@@ -1735,7 +1748,10 @@ public class TestWorkflowExecutor {
 
         PollData pollData1 =
                 new PollData(
-                        "queue1", "mydomain", "worker1", System.currentTimeMillis() - 99 * 100);
+                        "queue1",
+                        "mydomain",
+                        "worker1",
+                        TimeService.currentTimeMillis() - 99 * 100);
         when(executionDAOFacade.getTaskPollDataByDomain(anyString(), anyString()))
                 .thenReturn(pollData1);
         workflowExecutor.setTaskDomains(tasks, workflow);
@@ -1755,7 +1771,10 @@ public class TestWorkflowExecutor {
 
         PollData pollData1 =
                 new PollData(
-                        "queue1", "mydomain", "worker1", System.currentTimeMillis() - 99 * 100);
+                        "queue1",
+                        "mydomain",
+                        "worker1",
+                        TimeService.currentTimeMillis() - 99 * 100);
         when(executionDAOFacade.getTaskPollDataByDomain(eq("task1"), anyString()))
                 .thenReturn(pollData1);
         when(executionDAOFacade.getTaskPollDataByDomain(eq("task2"), anyString())).thenReturn(null);
@@ -1779,13 +1798,16 @@ public class TestWorkflowExecutor {
 
         PollData pollData1 =
                 new PollData(
-                        "queue1", "mydomain", "worker1", System.currentTimeMillis() - 99 * 100);
+                        "queue1",
+                        "mydomain",
+                        "worker1",
+                        TimeService.currentTimeMillis() - 99 * 100);
         PollData pollData2 =
                 new PollData(
                         "queue2",
                         "someActiveDomain",
                         "worker2",
-                        System.currentTimeMillis() - 99 * 100);
+                        TimeService.currentTimeMillis() - 99 * 100);
         when(executionDAOFacade.getTaskPollDataByDomain(anyString(), eq("mydomain")))
                 .thenReturn(pollData1);
         when(executionDAOFacade.getTaskPollDataByDomain(anyString(), eq("someInactiveDomain")))
@@ -1859,7 +1881,7 @@ public class TestWorkflowExecutor {
         completedTask.setTaskType(TaskType.SIMPLE.name());
         completedTask.setReferenceTaskName("completedTask");
         completedTask.setWorkflowInstanceId(workflowId);
-        completedTask.setScheduledTime(System.currentTimeMillis());
+        completedTask.setScheduledTime(TimeService.currentTimeMillis());
         completedTask.setCallbackAfterSeconds(300);
         completedTask.setTaskId("simple-task-id");
         completedTask.setStatus(TaskModel.Status.COMPLETED);
@@ -1868,7 +1890,7 @@ public class TestWorkflowExecutor {
         systemTask.setTaskType(TaskType.WAIT.name());
         systemTask.setReferenceTaskName("waitTask");
         systemTask.setWorkflowInstanceId(workflowId);
-        systemTask.setScheduledTime(System.currentTimeMillis());
+        systemTask.setScheduledTime(TimeService.currentTimeMillis());
         systemTask.setTaskId("system-task-id");
         systemTask.setStatus(TaskModel.Status.SCHEDULED);
 
@@ -1876,7 +1898,7 @@ public class TestWorkflowExecutor {
         simpleTask.setTaskType(TaskType.SIMPLE.name());
         simpleTask.setReferenceTaskName("simpleTask");
         simpleTask.setWorkflowInstanceId(workflowId);
-        simpleTask.setScheduledTime(System.currentTimeMillis());
+        simpleTask.setScheduledTime(TimeService.currentTimeMillis());
         simpleTask.setCallbackAfterSeconds(300);
         simpleTask.setTaskId("simple-task-id");
         simpleTask.setStatus(TaskModel.Status.SCHEDULED);
@@ -1885,7 +1907,7 @@ public class TestWorkflowExecutor {
         noCallbackTask.setTaskType(TaskType.SIMPLE.name());
         noCallbackTask.setReferenceTaskName("noCallbackTask");
         noCallbackTask.setWorkflowInstanceId(workflowId);
-        noCallbackTask.setScheduledTime(System.currentTimeMillis());
+        noCallbackTask.setScheduledTime(TimeService.currentTimeMillis());
         noCallbackTask.setCallbackAfterSeconds(0);
         noCallbackTask.setTaskId("no-callback-task-id");
         noCallbackTask.setStatus(TaskModel.Status.SCHEDULED);
@@ -2112,7 +2134,7 @@ public class TestWorkflowExecutor {
         task1.setTaskDefName("task1");
         task1.setReferenceTaskName("task1_ref");
         task1.setWorkflowInstanceId(subWorkflowId);
-        task1.setScheduledTime(System.currentTimeMillis());
+        task1.setScheduledTime(TimeService.currentTimeMillis());
         task1.setTaskId(idGenerator.generate());
         task1.setStatus(TaskModel.Status.COMPLETED);
         task1.setWorkflowTask(new WorkflowTask());
@@ -2123,7 +2145,7 @@ public class TestWorkflowExecutor {
         task2.setTaskDefName("task2");
         task2.setReferenceTaskName("task2_ref");
         task2.setWorkflowInstanceId(subWorkflowId);
-        task2.setScheduledTime(System.currentTimeMillis());
+        task2.setScheduledTime(TimeService.currentTimeMillis());
         task2.setTaskId(idGenerator.generate());
         task2.setStatus(TaskModel.Status.FAILED);
         task2.setWorkflowTask(new WorkflowTask());
@@ -2143,7 +2165,7 @@ public class TestWorkflowExecutor {
         // parent workflow setup
         TaskModel task = new TaskModel();
         task.setWorkflowInstanceId(parentWorkflowId);
-        task.setScheduledTime(System.currentTimeMillis());
+        task.setScheduledTime(TimeService.currentTimeMillis());
         task.setTaskId(idGenerator.generate());
         task.setStatus(TaskModel.Status.COMPLETED_WITH_ERRORS);
         task.setOutputData(new HashMap<>());
@@ -2198,7 +2220,7 @@ public class TestWorkflowExecutor {
         task1.setTaskDefName("task1");
         task1.setReferenceTaskName("task1_ref");
         task1.setWorkflowInstanceId(subWorkflowId);
-        task1.setScheduledTime(System.currentTimeMillis());
+        task1.setScheduledTime(TimeService.currentTimeMillis());
         task1.setTaskId(idGenerator.generate());
         task1.setStatus(TaskModel.Status.COMPLETED);
         task1.setWorkflowTask(new WorkflowTask());
@@ -2209,7 +2231,7 @@ public class TestWorkflowExecutor {
         task2.setTaskDefName("task2");
         task2.setReferenceTaskName("task2_ref");
         task2.setWorkflowInstanceId(subWorkflowId);
-        task2.setScheduledTime(System.currentTimeMillis());
+        task2.setScheduledTime(TimeService.currentTimeMillis());
         task2.setTaskId(idGenerator.generate());
         task2.setStatus(TaskModel.Status.FAILED);
         task2.setWorkflowTask(new WorkflowTask());
@@ -2229,7 +2251,7 @@ public class TestWorkflowExecutor {
         // parent workflow setup
         TaskModel task = new TaskModel();
         task.setWorkflowInstanceId(parentWorkflowId);
-        task.setScheduledTime(System.currentTimeMillis());
+        task.setScheduledTime(TimeService.currentTimeMillis());
         task.setTaskId(idGenerator.generate());
         task.setStatus(TaskModel.Status.COMPLETED_WITH_ERRORS);
         task.setOutputData(new HashMap<>());
@@ -2282,7 +2304,7 @@ public class TestWorkflowExecutor {
         task1.setTaskDefName("task1");
         task1.setReferenceTaskName("task1_ref");
         task1.setWorkflowInstanceId(subWorkflowId);
-        task1.setScheduledTime(System.currentTimeMillis());
+        task1.setScheduledTime(TimeService.currentTimeMillis());
         task1.setTaskId(idGenerator.generate());
         task1.setStatus(TaskModel.Status.COMPLETED);
         task1.setWorkflowTask(new WorkflowTask());
@@ -2293,7 +2315,7 @@ public class TestWorkflowExecutor {
         task2.setTaskDefName("task2");
         task2.setReferenceTaskName("task2_ref");
         task2.setWorkflowInstanceId(subWorkflowId);
-        task2.setScheduledTime(System.currentTimeMillis());
+        task2.setScheduledTime(TimeService.currentTimeMillis());
         task2.setTaskId(idGenerator.generate());
         task2.setStatus(TaskModel.Status.FAILED);
         task2.setWorkflowTask(new WorkflowTask());
@@ -2313,7 +2335,7 @@ public class TestWorkflowExecutor {
         // parent workflow setup
         TaskModel task = new TaskModel();
         task.setWorkflowInstanceId(parentWorkflowId);
-        task.setScheduledTime(System.currentTimeMillis());
+        task.setScheduledTime(TimeService.currentTimeMillis());
         task.setTaskId(idGenerator.generate());
         task.setStatus(TaskModel.Status.COMPLETED_WITH_ERRORS);
         task.setOutputData(new HashMap<>());
@@ -2365,7 +2387,7 @@ public class TestWorkflowExecutor {
         simpleTask.setTaskType(TaskType.SIMPLE.name());
         simpleTask.setReferenceTaskName("simpleTask");
         simpleTask.setWorkflowInstanceId(workflowId);
-        simpleTask.setScheduledTime(System.currentTimeMillis());
+        simpleTask.setScheduledTime(TimeService.currentTimeMillis());
         simpleTask.setCallbackAfterSeconds(0);
         simpleTask.setTaskId("simple-task-id");
         simpleTask.setStatus(TaskModel.Status.IN_PROGRESS);
@@ -2405,7 +2427,7 @@ public class TestWorkflowExecutor {
         simpleTask.setTaskType(TaskType.SIMPLE.name());
         simpleTask.setReferenceTaskName("simpleTask");
         simpleTask.setWorkflowInstanceId(workflowId);
-        simpleTask.setScheduledTime(System.currentTimeMillis());
+        simpleTask.setScheduledTime(TimeService.currentTimeMillis());
         simpleTask.setCallbackAfterSeconds(0);
         simpleTask.setTaskId("simple-task-id");
         simpleTask.setStatus(TaskModel.Status.IN_PROGRESS);
@@ -2510,7 +2532,7 @@ public class TestWorkflowExecutor {
         simpleTask.setTaskType(TaskType.SIMPLE.name());
         simpleTask.setReferenceTaskName("simpleTask");
         simpleTask.setWorkflowInstanceId("test-workflow-id");
-        simpleTask.setScheduledTime(System.currentTimeMillis());
+        simpleTask.setScheduledTime(TimeService.currentTimeMillis());
         simpleTask.setCallbackAfterSeconds(0);
         simpleTask.setTaskId("simple-task-id");
         simpleTask.setStatus(TaskModel.Status.IN_PROGRESS);

--- a/core/src/test/java/com/netflix/conductor/core/reconciliation/TestWorkflowSweeper.java
+++ b/core/src/test/java/com/netflix/conductor/core/reconciliation/TestWorkflowSweeper.java
@@ -30,6 +30,7 @@ import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.TaskModel.Status;
 import com.netflix.conductor.model.WorkflowModel;
 import com.netflix.conductor.service.ExecutionLockService;
+import com.netflix.conductor.service.TimeService;
 
 import static com.netflix.conductor.core.utils.Utils.DECIDER_QUEUE;
 
@@ -120,7 +121,7 @@ public class TestWorkflowSweeper {
         taskModel.setTaskId("task1");
         taskModel.setTaskType(TaskType.TASK_TYPE_WAIT);
         taskModel.setStatus(Status.IN_PROGRESS);
-        taskModel.setWaitTimeout(System.currentTimeMillis() + waitTimeout);
+        taskModel.setWaitTimeout(TimeService.currentTimeMillis() + waitTimeout);
         workflowModel.setTasks(List.of(taskModel));
         when(properties.getWorkflowOffsetTimeout())
                 .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
@@ -141,7 +142,7 @@ public class TestWorkflowSweeper {
         taskModel.setTaskId("task1");
         taskModel.setTaskType(TaskType.TASK_TYPE_WAIT);
         taskModel.setStatus(Status.IN_PROGRESS);
-        taskModel.setWaitTimeout(System.currentTimeMillis() + waitTimeout);
+        taskModel.setWaitTimeout(TimeService.currentTimeMillis() + waitTimeout);
         workflowModel.setTasks(List.of(taskModel));
         when(properties.getWorkflowOffsetTimeout())
                 .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));
@@ -160,7 +161,7 @@ public class TestWorkflowSweeper {
         taskModel.setTaskId("task1");
         taskModel.setTaskType(TaskType.TASK_TYPE_WAIT);
         taskModel.setStatus(Status.IN_PROGRESS);
-        taskModel.setWaitTimeout(System.currentTimeMillis() + waitTimeout);
+        taskModel.setWaitTimeout(TimeService.currentTimeMillis() + waitTimeout);
         workflowModel.setTasks(List.of(taskModel));
         when(properties.getWorkflowOffsetTimeout())
                 .thenReturn(Duration.ofSeconds(defaultPostPoneOffSetSeconds));

--- a/core/src/test/java/com/netflix/conductor/dao/ExecutionDAOTest.java
+++ b/core/src/test/java/com/netflix/conductor/dao/ExecutionDAOTest.java
@@ -32,6 +32,7 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.TimeService;
 
 import static org.junit.Assert.*;
 
@@ -340,8 +341,8 @@ public abstract class ExecutionDAOTest {
                 getExecutionDAO()
                         .getWorkflowsByType(
                                 workflow.getWorkflowName(),
-                                System.currentTimeMillis(),
-                                System.currentTimeMillis() + 100);
+                                TimeService.currentTimeMillis(),
+                                TimeService.currentTimeMillis() + 100);
         assertNotNull(bytime);
         assertTrue(bytime.isEmpty());
 


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [x] Other (please describe): Improve testing.


**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
We have a use case where we need to change time during execution of integration tests. This is an attempt to abstract out the time in conductor to a single place, so that during testing we can manipulate the time as per the need.


_Describe the new behavior from this PR, and why it's needed_
Issue #482
This PR adds a service to fetch current time in conductor via static methods. These methods can be overriden in tests to manipulate time. 

Alternatives considered
I also thought of using Bean (via @Bean config) to return clock instance or having TimeService as a `Component` but that would then require injecting the clock or TimeService into different classes which fetch current time. This breaks the backward compatibility and hence rejected those options.
