### PR TITLE
test: add integration tests for DO_WHILE list iteration (issue #624)

### DIFF
--- a/core/src/main/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraint.java
+++ b/core/src/main/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraint.java
@@ -260,7 +260,11 @@ public @interface WorkflowTaskTypeConstraint {
         private boolean isDoWhileTaskValid(
                 WorkflowTask workflowTask, ConstraintValidatorContext context) {
             boolean valid = true;
-            if (workflowTask.getLoopCondition() == null) {
+            boolean isListIterationMode =
+                    (workflowTask.getItems() != null && !workflowTask.getItems().trim().isEmpty())
+                            || (workflowTask.getInputParameters() != null
+                                    && workflowTask.getInputParameters().containsKey("_items"));
+            if (!isListIterationMode && workflowTask.getLoopCondition() == null) {
                 String message =
                         String.format(
                                 PARAM_REQUIRED_STRING_FORMAT,

--- a/core/src/test/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraintTest.java
+++ b/core/src/test/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraintTest.java
@@ -172,6 +172,46 @@ public class WorkflowTaskTypeConstraintTest {
     }
 
     @Test
+    public void testWorkflowTaskTypeDoWhileListIterationMode() {
+        // When 'items' is set, loopCondition should NOT be required (list-iteration mode)
+        WorkflowTask workflowTask = createSampleWorkflowTask();
+        workflowTask.setType("DO_WHILE");
+        workflowTask.setItems("${workflow.input.itemList}");
+
+        WorkflowTask loopTask = new WorkflowTask();
+        loopTask.setName("http");
+        loopTask.setTaskReferenceName("http_ref");
+        loopTask.setType("HTTP");
+        workflowTask.setLoopOver(List.of(loopTask));
+
+        when(mockMetadataDao.getTaskDef(anyString())).thenReturn(new TaskDef());
+
+        Set<ConstraintViolation<WorkflowTask>> result = validator.validate(workflowTask);
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testWorkflowTaskTypeDoWhileListIterationModeOrkesCompat() {
+        // When '_items' is in inputParameters (Orkes compat), loopCondition should NOT be required
+        WorkflowTask workflowTask = createSampleWorkflowTask();
+        workflowTask.setType("DO_WHILE");
+        Map<String, Object> inputParam = new HashMap<>();
+        inputParam.put("_items", "${workflow.input.itemList}");
+        workflowTask.setInputParameters(inputParam);
+
+        WorkflowTask loopTask = new WorkflowTask();
+        loopTask.setName("http");
+        loopTask.setTaskReferenceName("http_ref");
+        loopTask.setType("HTTP");
+        workflowTask.setLoopOver(List.of(loopTask));
+
+        when(mockMetadataDao.getTaskDef(anyString())).thenReturn(new TaskDef());
+
+        Set<ConstraintViolation<WorkflowTask>> result = validator.validate(workflowTask);
+        assertEquals(0, result.size());
+    }
+
+    @Test
     public void testWorkflowTaskTypeWait() {
         WorkflowTask workflowTask = createSampleWorkflowTask();
         workflowTask.setType("WAIT");

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/DoWhileSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/DoWhileSpec.groovy
@@ -45,7 +45,8 @@ class DoWhileSpec extends AbstractSpecification {
                 'do_while_system_tasks.json',
                 'do_while_with_decision_task.json',
                 'do_while_set_variable_fix.json',
-                'do_while_high_iteration_test.json')
+                'do_while_high_iteration_test.json',
+                'do_while_list_iteration_integration_test.json')
     }
 
     def "Test workflow with 2 iterations of five tasks"() {
@@ -1304,6 +1305,52 @@ class DoWhileSpec extends AbstractSpecification {
             tasks[500].taskType == 'LAMBDA'
             tasks[500].status == Task.Status.COMPLETED
             tasks[500].outputData.get("result") == 499
+        }
+    }
+
+    def "Test DO_WHILE list iteration with items parameter iterates over each item"() {
+        given: "A list of items to iterate over"
+        def workflowInput = new HashMap()
+        workflowInput['items'] = ['apple', 'banana', 'cherry']
+
+        when: "A do_while_list_iteration workflow is started"
+        def workflowInstanceId = startWorkflow("do_while_list_iteration", 1, "listtest", workflowInput, null)
+
+        then: "Verify the workflow runs all 3 iterations via LAMBDA tasks and completes"
+        with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
+            status == Workflow.WorkflowStatus.COMPLETED
+            // DO_WHILE task + 1 LAMBDA per iteration = 4 tasks total
+            tasks.size() == 4
+            tasks[0].taskType == 'DO_WHILE'
+            tasks[0].status == Task.Status.COMPLETED
+            tasks[0].iteration == 3
+            tasks[1].taskType == 'LAMBDA'
+            tasks[1].status == Task.Status.COMPLETED
+            tasks[1].iteration == 1
+            tasks[2].taskType == 'LAMBDA'
+            tasks[2].status == Task.Status.COMPLETED
+            tasks[2].iteration == 2
+            tasks[3].taskType == 'LAMBDA'
+            tasks[3].status == Task.Status.COMPLETED
+            tasks[3].iteration == 3
+        }
+    }
+
+    def "Test DO_WHILE list iteration with empty items list completes immediately"() {
+        given: "An empty items list"
+        def workflowInput = new HashMap()
+        workflowInput['items'] = []
+
+        when: "A do_while_list_iteration workflow is started with an empty list"
+        def workflowInstanceId = startWorkflow("do_while_list_iteration", 1, "emptylisttest", workflowInput, null)
+
+        then: "Verify the workflow completes immediately without executing any loop body tasks"
+        with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
+            status == Workflow.WorkflowStatus.COMPLETED
+            // Only the DO_WHILE task itself, no LAMBDA tasks scheduled
+            tasks.size() == 1
+            tasks[0].taskType == 'DO_WHILE'
+            tasks[0].status == Task.Status.COMPLETED
         }
     }
 

--- a/test-harness/src/test/resources/do_while_list_iteration_integration_test.json
+++ b/test-harness/src/test/resources/do_while_list_iteration_integration_test.json
@@ -1,0 +1,36 @@
+{
+  "name": "do_while_list_iteration",
+  "description": "DO_WHILE with native list iteration using items parameter",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "list_loop",
+      "taskReferenceName": "list_loop",
+      "inputParameters": {},
+      "type": "DO_WHILE",
+      "items": "${workflow.input.items}",
+      "loopOver": [
+        {
+          "name": "LAMBDA_TASK",
+          "taskReferenceName": "process_item",
+          "inputParameters": {
+            "scriptExpression": "return { processedItem: $.list_loop.loopItem, index: $.list_loop.loopIndex }",
+            "list_loop": "${list_loop.output}"
+          },
+          "type": "LAMBDA",
+          "startDelay": 0,
+          "optional": false,
+          "asyncComplete": false
+        }
+      ]
+    }
+  ],
+  "inputParameters": ["items"],
+  "outputParameters": {},
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false,
+  "timeoutPolicy": "ALERT_ONLY",
+  "timeoutSeconds": 0,
+  "ownerEmail": "test@harness.com"
+}


### PR DESCRIPTION
## Summary

- Adds two Spock integration tests for the DO_WHILE list iteration feature (`items` parameter) introduced in issue #624
- Adds `do_while_list_iteration_integration_test.json` — a self-contained workflow definition using LAMBDA tasks (no external HTTP dependencies)
- Covers: normal iteration over a 3-item list; and empty list completing immediately

## Context

The list iteration feature (`items` field on DO_WHILE tasks) was already merged into main. This PR adds the missing integration test coverage in the test-harness.

## Depends On

**Blocked by #820** — The test workflow uses `items` without `loopCondition`. Until the validator fix in #820 is merged, registering this workflow during `setup()` throws a `ConstraintViolationException` that causes all `DoWhileSpec` tests to fail. CI will be red until #820 merges.

## Test plan

- [ ] `Test DO_WHILE list iteration with items parameter iterates over each item` — starts workflow with `['apple', 'banana', 'cherry']`, verifies COMPLETED status, 4 tasks (DO_WHILE iter=3 + 3 LAMBDA executions)
- [ ] `Test DO_WHILE list iteration with empty items list completes immediately` — starts workflow with `[]`, verifies COMPLETED status, 1 task (DO_WHILE only, no iterations)

Closes #624 (integration test coverage)