### PR TITLE
Update generate_gh_pages.yml - switch to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/generate_gh_pages.yml
+++ b/.github/workflows/generate_gh_pages.yml
@@ -1,4 +1,8 @@
 name: Publish docs via GitHub Pages
+
+permissions:
+  contents: write
+
 on:
   push:
     branches:
@@ -16,6 +20,6 @@ jobs:
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONFIG_FILE: mkdocs.yml
           REQUIREMENTS: requirements.txt


### PR DESCRIPTION
switch to GITHUB_TOKEN for mkdocs publishing

Pull Request type
----
- [x] Build related changes

Changes in this PR
----
switch mkdocs build and publish to github actions token, but **with permission** - this one actually works, tested from this branch
