### PR TITLE
Fix quickstart docs: broken links, missing prereqs, troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Conductor is an open-source, durable workflow engine built at [Netflix](https://
 
 # Get Running in 60 Seconds
 
+**Prerequisites:** [Node.js](https://nodejs.org/) v16+ and [Java](https://adoptium.net/) 21+ must be installed.
+
 ```shell
 npm install -g @conductor-oss/conductor-cli
 conductor server start
@@ -42,7 +44,7 @@ conductor workflow create workflow.json
 conductor workflow start -w hello_workflow --sync
 ```
 
-See the [Quickstart guide](https://conductor-oss.org/quickstart) for the full walkthrough, including writing workers and replaying workflows.
+See the [Quickstart guide](https://docs.conductor-oss.org/quickstart/) for the full walkthrough, including writing workers and replaying workflows.
 
 <details>
 <summary><strong>Prefer Docker?</strong></summary>
@@ -51,7 +53,7 @@ See the [Quickstart guide](https://conductor-oss.org/quickstart) for the full wa
 docker run -p 8080:8080 conductoross/conductor:latest
 ```
 
-All CLI commands have equivalent cURL/API calls. See the [Quickstart](https://conductor-oss.org/quickstart) for details.
+All CLI commands have equivalent cURL/API calls. See the [Quickstart](https://docs.conductor-oss.org/quickstart/) for details.
 </details>
 
 ---

--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -6,7 +6,7 @@ description: Run your first Conductor workflow in 2 minutes. Call an API, parse 
 
 **See a workflow execute in 2 minutes. Build your own in 5.**
 
-You need [Node.js](https://nodejs.org/) (v16+) installed. That's it.
+You need [Node.js](https://nodejs.org/) (v16+) and [Java](https://adoptium.net/) (21+) installed. That's it.
 
 ## Phase 1: See it work
 
@@ -18,6 +18,11 @@ conductor server start
 ```
 
 Wait for the server to start, then open the UI at [http://localhost:8080](http://localhost:8080).
+
+!!! note "Troubleshooting"
+    - **"Java not found" or server won't start?** Install Java 21+ from [Adoptium](https://adoptium.net/) and make sure `java -version` shows 21 or higher.
+    - **Port 8080 already in use?** Start on a different port: `conductor server start --port 9090`
+    - **Prefer Docker?** Skip the CLI server and run: `docker run -p 8080:8080 conductoross/conductor:latest`
 
 ### Define the workflow
 


### PR DESCRIPTION
## Summary

- **Fix broken quickstart links** in README.md — the two links to `conductor-oss.org/quickstart` were returning 404. Updated to `docs.conductor-oss.org/quickstart/`.
- **Add missing prerequisites** — Java 21+ was not listed (README.md and docs/quickstart/index.md). Also added Node.js v16+ to README.md.
- **Add troubleshooting callout** in docs/quickstart/index.md for common issues new users hit: Java not found, port 8080 already in use, and a pointer to the Docker alternative.

## Motivation

New users following the quickstart were hitting dead links and missing prerequisite info, with no guidance when things went wrong. These are small changes that should reduce friction for first-time setup.

## Test plan

- [ ] Verify the quickstart links resolve correctly (https://docs.conductor-oss.org/quickstart/)
- [ ] Confirm the docs site renders the new troubleshooting callout box properly
- [ ] Review prerequisite versions are accurate