### PR TITLE
Fix: Add org.conductoross.conductor package to component scan

### DIFF
--- a/server/src/main/java/com/netflix/conductor/Conductor.java
+++ b/server/src/main/java/com/netflix/conductor/Conductor.java
@@ -28,7 +28,7 @@ import org.springframework.core.io.FileSystemResource;
 // In case that SQL database is selected this class will be imported back in the appropriate
 // database persistence module.
 @SpringBootApplication(exclude = DataSourceAutoConfiguration.class)
-@ComponentScan(basePackages = {"com.netflix.conductor", "io.orkes.conductor"})
+@ComponentScan(basePackages = {"com.netflix.conductor", "io.orkes.conductor", "org.conductoross.conductor"})
 public class Conductor {
 
     private static final Logger log = LoggerFactory.getLogger(Conductor.class);


### PR DESCRIPTION
The workflow sweeper was disabled which is causing some workflows to stuck.

Without the sweeper running, workflows can become stuck in RUNNING state when they should be periodically re-evaluated, particularly affecting subworkflows and async task completion scenarios (see issue #712).

This change adds "org.conductoross.conductor" to the component scan base packages, ensuring the WorkflowSweeper and other components in this package are properly discovered and loaded.

Pull Request type
----
- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
