### PR TITLE
Fix duplicate HTTP task execution via WorkflowRepairService race condition

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -149,6 +149,9 @@ public class AsyncSystemTaskExecutor {
             if (task.getStatus() == TaskModel.Status.SCHEDULED) {
                 task.setStartTime(System.currentTimeMillis());
                 Monitors.recordQueueWaitTime(task.getTaskType(), task.getQueueWaitTime());
+                // Persist pollCount to DB before blocking operation
+                // This prevents WorkflowRepairService from re-queueing during long-running tasks
+                executionDAOFacade.updateTask(task);
                 systemTask.start(workflow, task, workflowExecutor);
             } else if (task.getStatus() == TaskModel.Status.IN_PROGRESS) {
                 systemTask.execute(workflow, task, workflowExecutor);


### PR DESCRIPTION
## Summary

Fixes #630 

Long-running HTTP tasks (and other async system tasks) were being executed multiple times (typically 4x) due to a race condition in WorkflowRepairService.

## Problem

1. SystemTaskWorker polls task → removes from queue via `ackTaskReceived()`
2. AsyncSystemTaskExecutor increments `pollCount` **in-memory only**
3. HTTP call starts and blocks for minutes
4. WorkflowRepairService reads task from database → sees `pollCount = 0` (stale value)
5. Task not found in queue + `pollCount = 0` → WorkflowRepairService re-queues it
6. Another worker picks it up → duplicate execution
7. Repeats 3-4 times during long-running operations

## Solution

Two-part fix:

**1. WorkflowRepairService (lines 146-155)**
Check `pollCount > 0` before re-queueing. If task has been polled, a worker is actively processing it, so skip re-queueing.

**2. AsyncSystemTaskExecutor (lines 152-154)**
Persist task to database **before** calling `systemTask.start()`. This ensures `pollCount` is written to DB before any blocking operations, preventing WorkflowRepairService from reading stale data.

## Tradeoffs to Consider

### Current Behavior (Before Fix)
- ❌ Healthy workers executing long tasks → task re-queued immediately → **duplicate executions**
- ✅ Crashed workers → task re-queued immediately → fast recovery

### Proposed Behavior (After Fix)
- ✅ Healthy workers executing long tasks → task NOT re-queued → **no duplicates**
- ⏱️ Crashed workers → task NOT re-queued → recovery via timeout mechanisms

### Recovery for Crashed Workers

If a worker crashes with this change, recovery depends on existing timeout mechanisms:

1. **Queue unack timeout**: Message automatically returns to queue after timeout expires
2. **Response timeout** (`responseTimeoutSeconds`): DeciderService marks task as TIMED_OUT if no updates received
3. **Execution timeout** (`timeoutSeconds`): Overall time limit from first poll

This means recovery would be **delayed** by the responseTimeout duration (typically 30-60s) rather than immediate.

### Questions for Discussion

- What is the relative frequency of long-running tasks vs worker crashes in production?
- Is delayed recovery for crashed workers acceptable to prevent duplicate executions?
- Are there scenarios where aggressive re-queueing is beneficial that we haven't considered?
- Should we add additional logic (e.g., time-based thresholds) to handle both cases?

## Changes

**Modified:**
- `core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowRepairService.java` - Added pollCount check (lines 146-155)
- `core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java` - Persist task before blocking start() call (lines 152-154)
- `core/src/test/java/com/netflix/conductor/core/reconciliation/TestWorkflowRepairService.java` - Added 2 new tests:
  - `verifyScheduledTaskWithPollCountIsNotRequeued()`
  - `verifySystemTaskWithPollCountIsNotRequeued()`