### PR TITLE
Remove redundant ackTaskReceived() call in getLastPollTask()

### DIFF
--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -219,7 +219,7 @@ public class ExecutionService {
             return null;
         }
         Task task = tasks.get(0);
-        ackTaskReceived(task);
+
         LOGGER.debug(
                 "The Task {} being returned for /tasks/poll/{}?{}&{}",
                 task,

--- a/core/src/test/java/com/netflix/conductor/service/ExecutionServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/ExecutionServiceTest.java
@@ -36,8 +36,16 @@ import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.core.execution.tasks.SystemTaskRegistry;
 import com.netflix.conductor.core.listener.TaskStatusListener;
 import com.netflix.conductor.dao.QueueDAO;
+import com.netflix.conductor.model.TaskModel;
 
 import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
@@ -267,5 +275,66 @@ public class ExecutionServiceTest {
                 executionService.getSearchTasksV2("query", "*", 0, 2, "Sort");
         assertEquals(1, searchResult.getTotalHits());
         assertEquals(Collections.singletonList(taskWorkflow1), searchResult.getResults());
+    }
+
+
+    @Test
+    public void testGetLastPollTaskAcksOnlyOnce() {
+        // Setup: create a TaskModel that poll() will process
+        String taskType = "test_task";
+        String workerId = "worker1";
+        String domain = null;
+        String taskId = "task-123";
+        String queueName = taskType; // QueueUtils.getQueueName with null domain = taskType
+
+        TaskModel taskModel = new TaskModel();
+        taskModel.setTaskId(taskId);
+        taskModel.setTaskType(taskType);
+        taskModel.setStatus(TaskModel.Status.SCHEDULED);
+        taskModel.setWorkflowInstanceId("wf-123");
+
+        // Mock: queueDAO.pop returns the task ID
+        when(queueDAO.pop(eq(queueName), eq(1), anyInt()))
+                .thenReturn(Collections.singletonList(taskId));
+
+        // Mock: executionDAOFacade returns the TaskModel (called twice: once in poll loop,
+        // once in the taskStatusListener notification block)
+        when(executionDAOFacade.getTaskModel(taskId)).thenReturn(taskModel);
+        when(executionDAOFacade.exceedsInProgressLimit(taskModel)).thenReturn(false);
+
+        // Mock: ack returns true (standard behavior for most QueueDAO implementations)
+        when(queueDAO.ack(eq(queueName), eq(taskId))).thenReturn(true);
+
+        // Act
+        Task result = executionService.getLastPollTask(taskType, workerId, domain);
+
+        // Assert: task was returned
+        assertNotNull(result);
+        assertEquals(taskId, result.getTaskId());
+
+        // Assert: queueDAO.ack was called exactly ONCE (inside poll()), not twice.
+        // This is the core assertion — before the fix, ack was called twice:
+        // once in poll() via tasks.forEach(this::ackTaskReceived), and again
+        // redundantly in getLastPollTask() after poll() returned.
+        verify(queueDAO, times(1)).ack(queueName, taskId);
+    }
+
+    @Test
+    public void testGetLastPollTaskReturnsNullWhenEmpty() {
+        String taskType = "test_task";
+        String workerId = "worker1";
+        String domain = null;
+        String queueName = taskType;
+
+        // Mock: queueDAO.pop returns empty list (no tasks available)
+        when(queueDAO.pop(eq(queueName), eq(1), anyInt()))
+                .thenReturn(Collections.emptyList());
+
+        // Act
+        Task result = executionService.getLastPollTask(taskType, workerId, domain);
+
+        // Assert: null returned, no ack called
+        assertNull(result);
+        verify(queueDAO, times(0)).ack(anyString(), anyString());
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

This PR fixes a bug where `ackTaskReceived()` was being called twice for the same task in the `getLastPollTask()` method of `ExecutionService`.

**The Problem:**
- `getLastPollTask()` internally calls `poll()`, which already acknowledges tasks via `tasks.forEach(this::ackTaskReceived)`
- After `poll()` returns, `getLastPollTask()` was redundantly calling `ackTaskReceived()` again on the same task
- This resulted in duplicate acknowledgments for every task polled through `getLastPollTask()`

**The Solution:**
- Removed the redundant `ackTaskReceived()` call in `getLastPollTask()` (line 222 of ExecutionService.java)
- The task acknowledgment now happens only once, inside the `poll()` method where it belongs

**Testing:**
- Added unit test `testGetLastPollTaskAcksOnlyOnce()` that verifies `queueDAO.ack()` is called exactly once when a task is successfully polled
- Added unit test `testGetLastPollTaskReturnsNullWhenEmpty()` that verifies no acknowledgment occurs when the queue is empty
- Both tests use Mockito to verify the exact number of acknowledgment calls

Issue #768

Alternatives considered
----

**Alternative 1:** Remove the ack call from `poll()` instead
- Rejected because `poll()` is a public method used by multiple callers, and removing the ack there would break other parts of the system that depend on tasks being acknowledged during polling

**Alternative 2:** Add a flag to `poll()` to control whether it should ack
- Rejected as it would complicate the API unnecessarily. The simpler solution is to remove the redundant call in the wrapper method

**Alternative 3:** Make `ackTaskReceived()` idempotent
- This would mask the underlying issue rather than fixing it. The root cause is the duplicate call, which should simply be removed