### PR TITLE
upgrade shadow plugin to 8.3.6

### DIFF
--- a/es7-persistence/build.gradle
+++ b/es7-persistence/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'com.gradleup.shadow' version '8.3.6'
     id 'java'
 }
 

--- a/os-persistence-v2/build.gradle
+++ b/os-persistence-v2/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'com.gradleup.shadow' version '8.3.6'
     id 'java'
 }
 
@@ -52,5 +52,4 @@ shadowJar {
         include 'META-INF/maven/*'
     }
 }
-// Note: shadowJar is optional for shading dependencies, but not required for basic functionality
-// Use regular jar for now to avoid Shadow plugin issues with Java 21
+// Note: shadowJar is used to shade opensearch-java 2.x to avoid conflicts with v3

--- a/os-persistence-v3/build.gradle
+++ b/os-persistence-v3/build.gradle
@@ -5,7 +5,7 @@
 // See: https://opensearch.org/docs/latest/clients/java/
 
 plugins {
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'com.gradleup.shadow' version '8.3.6'
     id 'java'
 }
 
@@ -58,5 +58,4 @@ shadowJar {
         include 'META-INF/maven/*'
     }
 }
-// Note: shadowJar is optional for shading dependencies, but not required for basic functionality
-// Use regular jar for now to avoid Shadow plugin issues with Java 21
+// Note: shadowJar is used to shade opensearch-java 3.x to avoid conflicts with v2


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
The Shadow plugin 8.1.1 (com.github.johnrengelman.shadow) bundles ASM 9.5, which only supports up to Java 20 (class file major version 64). Your project compiles with Java 21 (major version 65), hence the Unsupported class file major version 65 error.
The com.github.johnrengelman.shadow plugin is abandoned — version 8.1.1 was the last release. The actively maintained successor is com.gradleup.shadow, which ships with an ASM version that supports Java 21.

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
