### PR TITLE
Fix test worker OOM

### DIFF
--- a/awssqs-event-queue/build.gradle
+++ b/awssqs-event-queue/build.gradle
@@ -14,3 +14,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter'
     testImplementation project(':conductor-common').sourceSets.test.output
 }
+
+tasks.withType(Test).configureEach {
+    // SQS/Rx tests are memory-heavy, so make heap explicit & stable
+    maxHeapSize = "1024m"
+}


### PR DESCRIPTION
Why:
Recent CI builds fail in module `conductor-awssqs-event-queue` with
```
java.lang.OutOfMemoryError: Java heap space
SQSObservableQueueTest > testPolicyJsonFormat FAILED
```
The OOM occurs in the JVM running the test task for this module, 
indicating heavy memory usage during `testPolicyJsonFormat` execution. 
The failure blocks pipeline runs and does not appear in other modules, 
suggesting the issue is isolated to this test or underlying code path it
invokes.

What:
Increased test JVM heap size specifically for 
`conductor-awssqs-event-queue:test` to prevent premature OOM.

Testing done: issue is reproducible locally, validated the fix there.
Also the build pipeline stabilized after the fix for some time now.
<img width="3218" height="752" alt="Screenshot 2025-12-04 at 15 30 39" src="https://github.com/user-attachments/assets/003aea3a-4d2b-4f95-9f85-0392a9d9e500" />
<img width="3296" height="786" alt="Screenshot 2025-12-04 at 15 31 05" src="https://github.com/user-attachments/assets/de64e5ee-06aa-4c0e-b5cb-96b618b762e7" />
