### PR TITLE
feat: add useSSL and trustCert fields to GrpcServiceDefDto

### DIFF
--- a/ui-next/src/types/RemoteServiceTypes.ts
+++ b/ui-next/src/types/RemoteServiceTypes.ts
@@ -83,6 +83,8 @@ export interface HttpServiceDefDto extends commonServiceDef {
 export interface GrpcServiceDefDto extends commonServiceDef {
   host: string;
   port: number;
+  useSSL?: boolean;
+  trustCert?: boolean;
 }
 
 export type ServiceDefDto = HttpServiceDefDto & GrpcServiceDefDto;


### PR DESCRIPTION
## Summary
- Add optional `useSSL` and `trustCert` fields to `GrpcServiceDefDto` type
- Needed by the enterprise UI to support SSL configuration checkboxes in the gRPC service registry form

## Related
- Enterprise UI PR: https://github.com/orkes-io/conductor-ui/pull/4144