### PR TITLE
build(deps): bump httpclient5 from 5.2.1 to 5.3.1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,7 +16,7 @@
  */
 ext {
     revActivation = '2.0.1'
-    revApacheHttpComponentsClient5 = '5.2.1'
+    revApacheHttpComponentsClient5 = '5.3.1'
     revAwaitility = '3.1.6'
     revAwsSdk = '2.31.68'
     revBval = '2.0.5'

--- a/os-persistence-v3/build.gradle
+++ b/os-persistence-v3/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-core:2.18.0'
 
     implementation 'org.opensearch.client:opensearch-java:3.5.0'
-    implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.3.1'
     implementation "org.opensearch.client:opensearch-rest-client:3.5.0"
     implementation "org.opensearch.client:opensearch-rest-high-level-client:3.5.0"
 

--- a/springboot-bom-overrides.gradle
+++ b/springboot-bom-overrides.gradle
@@ -19,3 +19,4 @@ ext['elasticsearch.version'] = revElasticSearch7
 
 // SB brings groovy 3.0.x which is not compatible with Spock
 ext['groovy.version'] = revGroovy
+


### PR DESCRIPTION
## Summary

- Bumps \`revApacheHttpComponentsClient5\` from \`5.2.1\` to \`5.3.1\` in \`dependencies.gradle\` (used by \`http-task\`)
- Bumps inline \`httpclient5\` declaration in \`os-persistence-v3\` from \`5.2.1\` to \`5.3.1\`
- \`os-persistence-v2\` left at \`5.2.1\` — intentionally pinned to the OpenSearch 2.x ecosystem

## Why 5.3.1 and not 5.6

Dependabot PR #840 proposed bumping to 5.6. Investigation found two incompatibilities:

1. **httpcore5 version conflict**: \`httpclient5:5.6\` requires \`httpcore5:5.4\` (adds \`ProtocolVersionParser\`). Spring Boot 3.3.11 BOM pins \`httpcore5=5.2.5\` via \`io.spring.dependency-management\`, causing \`NoSuchMethodError\` / \`ClassNotFoundException\` at runtime across \`http-task\` and \`os-persistence-v3\`.

2. **OpenSearch response decompression broken**: Even with \`httpcore5:5.4\` forced via BOM override, \`httpclient5:5.6\` changed content-decompression behavior in a way that breaks \`opensearch-rest-client:3.0.0\` — responses come back GZIP-encoded but Jackson tries to parse them as plain JSON (\`ZipException: Not in GZIP format\` in \`TestOpenSearchRestDAO\`).

5.3.1 is the version already managed by the Spring Boot 3.3.11 BOM, is proven compatible with \`httpcore5:5.2.5\` and \`opensearch-rest-client:3.0.0\`, and is a meaningful upgrade over 5.2.1.

## Test plan

- [ ] \`HttpTaskTest\` and \`HttpTaskUnitTest\` pass
- [ ] \`TestOpenSearchRestDAO\` in \`os-persistence-v3\` passes
- [ ] \`os-persistence-v2\` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)