### PR TITLE
add username config to redis lock

### DIFF
--- a/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockConfiguration.java
+++ b/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockConfiguration.java
@@ -49,6 +49,7 @@ public class RedisLockConfiguration {
             throw new RuntimeException(message, ie);
         }
         String redisServerAddress = properties.getServerAddress();
+        String redisServerUsername = properties.getServerUsername();
         String redisServerPassword = properties.getServerPassword();
         String masterName = properties.getServerMasterName();
 
@@ -64,6 +65,7 @@ public class RedisLockConfiguration {
                 redisConfig
                         .useSingleServer()
                         .setAddress(redisServerAddress)
+                        .setUsername(redisServerUsername)
                         .setPassword(redisServerPassword)
                         .setTimeout(connectionTimeout)
                         .setDnsMonitoringInterval(properties.getDnsMonitoringInterval());
@@ -74,6 +76,7 @@ public class RedisLockConfiguration {
                         .useClusterServers()
                         .setScanInterval(2000) // cluster state scan interval in milliseconds
                         .addNodeAddress(redisServerAddress.split(","))
+                        .setUsername(redisServerUsername)
                         .setPassword(redisServerPassword)
                         .setTimeout(connectionTimeout)
                         .setSlaveConnectionMinimumIdleSize(
@@ -93,6 +96,7 @@ public class RedisLockConfiguration {
                         .setScanInterval(2000)
                         .setMasterName(masterName)
                         .addSentinelAddress(redisServerAddress)
+                        .setUsername(redisServerUsername)
                         .setPassword(redisServerPassword)
                         .setTimeout(connectionTimeout)
                         .setDnsMonitoringInterval(properties.getDnsMonitoringInterval());

--- a/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockProperties.java
+++ b/redis-lock/src/main/java/com/netflix/conductor/redislock/config/RedisLockProperties.java
@@ -23,6 +23,9 @@ public class RedisLockProperties {
     /** The address of the redis server following format -- host:port */
     private String serverAddress = "redis://127.0.0.1:6379";
 
+    /** The username for redis authentication (Redis 6+). Default to null when not needed. */
+    private String serverUsername = null;
+
     /** The password for redis authentication */
     private String serverPassword = null;
 
@@ -70,6 +73,14 @@ public class RedisLockProperties {
 
     public void setServerAddress(String serverAddress) {
         this.serverAddress = serverAddress;
+    }
+
+    public String getServerUsername() {
+      return serverUsername;
+    }
+
+    public void setServerUsername(String serverUsername) {
+      this.serverUsername = serverUsername;
     }
 
     public String getServerPassword() {


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #577 
Allow username to be set while using redis 6.0+ for locks

Alternatives considered
----

_Describe alternative implementation you have considered_
