### PR TITLE
Add Redis Streams event queue provider

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -66,6 +66,7 @@ ext {
     revNatsStreaming = '2.6.5'
     revNats = '2.16.14'
     revStan = '2.2.3'
+    revLettuce = '6.3.0.RELEASE'
     revFlyway = '10.15.2'
     revConductorClient = '4.0.10'
 }

--- a/docker/server/config/config-redis-os-redis-event-queue.properties
+++ b/docker/server/config/config-redis-os-redis-event-queue.properties
@@ -1,0 +1,45 @@
+# Database persistence type.
+# Below are the properties for redis
+conductor.db.type=redis_standalone
+conductor.queue.type=redis_standalone
+
+conductor.redis.hosts=rs:6379:us-east-1c
+conductor.redis-lock.serverAddress=redis://rs:6379
+conductor.redis.taskDefCacheRefreshInterval=1
+conductor.redis.workflowNamespacePrefix=conductor
+conductor.redis.queueNamespacePrefix=conductor_queues
+
+conductor.event-queues.redis.enabled=true
+conductor.default-event-queue.type=redis
+conductor.event-queues.redis.host=rs
+conductor.event-queues.redis.port=6379
+conductor.event-queues.redis.consumer-group=conductor-consumer-group
+conductor.event-queues.redis.dlq-stream=conductor-dlq
+
+conductor.workflow-execution-lock.type=redis
+conductor.app.workflowExecutionLockEnabled=true
+conductor.app.lockTimeToTry=500
+
+conductor.app.systemTaskWorkerThreadCount=20
+conductor.app.systemTaskMaxPollCount=20
+
+
+# Elastic search instance indexing is enabled.
+conductor.indexing.enabled=true
+conductor.indexing.type=opensearch
+conductor.elasticsearch.url=http://os:9200
+conductor.elasticsearch.indexName=conductor
+conductor.elasticsearch.version=0
+conductor.elasticsearch.indexReplicasCount=0
+conductor.elasticsearch.clusterHealthColor=green
+
+# Additional modules for metrics collection exposed to Prometheus (optional)
+conductor.metrics-prometheus.enabled=true
+management.endpoints.web.exposure.include=health,prometheus
+
+# Redis health indicator
+management.health.redis.enabled=true
+
+# Load sample kitchen sink workflow
+loadSample=true
+

--- a/redis-event-queue/build.gradle
+++ b/redis-event-queue/build.gradle
@@ -1,0 +1,21 @@
+dependencies {
+    // Core Conductor dependencies
+    implementation project(':conductor-common')
+    implementation project(':conductor-core')
+
+    // Spring Boot support
+    implementation 'org.springframework.boot:spring-boot-starter'
+
+    // Apache Commons Lang for utility classes
+    implementation 'org.apache.commons:commons-lang3'
+
+    // Reactive programming support with RxJava
+    implementation "io.reactivex:rxjava:${revRxJava}"
+
+    // Lettuce Redis client
+    implementation "io.lettuce:lettuce-core:${revLettuce}"
+
+    // Test dependencies
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation project(':conductor-common').sourceSets.test.output
+}

--- a/redis-event-queue/src/main/java/com/netflix/conductor/rediseq/config/RedisEventQueueConfiguration.java
+++ b/redis-event-queue/src/main/java/com/netflix/conductor/rediseq/config/RedisEventQueueConfiguration.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.rediseq.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.core.events.EventQueueProvider;
+import com.netflix.conductor.core.events.queue.ObservableQueue;
+import com.netflix.conductor.model.TaskModel.Status;
+import com.netflix.conductor.rediseq.eventqueue.RedisObservableQueue;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+
+@Configuration
+@EnableConfigurationProperties(RedisEventQueueProperties.class)
+@ConditionalOnProperty(name = "conductor.event-queues.redis.enabled", havingValue = "true")
+public class RedisEventQueueConfiguration {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(RedisEventQueueConfiguration.class);
+
+    private final RedisEventQueueProperties properties;
+
+    public RedisEventQueueConfiguration(RedisEventQueueProperties properties) {
+        this.properties = properties;
+    }
+
+    @Bean(destroyMethod = "shutdown")
+    public RedisClient redisEventQueueClient() {
+        RedisURI.Builder uriBuilder =
+                RedisURI.builder()
+                        .withHost(properties.getHost())
+                        .withPort(properties.getPort())
+                        .withDatabase(properties.getDatabase())
+                        .withTimeout(properties.getConnectionTimeout());
+
+        if (properties.getPassword() != null && !properties.getPassword().isBlank()) {
+            uriBuilder.withPassword(properties.getPassword().toCharArray());
+        }
+
+        if (properties.isSsl()) {
+            uriBuilder.withSsl(true);
+        }
+
+        RedisClient client = RedisClient.create(uriBuilder.build());
+        client.setDefaultTimeout(properties.getCommandTimeout());
+
+        LOGGER.info(
+                "Created Redis client for event queue: {}:{}",
+                properties.getHost(),
+                properties.getPort());
+        return client;
+    }
+
+    @Bean
+    public EventQueueProvider redisEventQueueProvider(RedisClient redisEventQueueClient) {
+        return new RedisEventQueueProvider(redisEventQueueClient, properties);
+    }
+
+    @ConditionalOnProperty(
+            name = "conductor.default-event-queue.type",
+            havingValue = "redis",
+            matchIfMissing = false)
+    @Bean
+    public Map<Status, ObservableQueue> getQueues(
+            ConductorProperties conductorProperties, RedisClient redisEventQueueClient) {
+        try {
+            LOGGER.debug(
+                    "Starting to create RedisObservableQueues with properties: {}", properties);
+
+            String stack =
+                    Optional.ofNullable(conductorProperties.getStack())
+                            .filter(stackName -> stackName.length() > 0)
+                            .map(stackName -> stackName + "_")
+                            .orElse("");
+
+            LOGGER.debug("Using stack: {}", stack);
+
+            Status[] statuses = new Status[] {Status.COMPLETED, Status.FAILED};
+            Map<Status, ObservableQueue> queues = new HashMap<>();
+
+            for (Status status : statuses) {
+                LOGGER.debug("Processing status: {}", status);
+
+                String queuePrefix =
+                        StringUtils.isBlank(properties.getStreamPrefix())
+                                ? conductorProperties.getAppId() + "_redis_notify_" + stack
+                                : properties.getStreamPrefix();
+
+                LOGGER.debug("queuePrefix: {}", queuePrefix);
+
+                String streamName = queuePrefix + status.name();
+
+                LOGGER.debug("streamName: {}", streamName);
+
+                final ObservableQueue queue =
+                        new RedisObservableQueue(streamName, redisEventQueueClient, properties);
+                queues.put(status, queue);
+            }
+
+            LOGGER.debug("Successfully created queues: {}", queues);
+            return queues;
+        } catch (Exception e) {
+            LOGGER.error("Failed to create RedisObservableQueues", e);
+            throw new RuntimeException("Failed to getQueues on RedisEventQueueConfiguration", e);
+        }
+    }
+}

--- a/redis-event-queue/src/main/java/com/netflix/conductor/rediseq/config/RedisEventQueueProperties.java
+++ b/redis-event-queue/src/main/java/com/netflix/conductor/rediseq/config/RedisEventQueueProperties.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.rediseq.config;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.UUID;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@ConfigurationProperties("conductor.event-queues.redis")
+@Validated
+public class RedisEventQueueProperties {
+
+    /** Redis host. */
+    private String host = "localhost";
+
+    /** Redis port. */
+    private int port = 6379;
+
+    /** Redis password (optional). */
+    private String password;
+
+    /** Redis database index. */
+    private int database = 0;
+
+    /** Enable SSL/TLS connection. */
+    private boolean ssl = false;
+
+    /** Consumer group name for Redis Streams. */
+    private String consumerGroup = "conductor-consumer-group";
+
+    /** Unique consumer name (auto-generated if null). */
+    private String consumerName;
+
+    /** Dead Letter Queue stream name. */
+    private String dlqStream = "conductor-dlq";
+
+    /** Prefix for stream names. */
+    private String streamPrefix = "";
+
+    /** Polling interval for consuming messages. */
+    private Duration pollTimeDuration = Duration.ofMillis(100);
+
+    /** Number of messages to read per poll. */
+    private int batchSize = 10;
+
+    /** Block timeout for XREADGROUP (0 = non-blocking). */
+    private Duration blockTimeout = Duration.ofSeconds(2);
+
+    /** Connection timeout. */
+    private Duration connectionTimeout = Duration.ofSeconds(10);
+
+    /** Command timeout. */
+    private Duration commandTimeout = Duration.ofSeconds(5);
+
+    // Getters and setters
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public int getDatabase() {
+        return database;
+    }
+
+    public void setDatabase(int database) {
+        this.database = database;
+    }
+
+    public boolean isSsl() {
+        return ssl;
+    }
+
+    public void setSsl(boolean ssl) {
+        this.ssl = ssl;
+    }
+
+    public String getConsumerGroup() {
+        return consumerGroup;
+    }
+
+    public void setConsumerGroup(String consumerGroup) {
+        this.consumerGroup = consumerGroup;
+    }
+
+    public String getConsumerName() {
+        return consumerName;
+    }
+
+    public void setConsumerName(String consumerName) {
+        this.consumerName = consumerName;
+    }
+
+    public String getDlqStream() {
+        return dlqStream;
+    }
+
+    public void setDlqStream(String dlqStream) {
+        this.dlqStream = dlqStream;
+    }
+
+    public String getStreamPrefix() {
+        return streamPrefix;
+    }
+
+    public void setStreamPrefix(String streamPrefix) {
+        this.streamPrefix = streamPrefix;
+    }
+
+    public Duration getPollTimeDuration() {
+        return pollTimeDuration;
+    }
+
+    public void setPollTimeDuration(Duration pollTimeDuration) {
+        this.pollTimeDuration = pollTimeDuration;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    public Duration getBlockTimeout() {
+        return blockTimeout;
+    }
+
+    public void setBlockTimeout(Duration blockTimeout) {
+        this.blockTimeout = blockTimeout;
+    }
+
+    public Duration getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public void setConnectionTimeout(Duration connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+    }
+
+    public Duration getCommandTimeout() {
+        return commandTimeout;
+    }
+
+    public void setCommandTimeout(Duration commandTimeout) {
+        this.commandTimeout = commandTimeout;
+    }
+
+    /**
+     * Get the effective consumer name, generating one if not explicitly set.
+     *
+     * @return the consumer name
+     */
+    public String getEffectiveConsumerName() {
+        if (consumerName == null || consumerName.isBlank()) {
+            try {
+                return InetAddress.getLocalHost().getHostName()
+                        + "-"
+                        + UUID.randomUUID().toString().substring(0, 8);
+            } catch (UnknownHostException e) {
+                return "consumer-" + UUID.randomUUID().toString().substring(0, 8);
+            }
+        }
+        return consumerName;
+    }
+}

--- a/redis-event-queue/src/main/java/com/netflix/conductor/rediseq/config/RedisEventQueueProvider.java
+++ b/redis-event-queue/src/main/java/com/netflix/conductor/rediseq/config/RedisEventQueueProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.rediseq.config;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.conductor.core.events.EventQueueProvider;
+import com.netflix.conductor.core.events.queue.ObservableQueue;
+import com.netflix.conductor.rediseq.eventqueue.RedisObservableQueue;
+
+import io.lettuce.core.RedisClient;
+
+public class RedisEventQueueProvider implements EventQueueProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedisEventQueueProvider.class);
+    private static final String QUEUE_TYPE = "redis";
+
+    private final Map<String, ObservableQueue> queues = new ConcurrentHashMap<>();
+    private final RedisClient redisClient;
+    private final RedisEventQueueProperties properties;
+
+    public RedisEventQueueProvider(RedisClient redisClient, RedisEventQueueProperties properties) {
+        this.redisClient = redisClient;
+        this.properties = properties;
+    }
+
+    @Override
+    public String getQueueType() {
+        return QUEUE_TYPE;
+    }
+
+    @Override
+    public ObservableQueue getQueue(String queueURI) {
+        LOGGER.info("Creating/retrieving RedisObservableQueue for stream: {}", queueURI);
+
+        return queues.computeIfAbsent(
+                queueURI, q -> new RedisObservableQueue(queueURI, redisClient, properties));
+    }
+}

--- a/redis-event-queue/src/main/java/com/netflix/conductor/rediseq/eventqueue/RedisObservableQueue.java
+++ b/redis-event-queue/src/main/java/com/netflix/conductor/rediseq/eventqueue/RedisObservableQueue.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.rediseq.eventqueue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.conductor.core.events.queue.Message;
+import com.netflix.conductor.core.events.queue.ObservableQueue;
+import com.netflix.conductor.metrics.Monitors;
+import com.netflix.conductor.rediseq.config.RedisEventQueueProperties;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.lettuce.core.Consumer;
+import io.lettuce.core.RedisBusyException;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.StreamMessage;
+import io.lettuce.core.XAddArgs;
+import io.lettuce.core.XGroupCreateArgs;
+import io.lettuce.core.XReadArgs;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisStreamCommands;
+import rx.Observable;
+import rx.subscriptions.Subscriptions;
+
+public class RedisObservableQueue implements ObservableQueue {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedisObservableQueue.class);
+    private static final String QUEUE_TYPE = "redis";
+
+    private final String streamName;
+    private final RedisClient redisClient;
+    private final RedisEventQueueProperties properties;
+    private final String consumerGroup;
+    private final String consumerName;
+    private final String dlqStream;
+    private final long pollTimeInMS;
+    private final int batchSize;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private StatefulRedisConnection<String, String> connection;
+    private RedisStreamCommands<String, String> streamCommands;
+    private volatile boolean running = false;
+
+    public RedisObservableQueue(
+            String streamName, RedisClient redisClient, RedisEventQueueProperties properties) {
+        this.streamName = streamName;
+        this.redisClient = redisClient;
+        this.properties = properties;
+        this.consumerGroup = properties.getConsumerGroup();
+        this.consumerName = properties.getEffectiveConsumerName();
+        this.dlqStream = properties.getDlqStream();
+        this.pollTimeInMS = properties.getPollTimeDuration().toMillis();
+        this.batchSize = properties.getBatchSize();
+    }
+
+    // Constructor for testing with injected connection
+    RedisObservableQueue(
+            String streamName,
+            StatefulRedisConnection<String, String> connection,
+            RedisEventQueueProperties properties) {
+        this.streamName = streamName;
+        this.redisClient = null;
+        this.connection = connection;
+        this.streamCommands = connection.sync();
+        this.properties = properties;
+        this.consumerGroup = properties.getConsumerGroup();
+        this.consumerName = properties.getEffectiveConsumerName();
+        this.dlqStream = properties.getDlqStream();
+        this.pollTimeInMS = properties.getPollTimeDuration().toMillis();
+        this.batchSize = properties.getBatchSize();
+    }
+
+    @Override
+    public void start() {
+        LOGGER.info("Starting RedisObservableQueue for stream: {}", streamName);
+        if (running) {
+            LOGGER.warn("RedisObservableQueue is already running for stream: {}", streamName);
+            return;
+        }
+
+        try {
+            if (connection == null) {
+                connection = redisClient.connect();
+                streamCommands = connection.sync();
+            }
+
+            // Create consumer group if it doesn't exist
+            ensureConsumerGroupExists();
+
+            running = true;
+            LOGGER.info("RedisObservableQueue started for stream: {}", streamName);
+        } catch (Exception e) {
+            LOGGER.error("Error starting RedisObservableQueue for stream: {}", streamName, e);
+            throw new RuntimeException("Failed to start RedisObservableQueue", e);
+        }
+    }
+
+    private void ensureConsumerGroupExists() {
+        try {
+            // XGROUP CREATE <stream> <group> $ MKSTREAM
+            streamCommands.xgroupCreate(
+                    XReadArgs.StreamOffset.from(streamName, "0"),
+                    consumerGroup,
+                    XGroupCreateArgs.Builder.mkstream());
+            LOGGER.info(
+                    "Created consumer group '{}' for stream '{}'", consumerGroup, streamName);
+        } catch (RedisBusyException e) {
+            // Consumer group already exists, this is fine
+            LOGGER.debug(
+                    "Consumer group '{}' already exists for stream '{}'",
+                    consumerGroup,
+                    streamName);
+        } catch (Exception e) {
+            LOGGER.warn("Error creating consumer group: {}", e.getMessage());
+        }
+    }
+
+    @Override
+    public Observable<Message> observe() {
+        return Observable.create(
+                subscriber -> {
+                    Observable<Long> interval =
+                            Observable.interval(pollTimeInMS, TimeUnit.MILLISECONDS);
+
+                    interval.flatMap(
+                                    (Long x) -> {
+                                        if (!isRunning()) {
+                                            return Observable.from(Collections.emptyList());
+                                        }
+
+                                        try {
+                                            List<Message> messages = readMessages();
+                                            Monitors.recordEventQueueMessagesProcessed(
+                                                    QUEUE_TYPE, streamName, messages.size());
+                                            return Observable.from(messages);
+                                        } catch (Exception e) {
+                                            LOGGER.error(
+                                                    "Error while reading from Redis stream: {}",
+                                                    streamName,
+                                                    e);
+                                            Monitors.recordObservableQMessageReceivedErrors(
+                                                    QUEUE_TYPE);
+                                            return Observable.error(e);
+                                        }
+                                    })
+                            .subscribe(subscriber::onNext, subscriber::onError);
+
+                    subscriber.add(Subscriptions.create(this::stop));
+                });
+    }
+
+    private List<Message> readMessages() {
+        List<Message> messages = new ArrayList<>();
+
+        try {
+            // XREADGROUP GROUP <group> <consumer> COUNT <count> BLOCK <ms> STREAMS <stream> >
+            List<StreamMessage<String, String>> streamMessages =
+                    streamCommands.xreadgroup(
+                            Consumer.from(consumerGroup, consumerName),
+                            XReadArgs.Builder.count(batchSize)
+                                    .block(properties.getBlockTimeout().toMillis()),
+                            XReadArgs.StreamOffset.lastConsumed(streamName));
+
+            if (streamMessages != null) {
+                for (StreamMessage<String, String> streamMessage : streamMessages) {
+                    try {
+                        String messageId = streamMessage.getId();
+                        Map<String, String> body = streamMessage.getBody();
+
+                        // Extract payload from the message body
+                        String payload = constructJsonPayload(body);
+
+                        Message message = new Message(messageId, payload, messageId);
+                        messages.add(message);
+
+                        LOGGER.debug(
+                                "Received message: id={}, stream={}", messageId, streamName);
+                    } catch (Exception e) {
+                        LOGGER.error(
+                                "Failed to process message from Redis stream: {}",
+                                streamMessage,
+                                e);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error("Error reading messages from stream {}: {}", streamName, e.getMessage());
+            throw e;
+        }
+
+        return messages;
+    }
+
+    private String constructJsonPayload(Map<String, String> body) {
+        try {
+            // If body contains a single "payload" key, return its value if it's valid JSON
+            if (body.containsKey("payload")) {
+                String payload = body.get("payload");
+                if (isJsonValid(payload)) {
+                    return payload;
+                }
+                return objectMapper.writeValueAsString(Map.of("payload", payload));
+            }
+            // Otherwise serialize the entire body as JSON
+            return objectMapper.writeValueAsString(body);
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Failed to serialize message body to JSON", e);
+            return "{}";
+        }
+    }
+
+    private boolean isJsonValid(String json) {
+        if (json == null || json.isEmpty()) {
+            return false;
+        }
+        try {
+            objectMapper.readTree(json);
+            return true;
+        } catch (JsonProcessingException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public List<String> ack(List<Message> messages) {
+        List<String> failedAcks = new ArrayList<>();
+
+        for (Message message : messages) {
+            try {
+                // XACK <stream> <group> <messageId>
+                long acknowledged =
+                        streamCommands.xack(streamName, consumerGroup, message.getId());
+
+                if (acknowledged == 0) {
+                    LOGGER.warn(
+                            "Message {} was not acknowledged (may already be acked)",
+                            message.getId());
+                    failedAcks.add(message.getId());
+                } else {
+                    LOGGER.debug(
+                            "Acknowledged message: {} on stream: {}",
+                            message.getId(),
+                            streamName);
+                }
+            } catch (Exception e) {
+                LOGGER.error("Failed to acknowledge message: {}", message.getId(), e);
+                failedAcks.add(message.getId());
+            }
+        }
+
+        return failedAcks;
+    }
+
+    @Override
+    public void nack(List<Message> messages) {
+        // Move messages to DLQ stream
+        for (Message message : messages) {
+            try {
+                // XADD <dlq-stream> * payload <payload> original_stream <stream> original_id <id>
+                Map<String, String> dlqFields = new HashMap<>();
+                dlqFields.put("payload", message.getPayload());
+                dlqFields.put("original_stream", streamName);
+                dlqFields.put("original_id", message.getId());
+                dlqFields.put("nacked_at", String.valueOf(System.currentTimeMillis()));
+
+                streamCommands.xadd(dlqStream, dlqFields);
+
+                // Acknowledge the original message to remove it from pending
+                streamCommands.xack(streamName, consumerGroup, message.getId());
+
+                LOGGER.info("Moved message {} to DLQ: {}", message.getId(), dlqStream);
+            } catch (Exception e) {
+                LOGGER.error("Failed to nack message {} to DLQ", message.getId(), e);
+            }
+        }
+    }
+
+    @Override
+    public void publish(List<Message> messages) {
+        for (Message message : messages) {
+            try {
+                Map<String, String> fields = new HashMap<>();
+                fields.put("payload", message.getPayload());
+                if (message.getId() != null) {
+                    fields.put("id", message.getId());
+                }
+
+                // XADD <stream> * <field> <value> ...
+                String messageId = streamCommands.xadd(streamName, fields);
+
+                LOGGER.debug(
+                        "Published message to stream {}: messageId={}", streamName, messageId);
+            } catch (Exception e) {
+                LOGGER.error(
+                        "Error publishing message to stream {}: {}",
+                        streamName,
+                        e.getMessage(),
+                        e);
+            }
+        }
+    }
+
+    @Override
+    public boolean rePublishIfNoAck() {
+        // Redis Streams with consumer groups automatically makes unacknowledged
+        // messages available for re-claiming via XPENDING + XCLAIM
+        return false;
+    }
+
+    @Override
+    public void setUnackTimeout(Message message, long unackTimeout) {
+        // Redis Streams doesn't have a direct visibility timeout mechanism
+        // Messages stay in pending list until explicitly acknowledged
+        // Could implement via XCLAIM with IDLE parameter for reprocessing
+        LOGGER.debug("setUnackTimeout called but not implemented for Redis Streams");
+    }
+
+    @Override
+    public long size() {
+        try {
+            // XLEN <stream>
+            Long length = streamCommands.xlen(streamName);
+            return length != null ? length : 0;
+        } catch (Exception e) {
+            LOGGER.error("Error getting stream length for {}: {}", streamName, e.getMessage());
+            return -1;
+        }
+    }
+
+    @Override
+    public void stop() {
+        LOGGER.info("Stopping RedisObservableQueue for stream: {}", streamName);
+        if (!running) {
+            LOGGER.warn("RedisObservableQueue is already stopped for stream: {}", streamName);
+            return;
+        }
+
+        running = false;
+
+        try {
+            if (connection != null && redisClient != null) {
+                connection.close();
+                connection = null;
+                streamCommands = null;
+            }
+            LOGGER.info("RedisObservableQueue stopped for stream: {}", streamName);
+        } catch (Exception e) {
+            LOGGER.error("Error stopping RedisObservableQueue for stream: {}", streamName, e);
+        }
+    }
+
+    @Override
+    public void close() {
+        stop();
+    }
+
+    @Override
+    public String getType() {
+        return QUEUE_TYPE;
+    }
+
+    @Override
+    public String getName() {
+        return streamName;
+    }
+
+    @Override
+    public String getURI() {
+        return "redis://" + streamName;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
+}

--- a/redis-event-queue/src/test/java/com/netflix/conductor/rediseq/eventqueue/RedisObservableQueueTest.java
+++ b/redis-event-queue/src/test/java/com/netflix/conductor/rediseq/eventqueue/RedisObservableQueueTest.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.rediseq.eventqueue;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.netflix.conductor.core.events.queue.Message;
+import com.netflix.conductor.rediseq.config.RedisEventQueueProperties;
+
+import io.lettuce.core.Consumer;
+import io.lettuce.core.RedisBusyException;
+import io.lettuce.core.StreamMessage;
+import io.lettuce.core.XGroupCreateArgs;
+import io.lettuce.core.XReadArgs;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisStreamCommands;
+import rx.Observable;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("unchecked")
+@RunWith(SpringJUnit4ClassRunner.class)
+public class RedisObservableQueueTest {
+
+    private RedisObservableQueue queue;
+
+    @Mock private StatefulRedisConnection<String, String> mockConnection;
+
+    @Mock private RedisStreamCommands<String, String> mockStreamCommands;
+
+    @Mock private RedisEventQueueProperties mockProperties;
+
+    @Before
+    public void setUp() {
+        mockConnection = mock(StatefulRedisConnection.class);
+        mockStreamCommands = mock(RedisStreamCommands.class);
+        mockProperties = mock(RedisEventQueueProperties.class);
+
+        when(mockConnection.sync()).thenReturn(mockStreamCommands);
+        when(mockProperties.getPollTimeDuration()).thenReturn(Duration.ofMillis(100));
+        when(mockProperties.getDlqStream()).thenReturn("test-dlq");
+        when(mockProperties.getConsumerGroup()).thenReturn("test-group");
+        when(mockProperties.getEffectiveConsumerName()).thenReturn("test-consumer");
+        when(mockProperties.getBatchSize()).thenReturn(10);
+        when(mockProperties.getBlockTimeout()).thenReturn(Duration.ofSeconds(2));
+
+        queue = new RedisObservableQueue("test-stream", mockConnection, mockProperties);
+    }
+
+    @Test
+    public void testStart() {
+        // Consumer group already exists
+        doThrow(new RedisBusyException("BUSYGROUP Consumer Group name already exists"))
+                .when(mockStreamCommands)
+                .xgroupCreate(any(XReadArgs.StreamOffset.class), anyString(), any());
+
+        queue.start();
+
+        assertTrue(queue.isRunning());
+        verify(mockStreamCommands)
+                .xgroupCreate(
+                        any(XReadArgs.StreamOffset.class),
+                        eq("test-group"),
+                        any(XGroupCreateArgs.class));
+    }
+
+    @Test
+    public void testStartCreatesConsumerGroup() {
+        // Consumer group doesn't exist yet
+        when(mockStreamCommands.xgroupCreate(
+                        any(XReadArgs.StreamOffset.class), anyString(), any()))
+                .thenReturn("OK");
+
+        queue.start();
+
+        assertTrue(queue.isRunning());
+        verify(mockStreamCommands)
+                .xgroupCreate(
+                        any(XReadArgs.StreamOffset.class),
+                        eq("test-group"),
+                        any(XGroupCreateArgs.class));
+    }
+
+    @Test
+    public void testObserve() throws InterruptedException {
+        // Mock stream messages
+        StreamMessage<String, String> message1 =
+                new StreamMessage<>("test-stream", "1234567890123-0", Map.of("payload", "test-payload-1"));
+        StreamMessage<String, String> message2 =
+                new StreamMessage<>("test-stream", "1234567890124-0", Map.of("payload", "{\"key\":\"value\"}"));
+
+        List<StreamMessage<String, String>> streamMessages = List.of(message1, message2);
+
+        when(mockStreamCommands.xreadgroup(
+                        any(Consumer.class), any(XReadArgs.class), any(XReadArgs.StreamOffset.class)))
+                .thenReturn(streamMessages)
+                .thenReturn(null); // Subsequent calls return empty
+
+        queue.start();
+
+        List<Message> received = new ArrayList<>();
+        Observable<Message> observable = queue.observe();
+        assertNotNull(observable);
+        observable.subscribe(received::add);
+
+        Thread.sleep(500); // Allow time for polling
+
+        assertEquals(2, received.size());
+        assertEquals("1234567890123-0", received.get(0).getId());
+        assertEquals("1234567890124-0", received.get(1).getId());
+    }
+
+    @Test
+    public void testObserveWithJsonPayload() throws InterruptedException {
+        // Mock stream message with valid JSON payload
+        StreamMessage<String, String> message =
+                new StreamMessage<>(
+                        "test-stream",
+                        "1234567890123-0",
+                        Map.of("payload", "{\"workflowId\":\"123\",\"taskId\":\"456\"}"));
+
+        when(mockStreamCommands.xreadgroup(
+                        any(Consumer.class), any(XReadArgs.class), any(XReadArgs.StreamOffset.class)))
+                .thenReturn(List.of(message))
+                .thenReturn(null);
+
+        queue.start();
+
+        List<Message> received = new ArrayList<>();
+        Observable<Message> observable = queue.observe();
+        observable.subscribe(received::add);
+
+        Thread.sleep(500);
+
+        assertEquals(1, received.size());
+        assertEquals("{\"workflowId\":\"123\",\"taskId\":\"456\"}", received.get(0).getPayload());
+    }
+
+    @Test
+    public void testAck() {
+        when(mockStreamCommands.xack(eq("test-stream"), eq("test-group"), eq("1234567890123-0")))
+                .thenReturn(1L);
+
+        Message message = new Message("1234567890123-0", "payload", "1234567890123-0");
+        List<String> failedAcks = queue.ack(List.of(message));
+
+        assertTrue(failedAcks.isEmpty());
+        verify(mockStreamCommands).xack("test-stream", "test-group", "1234567890123-0");
+    }
+
+    @Test
+    public void testAckFailure() {
+        when(mockStreamCommands.xack(eq("test-stream"), eq("test-group"), eq("1234567890123-0")))
+                .thenReturn(0L); // Message not acknowledged
+
+        Message message = new Message("1234567890123-0", "payload", "1234567890123-0");
+        List<String> failedAcks = queue.ack(List.of(message));
+
+        assertEquals(1, failedAcks.size());
+        assertEquals("1234567890123-0", failedAcks.get(0));
+    }
+
+    @Test
+    public void testNack() {
+        when(mockStreamCommands.xadd(eq("test-dlq"), anyMap())).thenReturn("dlq-message-id");
+        when(mockStreamCommands.xack(eq("test-stream"), eq("test-group"), eq("1234567890123-0")))
+                .thenReturn(1L);
+
+        Message message = new Message("1234567890123-0", "payload", "1234567890123-0");
+        queue.nack(List.of(message));
+
+        // Verify message was added to DLQ
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(mockStreamCommands).xadd(eq("test-dlq"), captor.capture());
+
+        Map<String, String> dlqFields = captor.getValue();
+        assertEquals("payload", dlqFields.get("payload"));
+        assertEquals("test-stream", dlqFields.get("original_stream"));
+        assertEquals("1234567890123-0", dlqFields.get("original_id"));
+        assertNotNull(dlqFields.get("nacked_at"));
+
+        // Verify original message was acknowledged
+        verify(mockStreamCommands).xack("test-stream", "test-group", "1234567890123-0");
+    }
+
+    @Test
+    public void testPublish() {
+        when(mockStreamCommands.xadd(eq("test-stream"), anyMap())).thenReturn("new-message-id");
+
+        Message message = new Message("msg-1", "test-payload", null);
+        queue.publish(List.of(message));
+
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(mockStreamCommands).xadd(eq("test-stream"), captor.capture());
+
+        Map<String, String> fields = captor.getValue();
+        assertEquals("test-payload", fields.get("payload"));
+        assertEquals("msg-1", fields.get("id"));
+    }
+
+    @Test
+    public void testSize() {
+        when(mockStreamCommands.xlen("test-stream")).thenReturn(42L);
+
+        long size = queue.size();
+
+        assertEquals(42, size);
+        verify(mockStreamCommands).xlen("test-stream");
+    }
+
+    @Test
+    public void testSizeOnError() {
+        when(mockStreamCommands.xlen("test-stream")).thenThrow(new RuntimeException("Redis error"));
+
+        long size = queue.size();
+
+        assertEquals(-1, size);
+    }
+
+    @Test
+    public void testLifecycle() {
+        // Consumer group already exists
+        doThrow(new RedisBusyException("BUSYGROUP Consumer Group name already exists"))
+                .when(mockStreamCommands)
+                .xgroupCreate(any(XReadArgs.StreamOffset.class), anyString(), any());
+
+        assertFalse(queue.isRunning());
+
+        queue.start();
+        assertTrue(queue.isRunning());
+
+        queue.stop();
+        assertFalse(queue.isRunning());
+    }
+
+    @Test
+    public void testGetters() {
+        assertEquals("redis", queue.getType());
+        assertEquals("test-stream", queue.getName());
+        assertEquals("redis://test-stream", queue.getURI());
+        assertFalse(queue.rePublishIfNoAck());
+    }
+
+    @Test
+    public void testClose() {
+        // Consumer group already exists
+        doThrow(new RedisBusyException("BUSYGROUP Consumer Group name already exists"))
+                .when(mockStreamCommands)
+                .xgroupCreate(any(XReadArgs.StreamOffset.class), anyString(), any());
+
+        queue.start();
+        assertTrue(queue.isRunning());
+
+        queue.close();
+        assertFalse(queue.isRunning());
+    }
+}

--- a/server-lite/build.gradle
+++ b/server-lite/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation project(':conductor-nats-streaming')
     implementation project(':conductor-awssqs-event-queue')
     implementation project(':conductor-kafka-event-queue')
+    implementation project(':conductor-redis-event-queue')
 
     //External Payload Storage
     implementation project(':conductor-azureblob-storage')

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation project(':conductor-nats-streaming')
     implementation project(':conductor-awssqs-event-queue')
     implementation project(':conductor-kafka-event-queue')
+    implementation project(':conductor-redis-event-queue')
 
     //External Payload Storage
     implementation project(':conductor-azureblob-storage')

--- a/settings.gradle
+++ b/settings.gradle
@@ -75,6 +75,7 @@ include 'amqp'
 include 'nats'
 include 'nats-streaming'
 include 'kafka-event-queue'
+include 'redis-event-queue'
 
 include 'test-harness'
 


### PR DESCRIPTION
Implement a new event queue provider using Redis Streams with the Lettuce client for reliable messaging with consumer groups.

New module: redis-event-queue
- RedisObservableQueue: Core implementation using XREADGROUP/XACK
- RedisEventQueueProvider: Queue factory with caching
- RedisEventQueueConfiguration: Spring Boot auto-configuration
- Support for dead letter queue (DLQ) via separate stream

Configuration prefix: conductor.event-queues.redis.*

Pull Request type
----
- [ ] Bugfix
- [X] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

I could not find a suitable alternative.
