### PR TITLE
refactor dockerfile for UI

### DIFF
--- a/docker/server/bin/startup.sh
+++ b/docker/server/bin/startup.sh
@@ -13,12 +13,13 @@
 #
 
 # startup.sh - startup script for the server docker image
+if ! [ "$SERVER_ONLY" = "true" ];  then
+    echo "Running Nginx in background"
+    # Start nginx as daemon
+    nginx
+fi
 
 echo "Starting Conductor server"
-
-echo "Running Nginx in background"
-# Start nginx as daemon
-nginx
 
 # Start the server
 cd /app/libs

--- a/docker/ui/Dockerfile
+++ b/docker/ui/Dockerfile
@@ -1,7 +1,10 @@
 #
 # conductor:ui - Conductor UI
 #
-FROM node:20-alpine
+# ===========================================================================================================
+# 1. Build UI
+# ===========================================================================================================
+FROM node:20-alpine AS build
 LABEL maintainer="Orkes OSS <oss@orkes.io>"
 
 # Install the required packages for the node build
@@ -12,17 +15,36 @@ RUN apk update && apk add --no-cache python3 py3-pip make g++
 # Becomes more relevant when using Docker Compose later
 WORKDIR /usr/src/app
 
-# Copies package.json to Docker environment in a separate layer as a performance optimization
-COPY ./ui/package.json ./
-
-# Installs all node packages. Cached unless package.json changes
-RUN yarn install && mkdir -p public && cp -r node_modules/monaco-editor public/
-
 # Copies everything else over to Docker environment
 # node_modules excluded in .dockerignore.
 COPY ./ui .
 
+# Installs all node packages. Cached unless package.json changes
+RUN yarn install && mkdir -p public && cp -r node_modules/monaco-editor public/
+
 # Include monaco sources into bundle (instead of using CDN)
 ENV REACT_APP_MONACO_EDITOR_USING_CDN=false
 ENV REACT_APP_ENABLE_ERRORS_INSPECTOR=true
-CMD [ "yarn", "start" ]
+
+# build project to host on a production web server
+RUN yarn build
+
+# ===========================================================================================================
+# 2. Use Nginx as the production server
+# ===========================================================================================================
+
+FROM nginx:alpine
+
+WORKDIR /usr/share/nginx/html
+
+# copy built project
+COPY --from=build /usr/src/app/build .
+
+# copy default nginx config
+COPY ./docker/server/nginx/nginx.conf /etc/nginx/conf.d/nginx.conf.template 
+COPY ./docker/ui/bin/startup-ui.sh .
+
+EXPOSE 5000
+
+CMD [ "/usr/share/nginx/html/startup-ui.sh" ]
+ENTRYPOINT [ "/bin/sh"]

--- a/docker/ui/Dockerfile
+++ b/docker/ui/Dockerfile
@@ -42,7 +42,7 @@ COPY --from=build /usr/src/app/build .
 
 # copy default nginx config
 COPY ./docker/server/nginx/nginx.conf /etc/nginx/conf.d/nginx.conf.template 
-COPY ./docker/ui/bin/startup-ui.sh .
+COPY ./docker/ui/startup-ui.sh .
 
 EXPOSE 5000
 

--- a/docker/ui/startup-ui.sh
+++ b/docker/ui/startup-ui.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# startup script for the conductor ui docker image
+
+# replace default values in nginx config file. replace `localhost` by placeholder
+# placeholder will be feed by envsubst cmd
+echo "Populate nginx config file"
+sed -i 's,http://localhost:8080,\$WF_SERVER,g' /etc/nginx/conf.d/nginx.conf.template 
+envsubst '$WF_SERVER' < /etc/nginx/conf.d/nginx.conf.template > /etc/nginx/conf.d/default.conf
+
+echo "Starting Conductor UI"
+echo "Port: $PORT"
+echo "Conductor server: $WF_SERVER"
+
+# run nginx
+nginx -g 'daemon off;'


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
- Update UI dockerfile to use built code
- Use ngnix for path rewriting
- allow `WF_SERVER` usage in docker image
- allow to run server only in https://github.com/conductor-oss/conductor/blob/main/docker/server/bin/startup.sh

conductor configuration allow to have a main api and some workers, but the ui is built and ran every time. this update allow to deploy individually ui, server or both.

Issue #

Alternatives considered
- use custom dockerfile to build server only and ui only.
----

_Describe alternative implementation you have considered_
