### PR TITLE
UI Feature: Complete human task for running execution with refresh after api call

### DIFF
--- a/ui/src/components/formik/FormikStatusDropdown.jsx
+++ b/ui/src/components/formik/FormikStatusDropdown.jsx
@@ -1,0 +1,21 @@
+import { useField } from "formik";
+import { Dropdown } from "../index";
+
+export default function (props) {
+  const [field, meta, helper] = useField(props);
+  const touchedError = meta.touched && meta.error;
+
+  return (
+    <Dropdown
+      disableClearable
+      label={props.label || "Status"}
+      options={["COMPLETED", "FAILED"]}
+      placeholder={"Select Workflow Name"}
+      error={touchedError}
+      helperText={touchedError}
+      {...field}
+      {...props}
+      onChange={(e, value) => helper.setValue(value)}
+    />
+  );
+}

--- a/ui/src/data/task.js
+++ b/ui/src/data/task.js
@@ -140,3 +140,18 @@ export function useSaveTask(callbacks) {
     });
   }, callbacks);
 }
+
+export function useUpdateTask(callbacks) {
+  const path = "/tasks";
+  const fetchContext = useFetchContext();
+
+  return useMutation(({ body }) => {
+    return fetchWithContext(path, fetchContext, {
+      method: "post",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  }, callbacks);
+}

--- a/ui/src/pages/execution/TaskHuman.jsx
+++ b/ui/src/pages/execution/TaskHuman.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { useUpdateTask } from "../../data/task";
+import TaskHumanForm from "./TaskHumanForm";
+import { makeStyles } from "@material-ui/styles";
+
+const useStyles = makeStyles({
+  wrapper: {
+    height: "100%",
+    overflow: "hidden",
+    display: "flex",
+    flexDirection: "column",
+    position: "relative",
+  }
+});
+
+export default function TaskHuman({ taskResult, onTaskExecuted }) {
+  const classes = useStyles();
+
+  const { mutate: updateTask } = useUpdateTask({
+    onSuccess: () => {
+      console.log("Successfully updated task");
+      onTaskExecuted();
+    },
+  });
+
+  const completeTask = (payload) => {
+    updateTask({
+      body: payload
+    });
+  }
+
+  const initData = {
+    workflowInstanceId: taskResult.workflowInstanceId,
+    taskId: taskResult.taskId
+  }
+
+  return (
+    <div className={classes.wrapper}>
+      <TaskHumanForm
+        initialData={initData}
+        completeTask={completeTask}
+      />
+    </div>
+  );
+}

--- a/ui/src/pages/execution/TaskHumanForm.jsx
+++ b/ui/src/pages/execution/TaskHumanForm.jsx
@@ -1,0 +1,113 @@
+import * as Yup from "yup";
+import { Form, withFormik } from "formik";
+import _ from "lodash";
+import FormikInput from "../../components/formik/FormikInput";
+import FormikStatusDropdown from "../../components/formik/FormikStatusDropdown";
+import React from "react";
+import { makeStyles } from "@material-ui/styles";
+import { SecondaryButton } from "../../components";
+import FormikJsonInput from "../../components/formik/FormikJsonInput";
+
+Yup.addMethod(Yup.string, "isJson", function () {
+  return this.test("is-json", "is not valid json", (value) => {
+    if (_.isEmpty(value)) return true;
+
+    try {
+      JSON.parse(value);
+    } catch (e) {
+      return false;
+    }
+    return true;
+  });
+});
+
+const validationSchema = Yup.object({
+  workflowInstanceId: Yup.string().required("Workflow Instance ID is required"),
+  taskId: Yup.string().required("Task ID is required"),
+  status: Yup.string().required("Status is required"),
+  outputData: Yup.string().isJson(),
+});
+
+const useStyles = makeStyles({
+  fields: {
+    width: "100%",
+    padding: 30,
+    flex: 1,
+    display: "flex",
+    flexDirection: "column",
+    overflowX: "hidden",
+    overflowY: "auto",
+    gap: 15,
+  },
+});
+
+export default withFormik({
+  enableReinitialize: true,
+  mapPropsToValues: ({ initialData }) =>
+    initData(initialData),
+  validationSchema: validationSchema,
+})(TaskHumanForm);
+
+function initData(data) {
+  return {
+    workflowInstanceId: _.get(data, "workflowInstanceId", ""),
+    taskId: _.get(data, "taskId", ""),
+    status: _.get(data, "status", ""),
+    outputData: _.get(data, "outputData", ""),
+  }
+}
+
+function TaskHumanForm(props) {
+  const {
+    values,
+    validateForm,
+    completeTask
+  } = props;
+  const classes = useStyles();
+
+  function formDataToRunPayload(form) {
+    let payload = {
+      workflowInstanceId: form.workflowInstanceId,
+      taskId: form.taskId,
+      status: form.status
+    }
+
+    if (form.outputData) {
+      payload.outputData = JSON.parse(form.outputData)
+    }
+
+    return payload;
+  }
+
+  function handleCompleteTask() {
+    validateForm().then((errors) => {
+      if (Object.keys(errors).length === 0) {
+        const payload = formDataToRunPayload(values);
+        completeTask(payload)
+      }
+    })
+  }
+
+  return (
+    <Form>
+      <div className={classes.fields}>
+        <FormikInput fullWidth label="Workflow instance ID" name="workflowInstanceId"/>
+        <FormikInput fullWidth label="Task ID" name="taskId"/>
+        <FormikStatusDropdown
+          fullWidth
+          label="Status"
+          name="status"
+        />
+        <FormikJsonInput
+          reinitialize
+          height={200}
+          label="Output data (JSON)"
+          name="outputData"
+        />
+        <SecondaryButton onClick={handleCompleteTask}>
+          Complete task
+        </SecondaryButton>
+      </div>
+    </Form>
+  );
+}


### PR DESCRIPTION
…fresh after api call response

Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
Added new TabPanel inside RightPanel of execution to completion HUMAN task. At the moment is possible only to complete/update task by API. The new tab panel is visible only for HUMAN task and is enabled only for status IN_PROGRESS. After completion/update task is calling refresh of current visible workflow.

![Zrzut ekranu 2025-07-6 o 11 07 57](https://github.com/user-attachments/assets/9ca6ac96-f275-4577-b54d-f68652ce419d)
![Zrzut ekranu 2025-07-6 o 11 09 47](https://github.com/user-attachments/assets/395c0adc-a91d-4fea-b609-edb0acf9c0c4)
