### PR TITLE
Fix OpenSearchProperties Environment injection for integration tests

### DIFF
--- a/os-persistence/src/main/java/com/netflix/conductor/os/config/OpenSearchProperties.java
+++ b/os-persistence/src/main/java/com/netflix/conductor/os/config/OpenSearchProperties.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.convert.DurationUnit;
 import org.springframework.core.env.Environment;
@@ -307,6 +308,7 @@ public class OpenSearchProperties {
         return environment != null && environment.containsProperty(NEW_PREFIX + propertyName);
     }
 
+    @Autowired
     public void setEnvironment(Environment environment) {
         this.environment = environment;
     }


### PR DESCRIPTION
## Summary
- Add `@Autowired` annotation to `setEnvironment()` method in `OpenSearchProperties` to ensure Spring properly injects the Environment instance
- This enables the legacy property fallback logic in `@PostConstruct init()` method during integration tests

## Test plan
- [x] Integration tests pass with this fix
- [ ] Verify OpenSearch persistence module works correctly in test environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)