### PR TITLE
Upgrade cypress-io/github-action from v4 to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         run: yarn run build
 
       - name: Run E2E Tests
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v6
         with:
           working-directory: ui
           install: false
@@ -88,7 +88,7 @@ jobs:
           wait-on: "http://localhost:5000"
 
       - name: Run Component Tests
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v6
         with:
           working-directory: ui
           install: false


### PR DESCRIPTION
## Summary

Upgrades the Cypress GitHub Action from v4 to v6 (latest major version).

## Changes

- Update `cypress-io/github-action` from **v4** → **v6**
- Applies to both E2E and component test steps in CI workflow

## What's New in v6

- **Node.js 20**: v6 runs on Node.js 20 (v4 used Node.js 16, now EOL)
- **Latest Cypress support**: Full support for Cypress 13+
- **Performance improvements**: Faster test execution and caching

## Testing

The workflow changes will be validated when CI runs on this PR.

## Supersedes

This PR supersedes the outdated #152 (from May 2023).

Part of #640 (Epic: Dependabot PR Cleanup and Security Updates)