### PR TITLE
fix: propagate NotFound and Conflict exceptions directly

### DIFF
--- a/mysql-persistence/src/main/java/com/netflix/conductor/mysql/dao/MySQLBaseDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/mysql/dao/MySQLBaseDAO.java
@@ -27,7 +27,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.retry.support.RetryTemplate;
 
+import com.netflix.conductor.core.exception.ConflictException;
 import com.netflix.conductor.core.exception.NonTransientException;
+import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.mysql.util.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -98,8 +100,9 @@ public abstract class MySQLBaseDAO {
      * TransactionalFunction#apply(Connection)}.
      *
      * <p>If any {@link Throwable} thrown from {@code TransactionalFunction#apply(Connection)} will
-     * result in a rollback of the transaction and will be wrapped in an {@link
-     * NonTransientException} if it is not already one.
+     * result in a rollback of the transaction. Domain exceptions ({@link NotFoundException} and
+     * {@link ConflictException}) and {@link NonTransientException} are propagated unchanged. Other
+     * errors are wrapped in a {@link NonTransientException}.
      *
      * <p>Generally this is used to wrap multiple {@link #execute(Connection, String,
      * ExecuteFunction)} or {@link #query(Connection, String, QueryFunction)} invocations that
@@ -124,8 +127,14 @@ public abstract class MySQLBaseDAO {
                 return result;
             } catch (Throwable th) {
                 tx.rollback();
-                if (th instanceof NonTransientException) {
-                    throw th;
+                if (th instanceof NotFoundException notFoundException) {
+                    throw notFoundException;
+                }
+                if (th instanceof ConflictException conflictException) {
+                    throw conflictException;
+                }
+                if (th instanceof NonTransientException nonTransientException) {
+                    throw nonTransientException;
                 }
                 throw new NonTransientException(th.getMessage(), th);
             } finally {
@@ -145,6 +154,15 @@ public abstract class MySQLBaseDAO {
         try {
             return retryTemplate.execute(context -> getWithTransaction(function));
         } catch (Exception e) {
+            if (e instanceof NotFoundException notFoundException) {
+                throw notFoundException;
+            }
+            if (e instanceof ConflictException conflictException) {
+                throw conflictException;
+            }
+            if (e instanceof NonTransientException nonTransientException) {
+                throw nonTransientException;
+            }
             throw new NonTransientException(e.getMessage(), e);
         }
     }

--- a/mysql-persistence/src/test/java/com/netflix/conductor/mysql/dao/MySQLMetadataDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/mysql/dao/MySQLMetadataDAOTest.java
@@ -36,7 +36,8 @@ import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
 import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
-import com.netflix.conductor.core.exception.NonTransientException;
+import com.netflix.conductor.core.exception.ConflictException;
+import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.mysql.config.MySQLConfiguration;
 
 import static org.junit.Assert.assertEquals;
@@ -75,18 +76,17 @@ public class MySQLMetadataDAOTest {
 
         metadataDAO.createWorkflowDef(def);
 
-        NonTransientException applicationException =
-                assertThrows(NonTransientException.class, () -> metadataDAO.createWorkflowDef(def));
+        ConflictException applicationException =
+                assertThrows(ConflictException.class, () -> metadataDAO.createWorkflowDef(def));
         assertEquals(
                 "Workflow with testDuplicate.1 already exists!", applicationException.getMessage());
     }
 
     @Test
     public void testRemoveNotExistingWorkflowDef() {
-        NonTransientException applicationException =
+        NotFoundException applicationException =
                 assertThrows(
-                        NonTransientException.class,
-                        () -> metadataDAO.removeWorkflowDef("test", 1));
+                        NotFoundException.class, () -> metadataDAO.removeWorkflowDef("test", 1));
         assertEquals(
                 "No such workflow definition: test version: 1", applicationException.getMessage());
     }
@@ -231,9 +231,9 @@ public class MySQLMetadataDAOTest {
 
     @Test
     public void testRemoveNotExistingTaskDef() {
-        NonTransientException applicationException =
+        NotFoundException applicationException =
                 assertThrows(
-                        NonTransientException.class,
+                        NotFoundException.class,
                         () -> metadataDAO.removeTaskDef("test" + UUID.randomUUID().toString()));
         assertEquals("No such task definition", applicationException.getMessage());
     }

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresBaseDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresBaseDAO.java
@@ -27,7 +27,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.retry.support.RetryTemplate;
 
+import com.netflix.conductor.core.exception.ConflictException;
 import com.netflix.conductor.core.exception.NonTransientException;
+import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.postgres.util.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -98,8 +100,9 @@ public abstract class PostgresBaseDAO {
      * TransactionalFunction#apply(Connection)}.
      *
      * <p>If any {@link Throwable} thrown from {@code TransactionalFunction#apply(Connection)} will
-     * result in a rollback of the transaction and will be wrapped in an {@link
-     * NonTransientException} if it is not already one.
+     * result in a rollback of the transaction. Domain exceptions ({@link NotFoundException} and
+     * {@link ConflictException}) and {@link NonTransientException} are propagated unchanged. Other
+     * errors are wrapped in a {@link NonTransientException}.
      *
      * <p>Generally this is used to wrap multiple {@link #execute(Connection, String,
      * ExecuteFunction)} or {@link #query(Connection, String, QueryFunction)} invocations that
@@ -124,8 +127,14 @@ public abstract class PostgresBaseDAO {
                 return result;
             } catch (Throwable th) {
                 tx.rollback();
-                if (th instanceof NonTransientException) {
-                    throw th;
+                if (th instanceof NotFoundException notFoundException) {
+                    throw notFoundException;
+                }
+                if (th instanceof ConflictException conflictException) {
+                    throw conflictException;
+                }
+                if (th instanceof NonTransientException nonTransientException) {
+                    throw nonTransientException;
                 }
                 throw new NonTransientException(th.getMessage(), th);
             } finally {
@@ -145,6 +154,15 @@ public abstract class PostgresBaseDAO {
         try {
             return retryTemplate.execute(context -> getWithTransaction(function));
         } catch (Exception e) {
+            if (e instanceof NotFoundException notFoundException) {
+                throw notFoundException;
+            }
+            if (e instanceof ConflictException conflictException) {
+                throw conflictException;
+            }
+            if (e instanceof NonTransientException nonTransientException) {
+                throw nonTransientException;
+            }
             throw new NonTransientException(e.getMessage(), e);
         }
     }

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAOTest.java
@@ -38,7 +38,8 @@ import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
 import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
-import com.netflix.conductor.core.exception.NonTransientException;
+import com.netflix.conductor.core.exception.ConflictException;
+import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.postgres.config.PostgresConfiguration;
 
 import static org.junit.Assert.assertEquals;
@@ -77,18 +78,17 @@ public class PostgresMetadataDAOTest {
 
         metadataDAO.createWorkflowDef(def);
 
-        NonTransientException applicationException =
-                assertThrows(NonTransientException.class, () -> metadataDAO.createWorkflowDef(def));
+        ConflictException applicationException =
+                assertThrows(ConflictException.class, () -> metadataDAO.createWorkflowDef(def));
         assertEquals(
                 "Workflow with testDuplicate.1 already exists!", applicationException.getMessage());
     }
 
     @Test
     public void testRemoveNotExistingWorkflowDef() {
-        NonTransientException applicationException =
+        NotFoundException applicationException =
                 assertThrows(
-                        NonTransientException.class,
-                        () -> metadataDAO.removeWorkflowDef("test", 1));
+                        NotFoundException.class, () -> metadataDAO.removeWorkflowDef("test", 1));
         assertEquals(
                 "No such workflow definition: test version: 1", applicationException.getMessage());
     }
@@ -233,9 +233,9 @@ public class PostgresMetadataDAOTest {
 
     @Test
     public void testRemoveNotExistingTaskDef() {
-        NonTransientException applicationException =
+        NotFoundException applicationException =
                 assertThrows(
-                        NonTransientException.class,
+                        NotFoundException.class,
                         () -> metadataDAO.removeTaskDef("test" + UUID.randomUUID().toString()));
         assertEquals("No such task definition", applicationException.getMessage());
     }

--- a/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/dao/SqliteBaseDAO.java
+++ b/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/dao/SqliteBaseDAO.java
@@ -28,7 +28,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.retry.support.RetryTemplate;
 
+import com.netflix.conductor.core.exception.ConflictException;
 import com.netflix.conductor.core.exception.NonTransientException;
+import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.sqlite.util.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -77,6 +79,13 @@ public abstract class SqliteBaseDAO {
         }
     }
 
+    /**
+     * Initialize a transactional connection and apply {@code function}.
+     *
+     * <p>Domain exceptions ({@link NotFoundException} and {@link ConflictException}) and {@link
+     * NonTransientException} are propagated unchanged; all other failures are wrapped as {@link
+     * NonTransientException}.
+     */
     private <R> R getWithTransaction(final TransactionalFunction<R> function) {
         final Instant start = Instant.now();
         LazyToString callingMethod = getCallingMethod();
@@ -98,8 +107,14 @@ public abstract class SqliteBaseDAO {
                 return result;
             } catch (Throwable th) {
                 tx.rollback();
-                if (th instanceof NonTransientException) {
-                    throw th;
+                if (th instanceof NotFoundException notFoundException) {
+                    throw notFoundException;
+                }
+                if (th instanceof ConflictException conflictException) {
+                    throw conflictException;
+                }
+                if (th instanceof NonTransientException nonTransientException) {
+                    throw nonTransientException;
                 }
                 throw new NonTransientException(th.getMessage(), th);
             } finally {
@@ -119,6 +134,15 @@ public abstract class SqliteBaseDAO {
         try {
             return retryTemplate.execute(context -> getWithTransaction(function));
         } catch (Exception e) {
+            if (e instanceof NotFoundException notFoundException) {
+                throw notFoundException;
+            }
+            if (e instanceof ConflictException conflictException) {
+                throw conflictException;
+            }
+            if (e instanceof NonTransientException nonTransientException) {
+                throw nonTransientException;
+            }
             throw new NonTransientException(e.getMessage(), e);
         }
     }

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteMetadataDAOTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteMetadataDAOTest.java
@@ -33,7 +33,8 @@ import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
 import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
-import com.netflix.conductor.core.exception.NonTransientException;
+import com.netflix.conductor.core.exception.ConflictException;
+import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.sqlite.config.SqliteConfiguration;
 import com.netflix.conductor.sqlite.dao.metadata.SqliteMetadataDAO;
 
@@ -69,18 +70,17 @@ public class SqliteMetadataDAOTest {
 
         metadataDAO.createWorkflowDef(def);
 
-        NonTransientException applicationException =
-                assertThrows(NonTransientException.class, () -> metadataDAO.createWorkflowDef(def));
+        ConflictException applicationException =
+                assertThrows(ConflictException.class, () -> metadataDAO.createWorkflowDef(def));
         assertEquals(
                 "Workflow with testDuplicate.1 already exists!", applicationException.getMessage());
     }
 
     @Test
     public void testRemoveNotExistingWorkflowDef() {
-        NonTransientException applicationException =
+        NotFoundException applicationException =
                 assertThrows(
-                        NonTransientException.class,
-                        () -> metadataDAO.removeWorkflowDef("test", 1));
+                        NotFoundException.class, () -> metadataDAO.removeWorkflowDef("test", 1));
         assertEquals(
                 "No such workflow definition: test version: 1", applicationException.getMessage());
     }
@@ -227,9 +227,9 @@ public class SqliteMetadataDAOTest {
 
     @Test
     public void testRemoveNotExistingTaskDef() {
-        NonTransientException applicationException =
+        NotFoundException applicationException =
                 assertThrows(
-                        NonTransientException.class,
+                        NotFoundException.class,
                         () -> metadataDAO.removeTaskDef("test" + UUID.randomUUID().toString()));
         assertEquals("No such task definition", applicationException.getMessage());
     }


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md

Changes in this PR
----
**Fixes:** #172

Allowing Exceptions to propagate. 
(previously everything was thrown as NonTransientException ... getting 500 status code)
Tested in local. workiong good