### PR TITLE
Add support for dead letter exchange and queue arguments in AMQP

### DIFF
--- a/amqp/src/main/java/com/netflix/conductor/contribs/queue/amqp/util/AMQPConfigurations.java
+++ b/amqp/src/main/java/com/netflix/conductor/contribs/queue/amqp/util/AMQPConfigurations.java
@@ -25,7 +25,11 @@ public enum AMQPConfigurations {
     PARAM_DURABLE("durable"),
     PARAM_EXCLUSIVE("exclusive"),
     PARAM_AUTO_DELETE("autoDelete"),
-    PARAM_MAX_PRIORITY("maxPriority");
+    PARAM_MAX_PRIORITY("maxPriority"),
+    PARAM_DEAD_LETTER_EXCHANGE("deadLetterExchange"),
+    PARAM_DEAD_LETTER_ROUTING_KEY("deadLetterRoutingKey"),
+    PARAM_MESSAGE_TTL("messageTtl"),
+    PARAM_MAX_LENGTH("maxLength");
 
     String propertyName;
 

--- a/amqp/src/main/java/com/netflix/conductor/contribs/queue/amqp/util/AMQPSettings.java
+++ b/amqp/src/main/java/com/netflix/conductor/contribs/queue/amqp/util/AMQPSettings.java
@@ -154,11 +154,34 @@ public class AMQPSettings {
      * amqp_queue:myQueue?deliveryMode=1&autoDelete=true&exclusive=true
      * </pre>
      *
+     * <u>Example for queue with dead letter exchange:</u>
+     *
+     * <pre>
+     * amqp_queue:myQueue?durable=true&deadLetterExchange=myDLX&deadLetterRoutingKey=failed&messageTtl=60000&maxLength=1000
+     * </pre>
+     *
      * <u>Example for exchange:</u>
      *
      * <pre>
      * amqp_exchange:myExchange?bindQueueName=myQueue&exchangeType=topic&routingKey=myRoutingKey&exclusive=true
      * </pre>
+     *
+     * <p>Supported parameters:
+     *
+     * <ul>
+     *   <li>deliveryMode - Message delivery mode (1=non-persistent, 2=persistent)
+     *   <li>durable - Queue/Exchange durability (true/false)
+     *   <li>exclusive - Exclusive queue (true/false)
+     *   <li>autoDelete - Auto-delete queue/exchange (true/false)
+     *   <li>maxPriority - Maximum priority for messages (integer)
+     *   <li>deadLetterExchange - Dead letter exchange name for failed messages
+     *   <li>deadLetterRoutingKey - Routing key for dead lettered messages
+     *   <li>messageTtl - Message time-to-live in milliseconds (integer)
+     *   <li>maxLength - Maximum queue length (integer)
+     *   <li>exchangeType - Exchange type (topic, direct, fanout, headers)
+     *   <li>bindQueueName - Queue name to bind to exchange
+     *   <li>routingKey - Routing key for exchange binding
+     * </ul>
      *
      * @param queueURI
      * @return
@@ -226,6 +249,22 @@ public class AMQPSettings {
                                         if (kv[0].equalsIgnoreCase(
                                                 (String.valueOf(PARAM_MAX_PRIORITY)))) {
                                             arguments.put("x-max-priority", Integer.valueOf(kv[1]));
+                                        }
+                                        if (kv[0].equalsIgnoreCase(
+                                                (String.valueOf(PARAM_DEAD_LETTER_EXCHANGE)))) {
+                                            arguments.put("x-dead-letter-exchange", kv[1]);
+                                        }
+                                        if (kv[0].equalsIgnoreCase(
+                                                (String.valueOf(PARAM_DEAD_LETTER_ROUTING_KEY)))) {
+                                            arguments.put("x-dead-letter-routing-key", kv[1]);
+                                        }
+                                        if (kv[0].equalsIgnoreCase(
+                                                (String.valueOf(PARAM_MESSAGE_TTL)))) {
+                                            arguments.put("x-message-ttl", Integer.valueOf(kv[1]));
+                                        }
+                                        if (kv[0].equalsIgnoreCase(
+                                                (String.valueOf(PARAM_MAX_LENGTH)))) {
+                                            arguments.put("x-max-length", Integer.valueOf(kv[1]));
                                         }
                                     }
                                 });

--- a/amqp/src/test/java/com/netflix/conductor/contribs/queue/amqp/AMQPSettingsTest.java
+++ b/amqp/src/test/java/com/netflix/conductor/contribs/queue/amqp/AMQPSettingsTest.java
@@ -156,4 +156,48 @@ public class AMQPSettingsTest {
         AMQPSettings settings = new AMQPSettings(properties);
         settings.fromURI(exchangestring);
     }
+
+    @Test
+    public void testAMQPSettings_queue_with_dead_letter_exchange() {
+        String queuestring =
+                "amqp_queue:myQueueName?deadLetterExchange=myDLX&deadLetterRoutingKey=failed";
+        AMQPSettings settings = new AMQPSettings(properties);
+        settings.fromURI(queuestring);
+        assertEquals("myQueueName", settings.getQueueOrExchangeName());
+        assertEquals("myDLX", settings.getArguments().get("x-dead-letter-exchange"));
+        assertEquals("failed", settings.getArguments().get("x-dead-letter-routing-key"));
+    }
+
+    @Test
+    public void testAMQPSettings_queue_with_message_ttl() {
+        String queuestring = "amqp_queue:myQueueName?messageTtl=60000";
+        AMQPSettings settings = new AMQPSettings(properties);
+        settings.fromURI(queuestring);
+        assertEquals("myQueueName", settings.getQueueOrExchangeName());
+        assertEquals(60000, settings.getArguments().get("x-message-ttl"));
+    }
+
+    @Test
+    public void testAMQPSettings_queue_with_max_length() {
+        String queuestring = "amqp_queue:myQueueName?maxLength=1000";
+        AMQPSettings settings = new AMQPSettings(properties);
+        settings.fromURI(queuestring);
+        assertEquals("myQueueName", settings.getQueueOrExchangeName());
+        assertEquals(1000, settings.getArguments().get("x-max-length"));
+    }
+
+    @Test
+    public void testAMQPSettings_queue_with_all_arguments() {
+        String queuestring =
+                "amqp_queue:myQueueName?durable=true&deadLetterExchange=myDLX&deadLetterRoutingKey=failed&messageTtl=60000&maxLength=1000&maxPriority=10";
+        AMQPSettings settings = new AMQPSettings(properties);
+        settings.fromURI(queuestring);
+        assertEquals("myQueueName", settings.getQueueOrExchangeName());
+        assertTrue(settings.isDurable());
+        assertEquals("myDLX", settings.getArguments().get("x-dead-letter-exchange"));
+        assertEquals("failed", settings.getArguments().get("x-dead-letter-routing-key"));
+        assertEquals(60000, settings.getArguments().get("x-message-ttl"));
+        assertEquals(1000, settings.getArguments().get("x-max-length"));
+        assertEquals(10, settings.getArguments().get("x-max-priority"));
+    }
 }


### PR DESCRIPTION
Pull Request type
----
- [x] Feature

Changes in this PR
----
Enhanced AMQPSettings to support additional RabbitMQ queue arguments through URI parameters.

New URI Parameters:
  - deadLetterExchange: Configure x-dead-letter-exchange
  - deadLetterRoutingKey: Configure x-dead-letter-routing-key
  - messageTtl: Configure x-message-ttl (milliseconds)
  - maxLength: Configure x-max-length

Example usage:
```text
amqp_queue:myQueue?deadLetterExchange=myDLX&deadLetterRoutingKey=failed&messageTtl=60000
```

Problem
----
When workflows are triggered via Event Handlers sourced from RabbitMQ, and the workflow initiation fails due to backend database issues, the incoming message is nacked using `basic.nack` with `requeue=false`. As a result, the message is not requeued to the original queue and is expected to be routed to a Dead Letter Exchange (DLX). However, since the DLX configuration is currently not in place, the message is ultimately discarded.

Related issues: https://github.com/conductor-oss/conductor/issues/787

Solution
----
By introducing new parameters for Dead Letter Exchange (DLX) configuration that enable queues to use DLX settings, along with additional arguments for message expiration (TTL) and maximum queue length, all of which are optional.