### PR TITLE
fix(redis): load Redis connection beans when Redis is used for queues

### DIFF
--- a/redis-configuration/build.gradle
+++ b/redis-configuration/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 
     //Test
     testCompileOnly 'org.projectlombok:lombok:1.18.42'
+    testImplementation 'org.springframework.boot:spring-boot-test'
     testImplementation "org.testcontainers:testcontainers:${revTestContainer}"
     testImplementation "com.google.guava:guava:${revGuava}"
 }

--- a/redis-configuration/src/main/java/com/netflix/conductor/redis/config/RedisClusterConfiguration.java
+++ b/redis-configuration/src/main/java/com/netflix/conductor/redis/config/RedisClusterConfiguration.java
@@ -23,8 +23,8 @@ import javax.net.ssl.SSLContext;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 import com.netflix.conductor.redis.jedis.JedisClusterCommands;
@@ -40,7 +40,7 @@ import redis.clients.jedis.Protocol;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnProperty(name = "conductor.db.type", havingValue = "redis_cluster")
+@Conditional(RedisClusterCondition.class)
 @Slf4j
 public class RedisClusterConfiguration extends RedisConfiguration {
 

--- a/redis-configuration/src/main/java/com/netflix/conductor/redis/config/RedisSentinelCondition.java
+++ b/redis-configuration/src/main/java/com/netflix/conductor/redis/config/RedisSentinelCondition.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.redis.config;
+
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+/**
+ * Condition that matches when Redis Sentinel is needed for EITHER persistence (db.type) OR queuing
+ * (queue.type). Use this for Redis Sentinel connection infrastructure (connection pool,
+ * JedisCommands) that must be available whenever Redis Sentinel is in use, regardless of purpose.
+ */
+public class RedisSentinelCondition extends AnyNestedCondition {
+
+    public RedisSentinelCondition() {
+        super(ConfigurationPhase.PARSE_CONFIGURATION);
+    }
+
+    @ConditionalOnProperty(name = "conductor.db.type", havingValue = "redis_sentinel")
+    static class DbRedisSentinel {}
+
+    @ConditionalOnProperty(name = "conductor.queue.type", havingValue = "redis_sentinel")
+    static class QueueRedisSentinel {}
+}

--- a/redis-configuration/src/main/java/com/netflix/conductor/redis/config/RedisSentinelConfiguration.java
+++ b/redis-configuration/src/main/java/com/netflix/conductor/redis/config/RedisSentinelConfiguration.java
@@ -22,8 +22,8 @@ import javax.net.ssl.SSLContext;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 import com.netflix.conductor.redis.jedis.JedisCommands;
@@ -41,7 +41,7 @@ import redis.clients.jedis.UnifiedJedis;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnProperty(name = "conductor.db.type", havingValue = "redis_sentinel")
+@Conditional(RedisSentinelCondition.class)
 @Slf4j
 public class RedisSentinelConfiguration extends RedisConfiguration {
 

--- a/redis-configuration/src/main/java/com/netflix/conductor/redis/config/RedisStandaloneConfiguration.java
+++ b/redis-configuration/src/main/java/com/netflix/conductor/redis/config/RedisStandaloneConfiguration.java
@@ -15,8 +15,8 @@ package com.netflix.conductor.redis.config;
 import java.time.Duration;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
@@ -35,7 +35,7 @@ import redis.clients.jedis.UnifiedJedis;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnProperty(name = "conductor.db.type", havingValue = "redis_standalone")
+@Conditional(RedisStandaloneCondition.class)
 @Component
 @Slf4j
 public class RedisStandaloneConfiguration extends RedisConfiguration {

--- a/redis-configuration/src/test/java/com/netflix/conductor/redis/config/RedisConnectionConditionTest.java
+++ b/redis-configuration/src/test/java/com/netflix/conductor/redis/config/RedisConnectionConditionTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.redis.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RedisConnectionConditionTest {
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner()
+                    .withUserConfiguration(
+                            StandaloneMarkerConfiguration.class,
+                            ClusterMarkerConfiguration.class,
+                            SentinelMarkerConfiguration.class);
+
+    @Test
+    void standaloneConditionMatchesWhenQueueUsesRedisStandalone() {
+        contextRunner
+                .withPropertyValues("conductor.queue.type=redis_standalone")
+                .run(context -> assertTrue(context.containsBean("standaloneMarker")));
+    }
+
+    @Test
+    void clusterConditionMatchesWhenQueueUsesRedisCluster() {
+        contextRunner
+                .withPropertyValues("conductor.queue.type=redis_cluster")
+                .run(context -> assertTrue(context.containsBean("clusterMarker")));
+    }
+
+    @Test
+    void sentinelConditionMatchesWhenQueueUsesRedisSentinel() {
+        contextRunner
+                .withPropertyValues("conductor.queue.type=redis_sentinel")
+                .run(context -> assertTrue(context.containsBean("sentinelMarker")));
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @Conditional(RedisStandaloneCondition.class)
+    static class StandaloneMarkerConfiguration {
+
+        @Bean
+        String standaloneMarker() {
+            return "standalone";
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @Conditional(RedisClusterCondition.class)
+    static class ClusterMarkerConfiguration {
+
+        @Bean
+        String clusterMarker() {
+            return "cluster";
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @Conditional(RedisSentinelCondition.class)
+    static class SentinelMarkerConfiguration {
+
+        @Bean
+        String sentinelMarker() {
+            return "sentinel";
+        }
+    }
+}


### PR DESCRIPTION
Fixes #991 

## Summary
This fixes a startup regression where Conductor fails to boot when Redis is configured only as the queue backend, such as in the MySQL + Redis Docker Compose setup.

## Root cause
Redis connection configuration classes were only activated when `conductor.db.type` matched a Redis mode, but queue autoconfiguration also requires these beans when `conductor.queue.type` is set to Redis.

## Changes
- make standalone Redis connection config load for queue usage as well
- make cluster Redis connection config load for queue usage as well
- make sentinel Redis connection config load for queue usage as well
- add a sentinel condition class
- add a regression test covering queue-only Redis activation

## Validation
- `./gradlew spotlessApply`
- `./gradlew :conductor-redis-configuration:test --tests com.netflix.conductor.redis.config.RedisConnectionConditionTest`
- `docker compose -f docker/docker-compose-mysql.yaml up --build -d`
- verified `http://localhost:8000/health` returns healthy
