### PR TITLE
  Fix FORK_JOIN_DYNAMIC input wrapping when fed directly by JSON_JQ_TRANSFORM (#575)

### DIFF
--- a/json-jq-task/src/main/java/com/netflix/conductor/tasks/json/JsonJqTransform.java
+++ b/json-jq-task/src/main/java/com/netflix/conductor/tasks/json/JsonJqTransform.java
@@ -82,12 +82,14 @@ public class JsonJqTransform extends WorkflowSystemTask {
             if (result == null) {
                 task.addOutput(OUTPUT_RESULT, null);
                 task.addOutput(OUTPUT_RESULT_LIST, null);
-            } else if (result.isEmpty()) {
-                task.addOutput(OUTPUT_RESULT, null);
-                task.addOutput(OUTPUT_RESULT_LIST, result);
             } else {
-                task.addOutput(OUTPUT_RESULT, extractBody(result.get(0)));
-                task.addOutput(OUTPUT_RESULT_LIST, result);
+                List<Object> extractedResults = extractBodies(result);
+                if (extractedResults.isEmpty()) {
+                    task.addOutput(OUTPUT_RESULT, null);
+                } else {
+                    task.addOutput(OUTPUT_RESULT, extractedResults.get(0));
+                }
+                task.addOutput(OUTPUT_RESULT_LIST, extractedResults);
             }
         } catch (final Exception e) {
             LOGGER.error(
@@ -126,6 +128,14 @@ public class JsonJqTransform extends WorkflowSystemTask {
             messages.add(currentStack.getMessage());
         }
         return messages.stream().filter(it -> !it.contains("N/A")).findFirst().orElse("");
+    }
+
+    private List<Object> extractBodies(List<JsonNode> nodes) {
+        List<Object> values = new ArrayList<>(nodes.size());
+        for (JsonNode node : nodes) {
+            values.add(extractBody(node));
+        }
+        return values;
     }
 
     private Object extractBody(JsonNode node) {

--- a/json-jq-task/src/test/java/com/netflix/conductor/tasks/json/JsonJqTransformTest.java
+++ b/json-jq-task/src/test/java/com/netflix/conductor/tasks/json/JsonJqTransformTest.java
@@ -50,7 +50,9 @@ public class JsonJqTransformTest {
 
         assertNull(task.getOutputData().get("error"));
         assertEquals("VALUE", task.getOutputData().get("result").toString());
-        assertEquals("[\"VALUE\"]", task.getOutputData().get("resultList").toString());
+        List<?> resultList = (List<?>) task.getOutputData().get("resultList");
+        assertEquals(1, resultList.size());
+        assertEquals("VALUE", resultList.get(0));
     }
 
     @Test
@@ -126,6 +128,8 @@ public class JsonJqTransformTest {
                 result.get("requestTransform"));
         assertEquals(
                 "{result: \"reply: \" + .response.body.message}", result.get("responseTransform"));
+        List<Object> resultList = (List<Object>) task.getOutputData().get("resultList");
+        assertTrue(resultList.get(0) instanceof Map);
     }
 
     @Test


### PR DESCRIPTION
Fix FORK_JOIN_DYNAMIC input wrapping when fed directly by JSON_JQ_TRANSFORM (#575)

  ———

  Pull Request type

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring (no functional changes, no api changes)
  - [ ] Build related changes
  - [ ] WHOSUSING.md
  - [ ] Other (please describe):

  Changes in this PR

- Normalized JSON_JQ_TRANSFORM outputs so both result and resultList are plain Java maps/lists. In reproduction workflow fork_join_dynamic now receives inputs like
```
{
	"commonProperty": "common value",
	"property": "value1",
	"__index": 0
}
```
<img width="1907" height="840" alt="image" src="https://github.com/user-attachments/assets/c29c7f02-1004-4fe8-b0fa-4417c4d33525" />

instead of
```
{
	"input": {
		"commonProperty": "common value",
		"property": "value1"
	},
	"__index": 0
}
```
in the version before changes
<img width="1907" height="798" alt="image" src="https://github.com/user-attachments/assets/60b07c44-d1be-4597-8379-d5c18c116dff" />

Also this behaviour matching with Orkes Cloud behaviour.

- tests:
      - JsonJqTransformTest checks resultList equals a list of standard maps.
      - ForkJoinDynamicTaskMapperTest asserts dynamic fork inputs remain unwrapped and keep their parameters.
      - Verified manually on the workflow from issue #575. Before fixing the bug, it was reproduced only when JSON_JQ_TRANSFORM went immediately before FORK_JOIN_DYNAMIC; inserting an asynchronous task (WAIT/SIMPLE/...) between them serialized the data and hid the error. 

the screenshot from the version before fix with WAIT task
<img width="1901" height="882" alt="image" src="https://github.com/user-attachments/assets/ea460a13-f583-4ab7-bb91-dc13f0ec5970" />

The fix removes this dependency and the need for such workarounds
