### PR TITLE
fix(elasticsearch-dao): wait for index refresh and guarantee changes are visible for search

### DIFF
--- a/es6-persistence/src/main/java/com/netflix/conductor/es6/dao/index/ElasticSearchDAOV6.java
+++ b/es6-persistence/src/main/java/com/netflix/conductor/es6/dao/index/ElasticSearchDAOV6.java
@@ -22,6 +22,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
@@ -35,6 +37,7 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.Strings;
@@ -109,7 +112,8 @@ public class ElasticSearchDAOV6 extends ElasticSearchBaseDAO implements IndexDAO
     private final ExecutorService executorService;
     private final ExecutorService logExecutorService;
 
-    private final ConcurrentHashMap<String, BulkRequests> bulkRequests;
+    private final ConcurrentHashMap<Pair<String, WriteRequest.RefreshPolicy>, BulkRequests>
+            bulkRequests;
     private final int indexBatchSize;
     private final long asyncBufferFlushTimeout;
     private final ElasticSearchProperties properties;
@@ -270,7 +274,7 @@ public class ElasticSearchDAOV6 extends ElasticSearchBaseDAO implements IndexDAO
                         .execute()
                         .actionGet();
             } catch (Exception e) {
-                LOGGER.error("Failed to init " + template, e);
+                LOGGER.error("Failed to init {}", template, e);
             }
         }
     }
@@ -346,7 +350,7 @@ public class ElasticSearchDAOV6 extends ElasticSearchBaseDAO implements IndexDAO
                         .execute()
                         .actionGet();
             } catch (Exception e) {
-                LOGGER.error("Failed to init index " + indexName + " mappings", e);
+                LOGGER.error("Failed to init index {} mappings", indexName, e);
             }
         }
     }
@@ -360,7 +364,9 @@ public class ElasticSearchDAOV6 extends ElasticSearchBaseDAO implements IndexDAO
             String docType =
                     StringUtils.isBlank(docTypeOverride) ? WORKFLOW_DOC_TYPE : docTypeOverride;
 
-            UpdateRequest req = buildUpdateRequest(id, doc, workflowIndexName, docType);
+            UpdateRequest req =
+                    buildUpdateRequest(id, doc, workflowIndexName, docType)
+                            .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL);
             elasticSearchClient.update(req).actionGet();
 
             long endTime = Instant.now().toEpochMilli();
@@ -393,7 +399,7 @@ public class ElasticSearchDAOV6 extends ElasticSearchBaseDAO implements IndexDAO
             UpdateRequest req = new UpdateRequest(taskIndexName, docType, id);
             req.doc(doc, XContentType.JSON);
             req.upsert(doc, XContentType.JSON);
-            indexObject(req, TASK_DOC_TYPE);
+            indexObject(req, TASK_DOC_TYPE, WriteRequest.RefreshPolicy.WAIT_UNTIL);
             long endTime = Instant.now().toEpochMilli();
             LOGGER.debug(
                     "Time taken {} for  indexing task:{} in workflow: {}",
@@ -413,28 +419,44 @@ public class ElasticSearchDAOV6 extends ElasticSearchBaseDAO implements IndexDAO
         return CompletableFuture.runAsync(() -> indexTask(task), executorService);
     }
 
-    private void indexObject(UpdateRequest req, String docType) {
-        if (bulkRequests.get(docType) == null) {
+    private void indexObject(final UpdateRequest req, final String docType) {
+        indexObject(req, docType, null);
+    }
+
+    private void indexObject(
+            final UpdateRequest req,
+            final String docType,
+            final WriteRequest.RefreshPolicy refreshPolicy) {
+        Pair<String, WriteRequest.RefreshPolicy> requestTypeKey =
+                new ImmutablePair<>(docType, refreshPolicy);
+        if (bulkRequests.get(requestTypeKey) == null) {
+            BulkRequestBuilder bulkRequestBuilder = elasticSearchClient.prepareBulk();
+            Optional.ofNullable(requestTypeKey.getRight())
+                    .ifPresent(bulkRequestBuilder::setRefreshPolicy);
             bulkRequests.put(
-                    docType,
-                    new BulkRequests(
-                            System.currentTimeMillis(), elasticSearchClient.prepareBulk()));
+                    requestTypeKey,
+                    new BulkRequests(System.currentTimeMillis(), bulkRequestBuilder));
         }
-        bulkRequests.get(docType).getBulkRequestBuilder().add(req);
-        if (bulkRequests.get(docType).getBulkRequestBuilder().numberOfActions()
+        bulkRequests.get(requestTypeKey).getBulkRequestBuilder().add(req);
+        if (bulkRequests.get(requestTypeKey).getBulkRequestBuilder().numberOfActions()
                 >= this.indexBatchSize) {
-            indexBulkRequest(docType);
+            indexBulkRequest(requestTypeKey);
         }
     }
 
-    private synchronized void indexBulkRequest(String docType) {
-        if (bulkRequests.get(docType).getBulkRequestBuilder() != null
-                && bulkRequests.get(docType).getBulkRequestBuilder().numberOfActions() > 0) {
-            updateWithRetry(bulkRequests.get(docType).getBulkRequestBuilder(), docType);
+    private synchronized void indexBulkRequest(
+            Pair<String, WriteRequest.RefreshPolicy> requestTypeKey) {
+        if (bulkRequests.get(requestTypeKey).getBulkRequestBuilder() != null
+                && bulkRequests.get(requestTypeKey).getBulkRequestBuilder().numberOfActions() > 0) {
+            updateWithRetry(
+                    bulkRequests.get(requestTypeKey).getBulkRequestBuilder(),
+                    requestTypeKey.getLeft());
+            BulkRequestBuilder bulkRequestBuilder = elasticSearchClient.prepareBulk();
+            Optional.ofNullable(requestTypeKey.getRight())
+                    .ifPresent(bulkRequestBuilder::setRefreshPolicy);
             bulkRequests.put(
-                    docType,
-                    new BulkRequests(
-                            System.currentTimeMillis(), elasticSearchClient.prepareBulk()));
+                    requestTypeKey,
+                    new BulkRequests(System.currentTimeMillis(), bulkRequestBuilder));
         }
     }
 

--- a/es7-persistence/src/main/java/com/netflix/conductor/es7/dao/index/ElasticSearchRestDAOV7.java
+++ b/es7-persistence/src/main/java/com/netflix/conductor/es7/dao/index/ElasticSearchRestDAOV7.java
@@ -23,6 +23,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.entity.ContentType;
@@ -38,6 +40,7 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.*;
 import org.elasticsearch.client.core.CountRequest;
@@ -121,7 +124,8 @@ public class ElasticSearchRestDAOV7 extends ElasticSearchBaseDAO implements Inde
     private final RestClient elasticSearchAdminClient;
     private final ExecutorService executorService;
     private final ExecutorService logExecutorService;
-    private final ConcurrentHashMap<String, BulkRequests> bulkRequests;
+    private final ConcurrentHashMap<Pair<String, WriteRequest.RefreshPolicy>, BulkRequests>
+            bulkRequests;
     private final int indexBatchSize;
     private final int asyncBufferFlushTimeout;
     private final ElasticSearchProperties properties;
@@ -494,7 +498,8 @@ public class ElasticSearchRestDAOV7 extends ElasticSearchBaseDAO implements Inde
             IndexRequest request =
                     new IndexRequest(workflowIndexName)
                             .id(workflowId)
-                            .source(docBytes, XContentType.JSON);
+                            .source(docBytes, XContentType.JSON)
+                            .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL);
             elasticSearchClient.index(request, RequestOptions.DEFAULT);
             long endTime = Instant.now().toEpochMilli();
             logger.debug(
@@ -519,7 +524,12 @@ public class ElasticSearchRestDAOV7 extends ElasticSearchBaseDAO implements Inde
             long startTime = Instant.now().toEpochMilli();
             String taskId = task.getTaskId();
 
-            indexObject(taskIndexName, TASK_DOC_TYPE, taskId, task);
+            indexObject(
+                    taskIndexName,
+                    TASK_DOC_TYPE,
+                    taskId,
+                    task,
+                    WriteRequest.RefreshPolicy.WAIT_UNTIL);
             long endTime = Instant.now().toEpochMilli();
             logger.debug(
                     "Time taken {} for  indexing task:{} in workflow: {}",
@@ -731,7 +741,7 @@ public class ElasticSearchRestDAOV7 extends ElasticSearchBaseDAO implements Inde
                             + "."
                             + eventExecution.getId();
 
-            indexObject(eventIndexName, EVENT_DOC_TYPE, id, eventExecution);
+            indexObject(eventIndexName, EVENT_DOC_TYPE, id, eventExecution, null);
             long endTime = Instant.now().toEpochMilli();
             logger.debug(
                     "Time taken {} for indexing event execution: {}",
@@ -1231,12 +1241,15 @@ public class ElasticSearchRestDAOV7 extends ElasticSearchBaseDAO implements Inde
     }
 
     private void indexObject(final String index, final String docType, final Object doc) {
-        indexObject(index, docType, null, doc);
+        indexObject(index, docType, null, doc, null);
     }
 
     private void indexObject(
-            final String index, final String docType, final String docId, final Object doc) {
-
+            final String index,
+            final String docType,
+            final String docId,
+            final Object doc,
+            final WriteRequest.RefreshPolicy refreshPolicy) {
         byte[] docBytes;
         try {
             docBytes = objectMapper.writeValueAsBytes(doc);
@@ -1247,27 +1260,38 @@ public class ElasticSearchRestDAOV7 extends ElasticSearchBaseDAO implements Inde
         IndexRequest request = new IndexRequest(index);
         request.id(docId).source(docBytes, XContentType.JSON);
 
-        if (bulkRequests.get(docType) == null) {
-            bulkRequests.put(
-                    docType, new BulkRequests(System.currentTimeMillis(), new BulkRequest()));
+        Pair<String, WriteRequest.RefreshPolicy> requestKey =
+                new ImmutablePair<>(docType, refreshPolicy);
+        if (bulkRequests.get(requestKey) == null) {
+            BulkRequest bulkRequest = new BulkRequest();
+            Optional.ofNullable(requestKey.getRight()).map(bulkRequest::setRefreshPolicy);
+            bulkRequests.put(requestKey, new BulkRequests(System.currentTimeMillis(), bulkRequest));
         }
 
-        bulkRequests.get(docType).getBulkRequest().add(request);
-        if (bulkRequests.get(docType).getBulkRequest().numberOfActions() >= this.indexBatchSize) {
-            indexBulkRequest(docType);
+        bulkRequests.get(requestKey).getBulkRequest().add(request);
+        if (bulkRequests.get(requestKey).getBulkRequest().numberOfActions()
+                >= this.indexBatchSize) {
+            indexBulkRequest(requestKey);
         }
     }
 
-    private synchronized void indexBulkRequest(String docType) {
-        if (bulkRequests.get(docType).getBulkRequest() != null
-                && bulkRequests.get(docType).getBulkRequest().numberOfActions() > 0) {
-            synchronized (bulkRequests.get(docType).getBulkRequest()) {
+    private synchronized void indexBulkRequest(
+            Pair<String, WriteRequest.RefreshPolicy> requestKey) {
+        if (bulkRequests.get(requestKey).getBulkRequest() != null
+                && bulkRequests.get(requestKey).getBulkRequest().numberOfActions() > 0) {
+            synchronized (bulkRequests.get(requestKey).getBulkRequest()) {
                 indexWithRetry(
-                        bulkRequests.get(docType).getBulkRequest().get(),
-                        "Bulk Indexing " + docType,
-                        docType);
+                        bulkRequests.get(requestKey).getBulkRequest().get(),
+                        "Bulk Indexing "
+                                + requestKey.getLeft()
+                                + " with "
+                                + requestKey.getLeft()
+                                + " policy",
+                        requestKey.getLeft());
+                BulkRequest bulkRequest = new BulkRequest();
+                Optional.ofNullable(requestKey.getRight()).map(bulkRequest::setRefreshPolicy);
                 bulkRequests.put(
-                        docType, new BulkRequests(System.currentTimeMillis(), new BulkRequest()));
+                        requestKey, new BulkRequests(System.currentTimeMillis(), bulkRequest));
             }
         }
     }


### PR DESCRIPTION
…lowID

Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
## Bug description

It's hard to reproduce the bug in a consistent manner but `ElasticSearchDAOV6` and `ElasticSearchDAOV7` do not use the `wait_for` refresh policy when performing index/update/delete/bulk requests.

As [described here](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/refresh-parameter) this can result in the action not being immediately visible to the user depending on the ES refresh interval.

In my particular case it is very problematic as I start some workflows then poll them until they are complete. Sometimes when polling for the first time the workflow indexing is not visible yet to search hence my function returns because there are not running workflow.

This PR update the `ElasticSearchDAOV7` to use the `wait_for` / `WAIT_UNTIL` policy to that we wait until the indexed data is visible to search before returning, returning that indexed task and workflow will be visible for search.

_Describe alternative implementation you have considered_

**Important notes**:
- I made the change only for `indexTask`/`indexWorkflow`,  while I kept the `updateTask`/`updateWorkflow` and `removeTask`/`removeWorkflow` as is. This is a debatable choice some issues could also arise from the deletion/update not being reflected in the search. I my opinion the most problematic use case is returning an ID of an object which not yet exists and yet only fixed the index logic as using the `wait_for` refresh policy add some latency. Please let me know if you think I should also update the delete/update logic
- the change is not easy to test so I haven't implemented any, a valid test could be to intercept the queries made to ES and verify that they are done using the `wait_for` query parameter, let me know if you think that make sense.


_Describe alternative implementation you have considered_
