### PR TITLE
Support both ES & OS via gradle build flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,18 +111,19 @@ Check-out the [Conductor docs](https://github.com/conductor-oss/conductor/tree/m
 - - - 
 # Database Specifications
 * The default persistence used is Redis
-* The indexing backend is [Elasticsearch](https://www.elastic.co/) (7.x)
+* The default indexing backend is [Elasticsearch](https://www.elastic.co/) (7.x)
 * To use [Opensearch](https://opensearch.org/) (2.x), comment out Elasticsearch import so lucene dependencies don't conflict [server/build.gradle](https://github.com/conductor-oss/conductor/blob/main/server/build.gradle#L44-L46)
 
 
 ## Configuration for various database backends
 
-| Backend        | Configuration                                                                         |
-|----------------|---------------------------------------------------------------------------------------|
-| Redis + ES7    | [config-redis.properties](docker/server/config/config-redis.properties)               |
-| Postgres       | [config-postgres.properties](docker/server/config/config-postgres.properties)         |
-| Postgres + ES7 | [config-postgres-es7.properties](docker/server/config/config-postgres-es7.properties) |
-| MySQL + ES7    | [config-mysql.properties](docker/server/config/config-mysql.properties)               |
+| Backend              | Configuration                                                                             |
+|----------------------|-------------------------------------------------------------------------------------------|
+| Redis + ES7 (default)         | [config-redis.properties](docker/server/config/config-redis.properties)                   |
+| Redis + OS   | [config-redis-os.properties](docker/server/config/config-redis-os.properties)             |
+| Postgres             | [config-postgres.properties](docker/server/config/config-postgres.properties)             |
+| Postgres + ES7       | [config-postgres-es7.properties](docker/server/config/config-postgres-es7.properties)     |
+| MySQL + ES7          | [config-mysql.properties](docker/server/config/config-mysql.properties)                   |
 
 
 # Build from source

--- a/docker/docker-compose-redis-os.yaml
+++ b/docker/docker-compose-redis-os.yaml
@@ -12,6 +12,7 @@ services:
       dockerfile: docker/server/Dockerfile
       args:
         YARN_OPTS: ${YARN_OPTS}
+        INDEXING_BACKEND: opensearch
     networks:
       - internal
     ports:

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -6,6 +6,8 @@
 # ===========================================================================================================
 FROM openjdk:17-bullseye AS builder
 
+ARG INDEXING_BACKEND=elasticsearch
+
 LABEL maintainer="Orkes OSS <oss@orkes.io>"
 
 # Copy the project directly onto the image
@@ -13,7 +15,7 @@ COPY . /conductor
 WORKDIR /conductor
 
 # Build the server on run
-RUN ./gradlew build -x test -x spotlessCheck
+RUN ./gradlew build -x test -x spotlessCheck -PindexingBackend=${INDEXING_BACKEND}
 WORKDIR /server/build/libs
 RUN ls -ltr
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -40,10 +40,13 @@ dependencies {
     implementation project(':conductor-mysql-persistence')
     implementation project(':conductor-sqlite-persistence')
 
-    //Indexing (note: Elasticsearch 6 is deprecated)
-    implementation project(':conductor-es7-persistence')
-    // To use Opensearch, comment out above Elasticsearch, uncomment below Opensearch, and rebuild conductor
-    // implementation project(':conductor-os-persistence')
+    // Indexing backend selection (build-time) to avoid Lucene conflicts between ES and OS
+    def indexingBackend = project.findProperty('indexingBackend') ?: 'elasticsearch'
+    if (indexingBackend == 'opensearch' || indexingBackend == 'os') {
+        implementation project(':conductor-os-persistence')
+    } else {
+        implementation project(':conductor-es7-persistence')
+    }
 
     implementation project(':conductor-redis-lock')
     implementation project(':conductor-redis-concurrency-limit')


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Issue https://github.com/conductor-oss/conductor/issues/614

- Introduced build-time dynamic selection of the indexing backend (ES vs OS) to avoid Lucene version conflicts.
  - Improved fix on: https://github.com/conductor-oss/conductor/pull/527
- Default remains ES; OS is enabled per build via Docker build arg (`INDEXING_BACKEND`) and Gradle property (`indexingBackend`)
- Updated docs to list all available server config files and clarify defaults.


Testing
----
**ES setup**
`docker compose -f docker/docker-compose.yaml build --no-cache conductor-server`
`docker compose -f docker/docker-compose.yaml up`

**OS setup**
`docker compose -f docker/docker-compose-redis-os.yaml build --no-cache conductor-server`
`docker compose -f docker/docker-compose-redis-os.yaml up`

**Testing Instructions**
- Spin up the docker containers for ES/OS setup as stated above
- Navigate to Executions tab (http://localhost:8127/executions)
- Check the Workflow/Tasks search tab, test out different status filters, ensure there are no errors in the console log 