### PR TITLE
feat(wmq): add SQLite-backed WorkflowMessageQueueDAO

### DIFF
--- a/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/config/SqliteConfiguration.java
+++ b/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/config/SqliteConfiguration.java
@@ -35,8 +35,10 @@ import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
+import com.netflix.conductor.core.config.WorkflowMessageQueueProperties;
 import com.netflix.conductor.core.sync.Lock;
 import com.netflix.conductor.core.sync.local.LocalOnlyLock;
+import com.netflix.conductor.dao.WorkflowMessageQueueDAO;
 import com.netflix.conductor.sqlite.dao.*;
 import com.netflix.conductor.sqlite.dao.metadata.SqliteEventHandlerMetadataDAO;
 import com.netflix.conductor.sqlite.dao.metadata.SqliteMetadataDAO;
@@ -178,6 +180,17 @@ public class SqliteConfiguration {
             @Qualifier("sqliteRetryTemplate") RetryTemplate retryTemplate,
             ObjectMapper objectMapper) {
         return new LocalOnlyLock();
+    }
+
+    @Bean
+    @DependsOn({"flywayForPrimaryDb"})
+    @ConditionalOnProperty(name = "conductor.workflow-message-queue.enabled", havingValue = "true")
+    public WorkflowMessageQueueDAO sqliteWorkflowMessageQueueDAO(
+            @Qualifier("sqliteRetryTemplate") RetryTemplate retryTemplate,
+            ObjectMapper objectMapper,
+            WorkflowMessageQueueProperties wmqProperties) {
+        return new SqliteWorkflowMessageQueueDAO(
+                retryTemplate, objectMapper, dataSource, wmqProperties);
     }
 
     @Bean

--- a/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/dao/SqliteWorkflowMessageQueueDAO.java
+++ b/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/dao/SqliteWorkflowMessageQueueDAO.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.sqlite.dao;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.springframework.retry.support.RetryTemplate;
+
+import com.netflix.conductor.common.model.WorkflowMessage;
+import com.netflix.conductor.core.config.WorkflowMessageQueueProperties;
+import com.netflix.conductor.dao.WorkflowMessageQueueDAO;
+import com.netflix.conductor.sqlite.util.Query;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * SQLite-backed implementation of {@link WorkflowMessageQueueDAO}.
+ *
+ * <p>Each workflow's messages are stored in the {@code workflow_message_queue} table, ordered by an
+ * auto-increment {@code seq} column for reliable FIFO. Atomic pop is guaranteed by SQLite's
+ * SERIALIZABLE transactions (already enforced by {@link SqliteBaseDAO}).
+ *
+ * <p>Unlike the Redis implementation, this DAO does not implement TTL-based expiration. Cleanup
+ * relies on the workflow termination hook in {@code WorkflowExecutorOps}, which calls {@link
+ * #delete(String)} when a workflow reaches a terminal state.
+ */
+public class SqliteWorkflowMessageQueueDAO extends SqliteBaseDAO
+        implements WorkflowMessageQueueDAO {
+
+    private static final String PUSH_SQL =
+            "INSERT INTO workflow_message_queue (workflow_id, message_id, payload, received_at) VALUES (?, ?, ?, ?)";
+
+    private static final String POP_SELECT_SQL =
+            "SELECT seq, message_id, payload, received_at FROM workflow_message_queue WHERE workflow_id = ? ORDER BY seq LIMIT ?";
+
+    private static final String POP_DELETE_SQL =
+            "DELETE FROM workflow_message_queue WHERE seq IN (%s)";
+
+    private static final String SIZE_SQL =
+            "SELECT COUNT(*) FROM workflow_message_queue WHERE workflow_id = ?";
+
+    private static final String DELETE_SQL =
+            "DELETE FROM workflow_message_queue WHERE workflow_id = ?";
+
+    private static final TypeReference<Map<String, Object>> MAP_TYPE_REF = new TypeReference<>() {};
+
+    private final WorkflowMessageQueueProperties wmqProperties;
+
+    public SqliteWorkflowMessageQueueDAO(
+            RetryTemplate retryTemplate,
+            ObjectMapper objectMapper,
+            DataSource dataSource,
+            WorkflowMessageQueueProperties wmqProperties) {
+        super(retryTemplate, objectMapper, dataSource);
+        this.wmqProperties = wmqProperties;
+    }
+
+    @Override
+    public void push(String workflowId, WorkflowMessage message) {
+        getWithRetriedTransactions(
+                tx -> {
+                    long currentSize =
+                            query(tx, SIZE_SQL, q -> q.addParameter(workflowId).executeCount());
+                    if (currentSize >= wmqProperties.getMaxQueueSize()) {
+                        throw new IllegalStateException(
+                                "Workflow message queue for workflowId="
+                                        + workflowId
+                                        + " has reached the maximum size of "
+                                        + wmqProperties.getMaxQueueSize());
+                    }
+                    execute(
+                            tx,
+                            PUSH_SQL,
+                            q ->
+                                    q.addParameter(workflowId)
+                                            .addParameter(message.getId())
+                                            .addParameter(toJson(message.getPayload()))
+                                            .addParameter(message.getReceivedAt())
+                                            .executeUpdate());
+                    return null;
+                });
+    }
+
+    @Override
+    public List<WorkflowMessage> pop(String workflowId, int maxCount) {
+        return getWithRetriedTransactions(
+                tx -> {
+                    List<Long> seqs = new ArrayList<>();
+                    List<WorkflowMessage> messages =
+                            query(
+                                    tx,
+                                    POP_SELECT_SQL,
+                                    q -> {
+                                        q.addParameter(workflowId).addParameter(maxCount);
+                                        return q.executeAndFetch(
+                                                rs -> {
+                                                    List<WorkflowMessage> result =
+                                                            new ArrayList<>();
+                                                    while (rs.next()) {
+                                                        seqs.add(rs.getLong("seq"));
+                                                        WorkflowMessage msg = new WorkflowMessage();
+                                                        msg.setId(rs.getString("message_id"));
+                                                        msg.setWorkflowId(workflowId);
+                                                        msg.setPayload(
+                                                                readValue(
+                                                                        rs.getString("payload"),
+                                                                        MAP_TYPE_REF));
+                                                        msg.setReceivedAt(
+                                                                rs.getString("received_at"));
+                                                        result.add(msg);
+                                                    }
+                                                    return result;
+                                                });
+                                    });
+
+                    if (!seqs.isEmpty()) {
+                        String placeholders = Query.generateInBindings(seqs.size());
+                        String deleteSql = String.format(POP_DELETE_SQL, placeholders);
+                        execute(
+                                tx,
+                                deleteSql,
+                                q -> {
+                                    for (Long seq : seqs) {
+                                        q.addParameter(seq);
+                                    }
+                                    q.executeUpdate();
+                                });
+                    }
+
+                    return messages == null ? Collections.emptyList() : messages;
+                });
+    }
+
+    @Override
+    public long size(String workflowId) {
+        return queryWithTransaction(SIZE_SQL, q -> q.addParameter(workflowId).executeCount());
+    }
+
+    @Override
+    public void delete(String workflowId) {
+        executeWithTransaction(DELETE_SQL, q -> q.addParameter(workflowId).executeUpdate());
+    }
+}

--- a/sqlite-persistence/src/main/resources/db/migration_sqlite/V3__wmq_table.sql
+++ b/sqlite-persistence/src/main/resources/db/migration_sqlite/V3__wmq_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE workflow_message_queue (
+    seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+    workflow_id TEXT NOT NULL,
+    message_id  TEXT NOT NULL,
+    payload     TEXT NOT NULL,
+    received_at TEXT NOT NULL
+);
+
+CREATE INDEX wmq_workflow_id_idx ON workflow_message_queue(workflow_id);

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteWorkflowMessageQueueDAOTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteWorkflowMessageQueueDAOTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2024 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.sqlite.dao;
+
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.flywaydb.core.Flyway;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
+import com.netflix.conductor.common.model.WorkflowMessage;
+import com.netflix.conductor.core.config.WorkflowMessageQueueConfiguration;
+import com.netflix.conductor.sqlite.config.SqliteConfiguration;
+
+import static org.junit.Assert.*;
+
+@ContextConfiguration(
+        classes = {
+            TestObjectMapperConfiguration.class,
+            SqliteConfiguration.class,
+            FlywayAutoConfiguration.class,
+            WorkflowMessageQueueConfiguration.class,
+        })
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+        properties = {
+            "spring.flyway.clean-disabled=false",
+            "conductor.workflow-message-queue.enabled=true",
+            "conductor.workflow-message-queue.maxQueueSize=5"
+        })
+public class SqliteWorkflowMessageQueueDAOTest {
+
+    @Autowired private SqliteWorkflowMessageQueueDAO dao;
+
+    @Qualifier("dataSource")
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired Flyway flyway;
+
+    @Before
+    public void before() {
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            conn.prepareStatement("DELETE FROM workflow_message_queue").executeUpdate();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testPushAndPopSingleMessage() {
+        WorkflowMessage msg =
+                new WorkflowMessage(
+                        "msg-1", "wf-1", Map.of("key", "value"), "2026-01-01T00:00:00Z");
+        dao.push("wf-1", msg);
+
+        assertEquals(1, dao.size("wf-1"));
+
+        List<WorkflowMessage> popped = dao.pop("wf-1", 1);
+        assertEquals(1, popped.size());
+        assertEquals("msg-1", popped.get(0).getId());
+        assertEquals("wf-1", popped.get(0).getWorkflowId());
+        assertEquals("value", popped.get(0).getPayload().get("key"));
+        assertEquals("2026-01-01T00:00:00Z", popped.get(0).getReceivedAt());
+
+        assertEquals(0, dao.size("wf-1"));
+    }
+
+    @Test
+    public void testFifoOrdering() {
+        for (int i = 0; i < 5; i++) {
+            WorkflowMessage msg =
+                    new WorkflowMessage(
+                            "msg-" + i, "wf-1", Map.of("order", i), "2026-01-01T00:00:00Z");
+            dao.push("wf-1", msg);
+        }
+
+        List<WorkflowMessage> popped = dao.pop("wf-1", 5);
+        assertEquals(5, popped.size());
+        for (int i = 0; i < 5; i++) {
+            assertEquals("msg-" + i, popped.get(i).getId());
+            assertEquals(i, popped.get(i).getPayload().get("order"));
+        }
+    }
+
+    @Test
+    public void testPopWithBatchSize() {
+        for (int i = 0; i < 5; i++) {
+            dao.push(
+                    "wf-1",
+                    new WorkflowMessage(
+                            "msg-" + i, "wf-1", Map.of("i", i), "2026-01-01T00:00:00Z"));
+        }
+
+        List<WorkflowMessage> first = dao.pop("wf-1", 2);
+        assertEquals(2, first.size());
+        assertEquals("msg-0", first.get(0).getId());
+        assertEquals("msg-1", first.get(1).getId());
+
+        List<WorkflowMessage> second = dao.pop("wf-1", 10);
+        assertEquals(3, second.size());
+        assertEquals("msg-2", second.get(0).getId());
+        assertEquals("msg-3", second.get(1).getId());
+        assertEquals("msg-4", second.get(2).getId());
+    }
+
+    @Test
+    public void testPopEmptyQueue() {
+        List<WorkflowMessage> popped = dao.pop("nonexistent", 5);
+        assertNotNull(popped);
+        assertTrue(popped.isEmpty());
+    }
+
+    @Test
+    public void testMaxQueueSizeEnforced() {
+        for (int i = 0; i < 5; i++) {
+            dao.push(
+                    "wf-1",
+                    new WorkflowMessage("msg-" + i, "wf-1", Map.of(), "2026-01-01T00:00:00Z"));
+        }
+        // 6th push should fail (maxQueueSize=5)
+        try {
+            dao.push(
+                    "wf-1", new WorkflowMessage("msg-5", "wf-1", Map.of(), "2026-01-01T00:00:00Z"));
+            fail("Expected exception for exceeding max queue size");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("maximum size of 5"));
+        }
+    }
+
+    @Test
+    public void testSizeReflectsQueueDepth() {
+        assertEquals(0, dao.size("wf-1"));
+
+        dao.push("wf-1", new WorkflowMessage("msg-1", "wf-1", Map.of(), "2026-01-01T00:00:00Z"));
+        assertEquals(1, dao.size("wf-1"));
+
+        dao.push("wf-1", new WorkflowMessage("msg-2", "wf-1", Map.of(), "2026-01-01T00:00:00Z"));
+        assertEquals(2, dao.size("wf-1"));
+
+        dao.pop("wf-1", 1);
+        assertEquals(1, dao.size("wf-1"));
+    }
+
+    @Test
+    public void testDeleteRemovesAllMessages() {
+        for (int i = 0; i < 3; i++) {
+            dao.push(
+                    "wf-1",
+                    new WorkflowMessage("msg-" + i, "wf-1", Map.of(), "2026-01-01T00:00:00Z"));
+        }
+        assertEquals(3, dao.size("wf-1"));
+
+        dao.delete("wf-1");
+        assertEquals(0, dao.size("wf-1"));
+
+        List<WorkflowMessage> popped = dao.pop("wf-1", 10);
+        assertTrue(popped.isEmpty());
+    }
+
+    @Test
+    public void testDeleteOnEmptyQueueIsNoop() {
+        dao.delete("nonexistent");
+        assertEquals(0, dao.size("nonexistent"));
+    }
+
+    @Test
+    public void testWorkflowIsolation() {
+        dao.push(
+                "wf-1",
+                new WorkflowMessage("msg-1", "wf-1", Map.of("wf", "1"), "2026-01-01T00:00:00Z"));
+        dao.push(
+                "wf-2",
+                new WorkflowMessage("msg-2", "wf-2", Map.of("wf", "2"), "2026-01-01T00:00:00Z"));
+
+        assertEquals(1, dao.size("wf-1"));
+        assertEquals(1, dao.size("wf-2"));
+
+        List<WorkflowMessage> wf1 = dao.pop("wf-1", 10);
+        assertEquals(1, wf1.size());
+        assertEquals("1", wf1.get(0).getPayload().get("wf"));
+
+        // wf-2 should be unaffected
+        assertEquals(1, dao.size("wf-2"));
+
+        dao.delete("wf-2");
+        assertEquals(0, dao.size("wf-2"));
+        assertEquals(0, dao.size("wf-1"));
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #982 (Workflow Message Queue feature). Adds a SQLite-backed `WorkflowMessageQueueDAO` implementation in the `sqlite-persistence` module.

- **Flyway migration V3**: `workflow_message_queue` table with `AUTOINCREMENT` seq column for reliable FIFO ordering
- **`SqliteWorkflowMessageQueueDAO`**: implements `push`/`pop`/`size`/`delete` using SERIALIZABLE transactions for atomic operations
- **Spring config**: bean registered in `SqliteConfiguration`, activated when `conductor.db.type=sqlite` AND `conductor.workflow-message-queue.enabled=true`; otherwise the in-memory fallback is used
- **No TTL**: cleanup relies on the existing workflow termination hook in `WorkflowExecutorOps`. TTL for orphaned queues can be added later if needed.

## Test plan

- [x] Push and pop single message — verify fields round-trip correctly
- [x] FIFO ordering — push 5 messages, pop all, verify order matches insertion order
- [x] Batch pop — pop partial batch, then remaining, verify correct split
- [x] Empty queue pop — returns empty list, not null
- [x] Max queue size enforcement — push beyond limit throws exception
- [x] Size reflects queue depth after push/pop
- [x] Delete removes all messages for a workflow
- [x] Delete on empty queue is no-op
- [x] Workflow isolation — messages don't leak between workflow IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)