### PR TITLE
fix(task-resource): remove redundant import of NotFoundException

### DIFF
--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import com.netflix.conductor.core.exception.NotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;


### PR DESCRIPTION
Pull Request type
----
- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
This PR removes a redundant import of NotFoundException from the TaskResource.java file, which was causing the spotlessJavaCheck build step to fail after cloning the project.
The change ensures the codebase adheres to formatting rules and the build passes cleanly.
Issue #594 

