### PR TITLE
Add ssl mode and client name in redis cluster configuration

### DIFF
--- a/docker/server/config/config-redis.properties
+++ b/docker/server/config/config-redis.properties
@@ -32,3 +32,6 @@ management.health.redis.enabled=true
 
 # Load sample kitchen sink workflow
 loadSample=true
+
+# Redis cluster connection in SSL mode
+conductor.redis.ssl=false

--- a/redis-persistence/src/main/java/com/netflix/conductor/redis/config/RedisClusterConfiguration.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/redis/config/RedisClusterConfiguration.java
@@ -65,7 +65,9 @@ public class RedisClusterConfiguration extends JedisCommandsConfigurer {
                             DEFAULT_MAX_ATTEMPTS,
                             properties.getUsername(),
                             password,
-                            genericObjectPoolConfig));
+                            properties.getClientName(),
+                            genericObjectPoolConfig,
+                            properties.isSsl()));
         } else if (password != null) {
             log.info("Connecting to Redis Cluster with AUTH");
             return new JedisCluster(
@@ -75,7 +77,9 @@ public class RedisClusterConfiguration extends JedisCommandsConfigurer {
                             Protocol.DEFAULT_TIMEOUT,
                             DEFAULT_MAX_ATTEMPTS,
                             password,
-                            genericObjectPoolConfig));
+                            properties.getClientName(),
+                            genericObjectPoolConfig,
+                            properties.isSsl()));
         } else {
             return new JedisCluster(
                     new redis.clients.jedis.JedisCluster(hosts, genericObjectPoolConfig));

--- a/redis-persistence/src/main/java/com/netflix/conductor/redis/config/RedisProperties.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/redis/config/RedisProperties.java
@@ -112,6 +112,10 @@ public class RedisProperties {
 
     private String username = null;
 
+    private boolean ssl = false;
+
+    private String clientName = null;
+
     public int getNumTestsPerEvictionRun() {
         return numTestsPerEvictionRun;
     }
@@ -302,5 +306,21 @@ public class RedisProperties {
 
     public void setUsername(String username) {
         this.username = username;
+    }
+
+    public boolean isSsl() {
+        return ssl;
+    }
+
+    public void setSsl(boolean ssl) {
+        this.ssl = ssl;
+    }
+
+    public String getClientName() {
+        return clientName;
+    }
+
+    public void setClientName(String clientName) {
+        this.clientName = clientName;
     }
 }

--- a/redis-persistence/src/main/java/com/netflix/conductor/redis/config/RedisStandaloneConfiguration.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/redis/config/RedisStandaloneConfiguration.java
@@ -58,7 +58,8 @@ public class RedisStandaloneConfiguration extends JedisCommandsConfigurer {
                     Protocol.DEFAULT_TIMEOUT,
                     properties.getUsername(),
                     host.getPassword(),
-                    properties.getDatabase());
+                    properties.getDatabase(),
+                    properties.isSsl());
         } else if (host.getPassword() != null) {
             log.info("Connecting to Redis Standalone with AUTH");
             return new JedisPool(
@@ -67,9 +68,10 @@ public class RedisStandaloneConfiguration extends JedisCommandsConfigurer {
                     host.getPort(),
                     Protocol.DEFAULT_TIMEOUT,
                     host.getPassword(),
-                    properties.getDatabase());
+                    properties.getDatabase(),
+                    properties.isSsl());
         } else {
-            return new JedisPool(config, host.getHostName(), host.getPort());
+            return new JedisPool(config, host.getHostName(), host.getPort(), properties.isSsl());
         }
     }
 }

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -18,6 +18,9 @@ loadSample=true
 conductor.db.type=memory
 conductor.queue.type=redis_standalone
 
+# Redis cluster connection in SSL mode
+conductor.redis.ssl=false
+
 conductor.indexing.enabled=false
 
 #Redis configuration details.


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_

## Reference 

- [Reference link to github file](https://github.com/redis/jedis/blob/f24a817987fe1990a9ff65b31dba7fa4b44969e6/src/main/java/redis/clients/jedis/JedisCluster.java#L73)

<img width="1107" height="362" alt="image" src="https://github.com/user-attachments/assets/7e84b104-426d-415c-b45e-85ee6f074b8f" />