### PR TITLE
Fix OpenSearchProperties Environment injection for integration tests

### DIFF
--- a/os-persistence/src/main/java/com/netflix/conductor/os/config/OpenSearchProperties.java
+++ b/os-persistence/src/main/java/com/netflix/conductor/os/config/OpenSearchProperties.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.convert.DurationUnit;
 import org.springframework.core.env.Environment;
@@ -307,6 +308,7 @@ public class OpenSearchProperties {
         return environment != null && environment.containsProperty(NEW_PREFIX + propertyName);
     }
 
+    @Autowired
     public void setEnvironment(Environment environment) {
         this.environment = environment;
     }


### PR DESCRIPTION
Add @Autowired annotation to setEnvironment() method to ensure Spring properly injects Environment instance. This enables legacy property fallback logic in @PostConstruct init() method during integration tests.

Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [X] Other (build fix.):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
