### PR TITLE
Fix JetStream stream name generation for dot-separated subjects

### DIFF
--- a/nats/src/main/java/com/netflix/conductor/contribs/queue/nats/JetStreamObservableQueue.java
+++ b/nats/src/main/java/com/netflix/conductor/contribs/queue/nats/JetStreamObservableQueue.java
@@ -100,8 +100,7 @@ public class JetStreamObservableQueue implements ObservableQueue {
     }
 
     private static String streamNameFromSubject(String subject) {
-        return subject
-                .replace(".", "_")
+        return subject.replace(".", "_")
                 .replace("*", "ANY")
                 .replace(">", "ALL")
                 .toUpperCase(Locale.ROOT);

--- a/nats/src/test/java/com/netflix/conductor/contribs/queue/nats/JetStreamObservableQueueTest.java
+++ b/nats/src/test/java/com/netflix/conductor/contribs/queue/nats/JetStreamObservableQueueTest.java
@@ -1,10 +1,45 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.netflix.conductor.contribs.queue.nats;
 
-import io.nats.client.*;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.context.ApplicationEventPublisher;
+
+import com.netflix.conductor.contribs.queue.nats.config.JetStreamProperties;
+import com.netflix.conductor.core.config.ConductorProperties;
+
+import io.nats.client.Connection;
+import io.nats.client.Dispatcher;
+import io.nats.client.JetStream;
 import io.nats.client.JetStreamApiException;
-import io.nats.client.MessageHandler;
 import io.nats.client.JetStreamManagement;
-import io.nats.client.api.ApiResponse;
+import io.nats.client.JetStreamSubscription;
+import io.nats.client.Message;
+import io.nats.client.MessageHandler;
+import io.nats.client.PushSubscribeOptions;
 import io.nats.client.api.AckPolicy;
 import io.nats.client.api.ConsumerConfiguration;
 import io.nats.client.api.ConsumerInfo;
@@ -13,67 +48,39 @@ import io.nats.client.api.RetentionPolicy;
 import io.nats.client.api.StorageType;
 import io.nats.client.api.StreamConfiguration;
 import io.nats.client.api.StreamInfo;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.springframework.context.ApplicationEventPublisher;
 
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import com.netflix.conductor.contribs.queue.nats.config.JetStreamProperties;
-import com.netflix.conductor.core.config.ConductorProperties;
-
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.Locale;
-
-import static org.junit.Assert.*;
-
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
-import org.mockito.ArgumentCaptor;
-
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class JetStreamObservableQueueTest {
 
-    @Mock
-    private JetStreamManagement jsm;
+    @Mock private JetStreamManagement jsm;
 
-    @Mock
-    private ApplicationEventPublisher eventPublisher;
+    @Mock private ApplicationEventPublisher eventPublisher;
 
-    @Mock
-    private StreamInfo streamInfo;
+    @Mock private StreamInfo streamInfo;
 
-    @Mock
-    private ConductorProperties conductorProperties;
+    @Mock private ConductorProperties conductorProperties;
 
-    @Mock
-    private JetStreamProperties jetStreamProperties;
+    @Mock private JetStreamProperties jetStreamProperties;
 
-    @Mock
-    private Connection natsConnection;
+    @Mock private Connection natsConnection;
 
-    @Mock
-    private JetStream jetStream;
+    @Mock private JetStream jetStream;
 
-    @Mock
-    private Dispatcher dispatcher;
+    @Mock private Dispatcher dispatcher;
 
-    @Mock
-    private JetStreamSubscription subscription;
+    @Mock private JetStreamSubscription subscription;
 
     private JetStreamObservableQueue queue;
     private Method createStreamMethod;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
-        MockitoAnnotations.openMocks(this);
-
         when(conductorProperties.getStack()).thenReturn("test-stack");
         when(conductorProperties.getAppId()).thenReturn("test-app");
 
@@ -81,16 +88,18 @@ public class JetStreamObservableQueueTest {
         when(jetStreamProperties.getStreamMaxBytes()).thenReturn(1024L * 1024 * 100); // 100MB
         when(jetStreamProperties.getStreamStorageType()).thenReturn("Memory");
 
-        queue = new JetStreamObservableQueue(
-            conductorProperties,
-            jetStreamProperties,
-            "test-queue-type",
-            "test-subject",
-            null,
-            eventPublisher
-        );
+        queue =
+                new JetStreamObservableQueue(
+                        conductorProperties,
+                        jetStreamProperties,
+                        "test-queue-type",
+                        "test-subject",
+                        null,
+                        eventPublisher);
 
-        createStreamMethod = JetStreamObservableQueue.class.getDeclaredMethod("createStream", JetStreamManagement.class);
+        createStreamMethod =
+                JetStreamObservableQueue.class.getDeclaredMethod(
+                        "createStream", JetStreamManagement.class);
         createStreamMethod.setAccessible(true);
     }
 
@@ -102,103 +111,111 @@ public class JetStreamObservableQueueTest {
         when(jetStreamProperties.getStreamMaxBytes()).thenReturn(1024L * 1024 * 100);
         when(jetStreamProperties.getStreamStorageType()).thenReturn("Memory");
 
-        JetStreamObservableQueue testQueue = new JetStreamObservableQueue(
-            conductorProperties,
-            jetStreamProperties,
-            "test",
-            "workflow.task.*.status:workers",
-            null,
-            eventPublisher
-        );
+        JetStreamObservableQueue testQueue =
+                new JetStreamObservableQueue(
+                        conductorProperties,
+                        jetStreamProperties,
+                        "test",
+                        "workflow.task.*.status:workers",
+                        null,
+                        eventPublisher);
 
         when(jsm.addStream(any(StreamConfiguration.class))).thenReturn(streamInfo);
 
-        java.lang.reflect.Method createStreamMethod = JetStreamObservableQueue.class.getDeclaredMethod("createStream", JetStreamManagement.class);
+        Method createStreamMethod =
+                JetStreamObservableQueue.class.getDeclaredMethod(
+                        "createStream", JetStreamManagement.class);
         createStreamMethod.setAccessible(true);
         createStreamMethod.invoke(testQueue, jsm);
 
-        verify(jsm).addStream(argThat(config -> {
-            String expectedStreamName = "TESTAPP_JSM_NOTIFY_WORKFLOW_TASK_ANY_STATUS";
-            assertEquals("Stream name should be sanitized", expectedStreamName, config.getName());
+        verify(jsm)
+                .addStream(
+                        argThat(
+                                config -> {
+                                    String expectedStreamName =
+                                            "TESTAPP_JSM_NOTIFY_WORKFLOW_TASK_ANY_STATUS";
+                                    assertEquals(
+                                            expectedStreamName,
+                                            config.getName(),
+                                            "Stream name should be sanitized");
 
-            assertTrue("Subjects should contain original subject",
-                config.getSubjects().contains("testapp_jsm_notify_workflow.task.*.status"));
+                                    assertTrue(
+                                            config.getSubjects()
+                                                    .contains(
+                                                            "testapp_jsm_notify_workflow.task.*.status"),
+                                            "Subjects should contain original subject");
 
-            assertEquals("Replicas should match properties", 1, config.getReplicas());
+                                    assertEquals(
+                                            1,
+                                            config.getReplicas(),
+                                            "Replicas should match properties");
 
-            assertEquals("Retention policy should be Limits",
-                RetentionPolicy.Limits, config.getRetentionPolicy());
+                                    assertEquals(
+                                            RetentionPolicy.Limits,
+                                            config.getRetentionPolicy(),
+                                            "Retention policy should be Limits");
 
-            assertEquals("Max bytes should match properties",
-                1024L * 1024 * 100, config.getMaxBytes());
+                                    assertEquals(
+                                            1024L * 1024 * 100,
+                                            config.getMaxBytes(),
+                                            "Max bytes should match properties");
 
-            assertEquals("Storage type should be Memory",
-                StorageType.Memory, config.getStorageType());
+                                    assertEquals(
+                                            StorageType.Memory,
+                                            config.getStorageType(),
+                                            "Storage type should be Memory");
 
-            return true;
-        }));
+                                    return true;
+                                }));
         verify(eventPublisher, never()).publishEvent(any());
     }
 
     @Test
     public void testCreateStreamIOException() throws Exception {
-        // Arrange
         IOException ioException = new IOException("Network error");
         when(jsm.addStream(any(StreamConfiguration.class))).thenThrow(ioException);
 
-        // Act
         createStreamMethod.invoke(queue, jsm);
 
-        // Assert
         verify(jsm).addStream(any(StreamConfiguration.class));
         verify(eventPublisher).publishEvent(any());
     }
 
     @Test
     public void testCreateStreamJetStreamApiException() throws Exception {
-        // Arrange - Create a proper JetStreamApiException with Error
         io.nats.client.api.Error mockError = mock(io.nats.client.api.Error.class);
         when(mockError.toString()).thenReturn("API error");
         JetStreamApiException apiException = new JetStreamApiException(mockError);
         when(jsm.addStream(any(StreamConfiguration.class))).thenThrow(apiException);
 
-        // Act
         createStreamMethod.invoke(queue, jsm);
 
-        // Assert
         verify(jsm).addStream(any(StreamConfiguration.class));
         verify(eventPublisher).publishEvent(any());
     }
 
-
     @Test
     public void testStreamNameFromSubjectMethod() throws Exception {
-        Method method = JetStreamObservableQueue.class.getDeclaredMethod("streamNameFromSubject", String.class);
+        Method method =
+                JetStreamObservableQueue.class.getDeclaredMethod(
+                        "streamNameFromSubject", String.class);
         method.setAccessible(true);
 
-        String result1 = (String) method.invoke(null, "conductor.workflow.task.status");
-        assertEquals("CONDUCTOR_WORKFLOW_TASK_STATUS", result1);
-
-        String result2 = (String) method.invoke(null, "events.*");
-        assertEquals("EVENTS_ANY", result2);
-
-        String result3 = (String) method.invoke(null, "events.>");
-        assertEquals("EVENTS_ALL", result3);
-
-        // Test mixed replacements
-        String result4 = (String) method.invoke(null, "test.*.status.>");
-        assertEquals("TEST_ANY_STATUS_ALL", result4);
-
-        String result5 = (String) method.invoke(null, "simple_name");
-        assertEquals("SIMPLE_NAME", result5);
-
-        String result6 = (String) method.invoke(null, "");
-        assertEquals("", result6);
+        assertEquals(
+                "CONDUCTOR_WORKFLOW_TASK_STATUS",
+                method.invoke(null, "conductor.workflow.task.status"));
+        assertEquals("EVENTS_ANY", method.invoke(null, "events.*"));
+        assertEquals("EVENTS_ALL", method.invoke(null, "events.>"));
+        assertEquals("TEST_ANY_STATUS_ALL", method.invoke(null, "test.*.status.>"));
+        assertEquals("SIMPLE_NAME", method.invoke(null, "simple_name"));
+        assertEquals("", method.invoke(null, ""));
     }
 
     @Test
     public void testStreamNameFromSubjectComprehensive() throws Exception {
-        Method method = JetStreamObservableQueue.class.getDeclaredMethod("streamNameFromSubject", String.class);
+        Method method =
+                JetStreamObservableQueue.class.getDeclaredMethod(
+                        "streamNameFromSubject", String.class);
         method.setAccessible(true);
 
         String[][] testCases = {
@@ -217,55 +234,48 @@ public class JetStreamObservableQueueTest {
             String input = testCase[0];
             String expected = testCase[1];
             String actual = (String) method.invoke(null, input);
-            assertEquals("Failed for input: " + input, expected, actual);
+            assertEquals(expected, actual, "Failed for input: " + input);
         }
     }
 
     @Test
     public void testStreamNameFromSubjectNullInput() throws Exception {
-        Method method = JetStreamObservableQueue.class.getDeclaredMethod("streamNameFromSubject", String.class);
+        Method method =
+                JetStreamObservableQueue.class.getDeclaredMethod(
+                        "streamNameFromSubject", String.class);
         method.setAccessible(true);
 
-        try {
-            method.invoke(null, (String) null);
-            fail("Should have thrown NullPointerException for null input");
-        } catch (Exception e) {
-            assertTrue(e.getCause() instanceof NullPointerException ||
-                      e.getCause() instanceof IllegalArgumentException);
-        }
+        Exception ex = assertThrows(Exception.class, () -> method.invoke(null, (String) null));
+        assertTrue(
+                ex.getCause() instanceof NullPointerException
+                        || ex.getCause() instanceof IllegalArgumentException);
     }
 
     @Test
     public void testStreamNameFromSubjectEdgeCases() throws Exception {
-        Method method = JetStreamObservableQueue.class.getDeclaredMethod("streamNameFromSubject", String.class);
+        Method method =
+                JetStreamObservableQueue.class.getDeclaredMethod(
+                        "streamNameFromSubject", String.class);
         method.setAccessible(true);
 
-        String result1 = (String) method.invoke(null, "test..*..>");
-        assertEquals("TEST__ANY__ALL", result1);
-
-        String result2 = (String) method.invoke(null, "Test.Subject.*.>");
-        assertEquals("TEST_SUBJECT_ANY_ALL", result2);
-
-        String result3 = (String) method.invoke(null, "app_1.v2.*.logs.>");
-        assertEquals("APP_1_V2_ANY_LOGS_ALL", result3);
+        assertEquals("TEST__ANY__ALL", method.invoke(null, "test..*..>"));
+        assertEquals("TEST_SUBJECT_ANY_ALL", method.invoke(null, "Test.Subject.*.>"));
+        assertEquals("APP_1_V2_ANY_LOGS_ALL", method.invoke(null, "app_1.v2.*.logs.>"));
     }
-
-
-
 
     @Test
     public void testSubscribeMethodWorksCorrectly() throws Exception {
         when(conductorProperties.getStack()).thenReturn(null);
         when(conductorProperties.getAppId()).thenReturn("testapp");
 
-        JetStreamObservableQueue queue = new JetStreamObservableQueue(
-            conductorProperties,
-            jetStreamProperties,
-            "test",
-            "order.workflow.*.completed:processors",
-            null,
-            eventPublisher
-        );
+        JetStreamObservableQueue queue =
+                new JetStreamObservableQueue(
+                        conductorProperties,
+                        jetStreamProperties,
+                        "test",
+                        "order.workflow.*.completed:processors",
+                        null,
+                        eventPublisher);
 
         Field streamNameField = JetStreamObservableQueue.class.getDeclaredField("streamName");
         streamNameField.setAccessible(true);
@@ -273,43 +283,53 @@ public class JetStreamObservableQueueTest {
 
         when(natsConnection.jetStream()).thenReturn(jetStream);
         when(natsConnection.createDispatcher()).thenReturn(dispatcher);
-        when(jetStream.subscribe(any(String.class), any(String.class), any(Dispatcher.class), any(MessageHandler.class), eq(false), any(PushSubscribeOptions.class)))
-            .thenReturn(subscription);
+        when(jetStream.subscribe(
+                        any(String.class),
+                        any(String.class),
+                        any(Dispatcher.class),
+                        any(MessageHandler.class),
+                        eq(false),
+                        any(PushSubscribeOptions.class)))
+                .thenReturn(subscription);
 
-        ConsumerConfiguration consumerConfig = ConsumerConfiguration.builder()
-            .name("test-consumer")
-            .durable("test-consumer")
-            .build();
+        ConsumerConfiguration consumerConfig =
+                ConsumerConfiguration.builder()
+                        .name("test-consumer")
+                        .durable("test-consumer")
+                        .build();
 
-        java.lang.reflect.Method subscribeMethod = JetStreamObservableQueue.class.getDeclaredMethod(
-            "subscribe", Connection.class, ConsumerConfiguration.class);
+        Method subscribeMethod =
+                JetStreamObservableQueue.class.getDeclaredMethod(
+                        "subscribe", Connection.class, ConsumerConfiguration.class);
         subscribeMethod.setAccessible(true);
         subscribeMethod.invoke(queue, natsConnection, consumerConfig);
 
         verify(natsConnection).jetStream();
         verify(natsConnection).createDispatcher();
 
-        verify(jetStream).subscribe(
-            eq("testapp_jsm_notify_order.workflow.*.completed"),
-            eq("processors"),
-            eq(dispatcher),
-            any(MessageHandler.class),
-            eq(false),
-            any(PushSubscribeOptions.class)
-        );
+        verify(jetStream)
+                .subscribe(
+                        eq("testapp_jsm_notify_order.workflow.*.completed"),
+                        eq("processors"),
+                        eq(dispatcher),
+                        any(MessageHandler.class),
+                        eq(false),
+                        any(PushSubscribeOptions.class));
 
         Field subField = JetStreamObservableQueue.class.getDeclaredField("sub");
         subField.setAccessible(true);
-        Object actualSub = subField.get(queue);
-        assertEquals("Subscription should be stored in sub field", subscription, actualSub);
+        assertEquals(
+                subscription, subField.get(queue), "Subscription should be stored in sub field");
 
         Field runningField = JetStreamObservableQueue.class.getDeclaredField("running");
         runningField.setAccessible(true);
         AtomicBoolean running = (AtomicBoolean) runningField.get(queue);
-        assertTrue("Running flag should be set to true", running.get());
+        assertTrue(running.get(), "Running flag should be set to true");
 
-        // 6. Verify stream name sanitization worked
-        assertEquals("Stream name should be properly sanitized", "TESTAPP_JSM_NOTIFY_ORDER_WORKFLOW_ANY_COMPLETED", expectedStreamName);
+        assertEquals(
+                "TESTAPP_JSM_NOTIFY_ORDER_WORKFLOW_ANY_COMPLETED",
+                expectedStreamName,
+                "Stream name should be properly sanitized");
     }
 
     @Test
@@ -317,14 +337,14 @@ public class JetStreamObservableQueueTest {
         when(conductorProperties.getStack()).thenReturn(null);
         when(conductorProperties.getAppId()).thenReturn("testapp");
 
-        JetStreamObservableQueue queue = new JetStreamObservableQueue(
-            conductorProperties,
-            jetStreamProperties,
-            "test",
-            "test.subject:workers",
-            null,
-            eventPublisher
-        );
+        JetStreamObservableQueue queue =
+                new JetStreamObservableQueue(
+                        conductorProperties,
+                        jetStreamProperties,
+                        "test",
+                        "test.subject:workers",
+                        null,
+                        eventPublisher);
 
         Field streamNameField = JetStreamObservableQueue.class.getDeclaredField("streamName");
         Field subjectField = JetStreamObservableQueue.class.getDeclaredField("subject");
@@ -338,49 +358,63 @@ public class JetStreamObservableQueueTest {
         String actualSubject = (String) subjectField.get(queue);
         String actualQueueGroup = (String) queueGroupField.get(queue);
 
-        assertEquals("Subject should include prefix", "testapp_jsm_notify_test.subject", actualSubject);
-        assertEquals("Queue group should be extracted from subject:queueGroup", "workers", actualQueueGroup);
-        assertEquals("Stream name should be sanitized", "TESTAPP_JSM_NOTIFY_TEST_SUBJECT", actualStreamName);
+        assertEquals(
+                "testapp_jsm_notify_test.subject", actualSubject, "Subject should include prefix");
+        assertEquals(
+                "workers",
+                actualQueueGroup,
+                "Queue group should be extracted from subject:queueGroup");
+        assertEquals(
+                "TESTAPP_JSM_NOTIFY_TEST_SUBJECT",
+                actualStreamName,
+                "Stream name should be sanitized");
 
-        // Mock the subscription setup
         when(natsConnection.jetStream()).thenReturn(jetStream);
         when(natsConnection.createDispatcher()).thenReturn(dispatcher);
 
-        ArgumentCaptor<MessageHandler> messageHandlerCaptor = ArgumentCaptor.forClass(MessageHandler.class);
+        ArgumentCaptor<MessageHandler> messageHandlerCaptor =
+                ArgumentCaptor.forClass(MessageHandler.class);
 
-        when(jetStream.subscribe(any(String.class), any(String.class), any(Dispatcher.class),
-                messageHandlerCaptor.capture(), eq(false), any(PushSubscribeOptions.class)))
-            .thenReturn(subscription);
+        when(jetStream.subscribe(
+                        any(String.class),
+                        any(String.class),
+                        any(Dispatcher.class),
+                        messageHandlerCaptor.capture(),
+                        eq(false),
+                        any(PushSubscribeOptions.class)))
+                .thenReturn(subscription);
 
-        ConsumerConfiguration consumerConfig = ConsumerConfiguration.builder()
-            .name("test-consumer")
-            .durable("test-consumer")
-            .build();
+        ConsumerConfiguration consumerConfig =
+                ConsumerConfiguration.builder()
+                        .name("test-consumer")
+                        .durable("test-consumer")
+                        .build();
 
-        java.lang.reflect.Method subscribeMethod = JetStreamObservableQueue.class.getDeclaredMethod(
-            "subscribe", Connection.class, ConsumerConfiguration.class);
+        Method subscribeMethod =
+                JetStreamObservableQueue.class.getDeclaredMethod(
+                        "subscribe", Connection.class, ConsumerConfiguration.class);
         subscribeMethod.setAccessible(true);
         subscribeMethod.invoke(queue, natsConnection, consumerConfig);
 
-        verify(jetStream).subscribe(
-            eq(actualSubject),
-            eq(actualQueueGroup),
-            eq(dispatcher),
-            messageHandlerCaptor.capture(),
-            eq(false),
-            any(PushSubscribeOptions.class)
-        );
+        verify(jetStream)
+                .subscribe(
+                        eq(actualSubject),
+                        eq(actualQueueGroup),
+                        eq(dispatcher),
+                        messageHandlerCaptor.capture(),
+                        eq(false),
+                        any(PushSubscribeOptions.class));
 
         Field subField = JetStreamObservableQueue.class.getDeclaredField("sub");
         Field runningField = JetStreamObservableQueue.class.getDeclaredField("running");
         subField.setAccessible(true);
         runningField.setAccessible(true);
 
-        Object actualSub = subField.get(queue);
-        AtomicBoolean running = (AtomicBoolean) runningField.get(queue);
-
-        assertEquals("Subscription should be stored in sub field", subscription, actualSub);
-        assertTrue("Running flag should be set to true", running.get());
+        assertEquals(
+                subscription, subField.get(queue), "Subscription should be stored in sub field");
+        assertTrue(
+                ((AtomicBoolean) runningField.get(queue)).get(),
+                "Running flag should be set to true");
 
         Message mockMessage = mock(Message.class);
         String testPayload = "test message data";
@@ -388,24 +422,23 @@ public class JetStreamObservableQueueTest {
 
         Field messagesField = JetStreamObservableQueue.class.getDeclaredField("messages");
         messagesField.setAccessible(true);
+        @SuppressWarnings("unchecked")
         BlockingQueue<Message> messages = (BlockingQueue<Message>) messagesField.get(queue);
 
         MessageHandler capturedHandler = messageHandlerCaptor.getValue();
         capturedHandler.onMessage(mockMessage);
 
-        assertEquals("One message should be in the queue", 1, messages.size());
+        assertEquals(1, messages.size(), "One message should be in the queue");
 
         JsmMessage processedMessage = (JsmMessage) messages.poll();
-        assertNotNull("Message should be processed", processedMessage);
-        assertEquals("Message payload should match", testPayload, processedMessage.getPayload());
-        assertNotNull("Message should have JSM message set", processedMessage.getJsmMsg());
-        assertNotNull("Message should have ID generated", processedMessage.getId());
+        assertNotNull(processedMessage, "Message should be processed");
+        assertEquals(testPayload, processedMessage.getPayload(), "Message payload should match");
+        assertNotNull(processedMessage.getJsmMsg(), "Message should have JSM message set");
+        assertNotNull(processedMessage.getId(), "Message should have ID generated");
     }
 
     @Test
     public void testCreateConsumerUsesSanitizedStreamName() throws Exception {
-        // Test that createConsumer method uses sanitized streamName as first parameter to addOrUpdateConsumer
-
         when(conductorProperties.getStack()).thenReturn(null);
         when(conductorProperties.getAppId()).thenReturn("test");
         when(jetStreamProperties.getDurableName()).thenReturn("test-durable");
@@ -413,77 +446,80 @@ public class JetStreamObservableQueueTest {
         when(jetStreamProperties.getMaxDeliver()).thenReturn(3);
         when(jetStreamProperties.getMaxAckPending()).thenReturn(1000L);
 
-        // Create queue with subject containing special chars that need sanitization
-        JetStreamObservableQueue queue = new JetStreamObservableQueue(
-            conductorProperties,
-            jetStreamProperties,
-            "test",
-            "order.workflow.*.completed:processors", // Subject with * that gets sanitized
-            null,
-            eventPublisher
-        );
+        JetStreamObservableQueue queue =
+                new JetStreamObservableQueue(
+                        conductorProperties,
+                        jetStreamProperties,
+                        "test",
+                        "order.workflow.*.completed:processors",
+                        null,
+                        eventPublisher);
 
-        // Mock the consumer creation
         ConsumerInfo mockConsumerInfo = mock(ConsumerInfo.class);
         when(jsm.addOrUpdateConsumer(any(String.class), any(ConsumerConfiguration.class)))
-            .thenReturn(mockConsumerInfo);
+                .thenReturn(mockConsumerInfo);
 
-        // Act - Call createConsumer method directly
-        java.lang.reflect.Method createConsumerMethod = JetStreamObservableQueue.class.getDeclaredMethod("createConsumer", JetStreamManagement.class);
+        Method createConsumerMethod =
+                JetStreamObservableQueue.class.getDeclaredMethod(
+                        "createConsumer", JetStreamManagement.class);
         createConsumerMethod.setAccessible(true);
-        ConsumerConfiguration result = (ConsumerConfiguration) createConsumerMethod.invoke(queue, jsm);
+        ConsumerConfiguration result =
+                (ConsumerConfiguration) createConsumerMethod.invoke(queue, jsm);
 
-        // Assert - Verify addOrUpdateConsumer was called with the SANITIZED stream name
-        // This is critical: the consumer must be created on the sanitized stream name, not the original subject
-        verify(jsm).addOrUpdateConsumer(eq("TEST_JSM_NOTIFY_ORDER_WORKFLOW_ANY_COMPLETED"), any(ConsumerConfiguration.class));
+        verify(jsm)
+                .addOrUpdateConsumer(
+                        eq("TEST_JSM_NOTIFY_ORDER_WORKFLOW_ANY_COMPLETED"),
+                        any(ConsumerConfiguration.class));
 
-        // Verify the returned ConsumerConfiguration has ALL expected properties
-        assertNotNull("Should return a consumer configuration", result);
-        assertEquals("Consumer name should match durable name", "test-durable", result.getName());
-        assertEquals("Deliver group should match queue group", "processors", result.getDeliverGroup());
-        assertEquals("Durable name should match", "test-durable", result.getDurable());
-        assertEquals("Ack wait should match properties", java.time.Duration.ofSeconds(30), result.getAckWait());
-        assertEquals("Max deliver should match properties", 3, result.getMaxDeliver());
-        assertEquals("Max ack pending should match properties", 1000L, result.getMaxAckPending());
-        assertEquals("Ack policy should be Explicit", AckPolicy.Explicit, result.getAckPolicy());
-        assertEquals("Deliver policy should be New", DeliverPolicy.New, result.getDeliverPolicy());
-        assertEquals("Deliver subject should be subject + '-deliver'",
-            "test_jsm_notify_order.workflow.*.completed-deliver", result.getDeliverSubject());
+        assertNotNull(result, "Should return a consumer configuration");
+        assertEquals("test-durable", result.getName(), "Consumer name should match durable name");
+        assertEquals(
+                "processors", result.getDeliverGroup(), "Deliver group should match queue group");
+        assertEquals("test-durable", result.getDurable(), "Durable name should match");
+        assertEquals(
+                java.time.Duration.ofSeconds(30),
+                result.getAckWait(),
+                "Ack wait should match properties");
+        assertEquals(3, result.getMaxDeliver(), "Max deliver should match properties");
+        assertEquals(1000L, result.getMaxAckPending(), "Max ack pending should match properties");
+        assertEquals(AckPolicy.Explicit, result.getAckPolicy(), "Ack policy should be Explicit");
+        assertEquals(DeliverPolicy.New, result.getDeliverPolicy(), "Deliver policy should be New");
+        assertEquals(
+                "test_jsm_notify_order.workflow.*.completed-deliver",
+                result.getDeliverSubject(),
+                "Deliver subject should be subject + '-deliver'");
     }
 
     @Test
     public void testConstructorSetsSanitizedStreamName() throws Exception {
-        // Test that the constructor properly sets streamName using streamNameFromSubject
-
         when(conductorProperties.getStack()).thenReturn(null);
         when(conductorProperties.getAppId()).thenReturn("myapp");
 
-        // Create queue with various special characters that need sanitization
-        JetStreamObservableQueue queue = new JetStreamObservableQueue(
-            conductorProperties,
-            jetStreamProperties,
-            "test",
-            "workflow.task.*.status.>:workers", // Subject with *, >, and . that need sanitization
-            null,
-            eventPublisher
-        );
+        JetStreamObservableQueue queue =
+                new JetStreamObservableQueue(
+                        conductorProperties,
+                        jetStreamProperties,
+                        "test",
+                        "workflow.task.*.status.>:workers",
+                        null,
+                        eventPublisher);
 
-        // Verify the constructor set streamName correctly
         Field streamNameField = JetStreamObservableQueue.class.getDeclaredField("streamName");
         streamNameField.setAccessible(true);
         String actualStreamName = (String) streamNameField.get(queue);
 
-        // The constructor should have called streamNameFromSubject and set the result
-        String expectedStreamName = "MYAPP_JSM_NOTIFY_WORKFLOW_TASK_ANY_STATUS_ALL";
-        assertEquals("Constructor should set sanitized stream name", expectedStreamName, actualStreamName);
+        assertEquals(
+                "MYAPP_JSM_NOTIFY_WORKFLOW_TASK_ANY_STATUS_ALL",
+                actualStreamName,
+                "Constructor should set sanitized stream name");
 
-        // Verify the sanitization rules
-        assertFalse("Stream name should not contain dots", actualStreamName.contains("."));
-        assertFalse("Stream name should not contain asterisks", actualStreamName.contains("*"));
-        assertFalse("Stream name should not contain >", actualStreamName.contains(">"));
-        assertTrue("Stream name should contain ANY for *", actualStreamName.contains("ANY"));
-        assertTrue("Stream name should contain ALL for >", actualStreamName.contains("ALL"));
-        assertTrue("Stream name should be uppercase", actualStreamName.equals(actualStreamName.toUpperCase()));
+        assertFalse(actualStreamName.contains("."), "Stream name should not contain dots");
+        assertFalse(actualStreamName.contains("*"), "Stream name should not contain asterisks");
+        assertFalse(actualStreamName.contains(">"), "Stream name should not contain >");
+        assertTrue(actualStreamName.contains("ANY"), "Stream name should contain ANY for *");
+        assertTrue(actualStreamName.contains("ALL"), "Stream name should contain ALL for >");
+        assertTrue(
+                actualStreamName.equals(actualStreamName.toUpperCase()),
+                "Stream name should be uppercase");
     }
-
 }


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

In **NATS / JetStream**, a *subject* is a dot-separated routing key (e.g. `conductor.workflow.event.waiting`) and may contain wildcards (`*`, `>`).  
A **stream name**, however, is a plain identifier and **cannot contain dots or wildcards**.

In the current implementation, the **subject string is reused directly as the JetStream stream name**, which causes stream creation to fail when the subject contains:
- dots (`.`), or
- wildcards (`*`, `>`)

When the stream cannot be created, publishing events to that subject also fails because no stream is bound to it.

Proposed fix
---

Continue deriving the **stream name from the subject** (for simplicity and predictability), but **normalize it into a valid JetStream stream identifier**.

The normalization rules are:

| Subject character | Stream name replacement |
|------------------|------------------------|
| `.` | `_` |
| `*` | `ANY` |
| `>` | `ALL` |
| case | upper-cased |

### Examples

| Subject | Stream name |
|------|-------------|
| `system.entity.event.created` | `SYSTEM_ENTITY_EVENT_CREATED` |
| `system.entity.event.*` | `SYSTEM_ENTITY_EVENT_ANY` |
| `system.entity.>` | `SYSTEM_ENTITY_ALL` |

Caused errors
---

When dots are used in the subject name, stream creation fails, and any events published to that subject will also fail immediately, since no stream is bound to it.

```
546666 [scheduled-task-pool-3] ERROR com.netflix.conductor.core.events.DefaultEventQueueManager [] - refresh event queues failed
java.lang.NullPointerException: Cannot invoke "io.nats.client.JetStreamSubscription.getConsumerInfo()" because "this.sub" is null
	at com.netflix.conductor.contribs.queue.nats.JetStreamObservableQueue.size(JetStreamObservableQueue.java:179) ~[conductor-nats.jar!/:?]
	at com.netflix.conductor.core.events.DefaultEventQueueManager.lambda$getQueueSizes$1(DefaultEventQueueManager.java:89) ~[conductor-core.jar!/:?]
	at java.base/java.util.concurrent.ConcurrentHashMap.forEach(ConcurrentHashMap.java:1603) ~[?:?]
	at com.netflix.conductor.core.events.DefaultEventQueueManager.getQueueSizes(DefaultEventQueueManager.java:86) ~[conductor-core.jar!/:?]
	at com.netflix.conductor.core.events.DefaultEventQueueManager.refreshEventQueues(DefaultEventQueueManager.java:167) ~[conductor-core.jar!/:?]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[?:?]
	at org.springframework.scheduling.support.ScheduledMethodRunnable.runInternal(ScheduledMethodRunnable.java:130) ~[spring-context-6.1.14.jar!/:6.1.14]
	at org.springframework.scheduling.support.ScheduledMethodRunnable.lambda$run$2(ScheduledMethodRunnable.java:124) ~[spring-context-6.1.14.jar!/:6.1.14]
	at io.micrometer.observation.Observation.observe(Observation.java:499) ~[micrometer-observation-1.13.6.jar!/:1.13.6]
	at org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:124) ~[spring-context-6.1.14.jar!/:6.1.14]
	at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54) ~[spring-context-6.1.14.jar!/:6.1.14]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572) ~[?:?]
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358) ~[?:?]
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
550374 [http-nio-8080-exec-6] INFO  com.netflix.conductor.contribs.queue.nats.config.JetStreamEventQueueProvider [] - Getting obs queue, quri=conductor.events.track_file
550382 [http-nio-8080-exec-6] ERROR com.netflix.conductor.core.execution.tasks.Event [] - Error executing task: a44e51e0-d9e7-4f09-8db2-fd838a905891, workflow: 52044dab-323d-4ba4-b4da-edf8487296a8
```

<img width="1872" height="1231" alt="image" src="https://github.com/user-attachments/assets/2a26d84f-4588-43f5-939b-429c5f1e7634" />

