### PR TITLE
Address bug where the Kafka event queue is resuing the consumer client.id for each queue created

### DIFF
--- a/kafka-event-queue/src/main/java/com/netflix/conductor/kafkaeq/config/KafkaEventQueueConfiguration.java
+++ b/kafka-event-queue/src/main/java/com/netflix/conductor/kafkaeq/config/KafkaEventQueueConfiguration.java
@@ -15,8 +15,10 @@ package com.netflix.conductor.kafkaeq.config;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -87,8 +89,13 @@ public class KafkaEventQueueConfiguration {
                 String topicName = queuePrefix + status.name();
 
                 LOGGER.debug("topicName: {}", topicName);
+                // Create unique overrides
+                Properties consumerOverrides = new Properties();
+                consumerOverrides.put(ConsumerConfig.CLIENT_ID_CONFIG, topicName + "-consumer");
+                consumerOverrides.put(ConsumerConfig.GROUP_ID_CONFIG, topicName + "-group");
 
-                final ObservableQueue queue = new Builder(properties).build(topicName);
+                final ObservableQueue queue =
+                        new Builder(properties).build(topicName, consumerOverrides);
                 queues.put(status, queue);
             }
 

--- a/kafka-event-queue/src/main/java/com/netflix/conductor/kafkaeq/config/KafkaEventQueueProvider.java
+++ b/kafka-event-queue/src/main/java/com/netflix/conductor/kafkaeq/config/KafkaEventQueueProvider.java
@@ -42,6 +42,6 @@ public class KafkaEventQueueProvider implements EventQueueProvider {
     public ObservableQueue getQueue(String queueURI) {
         LOGGER.info("Creating KafkaObservableQueue for topic: {}", queueURI);
 
-        return queues.computeIfAbsent(queueURI, q -> new Builder(properties).build(queueURI));
+        return queues.computeIfAbsent(queueURI, q -> new Builder(properties).build(queueURI, null));
     }
 }

--- a/kafka-event-queue/src/main/java/com/netflix/conductor/kafkaeq/eventqueue/KafkaObservableQueue.java
+++ b/kafka-event-queue/src/main/java/com/netflix/conductor/kafkaeq/eventqueue/KafkaObservableQueue.java
@@ -567,9 +567,14 @@ public class KafkaObservableQueue implements ObservableQueue {
             this.properties = properties;
         }
 
-        public KafkaObservableQueue build(final String topic) {
+        public KafkaObservableQueue build(final String topic, final Properties consumerOverrides) {
             Properties consumerConfig = new Properties();
             consumerConfig.putAll(properties.toConsumerConfig());
+
+            // To handle condutors default COMPLETED and FAILED queues
+            if (consumerOverrides != null) {
+                consumerConfig.putAll(consumerOverrides);
+            }
 
             LOGGER.debug("Kafka Consumer Config: {}", consumerConfig);
 


### PR DESCRIPTION
Pull Request type
----
- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

I found the following bug when in the conductor logs when starting the server when enabling `conductor.event-queues.kafka.enabled`. When initializing the built-in queues COMPLETED and FAILED they reuse the same client.id.
This sometimes result below exception where the Kafka library is trying to reuse the same Consumer client across threads causing one queue consumer to fail.

```17406 [main] INFO  com.netflix.conductor.core.LifecycleAwareComponent [] - SystemTaskWorker started.
	at org.apache.kafka.clients.consumer.internals.LegacyKafkaConsumer.poll(LegacyKafkaConsumer.java:590) ~[kafka-clients-3.7.1.jar!/:?]
	at org.apache.kafka.clients.consumer.KafkaConsumer.poll(KafkaConsumer.java:874) ~[kafka-clients-3.7.1.jar!/:?]
	at com.netflix.conductor.kafkaeq.eventqueue.KafkaObservableQueue.lambda$observe$0(KafkaObservableQueue.java:117) ~[conductor-kafka-event-queue.jar!/:?]
	at rx.internal.operators.OnSubscribeMap$MapSubscriber.onNext(OnSubscribeMap.java:69) [rxjava-1.2.2.jar!/:1.2.2]
	at rx.internal.operators.OnSubscribeTimerPeriodically$1.call(OnSubscribeTimerPeriodically.java:52) [rxjava-1.2.2.jar!/:1.2.2]
	at rx.Scheduler$Worker$1.call(Scheduler.java:137) [rxjava-1.2.2.jar!/:1.2.2]
	at rx.internal.schedulers.EventLoopsScheduler$EventLoopWorker$2.call(EventLoopsScheduler.java:189) [rxjava-1.2.2.jar!/:1.2.2]
	at rx.internal.schedulers.ScheduledAction.run(ScheduledAction.java:55) [rxjava-1.2.2.jar!/:1.2.2]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) [?:?]
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.base/java.lang.Thread.run(Thread.java:840) [?:?]
17428 [RxComputationScheduler-1] ERROR com.netflix.conductor.core.events.queue.DefaultEventQueueProcessor [] - KafkaConsumer is not safe for multi-threaded access. currentThread(name: RxComputationScheduler-1, id: 34) otherThread(id: 1)
java.util.ConcurrentModificationException: KafkaConsumer is not safe for multi-threaded access. currentThread(name: RxComputationScheduler-1, id: 34) otherThread(id: 1)
	at org.apache.kafka.clients.consumer.internals.LegacyKafkaConsumer.acquire(LegacyKafkaConsumer.java:1226) ~[kafka-clients-3.7.1.jar!/:?]
	at org.apache.kafka.clients.consumer.internals.LegacyKafkaConsumer.acquireAndEnsureOpen(LegacyKafkaConsumer.java:1207) ~[kafka-clients-3.7.1.jar!/:?]
	at org.apache.kafka.clients.consumer.internals.LegacyKafkaConsumer.poll(LegacyKafkaConsumer.java:597) ~[kafka-clients-3.7.1.jar!/:?]
	at org.apache.kafka.clients.consumer.internals.LegacyKafkaConsumer.poll(LegacyKafkaConsumer.java:590) ~[kafka-clients-3.7.1.jar!/:?]
	at org.apache.kafka.clients.consumer.KafkaConsumer.poll(KafkaConsumer.java:874) ~[kafka-clients-3.7.1.jar!/:?]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) [?:?]
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.base/java.lang.Thread.run(Thread.java:840) [?:?]
17430 [RxComputationScheduler-1] INFO  com.netflix.conductor.kafkaeq.eventqueue.KafkaObservableQueue [] - Kafka consumer stopping for topic: conductor_FAILED
17431 [RxComputationScheduler-2] INFO  org.apache.kafka.clients.Metadata [] - [Consumer clientId=consumer-client, groupId=conductor-group] Cluster ID: MkU3OEVBNTcwNTJENDM2Qg
17432 [RxComputationScheduler-1] INFO  org.apache.kafka.clients.consumer.internals.ConsumerCoordinator [] - [Consumer clientId=consumer-client, groupId=conductor-group] Resetting generation and member id due to: consumer pro-actively leaving the group
17432 [RxComputationScheduler-1] INFO  org.apache.kafka.clients.consumer.internals.ConsumerCoordinator [] - [Consumer clientId=consumer-client, groupId=conductor-group] Request joining group due to: consumer pro-actively leaving the group
17433 [RxComputationScheduler-1] INFO  org.apache.kafka.clients.consumer.internals.LegacyKafkaConsumer [] - [Consumer clientId=consumer-client, groupId=conductor-group] Unsubscribed all topics or patterns and assigned partitions
17436 [RxComputationScheduler-1] INFO  org.apache.kafka.clients.consumer.internals.ConsumerCoordinator [] - [Consumer clientId=consumer-client, groupId=conductor-group] Resetting generation and member id due to: consumer pro-actively leaving the group
17436 [RxComputationScheduler-1] INFO  org.apache.kafka.clients.consumer.internals.ConsumerCoordinator [] - [Consumer clientId=consumer-client, groupId=conductor-group] Request joining group due to: consumer pro-actively leaving the group
17436 [RxComputationScheduler-2] INFO  org.apache.kafka.clients.consumer.internals.ConsumerCoordinator [] - [Consumer clientId=consumer-client, groupId=conductor-group] Discovered group coordinator kafka:29092 (id: 2147483646 rack: null)```


