### PR TITLE
Use mcp-core instead of mcp and remove dead MCP client code

### DIFF
--- a/ai/build.gradle
+++ b/ai/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     api "com.google.genai:google-genai:1.18.0"
     api "com.networknt:json-schema-validator:${revJSonSchemaValidator}"
 
-    api("io.modelcontextprotocol.sdk:mcp:${revMCP}")
+    api("io.modelcontextprotocol.sdk:mcp-core:${revMCP}")
     api "com.squareup.okhttp3:okhttp:4.12.0"
 
     // Markdown parsing for PDF generation

--- a/ai/src/main/java/org/conductoross/conductor/ai/mcp/MCPService.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/mcp/MCPService.java
@@ -27,7 +27,6 @@ import com.netflix.conductor.common.config.ObjectMapperProvider;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.spec.McpSchema;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -381,15 +380,6 @@ public class MCPService {
             return objectMapper.readTree(jsonData.toString());
         } catch (Exception e) {
             throw new RuntimeException("Failed to parse SSE data as JSON: " + jsonData, e);
-        }
-    }
-
-    /** Closes an HTTP MCP client. */
-    private void closeClient(McpSyncClient client) {
-        try {
-            client.close();
-        } catch (Exception e) {
-            log.warn("Error closing MCP client: {}", e.getMessage());
         }
     }
 


### PR DESCRIPTION
## Summary

This PR replaces `io.modelcontextprotocol.sdk:mcp` with `io.modelcontextprotocol.sdk:mcp-core` in the AI module and removes the only `McpSyncClient` usage from `MCPService`.

## Why

The aggregate `io.modelcontextprotocol.sdk:mcp` artifact pulls in `mcp-json-jackson3`, which introduces Jackson 3 onto the server runtime/image path.

In downstream image scanning, that showed up as new high-severity findings on `tools.jackson.core:jackson-core:3.0.3`, including:

- `CVE-2026-29062`
- `GHSA-2m67-wjpj-xhg9`

This module only needs MCP core/schema types. The only `McpSyncClient` reference in this code was an unused private helper in `MCPService`:

- it was `private`
- it had no call sites
- the active MCP implementation path uses direct HTTP/JSON-RPC via `OkHttpClient`

Because that client cleanup method was dead code, the aggregate `mcp` artifact is unnecessary here.

## Changes

- replace `io.modelcontextprotocol.sdk:mcp` with `io.modelcontextprotocol.sdk:mcp-core`
- remove the unused `McpSyncClient` import
- remove the unused private `closeClient(McpSyncClient client)` helper

## Impact

This is intended as a dependency/runtime cleanup, not a behavior change.

The MCP code in `MCPService` continues to use the same direct HTTP/JSON-RPC path as before, while avoiding the unused Jackson 3 adapter dependency.

## Verification

- `./gradlew test`
- verified that `tools.jackson.core:jackson-core` no longer appears on `:conductor-server:runtimeClasspath`
