### PR TITLE
Update Dockerfile to use OpenJDK 21

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -4,7 +4,7 @@
 # ===========================================================================================================
 # 0. Builder stage 1
 # ===========================================================================================================
-FROM azul/zulu-openjdk-debian:17 AS builder
+FROM azul/zulu-openjdk-debian:21 AS builder
 
 ARG INDEXING_BACKEND=elasticsearch
 
@@ -52,7 +52,7 @@ FROM alpine:3.19
 
 LABEL maintainer="Orkes OSS <oss@orkes.io>"
 
-RUN apk add openjdk17
+RUN apk add openjdk21
 RUN apk add nginx
 RUN apk add curl
 


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

Use JDK 21 in the Dockerfile. This was forgotten when migrating Gradle to JDK 17 ([with this commit](https://github.com/conductor-oss/conductor/commit/99ecc5f1)). 
This fixes the docker build.
Issue #711 

