### PR TITLE
fixes docker-compose build by disabling Spotless check

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ git clone https://github.com/conductor-oss/conductor
 cd conductor
 ```
 
+### (Optional) Install Git Hook for Auto-formatting
+
+To automatically format code before commits:
+
+```shell
+ln -s ../../hooks/pre-commit .git/hooks/pre-commit
+```
+
 ### Start with Docker Compose (_recommended for local deployment_)
 
 ```shell

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -13,7 +13,7 @@ COPY . /conductor
 WORKDIR /conductor
 
 # Build the server on run
-RUN ./gradlew build -x test
+RUN ./gradlew build -x test -x spotlessCheck
 WORKDIR /server/build/libs
 RUN ls -ltr
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Pre-commit hook to auto-format code with Spotless
+#
+# To install: ln -s ../../hooks/pre-commit .git/hooks/pre-commit
+#
+
+echo "Running Spotless formatter..."
+./gradlew spotlessApply
+
+# Re-add any files that were modified by spotless
+git diff --name-only --cached | xargs git add
+
+exit 0

--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/TaskResource.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import com.netflix.conductor.core.exception.NotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -80,7 +79,8 @@ public class TaskResource {
             @RequestParam(value = "count", defaultValue = "1") int count,
             @RequestParam(value = "timeout", defaultValue = "100") int timeout) {
         // for backwards compatibility with 2.x client which expects a 204 when no Task is found
-        return Optional.ofNullable(taskService.batchPoll(taskType, workerId, domain, count, timeout))
+        return Optional.ofNullable(
+                        taskService.batchPoll(taskType, workerId, domain, count, timeout))
                 .filter(tasks -> !tasks.isEmpty())
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.noContent().build());
@@ -156,7 +156,8 @@ public class TaskResource {
         return Optional.ofNullable(taskService.getTaskLogs(taskId))
                 .filter(logs -> !logs.isEmpty())
                 .map(ResponseEntity::ok)
-                .orElseThrow(() -> new NotFoundException("Task logs not found for taskId: %s", taskId));
+                .orElseThrow(
+                        () -> new NotFoundException("Task logs not found for taskId: %s", taskId));
     }
 
     @GetMapping("/{taskId}")


### PR DESCRIPTION
Pull Request type
----
- [ X ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

(Yes, ironically, this was also done -- fixing some code that was breaking the build due to some bad formatting that snuck in somehow.)

Changes in this PR
----

Issue #587 

This fix makes the docker compose NOT dependent on whether spotlessApply has been perfectly applied and allows it to compile regardless.

Talked to @v1r3n  about different possible solutions -- the other main one to consider would have been a docker build that tries to build with spotless enabled, and then runs spotlessApply if it doesn't.  This would make a build take a strangely long time for not a lot of benefit.

We should of course be running spotlessApply before each commit, and to that end, I'm putting in a suggested pre-commit hook (see the README and file in hooks/) that can be optionally added by a developer working on the project.