### PR TITLE
perf: Optimize /names-and-versions API with lightweight DAO query

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDefSummary.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDefSummary.java
@@ -35,6 +35,9 @@ public class WorkflowDefSummary implements Comparable<WorkflowDefSummary> {
     @ProtoField(id = 3)
     private Long createTime;
 
+    @ProtoField(id = 4)
+    private Long updateTime;
+
     /**
      * @return the version
      */
@@ -54,6 +57,13 @@ public class WorkflowDefSummary implements Comparable<WorkflowDefSummary> {
      */
     public Long getCreateTime() {
         return createTime;
+    }
+
+    /**
+     * @return the updateTime
+     */
+    public Long getUpdateTime() {
+        return updateTime;
     }
 
     @Override
@@ -78,6 +88,10 @@ public class WorkflowDefSummary implements Comparable<WorkflowDefSummary> {
 
     public void setCreateTime(Long createTime) {
         this.createTime = createTime;
+    }
+
+    public void setUpdateTime(Long updateTime) {
+        this.updateTime = updateTime;
     }
 
     @Override

--- a/core/src/main/java/com/netflix/conductor/dao/MetadataDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/MetadataDAO.java
@@ -12,11 +12,13 @@
  */
 package com.netflix.conductor.dao;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDefSummary;
 
 /** Data access layer for the workflow metadata - task definitions and workflow definitions */
 public interface MetadataDAO {
@@ -86,4 +88,24 @@ public interface MetadataDAO {
      * @return List the latest versions of the workflow definitions
      */
     List<WorkflowDef> getAllWorkflowDefsLatestVersions();
+
+    /**
+     * Returns lightweight summaries (name, version, timestamps) for all workflow definitions,
+     * without loading the full definition bodies. Persistence modules can override this with an
+     * optimized query that skips reading json_data.
+     *
+     * @return List of workflow definition summaries
+     */
+    default List<WorkflowDefSummary> getWorkflowNamesAndVersions() {
+        List<WorkflowDefSummary> summaries = new ArrayList<>();
+        for (WorkflowDef def : getAllWorkflowDefs()) {
+            WorkflowDefSummary summary = new WorkflowDefSummary();
+            summary.setName(def.getName());
+            summary.setVersion(def.getVersion());
+            summary.setCreateTime(def.getCreateTime());
+            summary.setUpdateTime(def.getUpdateTime());
+            summaries.add(summary);
+        }
+        return summaries;
+    }
 }

--- a/core/src/main/java/com/netflix/conductor/service/MetadataServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/MetadataServiceImpl.java
@@ -226,28 +226,12 @@ public class MetadataServiceImpl implements MetadataService {
     }
 
     public Map<String, ? extends Iterable<WorkflowDefSummary>> getWorkflowNamesAndVersions() {
-        List<WorkflowDef> workflowDefs = metadataDAO.getAllWorkflowDefs();
+        List<WorkflowDefSummary> summaries = metadataDAO.getWorkflowNamesAndVersions();
 
         Map<String, TreeSet<WorkflowDefSummary>> retval = new HashMap<>();
-        for (WorkflowDef def : workflowDefs) {
-            String workflowName = def.getName();
-            WorkflowDefSummary summary = fromWorkflowDef(def);
-
-            retval.putIfAbsent(workflowName, new TreeSet<WorkflowDefSummary>());
-
-            TreeSet<WorkflowDefSummary> versions = retval.get(workflowName);
-            versions.add(summary);
+        for (WorkflowDefSummary summary : summaries) {
+            retval.computeIfAbsent(summary.getName(), k -> new TreeSet<>()).add(summary);
         }
-
         return retval;
-    }
-
-    private WorkflowDefSummary fromWorkflowDef(WorkflowDef def) {
-        WorkflowDefSummary summary = new WorkflowDefSummary();
-        summary.setName(def.getName());
-        summary.setVersion(def.getVersion());
-        summary.setCreateTime(def.getCreateTime());
-
-        return summary;
     }
 }

--- a/core/src/main/java/com/netflix/conductor/service/MetadataServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/MetadataServiceImpl.java
@@ -12,11 +12,11 @@
  */
 package com.netflix.conductor.service;
 
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.TreeSet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -228,9 +228,11 @@ public class MetadataServiceImpl implements MetadataService {
     public Map<String, ? extends Iterable<WorkflowDefSummary>> getWorkflowNamesAndVersions() {
         List<WorkflowDefSummary> summaries = metadataDAO.getWorkflowNamesAndVersions();
 
-        Map<String, TreeSet<WorkflowDefSummary>> retval = new HashMap<>();
+        // DAO returns rows pre-sorted by (name, version), so LinkedHashMap + ArrayList
+        // preserves that order without the overhead of TreeSet rebalancing.
+        Map<String, List<WorkflowDefSummary>> retval = new LinkedHashMap<>();
         for (WorkflowDefSummary summary : summaries) {
-            retval.computeIfAbsent(summary.getName(), k -> new TreeSet<>()).add(summary);
+            retval.computeIfAbsent(summary.getName(), k -> new ArrayList<>()).add(summary);
         }
         return retval;
     }

--- a/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
@@ -78,6 +78,7 @@ public class MetadataServiceTest {
             Map<String, TaskDef> taskDefinitions = new HashMap<>();
 
             when(metadataDAO.getAllWorkflowDefs()).thenReturn(mockWorkflowDefs());
+            when(metadataDAO.getWorkflowNamesAndVersions()).thenReturn(mockWorkflowDefSummaries());
 
             Answer<TaskDef> upsertTaskDef =
                     (invocation) -> {
@@ -104,6 +105,18 @@ public class MetadataServiceTest {
                 def.setVersion(i);
                 def.setName("test_workflow_def");
                 retval.add(def);
+            }
+            return retval;
+        }
+
+        private List<WorkflowDefSummary> mockWorkflowDefSummaries() {
+            List<WorkflowDefSummary> retval = new ArrayList<>();
+            for (int i = 5; i > 0; i--) {
+                WorkflowDefSummary summary = new WorkflowDefSummary();
+                summary.setCreateTime(new Date().getTime());
+                summary.setVersion(i);
+                summary.setName("test_workflow_def");
+                retval.add(summary);
             }
             return retval;
         }

--- a/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
@@ -110,8 +110,9 @@ public class MetadataServiceTest {
         }
 
         private List<WorkflowDefSummary> mockWorkflowDefSummaries() {
+            // Sorted ascending by version, matching the DAO contract (ORDER BY name, version)
             List<WorkflowDefSummary> retval = new ArrayList<>();
-            for (int i = 5; i > 0; i--) {
+            for (int i = 1; i <= 5; i++) {
                 WorkflowDefSummary summary = new WorkflowDefSummary();
                 summary.setCreateTime(new Date().getTime());
                 summary.setVersion(i);

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -1544,6 +1544,9 @@ public abstract class AbstractProtoMapper {
         if (from.getCreateTime() != null) {
             to.setCreateTime( from.getCreateTime() );
         }
+        if (from.getUpdateTime() != null) {
+            to.setUpdateTime( from.getUpdateTime() );
+        }
         return to.build();
     }
 
@@ -1552,6 +1555,7 @@ public abstract class AbstractProtoMapper {
         to.setName( from.getName() );
         to.setVersion( from.getVersion() );
         to.setCreateTime( from.getCreateTime() );
+        to.setUpdateTime( from.getUpdateTime() );
         return to;
     }
 

--- a/grpc/src/main/proto/model/workflowdefsummary.proto
+++ b/grpc/src/main/proto/model/workflowdefsummary.proto
@@ -10,4 +10,5 @@ message WorkflowDefSummary {
     string name = 1;
     int32 version = 2;
     int64 create_time = 3;
+    int64 update_time = 4;
 }

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAO.java
@@ -26,6 +26,7 @@ import org.springframework.retry.support.RetryTemplate;
 import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDefSummary;
 import com.netflix.conductor.core.exception.ConflictException;
 import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.dao.EventHandlerDAO;
@@ -220,6 +221,43 @@ public class PostgresMetadataDAO extends PostgresBaseDAO implements MetadataDAO,
         return queryWithTransaction(
                 GET_ALL_WORKFLOW_DEF_LATEST_VERSIONS_QUERY,
                 q -> q.executeAndFetch(WorkflowDef.class));
+    }
+
+    /**
+     * Lightweight query that returns only name, version, and timestamps without deserializing the
+     * full workflow definition JSON. This avoids the CPU and memory cost of parsing large json_data
+     * blobs when only summary metadata is needed.
+     */
+    @Override
+    public List<WorkflowDefSummary> getWorkflowNamesAndVersions() {
+        final String QUERY =
+                "SELECT name, version, created_on, modified_on "
+                        + "FROM meta_workflow_def ORDER BY name, version";
+
+        return queryWithTransaction(
+                QUERY,
+                q ->
+                        q.executeAndFetch(
+                                rs -> {
+                                    List<WorkflowDefSummary> summaries = new ArrayList<>();
+                                    while (rs.next()) {
+                                        WorkflowDefSummary s = new WorkflowDefSummary();
+                                        s.setName(rs.getString("name"));
+                                        s.setVersion(rs.getInt("version"));
+                                        java.sql.Timestamp createdOn =
+                                                rs.getTimestamp("created_on");
+                                        if (createdOn != null) {
+                                            s.setCreateTime(createdOn.getTime());
+                                        }
+                                        java.sql.Timestamp modifiedOn =
+                                                rs.getTimestamp("modified_on");
+                                        if (modifiedOn != null) {
+                                            s.setUpdateTime(modifiedOn.getTime());
+                                        }
+                                        summaries.add(s);
+                                    }
+                                    return summaries;
+                                }));
     }
 
     public List<WorkflowDef> getAllLatest() {

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAOTest.java
@@ -38,6 +38,7 @@ import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
 import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDefSummary;
 import com.netflix.conductor.core.exception.NonTransientException;
 import com.netflix.conductor.postgres.config.PostgresConfiguration;
 
@@ -320,5 +321,39 @@ public class PostgresMetadataDAOTest {
         assertEquals(1, allMap.get("test1").getVersion());
         assertEquals(2, allMap.get("test2").getVersion());
         assertEquals(3, allMap.get("test3").getVersion());
+    }
+
+    @Test
+    public void testGetWorkflowNamesAndVersionsLightweight() {
+        WorkflowDef def = new WorkflowDef();
+        def.setName("wf_alpha");
+        def.setVersion(1);
+        def.setCreateTime(System.currentTimeMillis());
+        def.setUpdateTime(System.currentTimeMillis());
+        metadataDAO.createWorkflowDef(def);
+
+        def.setVersion(2);
+        metadataDAO.createWorkflowDef(def);
+
+        def.setName("wf_beta");
+        def.setVersion(1);
+        metadataDAO.createWorkflowDef(def);
+
+        List<WorkflowDefSummary> summaries = metadataDAO.getWorkflowNamesAndVersions();
+        assertNotNull(summaries);
+
+        // Filter to only our test data since the DB may contain rows from other tests
+        Map<String, List<WorkflowDefSummary>> byName =
+                summaries.stream()
+                        .filter(s -> s.getName().startsWith("wf_"))
+                        .collect(Collectors.groupingBy(WorkflowDefSummary::getName));
+        assertEquals(2, byName.size());
+        assertEquals(2, byName.get("wf_alpha").size());
+        assertEquals(1, byName.get("wf_beta").size());
+
+        for (WorkflowDefSummary s : summaries) {
+            assertNotNull(s.getName());
+            assertTrue(s.getVersion() > 0);
+        }
     }
 }

--- a/ui/cypress/e2e/spec.cy.js
+++ b/ui/cypress/e2e/spec.cy.js
@@ -5,6 +5,9 @@ describe("Landing Page", () => {
     cy.intercept("/api/metadata/workflow", {
       fixture: "metadataWorkflow.json",
     });
+    cy.intercept("/api/metadata/workflow/names-and-versions", {
+      fixture: "metadataWorkflowNamesAndVersions.json",
+    });
     cy.intercept("/api/metadata/taskdefs", { fixture: "metadataTasks.json" });
   });
 

--- a/ui/cypress/fixtures/metadataWorkflowNamesAndVersions.json
+++ b/ui/cypress/fixtures/metadataWorkflowNamesAndVersions.json
@@ -1,0 +1,23 @@
+{
+  "19test009": [
+    {
+      "name": "19test009",
+      "version": 1,
+      "createTime": 1638226947603
+    }
+  ],
+  "ConditionalTerminateWorkflow": [
+    {
+      "name": "ConditionalTerminateWorkflow",
+      "version": 1,
+      "createTime": 1610653237179
+    }
+  ],
+  "Do_While_Workflow_Iteration_Fix": [
+    {
+      "name": "Do_While_Workflow_Iteration_Fix",
+      "version": 1,
+      "createTime": 1654202968736
+    }
+  ]
+}

--- a/ui/src/data/workflow.js
+++ b/ui/src/data/workflow.js
@@ -131,43 +131,29 @@ export function useSaveWorkflow(callbacks) {
 }
 
 export function useWorkflowNames() {
-  const { data } = useWorkflowDefs();
-  // Extract unique names
-  return useMemo(() => {
-    if (data) {
-      const nameSet = new Set(data.map((def) => def.name));
-      return Array.from(nameSet);
-    } else {
-      return [];
-    }
-  }, [data]);
+  const { data } = useFetch(
+    ["workflowNamesAndVersions"],
+    "/metadata/workflow/names-and-versions",
+    { staleTime: STALE_TIME_WORKFLOW_DEFS }
+  );
+  return useMemo(() => (data ? Object.keys(data) : []), [data]);
 }
 
 // Version numbers do not necessarily start, or run contiguously from 1. Could be arbitrary integers e.g. 52335678.
 // By convention they should be monotonic (ever increasing) wrt time.
 export function useWorkflowNamesAndVersions() {
-  const { data, ...rest } = useWorkflowDefs();
+  const { data, ...rest } = useFetch(
+    ["workflowNamesAndVersions"],
+    "/metadata/workflow/names-and-versions",
+    { staleTime: STALE_TIME_WORKFLOW_DEFS }
+  );
 
   const newData = useMemo(() => {
     const retval = new Map();
     if (data) {
-      for (let def of data) {
-        let arr;
-        if (!retval.has(def.name)) {
-          arr = [];
-          retval.set(def.name, arr);
-        } else {
-          arr = retval.get(def.name);
-        }
-        arr.push({
-          version: def.version,
-          createTime: def.createTime,
-          updateTime: def.updateTime,
-        });
+      for (let [name, versions] of Object.entries(data)) {
+        retval.set(name, versions);
       }
-
-      // Sort arrays in place
-      retval.forEach((val) => val.sort());
     }
     return retval;
   }, [data]);


### PR DESCRIPTION
## Summary

- Optimize the `GET /metadata/workflow/names-and-versions` endpoint backend to avoid loading full `WorkflowDef` objects. Previously, this endpoint called `getAllWorkflowDefs()` which runs `SELECT json_data` — reading and deserializing every workflow definition just to extract name, version, and timestamps.
- Add a Postgres-optimized `getWorkflowNamesAndVersions()` DAO override that queries only `SELECT name, version, created_on, modified_on` — no `json_data` TOAST column read, no JSON deserialization.
- Replace `HashMap + TreeSet` with `LinkedHashMap + ArrayList` in the service layer, leveraging the pre-sorted data from the DAO to avoid TreeSet rebalancing overhead.
- Add `updateTime` field to `WorkflowDefSummary` with gRPC/protobuf compatibility.

## Changes

### Backend
- **`MetadataDAO`**: Added `default getWorkflowNamesAndVersions()` method — backward-compatible fallback that iterates `getAllWorkflowDefs()` and constructs `WorkflowDefSummary` objects
- **`PostgresMetadataDAO`**: Optimized override using `SELECT name, version, created_on, modified_on FROM meta_workflow_def ORDER BY name, version` — no `json_data` column, no deserialization
- **`MetadataServiceImpl`**: Rewritten `getWorkflowNamesAndVersions()` to call the new DAO method directly and group results using `LinkedHashMap + ArrayList` instead of `HashMap + TreeSet`

### Model
- **`WorkflowDefSummary`**: Added `updateTime` field with `@ProtoField(id = 4)`
- **`workflowdefsummary.proto`**: Added `int64 update_time = 4`
- **`AbstractProtoMapper`**: Updated `toProto()` and `fromProto()` for the new field

### Tests
- `MetadataServiceTest`: Updated mock to use `getWorkflowNamesAndVersions()` and verify ascending version order with the new `ArrayList`-based grouping
- `PostgresMetadataDAOTest`: Integration test for the optimized DAO query

## Backward Compatibility

- No database schema changes or migrations
- No existing endpoints modified or removed
- `MetadataDAO.getWorkflowNamesAndVersions()` is a `default` method — existing DAO implementations (Redis, MySQL, etc.) continue to work without changes
- New `updateTime` field in `WorkflowDefSummary` uses `@ProtoField(id = 4)` — additive and backward compatible for gRPC/protobuf clients

## Test Plan

- [ ] `./gradlew spotlessApply` passes
- [ ] `./gradlew test` passes (core, postgres-persistence)
- [ ] Verify `/metadata/workflow/names-and-versions` returns correct data with `updateTime`
- [ ] Verify version dropdown still works correctly on Workbench page
- [ ] Verify no regression on Workflow Definition editor pages