### PR TITLE
Fix standalone and sentinel Redis command retries

### DIFF
--- a/redis-configuration/src/main/java/com/netflix/conductor/redis/config/RedisSentinelConfiguration.java
+++ b/redis-configuration/src/main/java/com/netflix/conductor/redis/config/RedisSentinelConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.netflix.conductor.redis.jedis.JedisCommands;
+import com.netflix.conductor.redis.jedis.RetryingJedisCommands;
 import com.netflix.conductor.redis.jedis.UnifiedJedisCommands;
 import com.netflix.dyno.connectionpool.Host;
 
@@ -46,8 +47,9 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 public class RedisSentinelConfiguration extends RedisConfiguration {
 
     @Bean
-    public JedisCommands getJedisCommands(UnifiedJedis unifiedJedis) {
-        return new UnifiedJedisCommands(unifiedJedis);
+    public JedisCommands getJedisCommands(
+            UnifiedJedis unifiedJedis, RedisProperties redisProperties) {
+        return RetryingJedisCommands.wrap(new UnifiedJedisCommands(unifiedJedis), redisProperties);
     }
 
     @Override

--- a/redis-configuration/src/main/java/com/netflix/conductor/redis/config/RedisStandaloneConfiguration.java
+++ b/redis-configuration/src/main/java/com/netflix/conductor/redis/config/RedisStandaloneConfiguration.java
@@ -21,6 +21,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
 import com.netflix.conductor.redis.jedis.JedisCommands;
+import com.netflix.conductor.redis.jedis.RetryingJedisCommands;
 import com.netflix.conductor.redis.jedis.UnifiedJedisCommands;
 import com.netflix.dyno.connectionpool.Host;
 
@@ -45,8 +46,9 @@ public class RedisStandaloneConfiguration extends RedisConfiguration {
     }
 
     @Bean
-    public JedisCommands getJedisCommands(UnifiedJedis unifiedJedis) {
-        return new UnifiedJedisCommands(unifiedJedis);
+    public JedisCommands getJedisCommands(
+            UnifiedJedis unifiedJedis, RedisProperties redisProperties) {
+        return RetryingJedisCommands.wrap(new UnifiedJedisCommands(unifiedJedis), redisProperties);
     }
 
     @Override

--- a/redis-configuration/src/main/java/com/netflix/conductor/redis/jedis/RetryingJedisCommands.java
+++ b/redis-configuration/src/main/java/com/netflix/conductor/redis/jedis/RetryingJedisCommands.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.redis.jedis;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Locale;
+import java.util.Set;
+
+import com.netflix.conductor.redis.config.RedisProperties;
+
+import lombok.extern.slf4j.Slf4j;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.exceptions.JedisDataException;
+
+/**
+ * Adds bounded retries for transient Redis failover errors while preserving the existing {@link
+ * JedisCommands} contract.
+ */
+@Slf4j
+public final class RetryingJedisCommands implements InvocationHandler {
+
+    private static final Set<String> RETRYABLE_MESSAGES =
+            Set.of("READONLY", "MASTERDOWN", "TRYAGAIN", "LOADING");
+
+    private static final long RETRY_DELAY_MILLIS = 100L;
+
+    private final JedisCommands delegate;
+    private final int maxRetryAttempts;
+
+    private RetryingJedisCommands(JedisCommands delegate, int maxRetryAttempts) {
+        this.delegate = delegate;
+        this.maxRetryAttempts = maxRetryAttempts;
+    }
+
+    public static JedisCommands wrap(JedisCommands delegate, RedisProperties redisProperties) {
+        int maxRetryAttempts = redisProperties.getMaxRetryAttempts();
+        if (maxRetryAttempts <= 0) {
+            return delegate;
+        }
+        return (JedisCommands)
+                Proxy.newProxyInstance(
+                        JedisCommands.class.getClassLoader(),
+                        new Class<?>[] {JedisCommands.class},
+                        new RetryingJedisCommands(delegate, maxRetryAttempts));
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if (method.getDeclaringClass() == Object.class) {
+            return method.invoke(delegate, args);
+        }
+
+        int attempt = 0;
+        while (true) {
+            try {
+                return method.invoke(delegate, args);
+            } catch (InvocationTargetException e) {
+                RuntimeException failure = toRuntimeException(e);
+                if (!isRetryable(failure) || attempt >= maxRetryAttempts) {
+                    throw failure;
+                }
+
+                attempt++;
+                log.debug(
+                        "Retrying Redis command {} after transient failover error (attempt {}/{})",
+                        method.getName(),
+                        attempt,
+                        maxRetryAttempts,
+                        failure);
+                sleepBeforeRetry(failure);
+            }
+        }
+    }
+
+    static boolean isRetryable(RuntimeException exception) {
+        if (exception instanceof JedisConnectionException) {
+            return true;
+        }
+        if (!(exception instanceof JedisDataException)) {
+            return false;
+        }
+
+        String message = exception.getMessage();
+        if (message == null) {
+            return false;
+        }
+        String normalized = message.toUpperCase(Locale.ROOT);
+        return RETRYABLE_MESSAGES.stream().anyMatch(normalized::contains);
+    }
+
+    private static RuntimeException toRuntimeException(InvocationTargetException exception) {
+        Throwable cause = exception.getTargetException();
+        if (cause instanceof RuntimeException runtimeException) {
+            return runtimeException;
+        }
+        return new IllegalStateException(
+                "Unexpected checked exception invoking JedisCommands", cause);
+    }
+
+    private static void sleepBeforeRetry(RuntimeException failure) {
+        try {
+            Thread.sleep(RETRY_DELAY_MILLIS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw failure;
+        }
+    }
+}

--- a/redis-configuration/src/test/java/com/netflix/conductor/redis/config/RedisStandaloneConfigurationTest.java
+++ b/redis-configuration/src/test/java/com/netflix/conductor/redis/config/RedisStandaloneConfigurationTest.java
@@ -20,7 +20,6 @@ import org.testcontainers.utility.DockerImageName;
 
 import com.netflix.conductor.core.config.ConductorProperties;
 import com.netflix.conductor.redis.jedis.JedisCommands;
-import com.netflix.conductor.redis.jedis.UnifiedJedisCommands;
 
 import redis.clients.jedis.UnifiedJedis;
 
@@ -72,18 +71,17 @@ class RedisStandaloneConfigurationTest {
     }
 
     @Test
-    void getJedisCommands_returnsUnifiedJedisCommands() {
+    void getJedisCommands_returnsJedisCommands() {
         UnifiedJedis jedis = config.createUnifiedJedis(properties);
-        JedisCommands commands = config.getJedisCommands(jedis);
+        JedisCommands commands = config.getJedisCommands(jedis, properties);
 
         assertNotNull(commands);
-        assertInstanceOf(UnifiedJedisCommands.class, commands);
     }
 
     @Test
     void getJedisCommands_canPerformOperations() {
         UnifiedJedis jedis = config.createUnifiedJedis(properties);
-        JedisCommands commands = config.getJedisCommands(jedis);
+        JedisCommands commands = config.getJedisCommands(jedis, properties);
 
         commands.set("cmd-test-key", "value");
         assertEquals("value", commands.get("cmd-test-key"));

--- a/redis-configuration/src/test/java/com/netflix/conductor/redis/jedis/RetryingJedisCommandsTest.java
+++ b/redis-configuration/src/test/java/com/netflix/conductor/redis/jedis/RetryingJedisCommandsTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.redis.jedis;
+
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.redis.config.RedisProperties;
+
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.exceptions.JedisDataException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RetryingJedisCommandsTest {
+
+    @Test
+    void wrapReturnsDelegateWhenRetriesDisabled() {
+        JedisCommands delegate = delegate(Map.of("get", args -> "value"));
+
+        JedisCommands wrapped = RetryingJedisCommands.wrap(delegate, redisProperties(0));
+
+        assertSame(delegate, wrapped);
+    }
+
+    @Test
+    void retriesConnectionExceptionUntilSuccess() {
+        AtomicInteger attempts = new AtomicInteger();
+        JedisCommands delegate =
+                delegate(
+                        Map.of(
+                                "get",
+                                args -> {
+                                    if (attempts.getAndIncrement() == 0) {
+                                        throw new JedisConnectionException("socket closed");
+                                    }
+                                    return "value";
+                                }));
+
+        JedisCommands wrapped = RetryingJedisCommands.wrap(delegate, redisProperties(1));
+
+        assertEquals("value", wrapped.get("key"));
+        assertEquals(2, attempts.get());
+    }
+
+    @Test
+    void retriesFailoverDataExceptionUntilSuccess() {
+        AtomicInteger attempts = new AtomicInteger();
+        JedisCommands delegate =
+                delegate(
+                        Map.of(
+                                "set",
+                                args -> {
+                                    if (attempts.getAndIncrement() == 0) {
+                                        throw new JedisDataException(
+                                                "READONLY You can't write against a read only replica.");
+                                    }
+                                    return "OK";
+                                }));
+
+        JedisCommands wrapped = RetryingJedisCommands.wrap(delegate, redisProperties(1));
+
+        assertEquals("OK", wrapped.set("key", "value"));
+        assertEquals(2, attempts.get());
+    }
+
+    @Test
+    void doesNotRetryNonRetryableDataException() {
+        AtomicInteger attempts = new AtomicInteger();
+        JedisCommands delegate =
+                delegate(
+                        Map.of(
+                                "get",
+                                args -> {
+                                    attempts.incrementAndGet();
+                                    throw new JedisDataException(
+                                            "WRONGTYPE Operation against a key holding the wrong kind of value");
+                                }));
+
+        JedisCommands wrapped = RetryingJedisCommands.wrap(delegate, redisProperties(3));
+
+        JedisDataException exception =
+                assertThrows(JedisDataException.class, () -> wrapped.get("key"));
+        assertTrue(exception.getMessage().contains("WRONGTYPE"));
+        assertEquals(1, attempts.get());
+    }
+
+    @Test
+    void retriesEvalshaPath() {
+        AtomicInteger attempts = new AtomicInteger();
+        JedisCommands delegate =
+                delegate(
+                        Map.of(
+                                "evalsha",
+                                args -> {
+                                    if (attempts.getAndIncrement() == 0) {
+                                        throw new JedisConnectionException("failover in progress");
+                                    }
+                                    return List.of("message-1");
+                                }));
+
+        JedisCommands wrapped = RetryingJedisCommands.wrap(delegate, redisProperties(1));
+
+        assertEquals(
+                List.of("message-1"),
+                wrapped.evalsha("sha1", List.of("queue"), List.of("1", "2", "3")));
+        assertEquals(2, attempts.get());
+    }
+
+    private static RedisProperties redisProperties(int maxRetryAttempts) {
+        RedisProperties redisProperties = new RedisProperties(new ConductorProperties());
+        redisProperties.setMaxRetryAttempts(maxRetryAttempts);
+        return redisProperties;
+    }
+
+    private static JedisCommands delegate(Map<String, Invocation> methods) {
+        return (JedisCommands)
+                Proxy.newProxyInstance(
+                        JedisCommands.class.getClassLoader(),
+                        new Class<?>[] {JedisCommands.class},
+                        (proxy, method, args) -> {
+                            if (method.getDeclaringClass() == Object.class) {
+                                return switch (method.getName()) {
+                                    case "toString" -> "RetryingJedisCommandsTestDelegate";
+                                    case "hashCode" -> System.identityHashCode(proxy);
+                                    case "equals" -> proxy == args[0];
+                                    default -> null;
+                                };
+                            }
+                            Invocation invocation = methods.get(method.getName());
+                            if (invocation == null) {
+                                throw new UnsupportedOperationException(method.getName());
+                            }
+                            return invocation.invoke(args);
+                        });
+    }
+
+    @FunctionalInterface
+    private interface Invocation {
+        Object invoke(Object[] args) throws Throwable;
+    }
+}


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
This PR adds bounded retries to the shared `JedisCommands` bean used by Redis standalone and Redis Sentinel.

Root cause:
`conductor.redis.maxRetryAttempts` was defined, but it was not applied to the non-cluster `UnifiedJedisCommands` path. During Redis Sentinel failover, transient errors such as connection resets, `READONLY`, `MASTERDOWN`, `TRYAGAIN`, and `LOADING` could bubble straight back to Conductor instead of being retried for a short bounded window.

What changed:
- add a `RetryingJedisCommands` decorator driven by `conductor.redis.maxRetryAttempts`
- wrap the shared `JedisCommands` bean for `redis_standalone` and `redis_sentinel`
- retry only transient failover errors
- add unit coverage for retry classification and retries on command paths like `evalsha`
- update configuration tests for the new wrapped `JedisCommands` bean

Impact:
- improves Redis DAO resiliency during standalone and Sentinel failover windows
- improves queue-related Redis command paths that use the shared `JedisCommands` seam
- leaves Redis cluster behavior unchanged in this change set

Validation:
- `./gradlew spotlessApply --no-daemon`
- `./gradlew :conductor-redis-configuration:test :conductor-redis-persistence:test --no-daemon`

Issue #
Fixes #938

Alternatives considered
----
Retrying at the DAO layer was rejected because many DAO methods are multi-step and could duplicate side effects when retried wholesale. Restricting the fix to queue-specific code was also not enough, because the same missing retry behavior affects the broader OSS Redis command path outside the queue implementation.
