### PR TITLE
feat: add boundary timer fields to WorkflowTask

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowTask.java
@@ -176,6 +176,17 @@ public class WorkflowTask {
     @ProtoField(id = 34)
     private JoinMode joinMode;
 
+    private String boundaryTimerDuration;
+    private String boundaryTimerCompletionStatus;
+    private Map<String, Object> boundaryTimerOutput;
+
+    public String getBoundaryTimerDuration() { return boundaryTimerDuration; }
+    public void setBoundaryTimerDuration(String boundaryTimerDuration) { this.boundaryTimerDuration = boundaryTimerDuration; }
+    public String getBoundaryTimerCompletionStatus() { return boundaryTimerCompletionStatus; }
+    public void setBoundaryTimerCompletionStatus(String boundaryTimerCompletionStatus) { this.boundaryTimerCompletionStatus = boundaryTimerCompletionStatus; }
+    public Map<String, Object> getBoundaryTimerOutput() { return boundaryTimerOutput; }
+    public void setBoundaryTimerOutput(Map<String, Object> boundaryTimerOutput) { this.boundaryTimerOutput = boundaryTimerOutput; }
+
     /**
      * @return the name
      */

--- a/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/BoundaryTimerSection.tsx
+++ b/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/BoundaryTimerSection.tsx
@@ -23,13 +23,10 @@ const BoundaryTimerSection = () => {
     (state) => state.context.taskChanges,
   );
 
-  const inputParameters = (task?.inputParameters as any) ?? {};
-  const boundaryTimerDuration: string =
-    inputParameters.boundaryTimerDuration ?? "";
-  const completionStatus: string =
-    inputParameters.boundaryTimerCompletionStatus ?? "";
+  const boundaryTimerDuration: string = task?.boundaryTimerDuration ?? "";
+  const completionStatus: string = task?.boundaryTimerCompletionStatus ?? "";
 
-  const rawOutput = inputParameters.boundaryTimerOutput;
+  const rawOutput = task?.boundaryTimerOutput;
   const boundaryTimerOutput: string = rawOutput
     ? typeof rawOutput === "string"
       ? rawOutput
@@ -50,7 +47,7 @@ const BoundaryTimerSection = () => {
     } catch {
       // keep as string if not valid JSON yet
     }
-    sendUpdate("inputParameters.boundaryTimerOutput", parsed);
+    sendUpdate("boundaryTimerOutput", parsed);
   };
 
   return (
@@ -67,18 +64,14 @@ const BoundaryTimerSection = () => {
           </MuiTypography>
           <DurationWaitTaskForm
             value={boundaryTimerDuration}
-            onChange={(val) =>
-              sendUpdate("inputParameters.boundaryTimerDuration", val)
-            }
+            onChange={(val) => sendUpdate("boundaryTimerDuration", val)}
           />
         </Grid>
         <Grid size={12}>
           <ConductorAutocompleteVariables
             label="Completion Status"
             value={completionStatus}
-            onChange={(val) =>
-              sendUpdate("inputParameters.boundaryTimerCompletionStatus", val)
-            }
+            onChange={(val) => sendUpdate("boundaryTimerCompletionStatus", val)}
             otherOptions={BOUNDARY_TIMER_STATUSES}
           />
         </Grid>


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

- [x] Add boundaryTimerDuration, boundaryTimerCompletionStatus, and boundaryTimerOutput as top-level fields on WorkflowTask so they are persisted as part of the workflow definition.

- [x] Fix UI (BoundaryTimerSection) to read/write these fields from the top-level task object instead of inputParameters.
