### PR TITLE
Update DefaultEventQueueProcessorTest.java

### DIFF
--- a/awssqs-event-queue/src/test/java/com/netflix/conductor/sqs/eventqueue/DefaultEventQueueProcessorTest.java
+++ b/awssqs-event-queue/src/test/java/com/netflix/conductor/sqs/eventqueue/DefaultEventQueueProcessorTest.java
@@ -10,23 +10,11 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.netflix.conductor.sqs.eventqueue;
 
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.stubbing.Answer;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.TaskResult;
@@ -37,18 +25,20 @@ import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.TaskModel.Status;
 import com.netflix.conductor.model.WorkflowModel;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.util.concurrent.Uninterruptibles;
+import java.util.*;
 
 import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_WAIT;
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-@SuppressWarnings("unchecked")
 @ContextConfiguration(classes = {TestObjectMapperConfiguration.class})
 @RunWith(SpringRunner.class)
 public class DefaultEventQueueProcessorTest {
@@ -61,99 +51,88 @@ public class DefaultEventQueueProcessorTest {
 
     private static final List<Message> messages = new LinkedList<>();
     private static final List<TaskResult> updatedTasks = new LinkedList<>();
-    private static final List<Task> mappedTasks = new LinkedList<>();
-
-    @Before
-    public void init() {
-        Map<Status, ObservableQueue> queues = new HashMap<>();
-        queues.put(Status.COMPLETED, queue);
-        defaultEventQueueProcessor =
-                new DefaultEventQueueProcessor(queues, workflowExecutor, objectMapper);
-    }
 
     @BeforeClass
-    public static void setup() {
-
+    public static void setupMocks() {
         queue = mock(SQSObservableQueue.class);
+
         when(queue.getOrCreateQueue()).thenReturn("junit_queue_url");
         when(queue.isRunning()).thenReturn(true);
-        Answer<?> answer =
-                (Answer<List<Message>>)
-                        invocation -> {
-                            List<Message> copy = new LinkedList<>(messages);
-                            messages.clear();
-                            return copy;
-                        };
-
-        when(queue.receiveMessages()).thenAnswer(answer);
+        when(queue.receiveMessages()).thenAnswer((Answer<List<Message>>) invocation -> {
+            List<Message> copy = new ArrayList<>(messages);
+            messages.clear();
+            return copy;
+        });
         when(queue.getOnSubscribe()).thenCallRealMethod();
         when(queue.observe()).thenCallRealMethod();
         when(queue.getName()).thenReturn(Status.COMPLETED.name());
 
-        TaskModel task0 = new TaskModel();
-        task0.setStatus(Status.IN_PROGRESS);
-        task0.setTaskId("t0");
-        task0.setReferenceTaskName("t0");
-        task0.setTaskType(TASK_TYPE_WAIT);
-        WorkflowModel workflow0 = new WorkflowModel();
-        workflow0.setWorkflowId("v_0");
-        workflow0.getTasks().add(task0);
-
-        TaskModel task2 = new TaskModel();
-        task2.setStatus(Status.IN_PROGRESS);
-        task2.setTaskId("t2");
-        task2.setTaskType(TASK_TYPE_WAIT);
-        WorkflowModel workflow2 = new WorkflowModel();
-        workflow2.setWorkflowId("v_2");
-        workflow2.getTasks().add(task2);
-
-        doAnswer(
-                        (Answer<Void>)
-                                invocation -> {
-                                    List<Message> msgs = invocation.getArgument(0, List.class);
-                                    messages.addAll(msgs);
-                                    return null;
-                                })
-                .when(queue)
-                .publish(any());
+        doAnswer(invocation -> {
+            List<Message> msgs = invocation.getArgument(0);
+            messages.addAll(msgs);
+            return null;
+        }).when(queue).publish(any());
 
         workflowExecutor = mock(WorkflowExecutor.class);
         assertNotNull(workflowExecutor);
 
+        TaskModel task0 = createTask("t0", TASK_TYPE_WAIT, Status.IN_PROGRESS);
+        WorkflowModel workflow0 = createWorkflow("v_0", task0);
         doReturn(workflow0).when(workflowExecutor).getWorkflow(eq("v_0"), anyBoolean());
 
+        TaskModel task2 = createTask("t2", TASK_TYPE_WAIT, Status.IN_PROGRESS);
+        WorkflowModel workflow2 = createWorkflow("v_2", task2);
         doReturn(workflow2).when(workflowExecutor).getWorkflow(eq("v_2"), anyBoolean());
 
-        doAnswer(
-                        (Answer<Void>)
-                                invocation -> {
-                                    updatedTasks.add(invocation.getArgument(0, TaskResult.class));
-                                    return null;
-                                })
-                .when(workflowExecutor)
-                .updateTask(any(TaskResult.class));
+        doAnswer(invocation -> {
+            TaskResult result = invocation.getArgument(0);
+            updatedTasks.add(result);
+            return null;
+        }).when(workflowExecutor).updateTask(any(TaskResult.class));
+    }
+
+    @Before
+    public void initProcessor() {
+        messages.clear();
+        updatedTasks.clear();
+        Map<Status, ObservableQueue> queues = new HashMap<>();
+        queues.put(Status.COMPLETED, queue);
+        defaultEventQueueProcessor = new DefaultEventQueueProcessor(queues, workflowExecutor, objectMapper);
     }
 
     @Test
-    public void test() throws Exception {
-        defaultEventQueueProcessor.updateByTaskRefName(
-                "v_0", "t0", new HashMap<>(), Status.COMPLETED);
+    public void shouldUpdateTaskByReferenceName() {
+        defaultEventQueueProcessor.updateByTaskRefName("v_0", "t0", new HashMap<>(), Status.COMPLETED);
         Uninterruptibles.sleepUninterruptibly(1_000, TimeUnit.MILLISECONDS);
-
-        assertTrue(updatedTasks.stream().anyMatch(task -> task.getTaskId().equals("t0")));
+        assertTrue(updatedTasks.stream().anyMatch(task -> "t0".equals(task.getTaskId())));
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testFailure() throws Exception {
-        defaultEventQueueProcessor.updateByTaskRefName(
-                "v_1", "t1", new HashMap<>(), Status.CANCELED);
+    public void shouldThrowExceptionForUnknownWorkflow() {
+        defaultEventQueueProcessor.updateByTaskRefName("v_1", "t1", new HashMap<>(), Status.CANCELED);
         Uninterruptibles.sleepUninterruptibly(1_000, TimeUnit.MILLISECONDS);
     }
 
     @Test
-    public void testWithTaskId() throws Exception {
+    public void shouldUpdateTaskByTaskId() {
         defaultEventQueueProcessor.updateByTaskId("v_2", "t2", new HashMap<>(), Status.COMPLETED);
         Uninterruptibles.sleepUninterruptibly(1_000, TimeUnit.MILLISECONDS);
-        assertTrue(updatedTasks.stream().anyMatch(task -> task.getTaskId().equals("t2")));
+        assertTrue(updatedTasks.stream().anyMatch(task -> "t2".equals(task.getTaskId())));
+    }
+
+    private static TaskModel createTask(String taskId, String type, Status status) {
+        TaskModel task = new TaskModel();
+        task.setTaskId(taskId);
+        task.setTaskType(type);
+        task.setStatus(status);
+        task.setReferenceTaskName(taskId);
+        return task;
+    }
+
+    private static WorkflowModel createWorkflow(String workflowId, TaskModel task) {
+        WorkflowModel workflow = new WorkflowModel();
+        workflow.setWorkflowId(workflowId);
+        workflow.getTasks().add(task);
+        return workflow;
     }
 }


### PR DESCRIPTION
1)Cleared messages and updatedTasks in @Before to prevent cross-test contamination. 
2)Renamed test methods to meaningful names (shouldUpdateTaskByReferenceName, etc.). 
3)Replaced anonymous inner classes with cleaner lambda expressions.
4)Extracted task and workflow creation into helper methods for reuse (createTask, createWorkflow).

Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
