### PR TITLE
fix: remove GitHub account from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,3 @@ If a running server or CLI is unavailable:
 ## Other Guidelines
 
 See [AGENTS.md](AGENTS.md) for full project conventions: code style, testing, dependency pinning, PR guidelines.
-
-## GitHub Account
-
-Always use `nthmost-orkes` for all `gh` commands in this repo. Verify with `gh auth status` before filing issues or creating PRs.


### PR DESCRIPTION
## Summary

- Removes the `## GitHub Account` section from CLAUDE.md which hardcoded a specific contributor's GitHub account (`nthmost-orkes`) for all `gh` CLI commands
- This would cause every other contributor's Claude Code session to attempt filing PRs/issues under the wrong account

## Test plan

- [x] Verify CLAUDE.md no longer contains contributor-specific instructions
- [x] Remaining content (documentation-from-source guidelines, key source locations, AGENTS.md pointer) is project-wide and appropriate for all contributors

🤖 Generated with [Claude Code](https://claude.com/claude-code)