### PR TITLE
fix: stop PostgresPollDataDAO flush executor on context shutdown

### DIFF
--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresPollDataDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresPollDataDAO.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import javax.sql.DataSource;
@@ -32,11 +33,14 @@ import com.netflix.conductor.postgres.config.PostgresProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 
 public class PostgresPollDataDAO extends PostgresBaseDAO implements PollDataDAO {
 
     private ConcurrentHashMap<String, ConcurrentHashMap<String, PollData>> pollDataCache =
             new ConcurrentHashMap<>();
+
+    private ScheduledExecutorService flushExecutor;
 
     private long pollDataFlushInterval;
 
@@ -66,12 +70,19 @@ public class PostgresPollDataDAO extends PostgresBaseDAO implements PollDataDAO 
     @PostConstruct
     public void schedulePollDataRefresh() {
         if (pollDataFlushInterval > 0) {
-            Executors.newSingleThreadScheduledExecutor()
-                    .scheduleWithFixedDelay(
-                            this::flushData,
-                            pollDataFlushInterval,
-                            pollDataFlushInterval,
-                            TimeUnit.MILLISECONDS);
+            flushExecutor = Executors.newSingleThreadScheduledExecutor();
+            flushExecutor.scheduleWithFixedDelay(
+                    this::flushData,
+                    pollDataFlushInterval,
+                    pollDataFlushInterval,
+                    TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        if (flushExecutor != null) {
+            flushExecutor.shutdownNow();
         }
     }
 

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresPollDataDAOCacheTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresPollDataDAOCacheTest.java
@@ -27,6 +27,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -60,6 +62,7 @@ import static org.junit.Assert.*;
             "spring.flyway.clean-disabled=false"
         })
 @SpringBootTest
+@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 public class PostgresPollDataDAOCacheTest {
 
     @Autowired private PollDataDAO pollDataDAO;


### PR DESCRIPTION
## Flaky Test Fix

`PostgresPollDataDAO` spawned a `ScheduledExecutorService` in `@PostConstruct` but never shut it down. This caused a resource leak and, more critically, **test flakiness**:

1. `PostgresPollDataDAOCacheTest` runs with `pollDataFlushInterval=200ms`, creating a background flush thread
2. Spring's test context cache kept that context (and its thread) alive after all `CacheTest` tests finished
3. When `PostgresPollDataDAONoCacheTest` ran next, its `@Before` truncated `poll_data` and then verified the table was empty
4. The still-running `CacheTest` flush thread re-inserted cached poll data between the truncation and the verification — causing `IllegalStateException: poll_data table still has 1 records after truncation`

## Fix

- **`PostgresPollDataDAO`**: Store the `ScheduledExecutorService` reference and add a `@PreDestroy shutdown()` method so Spring properly stops the thread when the context closes
- **`PostgresPollDataDAOCacheTest`**: Add `@DirtiesContext(classMode = AFTER_CLASS)` so Spring closes (and calls `@PreDestroy` on) that context before `NoCacheTest` starts

## Test plan
- [ ] `./gradlew :conductor-postgres-persistence:test` passes consistently
- [ ] CI build on PR #680 no longer fails with the truncation assertion error

🤖 Generated with [Claude Code](https://claude.com/claude-code)