### PR TITLE
Relax task definition requirement for SIMPLE tasks

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SimpleTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SimpleTaskMapper.java
@@ -24,7 +24,6 @@ import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
-import com.netflix.conductor.core.exception.TerminateWorkflowException;
 import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
@@ -55,12 +54,10 @@ public class SimpleTaskMapper implements TaskMapper {
      *
      * @param taskMapperContext: A wrapper class containing the {@link WorkflowTask}, {@link
      *     WorkflowDef}, {@link WorkflowModel} and a string representation of the TaskId
-     * @throws TerminateWorkflowException In case if the task definition does not exist
      * @return a List with just one simple task
      */
     @Override
-    public List<TaskModel> getMappedTasks(TaskMapperContext taskMapperContext)
-            throws TerminateWorkflowException {
+    public List<TaskModel> getMappedTasks(TaskMapperContext taskMapperContext) {
 
         LOGGER.debug("TaskMapperContext {} in SimpleTaskMapper", taskMapperContext);
 
@@ -71,13 +68,12 @@ public class SimpleTaskMapper implements TaskMapper {
 
         TaskDef taskDefinition =
                 Optional.ofNullable(workflowTask.getTaskDefinition())
-                        .orElseThrow(
+                        .orElseGet(
                                 () -> {
-                                    String reason =
-                                            String.format(
-                                                    "Invalid task. Task %s does not have a definition",
-                                                    workflowTask.getName());
-                                    return new TerminateWorkflowException(reason);
+                                    LOGGER.warn(
+                                            "Task {} does not have a definition, using defaults",
+                                            workflowTask.getName());
+                                    return new TaskDef();
                                 });
 
         Map<String, Object> input =

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/SimpleTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/SimpleTaskMapperTest.java
@@ -16,14 +16,11 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
-import com.netflix.conductor.core.exception.TerminateWorkflowException;
 import com.netflix.conductor.core.utils.IDGenerator;
 import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.model.TaskModel;
@@ -38,8 +35,6 @@ public class SimpleTaskMapperTest {
     private SimpleTaskMapper simpleTaskMapper;
 
     private IDGenerator idGenerator = new IDGenerator();
-
-    @Rule public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -78,9 +73,9 @@ public class SimpleTaskMapperTest {
     }
 
     @Test
-    public void getMappedTasksException() {
+    public void getMappedTasksWithNoTaskDefinition() {
 
-        // Given
+        // Given a workflow task without a task definition
         WorkflowTask workflowTask = new WorkflowTask();
         workflowTask.setName("simple_task");
         String taskId = idGenerator.generate();
@@ -101,14 +96,12 @@ public class SimpleTaskMapperTest {
                         .withTaskId(taskId)
                         .build();
 
-        // then
-        expectedException.expect(TerminateWorkflowException.class);
-        expectedException.expectMessage(
-                String.format(
-                        "Invalid task. Task %s does not have a definition",
-                        workflowTask.getName()));
-
         // when
-        simpleTaskMapper.getMappedTasks(taskMapperContext);
+        List<TaskModel> mappedTasks = simpleTaskMapper.getMappedTasks(taskMapperContext);
+
+        // then a task is created with default task definition values
+        assertNotNull(mappedTasks);
+        assertEquals(1, mappedTasks.size());
+        assertEquals(TaskModel.Status.SCHEDULED, mappedTasks.get(0).getStatus());
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [x] Other (please describe): Breaking behavior change — tasks without a definition no longer fail

Changes in this PR
----
Modified `SimpleTaskMapper` to use a default `TaskDef` instead of throwing `TerminateWorkflowException` when a SIMPLE task has no registered task definition. Missing definitions are logged as warnings.

### Breaking Change
> [!CAUTION]
Previously, a SIMPLE task without a registered task definition would fail immediately with a `TerminateWorkflowException`. After this change, the task will proceed with default `TaskDef` values:

- 3 retries
- 60s retry delay
- 1hr response timeout
- FIXED retry logic
- TIME_OUT_WF timeout policy

Workflows that relied on the fail-fast behavior to catch misconfigured tasks will no longer fail at mapping time.

### Files changed

- `core/src/main/java/.../mapper/SimpleTaskMapper.java` — replaced `orElseThrow` with `orElseGet(() -> new TaskDef())`, removed unused `TerminateWorkflowException` import
- `core/src/test/java/.../mapper/SimpleTaskMapperTest.java` — replaced exception test with a test verifying successful mapping using default `TaskDef`

🤖 Generated with [Claude Code](https://claude.com/claude-code)