### PR TITLE
Add items field to WorkflowTask proto and mapper

### DIFF
--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -1702,6 +1702,9 @@ public abstract class AbstractProtoMapper {
         for (WorkflowTask elem : from.getLoopOver()) {
             to.addLoopOver( toProto(elem) );
         }
+        if (from.getItems() != null) {
+            to.setItems( from.getItems() );
+        }
         if (from.getRetryCount() != null) {
             to.setRetryCount( from.getRetryCount() );
         }
@@ -1760,6 +1763,7 @@ public abstract class AbstractProtoMapper {
         to.setAsyncComplete( from.getAsyncComplete() );
         to.setLoopCondition( from.getLoopCondition() );
         to.setLoopOver( from.getLoopOverList().stream().map(this::fromProto).collect(Collectors.toCollection(ArrayList::new)) );
+        to.setItems( from.getItems() );
         to.setRetryCount( from.getRetryCount() );
         to.setEvaluatorType( from.getEvaluatorType() );
         to.setExpression( from.getExpression() );

--- a/grpc/src/main/proto/model/workflowtask.proto
+++ b/grpc/src/main/proto/model/workflowtask.proto
@@ -39,6 +39,7 @@ message WorkflowTask {
     bool async_complete = 23;
     string loop_condition = 24;
     repeated WorkflowTask loop_over = 25;
+    string items = 33;
     int32 retry_count = 26;
     string evaluator_type = 27;
     string expression = 28;


### PR DESCRIPTION
Add items field to WorkflowTask protobuf definition and update AbstractProtoMapper to handle serialization/deserialization of the items field in both toProto and fromProto methods.

Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
