### PR TITLE
fix: replace broken jq pipeline with plain async start for WORKFLOW_ID capture

### DIFF
--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -286,9 +286,8 @@ Every Conductor workflow execution is fully replayable — restart from the begi
 Take any workflow execution ID from Phase 1 or Phase 2 and restart it:
 
 ```bash
-# The CLI writes "Auto-detected server: ..." to stdout before the JSON.
-# Use tail -1 to skip that line; 2>/dev/null silences stderr.
-WORKFLOW_ID=$(conductor workflow start -w hello_workflow --version 2 --sync 2>/dev/null | tail -1 | jq -r '.workflowId // empty')
+# Start a workflow and capture its ID (printed as a plain UUID)
+WORKFLOW_ID=$(conductor workflow start -w hello_workflow --version 2)
 
 # Restart the entire workflow from the beginning
 curl -X POST "http://localhost:8080/api/workflow/$WORKFLOW_ID/restart"


### PR DESCRIPTION
## Summary

Phase 3 of the quickstart used this command to capture a workflow ID:

\`\`\`bash
WORKFLOW_ID=\$(conductor workflow start -w hello_workflow --version 2 --sync | jq -r '.workflowId // empty' 2>/dev/null)
\`\`\`

This was broken for two reasons:
1. \`--sync\` returns the workflow's output fields, not the full \`WorkflowRun\` struct — so \`.workflowId\` is always empty
2. \`jq\` is not listed as a prerequisite, so users without it get a silent failure

The fix uses async start instead, which prints just the UUID to stdout with no parsing needed:

\`\`\`bash
WORKFLOW_ID=\$(conductor workflow start -w hello_workflow --version 2)
\`\`\`

Closes conductor-oss/getting-started#12

## Test plan
- [ ] \`WORKFLOW_ID=\$(conductor workflow start -w hello_workflow --version 2)\` captures a valid UUID
- [ ] \`curl -X POST "http://localhost:8080/api/workflow/\$WORKFLOW_ID/restart"\` succeeds with the captured ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)