### PR TITLE
Disable JMX Metrics by default

### DIFF
--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -181,6 +181,7 @@ management.cloudwatch.metrics.export.namespace=conductor
 
 management.azuremonitor.metrics.export.enabled=false
 management.azuremonitor.metrics.export.instrumentationKey=INSTRUMENTATION_KEY
+management.jmx.metrics.export.enabled=false
 
 # When enabled logs metrics as info level logs
 conductor.metrics-logger.enabled=false


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [x] Other (please describe):

Default config changes.

Changes in this PR
----

Disable JMX Metrics registry `io.micrometer.jmx.JmxMeterRegistry` by default.

We've seen this issue with this registry

```
java.lang.IllegalArgumentException: A metric named xxx already exists
        at com.codahale.metrics.MetricRegistry.register(MetricRegistry.java:168)
        at io.micrometer.core.instrument.dropwizard.DropwizardMeterRegistry.newGauge(DropwizardMeterRegistry.java:105)
        at io.micrometer.core.instrument.MeterRegistry.lambda$gauge$4(MeterRegistry.java:345)
        at io.micrometer.core.instrument.MeterRegistry.lambda$registerMeterIfNecessary$8(MeterRegistry.java:604)
        at io.micrometer.core.instrument.MeterRegistry.getOrCreateMeter(MeterRegistry.java:674)
        at io.micrometer.core.instrument.MeterRegistry.registerMeterIfNecessary(MeterRegistry.java:610)
        at io.micrometer.core.instrument.MeterRegistry.registerMeterIfNecessary(MeterRegistry.java:604)
        at io.micrometer.core.instrument.MeterRegistry.gauge(MeterRegistry.java:345)
        at io.micrometer.core.instrument.Gauge$Builder.register(Gauge.java:195)
        at io.micrometer.core.instrument.distribution.HistogramGauges.<init>(HistogramGauges.java:126)
        at io.micrometer.core.instrument.distribution.HistogramGauges.register(HistogramGauges.java:89)
        at io.micrometer.core.instrument.distribution.HistogramGauges.getHistogramGauges(HistogramGauges.java:53)
        at io.micrometer.core.instrument.distribution.HistogramGauges.registerWithCommonFormat(HistogramGauges.java:48)
        at io.micrometer.core.instrument.dropwizard.DropwizardMeterRegistry.newTimer(DropwizardMeterRegistry.java:116)
        at io.micrometer.core.instrument.MeterRegistry.lambda$timer$5(MeterRegistry.java:359)
        at io.micrometer.core.instrument.MeterRegistry.getOrCreateMeter(MeterRegistry.java:674)
        at io.micrometer.core.instrument.MeterRegistry.registerMeterIfNecessary(MeterRegistry.java:610)
```