### PR TITLE
feat: wildcard search and sub-workflow filtering

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
@@ -99,6 +99,9 @@ public class WorkflowSummary {
     @ProtoField(id = 21)
     private String idempotencyKey;
 
+    @ProtoField(id = 22)
+    private String parentWorkflowId = "";
+
     public WorkflowSummary() {}
 
     public WorkflowSummary(Workflow workflow) {
@@ -146,6 +149,7 @@ public class WorkflowSummary {
             this.taskToDomain = workflow.getTaskToDomain();
         }
         this.createdBy = workflow.getCreatedBy();
+        this.parentWorkflowId = workflow.getParentWorkflowId() != null ? workflow.getParentWorkflowId() : "";
     }
 
     /**
@@ -386,6 +390,14 @@ public class WorkflowSummary {
         this.idempotencyKey = idempotencyKey;
     }
 
+    public String getParentWorkflowId() {
+        return parentWorkflowId;
+    }
+
+    public void setParentWorkflowId(String parentWorkflowId) {
+        this.parentWorkflowId = parentWorkflowId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -409,7 +421,8 @@ public class WorkflowSummary {
                 && Objects.equals(getReasonForIncompletion(), that.getReasonForIncompletion())
                 && Objects.equals(getEvent(), that.getEvent())
                 && Objects.equals(getCreatedBy(), that.getCreatedBy())
-                && Objects.equals(getTaskToDomain(), that.getTaskToDomain());
+                && Objects.equals(getTaskToDomain(), that.getTaskToDomain())
+                && Objects.equals(getParentWorkflowId(), that.getParentWorkflowId());
     }
 
     @Override
@@ -429,6 +442,7 @@ public class WorkflowSummary {
                 getEvent(),
                 getPriority(),
                 getCreatedBy(),
-                getTaskToDomain());
+                getTaskToDomain(),
+                getParentWorkflowId());
     }
 }

--- a/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
@@ -149,7 +149,8 @@ public class WorkflowSummary {
             this.taskToDomain = workflow.getTaskToDomain();
         }
         this.createdBy = workflow.getCreatedBy();
-        this.parentWorkflowId = workflow.getParentWorkflowId() != null ? workflow.getParentWorkflowId() : "";
+        this.parentWorkflowId =
+                workflow.getParentWorkflowId() != null ? workflow.getParentWorkflowId() : "";
     }
 
     /**

--- a/es7-persistence/src/main/resources/mappings_docType_workflow.json
+++ b/es7-persistence/src/main/resources/mappings_docType_workflow.json
@@ -67,6 +67,11 @@
     "event": {
       "type": "keyword",
       "index": true
+    },
+    "parentWorkflowId": {
+      "type": "keyword",
+      "index": true,
+      "doc_values": true
     }
   }
 }

--- a/es8-persistence/src/main/java/org/conductoross/conductor/es8/dao/query/parser/NameValue.java
+++ b/es8-persistence/src/main/java/org/conductoross/conductor/es8/dao/query/parser/NameValue.java
@@ -101,6 +101,15 @@ public class NameValue extends AbstractNode implements FilterProvider {
             if (value.isSysConstant()) {
                 return systemConstantQuery(value.getSysConstant(), true);
             }
+            String unquoted = value.getUnquotedValue();
+            if (unquoted.contains("*")) {
+                return Query.of(
+                        q ->
+                                q.wildcard(
+                                        w ->
+                                                w.field(name.getName())
+                                                        .value(unquoted)));
+            }
             return Query.of(
                     q ->
                             q.term(

--- a/es8-persistence/src/main/java/org/conductoross/conductor/es8/dao/query/parser/NameValue.java
+++ b/es8-persistence/src/main/java/org/conductoross/conductor/es8/dao/query/parser/NameValue.java
@@ -103,12 +103,7 @@ public class NameValue extends AbstractNode implements FilterProvider {
             }
             String unquoted = value.getUnquotedValue();
             if (unquoted.contains("*")) {
-                return Query.of(
-                        q ->
-                                q.wildcard(
-                                        w ->
-                                                w.field(name.getName())
-                                                        .value(unquoted)));
+                return Query.of(q -> q.wildcard(w -> w.field(name.getName()).value(unquoted)));
             }
             return Query.of(
                     q ->

--- a/es8-persistence/src/main/resources/template_workflow.json
+++ b/es8-persistence/src/main/resources/template_workflow.json
@@ -79,6 +79,10 @@
         },
         "archived": {
           "type": "boolean"
+        },
+        "parentWorkflowId": {
+          "type": "keyword",
+          "index": true
         }
       }
     }

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -1610,6 +1610,9 @@ public abstract class AbstractProtoMapper {
         if (from.getIdempotencyKey() != null) {
             to.setIdempotencyKey( from.getIdempotencyKey() );
         }
+        if (from.getParentWorkflowId() != null) {
+            to.setParentWorkflowId( from.getParentWorkflowId() );
+        }
         return to.build();
     }
 
@@ -1636,6 +1639,7 @@ public abstract class AbstractProtoMapper {
         to.setCreatedBy( from.getCreatedBy() );
         to.setTaskToDomain( from.getTaskToDomainMap() );
         to.setIdempotencyKey( from.getIdempotencyKey() );
+        to.setParentWorkflowId( from.getParentWorkflowId() );
         return to;
     }
 

--- a/grpc/src/main/proto/model/workflowsummary.proto
+++ b/grpc/src/main/proto/model/workflowsummary.proto
@@ -29,4 +29,5 @@ message WorkflowSummary {
     string created_by = 19;
     map<string, string> task_to_domain = 20;
     string idempotency_key = 21;
+    string parent_workflow_id = 22;
 }

--- a/os-persistence-v3/src/main/resources/mappings_docType_workflow.json
+++ b/os-persistence-v3/src/main/resources/mappings_docType_workflow.json
@@ -67,6 +67,11 @@
     "event": {
       "type": "keyword",
       "index": true
+    },
+    "parentWorkflowId": {
+      "type": "keyword",
+      "index": true,
+      "doc_values": true
     }
   }
 }

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresIndexDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresIndexDAO.java
@@ -109,7 +109,10 @@ public class PostgresIndexDAO extends PostgresBaseDAO implements IndexDAO {
                                         .addParameter(startTime)
                                         .addParameter(updateTime)
                                         .addParameter(workflow.getStatus().toString())
-                                        .addParameter(workflow.getParentWorkflowId() != null ? workflow.getParentWorkflowId() : "")
+                                        .addParameter(
+                                                workflow.getParentWorkflowId() != null
+                                                        ? workflow.getParentWorkflowId()
+                                                        : "")
                                         .addJsonParameter(workflow)
                                         .executeUpdate());
         logger.debug("Postgres index workflow rows updated: {}", rowsUpdated);

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresIndexDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresIndexDAO.java
@@ -82,11 +82,11 @@ public class PostgresIndexDAO extends PostgresBaseDAO implements IndexDAO {
     @Override
     public void indexWorkflow(WorkflowSummary workflow) {
         String INSERT_WORKFLOW_INDEX_SQL =
-                "INSERT INTO workflow_index (workflow_id, correlation_id, workflow_type, start_time, update_time, status, json_data)"
-                        + "VALUES (?, ?, ?, ?, ?, ?, ?::JSONB) ON CONFLICT (workflow_id) \n"
+                "INSERT INTO workflow_index (workflow_id, correlation_id, workflow_type, start_time, update_time, status, parent_workflow_id, json_data)"
+                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?::JSONB) ON CONFLICT (workflow_id) \n"
                         + "DO UPDATE SET correlation_id = EXCLUDED.correlation_id, workflow_type = EXCLUDED.workflow_type, "
                         + "start_time = EXCLUDED.start_time, status = EXCLUDED.status, json_data = EXCLUDED.json_data, "
-                        + "update_time = EXCLUDED.update_time "
+                        + "update_time = EXCLUDED.update_time, parent_workflow_id = EXCLUDED.parent_workflow_id "
                         + "WHERE EXCLUDED.update_time >= workflow_index.update_time";
 
         if (onlyIndexOnStatusChange) {
@@ -109,6 +109,7 @@ public class PostgresIndexDAO extends PostgresBaseDAO implements IndexDAO {
                                         .addParameter(startTime)
                                         .addParameter(updateTime)
                                         .addParameter(workflow.getStatus().toString())
+                                        .addParameter(workflow.getParentWorkflowId() != null ? workflow.getParentWorkflowId() : "")
                                         .addJsonParameter(workflow)
                                         .executeUpdate());
         logger.debug("Postgres index workflow rows updated: {}", rowsUpdated);

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilder.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilder.java
@@ -91,7 +91,9 @@ public class PostgresIndexQueryBuilder {
             } else {
                 if (attribute.endsWith("_time")) {
                     return attribute + " " + operator + " ?::TIMESTAMPTZ";
-                } else if (operator.equals("=") && values.size() == 1 && values.get(0).contains("*")) {
+                } else if (operator.equals("=")
+                        && values.size() == 1
+                        && values.get(0).contains("*")) {
                     return attribute + " LIKE ?";
                 } else {
                     return attribute + " " + operator + " ?";

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilder.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilder.java
@@ -50,6 +50,7 @@ public class PostgresIndexQueryBuilder {
         "task_def_name",
         "update_time",
         "json_data",
+        "parent_workflow_id",
         "jsonb_to_tsvector('english', json_data, '[\"all\"]')"
     };
 
@@ -90,6 +91,8 @@ public class PostgresIndexQueryBuilder {
             } else {
                 if (attribute.endsWith("_time")) {
                     return attribute + " " + operator + " ?::TIMESTAMPTZ";
+                } else if (operator.equals("=") && values.size() == 1 && values.get(0).contains("*")) {
+                    return attribute + " LIKE ?";
                 } else {
                     return attribute + " " + operator + " ?";
                 }
@@ -107,7 +110,11 @@ public class PostgresIndexQueryBuilder {
             if (values.size() > 1) {
                 q.addParameter(values);
             } else {
-                q.addParameter(values.get(0));
+                String val = values.get(0);
+                if (val.contains("*")) {
+                    val = val.replace("*", "%");
+                }
+                q.addParameter(val);
             }
         }
 

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V14__parent_workflow_id.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V14__parent_workflow_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE workflow_index ADD COLUMN parent_workflow_id VARCHAR(255) NOT NULL DEFAULT '';
+CREATE INDEX workflow_index_parent_workflow_id_idx ON workflow_index (parent_workflow_id);

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresIndexDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresIndexDAOTest.java
@@ -470,7 +470,8 @@ public class PostgresIndexDAOTest {
         }
 
         List<String> orderBy = Arrays.asList(new String[] {"taskId:DESC"});
-        SearchResult<TaskSummary> results = indexDAO.searchTaskSummary("", "task-id-pagination*", 0, 2, orderBy);
+        SearchResult<TaskSummary> results =
+                indexDAO.searchTaskSummary("", "task-id-pagination*", 0, 2, orderBy);
         assertEquals("Wrong totalHits returned", 5, results.getTotalHits());
         assertEquals("Wrong number of results returned", 2, results.getResults().size());
         assertEquals(
@@ -662,7 +663,8 @@ public class PostgresIndexDAOTest {
         String query = "parentWorkflowId=\"wf-nonexistent-parent\"";
         SearchResult<WorkflowSummary> results =
                 indexDAO.searchWorkflowSummary(query, "*", 0, 15, new ArrayList<>());
-        assertEquals("Should find 0 workflows for nonexistent parent", 0, results.getResults().size());
+        assertEquals(
+                "Should find 0 workflows for nonexistent parent", 0, results.getResults().size());
     }
 
     @Test

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresIndexDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresIndexDAOTest.java
@@ -22,7 +22,6 @@ import java.util.*;
 
 import javax.sql.DataSource;
 
-import org.flywaydb.core.Flyway;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -59,8 +58,7 @@ import static org.junit.Assert.*;
         properties = {
             "conductor.app.asyncIndexingEnabled=false",
             "conductor.elasticsearch.version=0",
-            "conductor.indexing.type=postgres",
-            "spring.flyway.clean-disabled=false"
+            "conductor.indexing.type=postgres"
         })
 @SpringBootTest
 public class PostgresIndexDAOTest {
@@ -73,12 +71,9 @@ public class PostgresIndexDAOTest {
     @Autowired
     private DataSource dataSource;
 
-    @Autowired Flyway flyway;
-
-    // clean the database between tests.
     @Before
     public void before() {
-        flyway.migrate();
+        // Tests share a single database instance; each test scopes its own queries.
     }
 
     private WorkflowSummary getMockWorkflowSummary(String id) {
@@ -433,8 +428,8 @@ public class PostgresIndexDAOTest {
                 "Results returned in wrong order",
                 "workflow-id-pagination-3",
                 results.getResults().get(1).getWorkflowId());
-        results = indexDAO.searchWorkflowSummary("", "*", 2, 2, orderBy);
-        assertEquals("Wrong totalHits returned", 8, results.getTotalHits());
+        results = indexDAO.searchWorkflowSummary("", "workflow-id-pagination*", 2, 2, orderBy);
+        assertEquals("Wrong totalHits returned", 5, results.getTotalHits());
         assertEquals("Wrong number of results returned", 2, results.getResults().size());
         assertEquals(
                 "Results returned in wrong order",
@@ -444,9 +439,9 @@ public class PostgresIndexDAOTest {
                 "Results returned in wrong order",
                 "workflow-id-pagination-1",
                 results.getResults().get(1).getWorkflowId());
-        results = indexDAO.searchWorkflowSummary("", "*", 4, 2, orderBy);
-        assertEquals("Wrong totalHits returned", 8, results.getTotalHits());
-        assertEquals("Wrong number of results returned", 2, results.getResults().size());
+        results = indexDAO.searchWorkflowSummary("", "workflow-id-pagination*", 4, 2, orderBy);
+        assertEquals("Wrong totalHits returned", 5, results.getTotalHits());
+        assertEquals("Wrong number of results returned", 1, results.getResults().size());
         assertEquals(
                 "Results returned in wrong order",
                 "workflow-id-pagination-0",
@@ -475,8 +470,8 @@ public class PostgresIndexDAOTest {
         }
 
         List<String> orderBy = Arrays.asList(new String[] {"taskId:DESC"});
-        SearchResult<TaskSummary> results = indexDAO.searchTaskSummary("", "*", 0, 2, orderBy);
-        assertEquals("Wrong totalHits returned", 10, results.getTotalHits());
+        SearchResult<TaskSummary> results = indexDAO.searchTaskSummary("", "task-id-pagination*", 0, 2, orderBy);
+        assertEquals("Wrong totalHits returned", 5, results.getTotalHits());
         assertEquals("Wrong number of results returned", 2, results.getResults().size());
         assertEquals(
                 "Results returned in wrong order",
@@ -486,8 +481,8 @@ public class PostgresIndexDAOTest {
                 "Results returned in wrong order",
                 "task-id-pagination-3",
                 results.getResults().get(1).getTaskId());
-        results = indexDAO.searchTaskSummary("", "*", 2, 2, orderBy);
-        assertEquals("Wrong totalHits returned", 10, results.getTotalHits());
+        results = indexDAO.searchTaskSummary("", "task-id-pagination*", 2, 2, orderBy);
+        assertEquals("Wrong totalHits returned", 5, results.getTotalHits());
         assertEquals("Wrong number of results returned", 2, results.getResults().size());
         assertEquals(
                 "Results returned in wrong order",
@@ -497,9 +492,9 @@ public class PostgresIndexDAOTest {
                 "Results returned in wrong order",
                 "task-id-pagination-1",
                 results.getResults().get(1).getTaskId());
-        results = indexDAO.searchTaskSummary("", "*", 4, 2, orderBy);
-        assertEquals("Wrong totalHits returned", 10, results.getTotalHits());
-        assertEquals("Wrong number of results returned", 2, results.getResults().size());
+        results = indexDAO.searchTaskSummary("", "task-id-pagination*", 4, 2, orderBy);
+        assertEquals("Wrong totalHits returned", 5, results.getTotalHits());
+        assertEquals("Wrong number of results returned", 1, results.getResults().size());
         assertEquals(
                 "Results returned in wrong order",
                 "task-id-pagination-0",
@@ -568,5 +563,127 @@ public class PostgresIndexDAOTest {
 
         log_records = queryDb("SELECT * FROM task_execution_logs WHERE task_id = '" + taskId + "'");
         assertEquals("Task execution logs were not deleted", 0, log_records.size());
+    }
+
+    private WorkflowSummary getMockWorkflowSummary(String id, String parentWorkflowId) {
+        WorkflowSummary wfs = getMockWorkflowSummary(id);
+        wfs.setParentWorkflowId(parentWorkflowId);
+        return wfs;
+    }
+
+    @Test
+    public void testWildcardSearchWorkflowSummaryByType() {
+        WorkflowSummary wfs1 = getMockWorkflowSummary("wf-wildcard-1");
+        wfs1.setWorkflowType("wc_order_proc_v1");
+        indexDAO.indexWorkflow(wfs1);
+
+        WorkflowSummary wfs2 = getMockWorkflowSummary("wf-wildcard-2");
+        wfs2.setWorkflowType("wc_order_proc_v2");
+        indexDAO.indexWorkflow(wfs2);
+
+        WorkflowSummary wfs3 = getMockWorkflowSummary("wf-wildcard-3");
+        wfs3.setWorkflowType("wc_payment_proc_v1");
+        indexDAO.indexWorkflow(wfs3);
+
+        // Prefix wildcard: should match wfs1 and wfs2
+        String query = "workflowType=wc_order_proc*";
+        SearchResult<WorkflowSummary> results =
+                indexDAO.searchWorkflowSummary(query, "*", 0, 15, new ArrayList<>());
+        assertEquals("Should find 2 wc_order_proc workflows", 2, results.getResults().size());
+
+        // Contains wildcard: should match all 3
+        query = "workflowType=wc_*_proc*";
+        results = indexDAO.searchWorkflowSummary(query, "*", 0, 15, new ArrayList<>());
+        assertEquals("Should find 3 processing workflows", 3, results.getResults().size());
+    }
+
+    @Test
+    public void testWildcardSearchNoMatches() {
+        WorkflowSummary wfs = getMockWorkflowSummary("wf-wildcard-nomatch");
+        wfs.setWorkflowType("nomatch_order_type_v1");
+        indexDAO.indexWorkflow(wfs);
+
+        String query = "workflowType=nomatch_zzz*";
+        SearchResult<WorkflowSummary> results =
+                indexDAO.searchWorkflowSummary(query, "*", 0, 15, new ArrayList<>());
+        assertEquals("Should find 0 workflows", 0, results.getResults().size());
+    }
+
+    @Test
+    public void testSearchExcludeSubWorkflows() {
+        WorkflowSummary topLevel1 = getMockWorkflowSummary("wf-top-1", "");
+        topLevel1.setWorkflowType("subwf_test_type");
+        indexDAO.indexWorkflow(topLevel1);
+
+        WorkflowSummary topLevel2 = getMockWorkflowSummary("wf-top-2", "");
+        topLevel2.setWorkflowType("subwf_test_type");
+        indexDAO.indexWorkflow(topLevel2);
+
+        WorkflowSummary subWf1 = getMockWorkflowSummary("wf-sub-1", "wf-top-1");
+        subWf1.setWorkflowType("subwf_test_type");
+        indexDAO.indexWorkflow(subWf1);
+
+        WorkflowSummary subWf2 = getMockWorkflowSummary("wf-sub-2", "wf-top-1");
+        subWf2.setWorkflowType("subwf_test_type");
+        indexDAO.indexWorkflow(subWf2);
+
+        // Search for top-level only, scoped to our unique type
+        String query = "parentWorkflowId=\"\" AND workflowType=subwf_test_type";
+        SearchResult<WorkflowSummary> results =
+                indexDAO.searchWorkflowSummary(query, "*", 0, 15, new ArrayList<>());
+        assertEquals("Should find only 2 top-level workflows", 2, results.getResults().size());
+    }
+
+    @Test
+    public void testSearchSubWorkflowsOfParent() {
+        WorkflowSummary topLevel = getMockWorkflowSummary("wf-parent-1", "");
+        indexDAO.indexWorkflow(topLevel);
+
+        WorkflowSummary subWf1 = getMockWorkflowSummary("wf-child-1", "wf-parent-1");
+        indexDAO.indexWorkflow(subWf1);
+
+        WorkflowSummary subWf2 = getMockWorkflowSummary("wf-child-2", "wf-parent-1");
+        indexDAO.indexWorkflow(subWf2);
+
+        WorkflowSummary subWf3 = getMockWorkflowSummary("wf-child-3", "wf-parent-other");
+        indexDAO.indexWorkflow(subWf3);
+
+        String query = "parentWorkflowId=\"wf-parent-1\"";
+        SearchResult<WorkflowSummary> results =
+                indexDAO.searchWorkflowSummary(query, "*", 0, 15, new ArrayList<>());
+        assertEquals("Should find 2 child workflows", 2, results.getResults().size());
+    }
+
+    @Test
+    public void testSearchSubWorkflowsWrongParentReturnsEmpty() {
+        WorkflowSummary subWf1 = getMockWorkflowSummary("wf-orphan-1", "wf-parent-1");
+        indexDAO.indexWorkflow(subWf1);
+
+        String query = "parentWorkflowId=\"wf-nonexistent-parent\"";
+        SearchResult<WorkflowSummary> results =
+                indexDAO.searchWorkflowSummary(query, "*", 0, 15, new ArrayList<>());
+        assertEquals("Should find 0 workflows for nonexistent parent", 0, results.getResults().size());
+    }
+
+    @Test
+    public void testWildcardWithParentWorkflowIdFilter() {
+        WorkflowSummary topOrder = getMockWorkflowSummary("wf-combined-1", "");
+        topOrder.setWorkflowType("cmb_order_v1");
+        indexDAO.indexWorkflow(topOrder);
+
+        WorkflowSummary topPayment = getMockWorkflowSummary("wf-combined-2", "");
+        topPayment.setWorkflowType("cmb_payment_v1");
+        indexDAO.indexWorkflow(topPayment);
+
+        WorkflowSummary subOrder = getMockWorkflowSummary("wf-combined-3", "wf-combined-1");
+        subOrder.setWorkflowType("cmb_order_v1");
+        indexDAO.indexWorkflow(subOrder);
+
+        // Only top-level order workflows
+        String query = "parentWorkflowId=\"\" AND workflowType=cmb_order*";
+        SearchResult<WorkflowSummary> results =
+                indexDAO.searchWorkflowSummary(query, "*", 0, 15, new ArrayList<>());
+        assertEquals("Should find 1 top-level order workflow", 1, results.getResults().size());
+        assertEquals("wf-combined-1", results.getResults().get(0).getWorkflowId());
     }
 }

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilderTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilderTest.java
@@ -523,4 +523,104 @@ public class PostgresIndexQueryBuilderTest {
             assertEquals("Incorrectly formatted query string: xyz", e.getMessage());
         }
     }
+
+    @Test
+    void shouldGenerateQueryWithWildcardPrefix() throws SQLException {
+        String inputQuery = "workflowType=abc*";
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data::TEXT FROM table_name WHERE workflow_type LIKE ? LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        builder.addPagingParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("abc%");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldGenerateQueryWithWildcardContains() throws SQLException {
+        String inputQuery = "correlationId=\"*order*\"";
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data::TEXT FROM table_name WHERE correlation_id LIKE ? LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        builder.addPagingParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("%order%");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldGenerateExactMatchQueryWhenNoWildcard() throws SQLException {
+        String inputQuery = "workflowType=abc";
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data::TEXT FROM table_name WHERE workflow_type = ? LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        builder.addPagingParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("abc");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldNotExpandWildcardInINClause() throws SQLException {
+        String inputQuery = "status IN (COMP*,RUNNING)";
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data::TEXT FROM table_name WHERE status = ANY(?) LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        builder.addPagingParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter(new ArrayList<>(List.of("COMP*", "RUNNING")));
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldGenerateQueryForParentWorkflowId() throws SQLException {
+        String inputQuery = "parentWorkflowId=\"\"";
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data::TEXT FROM table_name WHERE parent_workflow_id = ? LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        builder.addPagingParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
 }

--- a/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAO.java
+++ b/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAO.java
@@ -106,7 +106,10 @@ public class SqliteIndexDAO extends SqliteBaseDAO implements IndexDAO {
                                         .addParameter(startTime.toString())
                                         .addParameter(updateTime.toString())
                                         .addParameter(workflow.getStatus().toString())
-                                        .addParameter(workflow.getParentWorkflowId() != null ? workflow.getParentWorkflowId() : "")
+                                        .addParameter(
+                                                workflow.getParentWorkflowId() != null
+                                                        ? workflow.getParentWorkflowId()
+                                                        : "")
                                         .addJsonParameter(workflow)
                                         .executeUpdate());
         logger.debug("Sqlite index workflow rows updated: {}", rowsUpdated);

--- a/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAO.java
+++ b/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAO.java
@@ -79,11 +79,11 @@ public class SqliteIndexDAO extends SqliteBaseDAO implements IndexDAO {
     @Override
     public void indexWorkflow(WorkflowSummary workflow) {
         String INSERT_WORKFLOW_INDEX_SQL =
-                "INSERT INTO workflow_index (workflow_id, correlation_id, workflow_type, start_time, update_time, status, json_data) "
-                        + " VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT (workflow_id) "
+                "INSERT INTO workflow_index (workflow_id, correlation_id, workflow_type, start_time, update_time, status, parent_workflow_id, json_data) "
+                        + " VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT (workflow_id) "
                         + " DO UPDATE SET correlation_id = excluded.correlation_id, workflow_type = excluded.workflow_type, "
                         + " start_time = excluded.start_time, status = excluded.status, json_data = excluded.json_data, "
-                        + " update_time = excluded.update_time "
+                        + " update_time = excluded.update_time, parent_workflow_id = excluded.parent_workflow_id "
                         + " WHERE excluded.update_time >= workflow_index.update_time";
 
         if (onlyIndexOnStatusChange) {
@@ -106,6 +106,7 @@ public class SqliteIndexDAO extends SqliteBaseDAO implements IndexDAO {
                                         .addParameter(startTime.toString())
                                         .addParameter(updateTime.toString())
                                         .addParameter(workflow.getStatus().toString())
+                                        .addParameter(workflow.getParentWorkflowId() != null ? workflow.getParentWorkflowId() : "")
                                         .addJsonParameter(workflow)
                                         .executeUpdate());
         logger.debug("Sqlite index workflow rows updated: {}", rowsUpdated);

--- a/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilder.java
+++ b/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilder.java
@@ -97,7 +97,9 @@ public class SqliteIndexQueryBuilder {
             } else {
                 if (attribute.endsWith("_time")) {
                     return attribute + " " + operator + " datetime(?)";
-                } else if (operator.equals("=") && values.size() == 1 && values.get(0).contains("*")) {
+                } else if (operator.equals("=")
+                        && values.size() == 1
+                        && values.get(0).contains("*")) {
                     return "lower(" + attribute + ") LIKE lower(?)";
                 } else {
                     return attribute + " " + operator + " ?";

--- a/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilder.java
+++ b/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilder.java
@@ -48,7 +48,8 @@ public class SqliteIndexQueryBuilder {
         "task_type",
         "task_def_name",
         "update_time",
-        "json_data"
+        "json_data",
+        "parent_workflow_id"
     };
 
     private static final String[] VALID_SORT_ORDER = {"ASC", "DESC"};
@@ -96,6 +97,8 @@ public class SqliteIndexQueryBuilder {
             } else {
                 if (attribute.endsWith("_time")) {
                     return attribute + " " + operator + " datetime(?)";
+                } else if (operator.equals("=") && values.size() == 1 && values.get(0).contains("*")) {
+                    return "lower(" + attribute + ") LIKE lower(?)";
                 } else {
                     return attribute + " " + operator + " ?";
                 }
@@ -116,7 +119,11 @@ public class SqliteIndexQueryBuilder {
                     q.addParameter(value);
                 }
             } else {
-                q.addParameter(values.get(0));
+                String val = values.get(0);
+                if (val.contains("*")) {
+                    val = val.replace("*", "%");
+                }
+                q.addParameter(val);
             }
         }
 

--- a/sqlite-persistence/src/main/resources/db/migration_sqlite/V2__parent_workflow_id.sql
+++ b/sqlite-persistence/src/main/resources/db/migration_sqlite/V2__parent_workflow_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE workflow_index ADD COLUMN parent_workflow_id TEXT NOT NULL DEFAULT '';
+CREATE INDEX workflow_index_parent_workflow_id_idx ON workflow_index (parent_workflow_id);

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAOTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAOTest.java
@@ -788,7 +788,8 @@ public class SqliteIndexDAOTest {
         String query = "parentWorkflowId=\"wf-nonexistent-parent\"";
         SearchResult<WorkflowSummary> results =
                 indexDAO.searchWorkflowSummary(query, "*", 0, 15, new ArrayList<>());
-        assertEquals("Should find 0 workflows for nonexistent parent", 0, results.getResults().size());
+        assertEquals(
+                "Should find 0 workflows for nonexistent parent", 0, results.getResults().size());
     }
 
     @Test

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAOTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAOTest.java
@@ -697,4 +697,118 @@ public class SqliteIndexDAOTest {
         log_records = queryDb("SELECT * FROM task_execution_logs WHERE task_id = '" + taskId + "'");
         assertEquals("Task execution logs were not deleted", 0, log_records.size());
     }
+
+    private WorkflowSummary getMockWorkflowSummary(String id, String parentWorkflowId) {
+        WorkflowSummary wfs = getMockWorkflowSummary(id);
+        wfs.setParentWorkflowId(parentWorkflowId);
+        return wfs;
+    }
+
+    @Test
+    public void testWildcardSearchWorkflowSummaryByType() {
+        WorkflowSummary wfs1 = getMockWorkflowSummary("wf-wildcard-1");
+        wfs1.setWorkflowType("order_processing_v1");
+        indexDAO.indexWorkflow(wfs1);
+
+        WorkflowSummary wfs2 = getMockWorkflowSummary("wf-wildcard-2");
+        wfs2.setWorkflowType("order_processing_v2");
+        indexDAO.indexWorkflow(wfs2);
+
+        WorkflowSummary wfs3 = getMockWorkflowSummary("wf-wildcard-3");
+        wfs3.setWorkflowType("payment_processing_v1");
+        indexDAO.indexWorkflow(wfs3);
+
+        String query = "workflowType=order_processing*";
+        SearchResult<WorkflowSummary> results =
+                indexDAO.searchWorkflowSummary(query, "*", 0, 15, new ArrayList<>());
+        assertEquals("Should find 2 order_processing workflows", 2, results.getResults().size());
+
+        query = "workflowType=*processing*";
+        results = indexDAO.searchWorkflowSummary(query, "*", 0, 15, new ArrayList<>());
+        assertEquals("Should find 3 processing workflows", 3, results.getResults().size());
+    }
+
+    @Test
+    public void testWildcardSearchNoMatches() {
+        WorkflowSummary wfs = getMockWorkflowSummary("wf-wildcard-nomatch");
+        wfs.setWorkflowType("order_processing_v1");
+        indexDAO.indexWorkflow(wfs);
+
+        String query = "workflowType=payment*";
+        SearchResult<WorkflowSummary> results =
+                indexDAO.searchWorkflowSummary(query, "*", 0, 15, new ArrayList<>());
+        assertEquals("Should find 0 workflows", 0, results.getResults().size());
+    }
+
+    @Test
+    public void testSearchExcludeSubWorkflows() {
+        WorkflowSummary topLevel1 = getMockWorkflowSummary("wf-top-1", "");
+        indexDAO.indexWorkflow(topLevel1);
+
+        WorkflowSummary topLevel2 = getMockWorkflowSummary("wf-top-2", "");
+        indexDAO.indexWorkflow(topLevel2);
+
+        WorkflowSummary subWf1 = getMockWorkflowSummary("wf-sub-1", "wf-top-1");
+        indexDAO.indexWorkflow(subWf1);
+
+        WorkflowSummary subWf2 = getMockWorkflowSummary("wf-sub-2", "wf-top-1");
+        indexDAO.indexWorkflow(subWf2);
+
+        String query = "parentWorkflowId=\"\"";
+        SearchResult<WorkflowSummary> results =
+                indexDAO.searchWorkflowSummary(query, "*", 0, 15, new ArrayList<>());
+        assertEquals("Should find only 2 top-level workflows", 2, results.getResults().size());
+    }
+
+    @Test
+    public void testSearchSubWorkflowsOfParent() {
+        WorkflowSummary topLevel = getMockWorkflowSummary("wf-parent-1", "");
+        indexDAO.indexWorkflow(topLevel);
+
+        WorkflowSummary subWf1 = getMockWorkflowSummary("wf-child-1", "wf-parent-1");
+        indexDAO.indexWorkflow(subWf1);
+
+        WorkflowSummary subWf2 = getMockWorkflowSummary("wf-child-2", "wf-parent-1");
+        indexDAO.indexWorkflow(subWf2);
+
+        WorkflowSummary subWf3 = getMockWorkflowSummary("wf-child-3", "wf-parent-other");
+        indexDAO.indexWorkflow(subWf3);
+
+        String query = "parentWorkflowId=\"wf-parent-1\"";
+        SearchResult<WorkflowSummary> results =
+                indexDAO.searchWorkflowSummary(query, "*", 0, 15, new ArrayList<>());
+        assertEquals("Should find 2 child workflows", 2, results.getResults().size());
+    }
+
+    @Test
+    public void testSearchSubWorkflowsWrongParentReturnsEmpty() {
+        WorkflowSummary subWf1 = getMockWorkflowSummary("wf-orphan-1", "wf-parent-1");
+        indexDAO.indexWorkflow(subWf1);
+
+        String query = "parentWorkflowId=\"wf-nonexistent-parent\"";
+        SearchResult<WorkflowSummary> results =
+                indexDAO.searchWorkflowSummary(query, "*", 0, 15, new ArrayList<>());
+        assertEquals("Should find 0 workflows for nonexistent parent", 0, results.getResults().size());
+    }
+
+    @Test
+    public void testWildcardWithParentWorkflowIdFilter() {
+        WorkflowSummary topOrder = getMockWorkflowSummary("wf-combined-1", "");
+        topOrder.setWorkflowType("order_processing_v1");
+        indexDAO.indexWorkflow(topOrder);
+
+        WorkflowSummary topPayment = getMockWorkflowSummary("wf-combined-2", "");
+        topPayment.setWorkflowType("payment_processing_v1");
+        indexDAO.indexWorkflow(topPayment);
+
+        WorkflowSummary subOrder = getMockWorkflowSummary("wf-combined-3", "wf-combined-1");
+        subOrder.setWorkflowType("order_processing_v1");
+        indexDAO.indexWorkflow(subOrder);
+
+        String query = "parentWorkflowId=\"\" AND workflowType=order*";
+        SearchResult<WorkflowSummary> results =
+                indexDAO.searchWorkflowSummary(query, "*", 0, 15, new ArrayList<>());
+        assertEquals("Should find 1 top-level order workflow", 1, results.getResults().size());
+        assertEquals("wf-combined-1", results.getResults().get(0).getWorkflowId());
+    }
 }

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilderTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilderTest.java
@@ -14,7 +14,6 @@ package com.netflix.conductor.sqlite.util;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilderTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilderTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2023 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.sqlite.util;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import com.netflix.conductor.sqlite.config.SqliteProperties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class SqliteIndexQueryBuilderTest {
+
+    private SqliteProperties properties = new SqliteProperties();
+
+    @Test
+    void shouldGenerateQueryForEmptyString() throws SQLException {
+        SqliteIndexQueryBuilder builder =
+                new SqliteIndexQueryBuilder(
+                        "table_name", "", "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals("SELECT json_data FROM table_name LIMIT ? OFFSET ?", generatedQuery);
+    }
+
+    @Test
+    void shouldGenerateQueryForExactMatch() throws SQLException {
+        String inputQuery = "workflowId=\"abc123\"";
+        SqliteIndexQueryBuilder builder =
+                new SqliteIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data FROM table_name WHERE workflow_id = ? LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        builder.addPagingParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("abc123");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldGenerateQueryWithWildcardPrefix() throws SQLException {
+        String inputQuery = "workflowType=abc*";
+        SqliteIndexQueryBuilder builder =
+                new SqliteIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data FROM table_name WHERE lower(workflow_type) LIKE lower(?) LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        builder.addPagingParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("abc%");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldGenerateQueryWithWildcardContains() throws SQLException {
+        String inputQuery = "correlationId=\"*order*\"";
+        SqliteIndexQueryBuilder builder =
+                new SqliteIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data FROM table_name WHERE lower(correlation_id) LIKE lower(?) LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        builder.addPagingParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("%order%");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldGenerateExactMatchQueryWhenNoWildcard() throws SQLException {
+        String inputQuery = "workflowType=abc";
+        SqliteIndexQueryBuilder builder =
+                new SqliteIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data FROM table_name WHERE workflow_type = ? LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        builder.addPagingParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("abc");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldNotExpandWildcardInINClause() throws SQLException {
+        String inputQuery = "status IN (COMP*,RUNNING)";
+        SqliteIndexQueryBuilder builder =
+                new SqliteIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data FROM table_name WHERE status IN (?,?) LIMIT ? OFFSET ?",
+                generatedQuery);
+    }
+
+    @Test
+    void shouldGenerateQueryForParentWorkflowId() throws SQLException {
+        String inputQuery = "parentWorkflowId=\"\"";
+        SqliteIndexQueryBuilder builder =
+                new SqliteIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data FROM table_name WHERE parent_workflow_id = ? LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        builder.addPagingParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+}

--- a/ui-next/src/pages/executions/WorkflowSearch.tsx
+++ b/ui-next/src/pages/executions/WorkflowSearch.tsx
@@ -53,6 +53,10 @@ export default function WorkflowPanel() {
   const [asQuery, setAsQuery] = useQueryState("asQuery", false);
   const [freeText, setFreeText] = useQueryState("freeText", "");
   const [status, setStatus] = useQueryState<string[]>("status", []);
+  const [excludeSubWorkflows, setExcludeSubWorkflows] = useQueryState(
+    "excludeSubWorkflows",
+    false,
+  );
   const [openDateSelect, setOpenDateSelect] = useState(false);
   const [openStartDatePicker, setStartOpenDatePicker] = useState(false);
   const [openEndDatePicker, setEndOpenDatePicker] = useState(false);
@@ -207,6 +211,8 @@ export default function WorkflowPanel() {
             setFreeText={setFreeText}
             status={status}
             setStatus={setStatus}
+            excludeSubWorkflows={excludeSubWorkflows}
+            setExcludeSubWorkflows={setExcludeSubWorkflows}
             startTimeFrom={startTimeFrom}
             setStartTimeFrom={setStartTimeFrom}
             onStartFromChange={onStartFromChange}

--- a/ui-next/src/pages/executions/workflowSearchComponents/BasicSearch.tsx
+++ b/ui-next/src/pages/executions/workflowSearchComponents/BasicSearch.tsx
@@ -1,8 +1,10 @@
 import {
   Box,
   FormControl,
+  FormControlLabel,
   Grid,
   InputLabel,
+  Switch,
   useMediaQuery,
 } from "@mui/material";
 import { Theme } from "@mui/material/styles";
@@ -75,6 +77,8 @@ export interface BasicSearchProps {
   setStartOpenDatePicker: (val: boolean) => void;
   openEndDatePicker: boolean;
   setEndOpenDatePicker: (val: boolean) => void;
+  excludeSubWorkflows: boolean;
+  setExcludeSubWorkflows: (val: boolean) => void;
   recentSearches: { start: string; end: string };
 }
 
@@ -108,6 +112,8 @@ export default function BasicSearch({
   setStartOpenDatePicker,
   openEndDatePicker,
   setEndOpenDatePicker,
+  excludeSubWorkflows,
+  setExcludeSubWorkflows,
   recentSearches,
 }: BasicSearchProps) {
   const [page, setPage] = useQueryState("page", 1);
@@ -180,6 +186,7 @@ export default function BasicSearch({
     setModifiedTo("");
     setEndTimeFrom("");
     setEndTimeTo("");
+    setExcludeSubWorkflows(false);
     setToDisplayTime("Now");
     setFromDisplayTime("Last 72 Hours");
   };
@@ -246,6 +253,10 @@ export default function BasicSearch({
       clauses.push(`idempotencyKey IN (${idempotencyKey.join(",")})`);
     }
 
+    if (excludeSubWorkflows) {
+      clauses.push(`parentWorkflowId=""`);
+    }
+
     return {
       query: clauses.join(" AND "),
       freeText: _isEmpty(freeText) ? "*" : freeText,
@@ -263,6 +274,7 @@ export default function BasicSearch({
     idempotencyKey,
     endTimeFrom,
     endTimeTo,
+    excludeSubWorkflows,
   ]);
 
   const [queryFT, setQueryFT] = useState(buildQuery);
@@ -610,7 +622,7 @@ export default function BasicSearch({
                 xs: 12,
                 sm: 6,
                 md: 6,
-                lg: 3,
+                lg: 2,
               }}
             >
               <ConductorInput
@@ -623,12 +635,38 @@ export default function BasicSearch({
             </Grid>
             <Grid
               display="flex"
+              alignItems="end"
+              size={{
+                xs: 12,
+                sm: 6,
+                md: 3,
+                lg: 2,
+              }}
+            >
+              <FormControlLabel
+                sx={{ whiteSpace: "nowrap", mb: 0.5 }}
+                control={
+                  <Switch
+                    color="primary"
+                    checked={excludeSubWorkflows}
+                    onChange={(e) => setExcludeSubWorkflows(e.target.checked)}
+                    size="small"
+                  />
+                }
+                label="Exclude sub-workflows"
+                slotProps={{
+                  typography: { variant: "body2" },
+                }}
+              />
+            </Grid>
+            <Grid
+              display="flex"
               justifyContent="end"
               size={{
                 xs: 12,
                 sm: 6,
-                md: 6,
-                lg: 3,
+                md: 3,
+                lg: 2,
               }}
             >
               <Grid size={5}>


### PR DESCRIPTION
## Summary

- **Wildcard search**: `workflowType=order*` now works across all backends (Postgres, SQLite, ES7, ES8, OpenSearch). Postgres/SQLite translate `*` to SQL `LIKE %`. ES7/OpenSearch already support Lucene wildcards natively. ES8 now uses `wildcard` query instead of `term` when `*` is detected.
- **Sub-workflow filtering**: `parentWorkflowId` is now an indexed, queryable field. Top-level workflows store `""`, sub-workflows store the parent's ID. Query with `parentWorkflowId=""` to exclude sub-workflows.
- **UI toggle**: "Exclude sub-workflows" switch added to the workflow search BasicSearch filter bar.

### Backend changes
- `WorkflowSummary`: added `parentWorkflowId` field (`@ProtoField(id=22)`) + proto/gRPC mapping
- Flyway migrations: Postgres V14, SQLite V2 — adds `parent_workflow_id` column + index
- ES7/ES8/OpenSearch: added `parentWorkflowId` keyword mapping
- `PostgresIndexQueryBuilder` / `SqliteIndexQueryBuilder`: wildcard `*` in `=` operator emits `LIKE` with `%` substitution; `parent_workflow_id` added to valid fields
- `PostgresIndexDAO` / `SqliteIndexDAO`: persist `parentWorkflowId` in INSERT/UPSERT
- ES8 `NameValue`: detect `*` in EQUALS values and use `wildcard` query instead of `term`

### UI changes
- `WorkflowSearch.tsx`: new `excludeSubWorkflows` URL query state
- `BasicSearch.tsx`: toggle switch + `parentWorkflowId=""` clause in `buildQuery()`