### PR TITLE
add @JsonProperty annotations to fix AWS policy JSON format

### DIFF
--- a/awssqs-event-queue/src/main/java/com/netflix/conductor/sqs/eventqueue/SQSObservableQueue.java
+++ b/awssqs-event-queue/src/main/java/com/netflix/conductor/sqs/eventqueue/SQSObservableQueue.java
@@ -28,6 +28,7 @@ import com.netflix.conductor.core.events.queue.Message;
 import com.netflix.conductor.core.events.queue.ObservableQueue;
 import com.netflix.conductor.metrics.Monitors;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import rx.Observable;
@@ -417,7 +418,10 @@ public class SQSObservableQueue implements ObservableQueue {
     }
 
     private static class SqsPolicy {
+        @JsonProperty("Version")
         private String version;
+
+        @JsonProperty("Statement")
         private List<SqsStatement> statement;
 
         public String getVersion() {
@@ -438,9 +442,16 @@ public class SQSObservableQueue implements ObservableQueue {
     }
 
     private static class SqsStatement {
+        @JsonProperty("Effect")
         private String effect;
+
+        @JsonProperty("Principal")
         private SqsPrincipal principal;
+
+        @JsonProperty("Action")
         private String action;
+
+        @JsonProperty("Resource")
         private String resource;
 
         public String getEffect() {
@@ -477,6 +488,7 @@ public class SQSObservableQueue implements ObservableQueue {
     }
 
     private static class SqsPrincipal {
+        @JsonProperty("AWS")
         private List<String> aws;
 
         public List<String> getAws() {

--- a/awssqs-event-queue/src/test/java/com/netflix/conductor/sqs/eventqueue/SQSObservableQueueTest.java
+++ b/awssqs-event-queue/src/test/java/com/netflix/conductor/sqs/eventqueue/SQSObservableQueueTest.java
@@ -12,6 +12,8 @@
  */
 package com.netflix.conductor.sqs.eventqueue;
 
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -22,9 +24,13 @@ import org.mockito.stubbing.Answer;
 
 import com.netflix.conductor.core.events.queue.Message;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.Uninterruptibles;
 import rx.Observable;
 import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest;
+import software.amazon.awssdk.services.sqs.model.GetQueueAttributesResponse;
 import software.amazon.awssdk.services.sqs.model.ListQueuesRequest;
 import software.amazon.awssdk.services.sqs.model.ListQueuesResponse;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
@@ -32,6 +38,7 @@ import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -97,5 +104,76 @@ public class SQSObservableQueueTest {
 
         Uninterruptibles.sleepUninterruptibly(1000, TimeUnit.MILLISECONDS);
         assertEquals(1, found.size());
+    }
+
+    @Test
+    public void testPolicyJsonFormat() throws Exception {
+        // Mock SQS client
+        SqsClient client = mock(SqsClient.class);
+        when(client.listQueues(any(ListQueuesRequest.class)))
+                .thenReturn(
+                        ListQueuesResponse.builder()
+                                .queueUrls(
+                                        "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue")
+                                .build());
+        when(client.getQueueAttributes(any(GetQueueAttributesRequest.class)))
+                .thenReturn(
+                        GetQueueAttributesResponse.builder()
+                                .attributesWithStrings(
+                                        Collections.singletonMap(
+                                                "QueueArn",
+                                                "arn:aws:sqs:us-east-1:123456789012:test-queue"))
+                                .build());
+
+        // Create queue instance using reflection to access private getPolicy method
+        SQSObservableQueue queue =
+                new SQSObservableQueue.Builder()
+                        .withQueueName("test-queue")
+                        .withClient(client)
+                        .build();
+
+        // Use reflection to call private getPolicy method
+        Method getPolicyMethod =
+                SQSObservableQueue.class.getDeclaredMethod("getPolicy", List.class);
+        getPolicyMethod.setAccessible(true);
+
+        List<String> accountIds = Arrays.asList("111122223333", "444455556666");
+        String policyJson = (String) getPolicyMethod.invoke(queue, accountIds);
+
+        // Parse the JSON and verify structure
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode policyNode = mapper.readTree(policyJson);
+
+        // Verify top-level fields have correct capitalization
+        assertTrue("Policy must have 'Version' field", policyNode.has("Version"));
+        assertTrue("Policy must have 'Statement' field", policyNode.has("Statement"));
+        assertEquals("2012-10-17", policyNode.get("Version").asText());
+
+        // Verify Statement array
+        JsonNode statementArray = policyNode.get("Statement");
+        assertTrue("Statement must be an array", statementArray.isArray());
+        assertEquals(1, statementArray.size());
+
+        // Verify Statement object fields
+        JsonNode statement = statementArray.get(0);
+        assertTrue("Statement must have 'Effect' field", statement.has("Effect"));
+        assertTrue("Statement must have 'Principal' field", statement.has("Principal"));
+        assertTrue("Statement must have 'Action' field", statement.has("Action"));
+        assertTrue("Statement must have 'Resource' field", statement.has("Resource"));
+
+        assertEquals("Allow", statement.get("Effect").asText());
+        assertEquals("sqs:SendMessage", statement.get("Action").asText());
+        assertEquals(
+                "arn:aws:sqs:us-east-1:123456789012:test-queue",
+                statement.get("Resource").asText());
+
+        // Verify Principal object
+        JsonNode principal = statement.get("Principal");
+        assertTrue("Principal must have 'AWS' field", principal.has("AWS"));
+        JsonNode awsArray = principal.get("AWS");
+        assertTrue("AWS must be an array", awsArray.isArray());
+        assertEquals(2, awsArray.size());
+        assertEquals("111122223333", awsArray.get(0).asText());
+        assertEquals("444455556666", awsArray.get(1).asText());
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Fixes (SQSObservableQueue.java)
   - Added @JsonProperty annotations to ensure correct AWS policy JSON format
   - Fixes issue #591 where policies were rejected after AWS SDK v2 migration

Unit Test (SQSObservableQueueTest.java)
   - Tests that policy JSON has correct field capitalization
   - Prevents regression of this issue

E2E Test (SQSEventQueueE2ESpec.groovy)
   - Tests actual policy setting against LocalStack
   - Validates the accountsToAuthorize feature works end-to-end


The relevant E2E test can be run with:

./gradlew :test-harness:test --tests "SQSEventQueueE2ESpec"
