### PR TITLE
[Bug Fix] Allow Json Keys with spaces in the placeholders

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -26,7 +26,6 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${revSpringDoc}"
-
 }
 
 /*

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -22,11 +22,11 @@ dependencies {
     // https://github.com/FasterXML/jackson-modules-base/tree/master/afterburner
     implementation "com.fasterxml.jackson.module:jackson-module-afterburner:${revFasterXml}"
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:${revFasterXml}"
+    implementation "com.jayway.jsonpath:json-path:${revJsonPath}"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${revSpringDoc}"
 
-    implementation "com.jayway.jsonpath:json-path:${revJsonPath}"
 }
 
 /*

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -25,6 +25,8 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${revSpringDoc}"
+
+    implementation "com.jayway.jsonpath:json-path:${revJsonPath}"
 }
 
 /*

--- a/common/src/main/java/com/netflix/conductor/common/utils/ConstraintParamUtil.java
+++ b/common/src/main/java/com/netflix/conductor/common/utils/ConstraintParamUtil.java
@@ -17,10 +17,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import com.jayway.jsonpath.JsonPath;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.common.utils.EnvUtils.SystemParameters;
+
+import com.jayway.jsonpath.JsonPath;
 
 @SuppressWarnings("unchecked")
 public class ConstraintParamUtil {
@@ -141,11 +142,11 @@ public class ConstraintParamUtil {
     }
 
     public static boolean isValidPath(String path) {
-      try {
-        JsonPath.compile(path);
-        return true;
-      } catch (Exception e) {
-        return false;
-      }
+        try {
+            JsonPath.compile(path);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/common/src/main/java/com/netflix/conductor/common/utils/ConstraintParamUtil.java
+++ b/common/src/main/java/com/netflix/conductor/common/utils/ConstraintParamUtil.java
@@ -17,8 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.commons.lang3.StringUtils;
-
+import com.jayway.jsonpath.JsonPath;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.common.utils.EnvUtils.SystemParameters;
@@ -91,8 +90,7 @@ public class ConstraintParamUtil {
         for (String s : values) {
             if (s.startsWith("${") && s.endsWith("}")) {
                 String paramPath = s.substring(2, s.length() - 1);
-
-                if (StringUtils.containsWhitespace(paramPath)) {
+                if (!isValidPath(paramPath)) {
                     String message =
                             String.format(
                                     "key: %s input parameter value: %s is not valid",
@@ -140,5 +138,14 @@ public class ConstraintParamUtil {
             }
         }
         return errorList;
+    }
+
+    public static boolean isValidPath(String path) {
+      try {
+        JsonPath.compile(path);
+        return true;
+      } catch (Exception e) {
+        return false;
+      }
     }
 }

--- a/common/src/test/java/com/netflix/conductor/common/utils/ConstraintParamUtilTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/utils/ConstraintParamUtilTest.java
@@ -67,6 +67,64 @@ public class ConstraintParamUtilTest {
     }
 
     @Test
+    public void testExtractParamPathComponentsWithValidJsonPath() {
+        WorkflowDef workflowDef = constructWorkflowDef();
+
+        WorkflowTask workflowTask_1 = new WorkflowTask();
+        workflowTask_1.setName("task_1");
+        workflowTask_1.setTaskReferenceName("task_1");
+        workflowTask_1.setType(TaskType.TASK_TYPE_SIMPLE);
+
+        WorkflowTask workflowTask_2 = new WorkflowTask();
+        workflowTask_2.setName("task_2");
+        workflowTask_2.setTaskReferenceName("task_2");
+        workflowTask_2.setType(TaskType.TASK_TYPE_SIMPLE);
+
+        Map<String, Object> inputParam = new HashMap<>();
+        inputParam.put("taskId", "${task_1.output.[\"task ref\"]}");
+
+        workflowTask_2.setInputParameters(inputParam);
+
+        List<WorkflowTask> tasks = new ArrayList<>();
+        tasks.add(workflowTask_1);
+
+        workflowDef.setTasks(tasks);
+
+        List<String> results =
+              ConstraintParamUtil.validateInputParam(inputParam, "task_2", workflowDef);
+        assertEquals(0, results.size());
+    }
+
+    @Test
+    public void testExtractParamPathComponentsWithInValidJsonPath() {
+        WorkflowDef workflowDef = constructWorkflowDef();
+
+        WorkflowTask workflowTask_1 = new WorkflowTask();
+        workflowTask_1.setName("task_1");
+        workflowTask_1.setTaskReferenceName("task_1");
+        workflowTask_1.setType(TaskType.TASK_TYPE_SIMPLE);
+
+        WorkflowTask workflowTask_2 = new WorkflowTask();
+        workflowTask_2.setName("task_2");
+        workflowTask_2.setTaskReferenceName("task_2");
+        workflowTask_2.setType(TaskType.TASK_TYPE_SIMPLE);
+
+        Map<String, Object> inputParam = new HashMap<>();
+        inputParam.put("taskId", "${task_1.output [\"task ref\"]}");
+
+        workflowTask_2.setInputParameters(inputParam);
+
+        List<WorkflowTask> tasks = new ArrayList<>();
+        tasks.add(workflowTask_1);
+
+        workflowDef.setTasks(tasks);
+
+        List<String> results =
+              ConstraintParamUtil.validateInputParam(inputParam, "task_2", workflowDef);
+        assertEquals(1, results.size());
+    }
+
+    @Test
     public void testExtractParamPathComponentsWithMissingEnvVariable() {
         WorkflowDef workflowDef = constructWorkflowDef();
 

--- a/common/src/test/java/com/netflix/conductor/common/utils/ConstraintParamUtilTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/utils/ConstraintParamUtilTest.java
@@ -91,7 +91,7 @@ public class ConstraintParamUtilTest {
         workflowDef.setTasks(tasks);
 
         List<String> results =
-              ConstraintParamUtil.validateInputParam(inputParam, "task_2", workflowDef);
+                ConstraintParamUtil.validateInputParam(inputParam, "task_2", workflowDef);
         assertEquals(0, results.size());
     }
 
@@ -120,7 +120,7 @@ public class ConstraintParamUtilTest {
         workflowDef.setTasks(tasks);
 
         List<String> results =
-              ConstraintParamUtil.validateInputParam(inputParam, "task_2", workflowDef);
+                ConstraintParamUtil.validateInputParam(inputParam, "task_2", workflowDef);
         assertEquals(1, results.size());
     }
 


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue # https://github.com/conductor-oss/conductor/issues/551

- Current the spaces for json keys are not causing validation exception when creating/updating the workflow def. 
- Since we are using json path to resolve the paths, we are compiling and checking if the paths is right one.  

Alternatives considered
----

_Describe alternative implementation you have considered_

- There is an alternative to remove the whitespace check. however this may start allowing users to provide invalid paths 