### PR TITLE
`WF_SERVER` documentation in `ui/README.md`

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -14,9 +14,18 @@ To run the UI on the bundled development server, run `yarn run start`. Navigate 
 
 To enable errors inspector module export env var: `REACT_APP_ENABLE_ERRORS_INSPECTOR=true`, then run `yarn start`.
 
-#### Reverse Proxy configuration
+#### Reverse Proxy Configuration
 
-The default setup expects that the Conductor Server API will be available at `localhost:8080/api`. You may select an alternate port and hostname, or rewrite the API path by editing `setupProxy.js`. Note that `setupProxy.js` is used ONLY by the development server.
+By default, the development server proxies requests to `http://localhost:8080/api`. 
+
+To use a different Conductor Server, set the `WF_SERVER` environment variable:
+
+```
+export WF_SERVER=http://localhost:8081
+yarn run start
+```
+
+For additional customization (e.g., path rewriting), edit `setupProxy.js`. Note that this file is only used by the development server.
 
 ### Hosting for Production
 


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [x] Other (please describe):

Documentation

Changes in this PR
----

Added `WF_SERVER` env variable documentation to `ui/README.md`. There's no mention of it but it's used in the `setupProxy.js`

```js
const target = process.env.WF_SERVER || "http://localhost:8080";
```

You can use it to start the UI with a different Conductor server without editing that file:

```shell
export WF_SERVER=http://localhost:8081
yarn run start
```