### PR TITLE
fix: prevent HUMAN tasks from churning the decider queue

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
@@ -1192,19 +1192,18 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
                 Duration timeout = properties.getWorkflowOffsetTimeout();
                 if (!workflow.getStatus().isTerminal()) {
                     Duration updatedOffset = computePostpone(workflow, timeout);
-                    if (updatedOffset.getSeconds() != timeout.getSeconds()) {
-                        // we have a new value, setUnack uses time in millis
-                        LOGGER.debug(
-                                "Pushing the workflow {} into decider queue by {} millis",
-                                workflow.getWorkflowId(),
-                                updatedOffset.getSeconds() * 1000);
-                        queueDAO.setUnackTimeout(
-                                DECIDER_QUEUE,
-                                workflow.getWorkflowId(),
-                                updatedOffset.getSeconds() * 1000);
-                    }
+                    // Always explicitly set the unack timeout so queue-backend defaults do not
+                    // determine re-sweep frequency (e.g. HUMAN/WAIT tasks would otherwise be
+                    // re-swept at the queue's own default unack interval, which may be very short).
+                    LOGGER.debug(
+                            "Pushing the workflow {} into decider queue by {} millis",
+                            workflow.getWorkflowId(),
+                            updatedOffset.getSeconds() * 1000);
+                    queueDAO.setUnackTimeout(
+                            DECIDER_QUEUE,
+                            workflow.getWorkflowId(),
+                            updatedOffset.getSeconds() * 1000);
                 }
-            }
 
             return workflow;
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
@@ -1204,7 +1204,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
                             workflow.getWorkflowId(),
                             updatedOffset.getSeconds() * 1000);
                 }
-
+            }
             return workflow;
 
         } catch (TerminateWorkflowException twe) {

--- a/core/src/main/java/org/conductoross/conductor/core/execution/ExecutorUtils.java
+++ b/core/src/main/java/org/conductoross/conductor/core/execution/ExecutorUtils.java
@@ -20,6 +20,7 @@ import com.netflix.conductor.model.WorkflowModel;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_HUMAN;
 import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_WAIT;
 
 @Slf4j
@@ -39,7 +40,15 @@ public class ExecutorUtils {
                         long deltaInSeconds =
                                 (taskModel.getWaitTimeout() - currentTimeMillis) / 1000;
                         postponeDurationSeconds = (deltaInSeconds > 0) ? deltaInSeconds : 0;
+                    } else {
+                        // WAIT with no timeout: defer by the workflow offset.
+                        postponeDurationSeconds = workflowOffsetTimeoutSeconds;
                     }
+                } else if (taskModel.getTaskType().equals(TASK_TYPE_HUMAN)) {
+                    // HUMAN tasks are long-lived with no predictable completion time.
+                    // Defer the sweep by the workflow offset; the workflow will be re-queued
+                    // immediately when the HUMAN task is updated externally.
+                    postponeDurationSeconds = workflowOffsetTimeoutSeconds;
                 } else {
                     // Could taskModel.getResponseTimeoutSeconds() be set and no taskDef?...
                     // not sure but keeping it this way just in case.

--- a/core/src/test/java/org/conductoross/conductor/core/execution/ExecutorUtilsTest.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/ExecutorUtilsTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.core.execution;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.netflix.conductor.common.metadata.tasks.TaskType;
+import com.netflix.conductor.model.TaskModel;
+import com.netflix.conductor.model.WorkflowModel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ExecutorUtilsTest {
+
+    private static final Duration WORKFLOW_OFFSET = Duration.ofSeconds(30);
+
+    private WorkflowModel workflowWithTask(String taskType, TaskModel.Status status) {
+        WorkflowModel workflow = new WorkflowModel();
+        workflow.setWorkflowId("test-workflow");
+        TaskModel task = new TaskModel();
+        task.setTaskId("task1");
+        task.setTaskType(taskType);
+        task.setStatus(status);
+        workflow.setTasks(List.of(task));
+        return workflow;
+    }
+
+    @Test
+    public void testHumanTaskInProgressPostponesToWorkflowOffset() {
+        WorkflowModel workflow =
+                workflowWithTask(TaskType.TASK_TYPE_HUMAN, TaskModel.Status.IN_PROGRESS);
+        Duration result = ExecutorUtils.computePostpone(workflow, WORKFLOW_OFFSET);
+        assertEquals(WORKFLOW_OFFSET.getSeconds(), result.getSeconds(),
+                "HUMAN task should postpone by workflowOffsetTimeout");
+    }
+
+    @Test
+    public void testWaitTaskWithNoTimeoutPostponesToWorkflowOffset() {
+        WorkflowModel workflow =
+                workflowWithTask(TaskType.TASK_TYPE_WAIT, TaskModel.Status.IN_PROGRESS);
+        // waitTimeout defaults to 0 — no deadline
+        Duration result = ExecutorUtils.computePostpone(workflow, WORKFLOW_OFFSET);
+        assertEquals(WORKFLOW_OFFSET.getSeconds(), result.getSeconds(),
+                "WAIT task with no timeout should postpone by workflowOffsetTimeout");
+    }
+
+    @Test
+    public void testWaitTaskWithFutureTimeoutPostponesToRemainingTime() {
+        WorkflowModel workflow =
+                workflowWithTask(TaskType.TASK_TYPE_WAIT, TaskModel.Status.IN_PROGRESS);
+        // Set waitTimeout to 60 seconds from now
+        long waitTimeout = System.currentTimeMillis() + 60_000;
+        workflow.getTasks().get(0).setWaitTimeout(waitTimeout);
+
+        Duration result = ExecutorUtils.computePostpone(workflow, WORKFLOW_OFFSET);
+        // Should be at most 30s (capped to workflowOffsetTimeout) and greater than 0
+        assertEquals(WORKFLOW_OFFSET.getSeconds(), result.getSeconds(),
+                "WAIT task with future timeout > workflowOffset should be capped to workflowOffset");
+    }
+
+    @Test
+    public void testWaitTaskWithExpiredTimeoutPostponesToWorkflowOffset() {
+        WorkflowModel workflow =
+                workflowWithTask(TaskType.TASK_TYPE_WAIT, TaskModel.Status.IN_PROGRESS);
+        // Set waitTimeout to 10 seconds ago (elapsed)
+        long waitTimeout = System.currentTimeMillis() - 10_000;
+        workflow.getTasks().get(0).setWaitTimeout(waitTimeout);
+
+        Duration result = ExecutorUtils.computePostpone(workflow, WORKFLOW_OFFSET);
+        // postponeDurationSeconds == 0 (elapsed), so falls back to workflowOffsetTimeout.
+        // The decider itself handles the timeout transition, not the sweep timer.
+        assertEquals(WORKFLOW_OFFSET.getSeconds(), result.getSeconds(),
+                "WAIT task with elapsed timeout should fall back to workflowOffsetTimeout");
+    }
+
+    @Test
+    public void testNonHumanTaskWithNoResponseTimeoutPostponesToWorkflowOffset() {
+        WorkflowModel workflow =
+                workflowWithTask("SIMPLE", TaskModel.Status.IN_PROGRESS);
+        Duration result = ExecutorUtils.computePostpone(workflow, WORKFLOW_OFFSET);
+        assertEquals(WORKFLOW_OFFSET.getSeconds(), result.getSeconds(),
+                "Task with no response timeout should fall back to workflowOffsetTimeout");
+    }
+}

--- a/core/src/test/java/org/conductoross/conductor/core/execution/ExecutorUtilsTest.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/ExecutorUtilsTest.java
@@ -43,7 +43,9 @@ public class ExecutorUtilsTest {
         WorkflowModel workflow =
                 workflowWithTask(TaskType.TASK_TYPE_HUMAN, TaskModel.Status.IN_PROGRESS);
         Duration result = ExecutorUtils.computePostpone(workflow, WORKFLOW_OFFSET);
-        assertEquals(WORKFLOW_OFFSET.getSeconds(), result.getSeconds(),
+        assertEquals(
+                WORKFLOW_OFFSET.getSeconds(),
+                result.getSeconds(),
                 "HUMAN task should postpone by workflowOffsetTimeout");
     }
 
@@ -53,7 +55,9 @@ public class ExecutorUtilsTest {
                 workflowWithTask(TaskType.TASK_TYPE_WAIT, TaskModel.Status.IN_PROGRESS);
         // waitTimeout defaults to 0 — no deadline
         Duration result = ExecutorUtils.computePostpone(workflow, WORKFLOW_OFFSET);
-        assertEquals(WORKFLOW_OFFSET.getSeconds(), result.getSeconds(),
+        assertEquals(
+                WORKFLOW_OFFSET.getSeconds(),
+                result.getSeconds(),
                 "WAIT task with no timeout should postpone by workflowOffsetTimeout");
     }
 
@@ -67,7 +71,9 @@ public class ExecutorUtilsTest {
 
         Duration result = ExecutorUtils.computePostpone(workflow, WORKFLOW_OFFSET);
         // Should be at most 30s (capped to workflowOffsetTimeout) and greater than 0
-        assertEquals(WORKFLOW_OFFSET.getSeconds(), result.getSeconds(),
+        assertEquals(
+                WORKFLOW_OFFSET.getSeconds(),
+                result.getSeconds(),
                 "WAIT task with future timeout > workflowOffset should be capped to workflowOffset");
     }
 
@@ -82,16 +88,19 @@ public class ExecutorUtilsTest {
         Duration result = ExecutorUtils.computePostpone(workflow, WORKFLOW_OFFSET);
         // postponeDurationSeconds == 0 (elapsed), so falls back to workflowOffsetTimeout.
         // The decider itself handles the timeout transition, not the sweep timer.
-        assertEquals(WORKFLOW_OFFSET.getSeconds(), result.getSeconds(),
+        assertEquals(
+                WORKFLOW_OFFSET.getSeconds(),
+                result.getSeconds(),
                 "WAIT task with elapsed timeout should fall back to workflowOffsetTimeout");
     }
 
     @Test
     public void testNonHumanTaskWithNoResponseTimeoutPostponesToWorkflowOffset() {
-        WorkflowModel workflow =
-                workflowWithTask("SIMPLE", TaskModel.Status.IN_PROGRESS);
+        WorkflowModel workflow = workflowWithTask("SIMPLE", TaskModel.Status.IN_PROGRESS);
         Duration result = ExecutorUtils.computePostpone(workflow, WORKFLOW_OFFSET);
-        assertEquals(WORKFLOW_OFFSET.getSeconds(), result.getSeconds(),
+        assertEquals(
+                WORKFLOW_OFFSET.getSeconds(),
+                result.getSeconds(),
                 "Task with no response timeout should fall back to workflowOffsetTimeout");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #795 (part of epic #825: HUMAN task stub implementation)

Two bugs caused workflows blocked on a HUMAN task to be re-swept far more frequently than intended:

1. **`ExecutorUtils.computePostpone()` had no HUMAN task branch** — `postponeDurationSeconds` stayed at `0`, so the method returned `workflowOffsetTimeoutSeconds` unchanged. Same issue existed for WAIT tasks with no timeout.

2. **`WorkflowExecutorOps.decide()` only called `setUnackTimeout` when `computePostpone()` returned a value *different* from the default `workflowOffsetTimeout`** — when they were equal (HUMAN, WAIT-no-timeout, SIMPLE with no response timeout), no explicit unack timeout was set. This left the queue backend's own default unack interval in control, which can be much shorter than `workflowOffsetTimeout`.

## Changes

- **`ExecutorUtils.computePostpone()`**: Added explicit branches for `TASK_TYPE_HUMAN` and WAIT tasks with no timeout, both returning `workflowOffsetTimeoutSeconds`. This is parity with the legacy sweeper's `unack()` implementation.

- **`WorkflowExecutorOps.decide()`**: Removed the `updatedOffset != timeout` guard. `setUnackTimeout` is now always called for non-terminal workflows so the decider queue position is always explicitly managed.

- **`ExecutorUtilsTest`**: New test class covering HUMAN, WAIT (with/without timeout), and default task scenarios.

## Re-queue on completion

When a HUMAN task is completed externally via the task update API, `updateTask()` already calls `decide()`, which re-queues the workflow with immediate priority. No additional change needed.

## Test plan

- [x] `ExecutorUtilsTest` passes (5 new tests)
- [x] Full `conductor-core` test suite passes