### PR TITLE
Fix the link to Getting Started in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ conductor workflow create workflow.json
 conductor workflow start -w hello_workflow --sync
 ```
 
-See the [Quickstart guide](https://conductor-oss.org/quickstart) for the full walkthrough, including writing workers and replaying workflows.
+See the [Quickstart guide](https://conductor-oss.github.io/conductor/quickstart/index.html) for the full walkthrough, including writing workers and replaying workflows.
 
 <details>
 <summary><strong>Prefer Docker?</strong></summary>
@@ -53,7 +53,7 @@ See the [Quickstart guide](https://conductor-oss.org/quickstart) for the full wa
 docker run -p 8080:8080 conductoross/conductor:latest
 ```
 
-All CLI commands have equivalent cURL/API calls. See the [Quickstart](https://conductor-oss.org/quickstart) for details.
+All CLI commands have equivalent cURL/API calls. See the [Quickstart](https://conductor-oss.github.io/conductor/quickstart/index.html) for details.
 </details>
 
 ---


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [x] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

Corrected ReadMe file Getting Started links

Alternatives considered
----
N/A

_Describe alternative implementation you have considered_
