### PR TITLE
Improvement: Atomic Task updates

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -25,6 +25,7 @@ import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.metrics.Monitors;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.service.ExecutionLockService;
 
 @Component
 public class AsyncSystemTaskExecutor {
@@ -35,6 +36,7 @@ public class AsyncSystemTaskExecutor {
     private final long queueTaskMessagePostponeSecs;
     private final long systemTaskCallbackTime;
     private final WorkflowExecutor workflowExecutor;
+    private final ExecutionLockService executionLockService;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AsyncSystemTaskExecutor.class);
 
@@ -43,11 +45,13 @@ public class AsyncSystemTaskExecutor {
             QueueDAO queueDAO,
             MetadataDAO metadataDAO,
             ConductorProperties conductorProperties,
-            WorkflowExecutor workflowExecutor) {
+            WorkflowExecutor workflowExecutor,
+            ExecutionLockService executionLockService) {
         this.executionDAOFacade = executionDAOFacade;
         this.queueDAO = queueDAO;
         this.metadataDAO = metadataDAO;
         this.workflowExecutor = workflowExecutor;
+        this.executionLockService = executionLockService;
         this.systemTaskCallbackTime =
                 conductorProperties.getSystemTaskWorkerCallbackDuration().getSeconds();
         this.queueTaskMessagePostponeSecs =
@@ -114,88 +118,107 @@ public class AsyncSystemTaskExecutor {
         String workflowId = task.getWorkflowInstanceId();
         // if we are here the Task object is updated and needs to be persisted regardless of an
         // exception
+        executionLockService.waitForLock(workflowId);
         try {
-            WorkflowModel workflow =
-                    executionDAOFacade.getWorkflowModel(
-                            workflowId, systemTask.isTaskRetrievalRequired());
-
-            if (workflow.getStatus().isTerminal()) {
-                LOGGER.info(
-                        "Workflow {} has been completed for {}/{}",
-                        workflow.toShortString(),
-                        systemTask,
-                        task.getTaskId());
-                if (!task.getStatus().isTerminal()) {
-                    task.setStatus(TaskModel.Status.CANCELED);
-                    task.setReasonForIncompletion(
-                            String.format(
-                                    "Workflow is in %s state", workflow.getStatus().toString()));
-                }
-                shouldRemoveTaskFromQueue = true;
+            task = loadTaskQuietly(taskId);
+            if (task == null) {
+                LOGGER.error(
+                        "TaskId: {} could not be reloaded while executing {}", taskId, systemTask);
+                queueDAO.remove(queueName, taskId);
                 return;
             }
 
-            LOGGER.debug(
-                    "Executing {}/{} in {} state",
-                    task.getTaskType(),
-                    task.getTaskId(),
-                    task.getStatus());
+            try {
+                WorkflowModel workflow =
+                        executionDAOFacade.getWorkflowModel(
+                                workflowId, systemTask.isTaskRetrievalRequired());
 
-            boolean isTaskAsyncComplete = systemTask.isAsyncComplete(task);
-            if (task.getStatus() == TaskModel.Status.SCHEDULED || !isTaskAsyncComplete) {
-                task.incrementPollCount();
-            }
+                if (workflow.getStatus().isTerminal()) {
+                    LOGGER.info(
+                            "Workflow {} has been completed for {}/{}",
+                            workflow.toShortString(),
+                            systemTask,
+                            task.getTaskId());
+                    if (!task.getStatus().isTerminal()) {
+                        task.setStatus(TaskModel.Status.CANCELED);
+                        task.setReasonForIncompletion(
+                                String.format(
+                                        "Workflow is in %s state",
+                                        workflow.getStatus().toString()));
+                    }
+                    shouldRemoveTaskFromQueue = true;
+                    return;
+                }
 
-            if (task.getStatus() == TaskModel.Status.SCHEDULED) {
-                task.setStartTime(System.currentTimeMillis());
-                Monitors.recordQueueWaitTime(task.getTaskType(), task.getQueueWaitTime());
-                systemTask.start(workflow, task, workflowExecutor);
-            } else if (task.getStatus() == TaskModel.Status.IN_PROGRESS) {
-                systemTask.execute(workflow, task, workflowExecutor);
-            }
-
-            // Update message in Task queue based on Task status
-            // Remove asyncComplete system tasks from the queue that are not in SCHEDULED state
-            if (isTaskAsyncComplete && task.getStatus() != TaskModel.Status.SCHEDULED) {
-                shouldRemoveTaskFromQueue = true;
-                hasTaskExecutionCompleted = true;
-            } else if (task.getStatus().isTerminal()) {
-                task.setEndTime(System.currentTimeMillis());
-                shouldRemoveTaskFromQueue = true;
-                hasTaskExecutionCompleted = true;
-            } else {
-                task.setCallbackAfterSeconds(systemTaskCallbackTime);
-                systemTask
-                        .getEvaluationOffset(task, systemTaskCallbackTime)
-                        .ifPresentOrElse(
-                                task::setCallbackAfterSeconds,
-                                () -> task.setCallbackAfterSeconds(systemTaskCallbackTime));
-                queueDAO.postpone(
-                        queueName,
+                LOGGER.debug(
+                        "Executing {}/{} in {} state",
+                        task.getTaskType(),
                         task.getTaskId(),
-                        task.getWorkflowPriority(),
-                        task.getCallbackAfterSeconds());
-                LOGGER.debug("{} postponed in queue: {}", task, queueName);
-            }
+                        task.getStatus());
 
-            LOGGER.debug(
-                    "Finished execution of {}/{}-{}",
-                    systemTask,
-                    task.getTaskId(),
-                    task.getStatus());
-        } catch (Exception e) {
-            Monitors.error(AsyncSystemTaskExecutor.class.getSimpleName(), "executeSystemTask");
-            LOGGER.error("Error executing system task - {}, with id: {}", systemTask, taskId, e);
+                boolean isTaskAsyncComplete = systemTask.isAsyncComplete(task);
+                if (task.getStatus() == TaskModel.Status.SCHEDULED || !isTaskAsyncComplete) {
+                    task.incrementPollCount();
+                }
+
+                if (task.getStatus() == TaskModel.Status.SCHEDULED) {
+                    task.setStartTime(System.currentTimeMillis());
+                    Monitors.recordQueueWaitTime(task.getTaskType(), task.getQueueWaitTime());
+                    systemTask.start(workflow, task, workflowExecutor);
+                } else if (task.getStatus() == TaskModel.Status.IN_PROGRESS) {
+                    systemTask.execute(workflow, task, workflowExecutor);
+                }
+
+                // Update message in Task queue based on Task status
+                // Remove asyncComplete system tasks from the queue that are not in SCHEDULED state
+                if (isTaskAsyncComplete && task.getStatus() != TaskModel.Status.SCHEDULED) {
+                    shouldRemoveTaskFromQueue = true;
+                    hasTaskExecutionCompleted = true;
+                } else if (task.getStatus().isTerminal()) {
+                    task.setEndTime(System.currentTimeMillis());
+                    shouldRemoveTaskFromQueue = true;
+                    hasTaskExecutionCompleted = true;
+                } else {
+                    task.setCallbackAfterSeconds(systemTaskCallbackTime);
+                    TaskModel taskForEvaluationOffset = task;
+                    systemTask
+                            .getEvaluationOffset(taskForEvaluationOffset, systemTaskCallbackTime)
+                            .ifPresentOrElse(
+                                    taskForEvaluationOffset::setCallbackAfterSeconds,
+                                    () ->
+                                            taskForEvaluationOffset.setCallbackAfterSeconds(
+                                                    systemTaskCallbackTime));
+                    queueDAO.postpone(
+                            queueName,
+                            task.getTaskId(),
+                            task.getWorkflowPriority(),
+                            task.getCallbackAfterSeconds());
+                    LOGGER.debug("{} postponed in queue: {}", task, queueName);
+                }
+
+                LOGGER.debug(
+                        "Finished execution of {}/{}-{}",
+                        systemTask,
+                        task.getTaskId(),
+                        task.getStatus());
+            } catch (Exception e) {
+                Monitors.error(AsyncSystemTaskExecutor.class.getSimpleName(), "executeSystemTask");
+                LOGGER.error(
+                        "Error executing system task - {}, with id: {}", systemTask, taskId, e);
+            } finally {
+                executionDAOFacade.updateTask(task);
+                if (shouldRemoveTaskFromQueue) {
+                    queueDAO.remove(queueName, task.getTaskId());
+                    LOGGER.debug("{} removed from queue: {}", task, queueName);
+                }
+                // if the current task execution has completed, then the workflow needs to be
+                // evaluated
+                if (hasTaskExecutionCompleted) {
+                    workflowExecutor.decide(workflowId);
+                }
+            }
         } finally {
-            executionDAOFacade.updateTask(task);
-            if (shouldRemoveTaskFromQueue) {
-                queueDAO.remove(queueName, task.getTaskId());
-                LOGGER.debug("{} removed from queue: {}", task, queueName);
-            }
-            // if the current task execution has completed, then the workflow needs to be evaluated
-            if (hasTaskExecutionCompleted) {
-                workflowExecutor.decide(workflowId);
-            }
+            executionLockService.releaseLock(workflowId);
         }
     }
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
@@ -783,172 +783,181 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
         }
 
         String workflowId = taskResult.getWorkflowInstanceId();
-        WorkflowModel workflowInstance = executionDAOFacade.getWorkflowModel(workflowId, false);
-
-        TaskModel task =
-                Optional.ofNullable(executionDAOFacade.getTaskModel(taskResult.getTaskId()))
-                        .orElseThrow(
-                                () ->
-                                        new NotFoundException(
-                                                "No such task found by id: %s",
-                                                taskResult.getTaskId()));
-
-        LOGGER.debug("Task: {} belonging to Workflow {} being updated", task, workflowInstance);
-
-        String taskQueueName = QueueUtils.getQueueName(task);
-
-        if (task.getStatus().isTerminal()) {
-            // Task was already updated....
-            queueDAO.remove(taskQueueName, taskResult.getTaskId());
-            LOGGER.info(
-                    "Task: {} has already finished execution with status: {} within workflow: {}. Removed task from queue: {}",
-                    task.getTaskId(),
-                    task.getStatus(),
-                    task.getWorkflowInstanceId(),
-                    taskQueueName);
-            Monitors.recordUpdateConflict(
-                    task.getTaskType(), workflowInstance.getWorkflowName(), task.getStatus());
-            return task;
-        }
-
-        if (workflowInstance.getStatus().isTerminal()) {
-            // Workflow is in terminal state
-            queueDAO.remove(taskQueueName, taskResult.getTaskId());
-            LOGGER.info(
-                    "Workflow: {} has already finished execution. Task update for: {} ignored and removed from Queue: {}.",
-                    workflowInstance,
-                    taskResult.getTaskId(),
-                    taskQueueName);
-            Monitors.recordUpdateConflict(
-                    task.getTaskType(),
-                    workflowInstance.getWorkflowName(),
-                    workflowInstance.getStatus());
-            return task;
-        }
-
-        // for system tasks, setting to SCHEDULED would mean restarting the task which
-        // is
-        // undesirable
-        // for worker tasks, set status to SCHEDULED and push to the queue
-        if (!systemTaskRegistry.isSystemTask(task.getTaskType())
-                && taskResult.getStatus() == TaskResult.Status.IN_PROGRESS) {
-            task.setStatus(SCHEDULED);
-        } else {
-            task.setStatus(TaskModel.Status.valueOf(taskResult.getStatus().name()));
-        }
-        task.setOutputMessage(taskResult.getOutputMessage());
-        task.setReasonForIncompletion(taskResult.getReasonForIncompletion());
-        task.setWorkerId(taskResult.getWorkerId());
-        task.setCallbackAfterSeconds(taskResult.getCallbackAfterSeconds());
-        task.setOutputData(taskResult.getOutputData());
-        task.setSubWorkflowId(taskResult.getSubWorkflowId());
-
-        if (StringUtils.isNotBlank(taskResult.getExternalOutputPayloadStoragePath())) {
-            task.setExternalOutputPayloadStoragePath(
-                    taskResult.getExternalOutputPayloadStoragePath());
-        }
-
-        if (task.getStatus().isTerminal()) {
-            task.setEndTime(System.currentTimeMillis());
-        }
-
-        // Update message in Task queue based on Task status
-        switch (task.getStatus()) {
-            case COMPLETED:
-            case CANCELED:
-            case FAILED:
-            case FAILED_WITH_TERMINAL_ERROR:
-            case TIMED_OUT:
-                try {
-                    queueDAO.remove(taskQueueName, taskResult.getTaskId());
-                    LOGGER.debug(
-                            "Task: {} removed from taskQueue: {} since the task status is {}",
-                            task,
-                            taskQueueName,
-                            task.getStatus().name());
-                } catch (Exception e) {
-                    // Ignore exceptions on queue remove as it wouldn't impact task and workflow
-                    // execution, and will be cleaned up eventually
-                    String errorMsg =
-                            String.format(
-                                    "Error removing the message in queue for task: %s for workflow: %s",
-                                    task.getTaskId(), workflowId);
-                    LOGGER.warn(errorMsg, e);
-                    Monitors.recordTaskQueueOpError(
-                            task.getTaskType(), workflowInstance.getWorkflowName());
-                }
-                break;
-            case IN_PROGRESS:
-            case SCHEDULED:
-                try {
-                    long callBack = taskResult.getCallbackAfterSeconds();
-                    queueDAO.postpone(
-                            taskQueueName, task.getTaskId(), task.getWorkflowPriority(), callBack);
-                    LOGGER.debug(
-                            "Task: {} postponed in taskQueue: {} since the task status is {} with callbackAfterSeconds: {}",
-                            task,
-                            taskQueueName,
-                            task.getStatus().name(),
-                            callBack);
-                } catch (Exception e) {
-                    // Throw exceptions on queue postpone, this would impact task execution
-                    String errorMsg =
-                            String.format(
-                                    "Error postponing the message in queue for task: %s for workflow: %s",
-                                    task.getTaskId(), workflowId);
-                    LOGGER.error(errorMsg, e);
-                    Monitors.recordTaskQueueOpError(
-                            task.getTaskType(), workflowInstance.getWorkflowName());
-                    throw new TransientException(errorMsg, e);
-                }
-                break;
-            default:
-                break;
-        }
-
-        // Throw a TransientException if below operations fail to avoid workflow
-        // inconsistencies.
+        executionLockService.waitForLock(workflowId);
         try {
-            executionDAOFacade.updateTask(task);
-        } catch (Exception e) {
-            String errorMsg =
-                    String.format(
-                            "Error updating task: %s for workflow: %s",
-                            task.getTaskId(), workflowId);
-            LOGGER.error(errorMsg, e);
-            Monitors.recordTaskUpdateError(task.getTaskType(), workflowInstance.getWorkflowName());
-            throw new TransientException(errorMsg, e);
-        }
+            WorkflowModel workflowInstance = executionDAOFacade.getWorkflowModel(workflowId, false);
 
-        try {
-            notifyTaskStatusListener(task);
-        } catch (Exception e) {
-            String errorMsg =
-                    String.format(
-                            "Error while notifying TaskStatusListener: %s for workflow: %s",
-                            task.getTaskId(), workflowId);
-            LOGGER.error(errorMsg, e);
-        }
+            TaskModel task =
+                    Optional.ofNullable(executionDAOFacade.getTaskModel(taskResult.getTaskId()))
+                            .orElseThrow(
+                                    () ->
+                                            new NotFoundException(
+                                                    "No such task found by id: %s",
+                                                    taskResult.getTaskId()));
 
-        List<TaskExecLog> taskLogs = taskResult.getLogs();
-        if (taskLogs != null) {
-            taskLogs.forEach(taskExecLog -> taskExecLog.setTaskId(task.getTaskId()));
-            executionDAOFacade.addTaskExecLog(taskLogs);
-        }
+            LOGGER.debug("Task: {} belonging to Workflow {} being updated", task, workflowInstance);
 
-        if (task.getStatus().isTerminal()) {
-            long duration = getTaskDuration(0, task);
-            long lastDuration = task.getEndTime() - task.getStartTime();
-            Monitors.recordTaskExecutionTime(
-                    task.getTaskDefName(), duration, true, task.getStatus());
-            Monitors.recordTaskExecutionTime(
-                    task.getTaskDefName(), lastDuration, false, task.getStatus());
-        }
+            String taskQueueName = QueueUtils.getQueueName(task);
 
-        if (!isLazyEvaluateWorkflow(workflowInstance.getWorkflowDefinition(), task)) {
-            decide(workflowId);
+            if (task.getStatus().isTerminal()) {
+                // Task was already updated....
+                queueDAO.remove(taskQueueName, taskResult.getTaskId());
+                LOGGER.info(
+                        "Task: {} has already finished execution with status: {} within workflow: {}. Removed task from queue: {}",
+                        task.getTaskId(),
+                        task.getStatus(),
+                        task.getWorkflowInstanceId(),
+                        taskQueueName);
+                Monitors.recordUpdateConflict(
+                        task.getTaskType(), workflowInstance.getWorkflowName(), task.getStatus());
+                return task;
+            }
+
+            if (workflowInstance.getStatus().isTerminal()) {
+                // Workflow is in terminal state
+                queueDAO.remove(taskQueueName, taskResult.getTaskId());
+                LOGGER.info(
+                        "Workflow: {} has already finished execution. Task update for: {} ignored and removed from Queue: {}.",
+                        workflowInstance,
+                        taskResult.getTaskId(),
+                        taskQueueName);
+                Monitors.recordUpdateConflict(
+                        task.getTaskType(),
+                        workflowInstance.getWorkflowName(),
+                        workflowInstance.getStatus());
+                return task;
+            }
+
+            // for system tasks, setting to SCHEDULED would mean restarting the task which
+            // is
+            // undesirable
+            // for worker tasks, set status to SCHEDULED and push to the queue
+            if (!systemTaskRegistry.isSystemTask(task.getTaskType())
+                    && taskResult.getStatus() == TaskResult.Status.IN_PROGRESS) {
+                task.setStatus(SCHEDULED);
+            } else {
+                task.setStatus(TaskModel.Status.valueOf(taskResult.getStatus().name()));
+            }
+            task.setOutputMessage(taskResult.getOutputMessage());
+            task.setReasonForIncompletion(taskResult.getReasonForIncompletion());
+            task.setWorkerId(taskResult.getWorkerId());
+            task.setCallbackAfterSeconds(taskResult.getCallbackAfterSeconds());
+            task.setOutputData(taskResult.getOutputData());
+            task.setSubWorkflowId(taskResult.getSubWorkflowId());
+
+            if (StringUtils.isNotBlank(taskResult.getExternalOutputPayloadStoragePath())) {
+                task.setExternalOutputPayloadStoragePath(
+                        taskResult.getExternalOutputPayloadStoragePath());
+            }
+
+            if (task.getStatus().isTerminal()) {
+                task.setEndTime(System.currentTimeMillis());
+            }
+
+            // Update message in Task queue based on Task status
+            switch (task.getStatus()) {
+                case COMPLETED:
+                case CANCELED:
+                case FAILED:
+                case FAILED_WITH_TERMINAL_ERROR:
+                case TIMED_OUT:
+                    try {
+                        queueDAO.remove(taskQueueName, taskResult.getTaskId());
+                        LOGGER.debug(
+                                "Task: {} removed from taskQueue: {} since the task status is {}",
+                                task,
+                                taskQueueName,
+                                task.getStatus().name());
+                    } catch (Exception e) {
+                        // Ignore exceptions on queue remove as it wouldn't impact task and workflow
+                        // execution, and will be cleaned up eventually
+                        String errorMsg =
+                                String.format(
+                                        "Error removing the message in queue for task: %s for workflow: %s",
+                                        task.getTaskId(), workflowId);
+                        LOGGER.warn(errorMsg, e);
+                        Monitors.recordTaskQueueOpError(
+                                task.getTaskType(), workflowInstance.getWorkflowName());
+                    }
+                    break;
+                case IN_PROGRESS:
+                case SCHEDULED:
+                    try {
+                        long callBack = taskResult.getCallbackAfterSeconds();
+                        queueDAO.postpone(
+                                taskQueueName,
+                                task.getTaskId(),
+                                task.getWorkflowPriority(),
+                                callBack);
+                        LOGGER.debug(
+                                "Task: {} postponed in taskQueue: {} since the task status is {} with callbackAfterSeconds: {}",
+                                task,
+                                taskQueueName,
+                                task.getStatus().name(),
+                                callBack);
+                    } catch (Exception e) {
+                        // Throw exceptions on queue postpone, this would impact task execution
+                        String errorMsg =
+                                String.format(
+                                        "Error postponing the message in queue for task: %s for workflow: %s",
+                                        task.getTaskId(), workflowId);
+                        LOGGER.error(errorMsg, e);
+                        Monitors.recordTaskQueueOpError(
+                                task.getTaskType(), workflowInstance.getWorkflowName());
+                        throw new TransientException(errorMsg, e);
+                    }
+                    break;
+                default:
+                    break;
+            }
+
+            // Throw a TransientException if below operations fail to avoid workflow
+            // inconsistencies.
+            try {
+                executionDAOFacade.updateTask(task);
+            } catch (Exception e) {
+                String errorMsg =
+                        String.format(
+                                "Error updating task: %s for workflow: %s",
+                                task.getTaskId(), workflowId);
+                LOGGER.error(errorMsg, e);
+                Monitors.recordTaskUpdateError(
+                        task.getTaskType(), workflowInstance.getWorkflowName());
+                throw new TransientException(errorMsg, e);
+            }
+
+            try {
+                notifyTaskStatusListener(task);
+            } catch (Exception e) {
+                String errorMsg =
+                        String.format(
+                                "Error while notifying TaskStatusListener: %s for workflow: %s",
+                                task.getTaskId(), workflowId);
+                LOGGER.error(errorMsg, e);
+            }
+
+            List<TaskExecLog> taskLogs = taskResult.getLogs();
+            if (taskLogs != null) {
+                taskLogs.forEach(taskExecLog -> taskExecLog.setTaskId(task.getTaskId()));
+                executionDAOFacade.addTaskExecLog(taskLogs);
+            }
+
+            if (task.getStatus().isTerminal()) {
+                long duration = getTaskDuration(0, task);
+                long lastDuration = task.getEndTime() - task.getStartTime();
+                Monitors.recordTaskExecutionTime(
+                        task.getTaskDefName(), duration, true, task.getStatus());
+                Monitors.recordTaskExecutionTime(
+                        task.getTaskDefName(), lastDuration, false, task.getStatus());
+            }
+
+            if (!isLazyEvaluateWorkflow(workflowInstance.getWorkflowDefinition(), task)) {
+                decide(workflowId);
+            }
+            return task;
+        } finally {
+            executionLockService.releaseLock(workflowId);
         }
-        return task;
     }
 
     private void notifyTaskStatusListener(TaskModel task) {
@@ -979,30 +988,36 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
     }
 
     private void extendLease(TaskResult taskResult) {
-        TaskModel task =
-                Optional.ofNullable(executionDAOFacade.getTaskModel(taskResult.getTaskId()))
-                        .orElseThrow(
-                                () ->
-                                        new NotFoundException(
-                                                "No such task found by id: %s",
-                                                taskResult.getTaskId()));
+        String workflowId = taskResult.getWorkflowInstanceId();
+        executionLockService.waitForLock(workflowId);
+        try {
+            TaskModel task =
+                    Optional.ofNullable(executionDAOFacade.getTaskModel(taskResult.getTaskId()))
+                            .orElseThrow(
+                                    () ->
+                                            new NotFoundException(
+                                                    "No such task found by id: %s",
+                                                    taskResult.getTaskId()));
 
-        LOGGER.debug(
-                "Extend lease for Task: {} belonging to Workflow: {}",
-                task,
-                task.getWorkflowInstanceId());
-        if (!task.getStatus().isTerminal()) {
-            try {
-                executionDAOFacade.extendLease(task);
-            } catch (Exception e) {
-                String errorMsg =
-                        String.format(
-                                "Error extend lease for Task: %s belonging to Workflow: %s",
-                                task.getTaskId(), task.getWorkflowInstanceId());
-                LOGGER.error(errorMsg, e);
-                Monitors.recordTaskExtendLeaseError(task.getTaskType(), task.getWorkflowType());
-                throw new TransientException(errorMsg, e);
+            LOGGER.debug(
+                    "Extend lease for Task: {} belonging to Workflow: {}",
+                    task,
+                    task.getWorkflowInstanceId());
+            if (!task.getStatus().isTerminal()) {
+                try {
+                    executionDAOFacade.extendLease(task);
+                } catch (Exception e) {
+                    String errorMsg =
+                            String.format(
+                                    "Error extend lease for Task: %s belonging to Workflow: %s",
+                                    task.getTaskId(), task.getWorkflowInstanceId());
+                    LOGGER.error(errorMsg, e);
+                    Monitors.recordTaskExtendLeaseError(task.getTaskType(), task.getWorkflowType());
+                    throw new TransientException(errorMsg, e);
+                }
             }
+        } finally {
+            executionLockService.releaseLock(workflowId);
         }
     }
 

--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -55,6 +55,7 @@ public class ExecutionService {
     private final ExternalPayloadStorage externalPayloadStorage;
     private final SystemTaskRegistry systemTaskRegistry;
     private final TaskStatusListener taskStatusListener;
+    private final ExecutionLockService executionLockService;
 
     private final long queueTaskMessagePostponeSecs;
 
@@ -69,7 +70,8 @@ public class ExecutionService {
             ConductorProperties properties,
             ExternalPayloadStorage externalPayloadStorage,
             SystemTaskRegistry systemTaskRegistry,
-            TaskStatusListener taskStatusListener) {
+            TaskStatusListener taskStatusListener,
+            ExecutionLockService executionLockService) {
         this.workflowExecutor = workflowExecutor;
         this.executionDAOFacade = executionDAOFacade;
         this.queueDAO = queueDAO;
@@ -79,6 +81,7 @@ public class ExecutionService {
                 properties.getTaskExecutionPostponeDuration().getSeconds();
         this.systemTaskRegistry = systemTaskRegistry;
         this.taskStatusListener = taskStatusListener;
+        this.executionLockService = executionLockService;
     }
 
     public Task poll(String taskType, String workerId) {
@@ -166,18 +169,31 @@ public class ExecutionService {
                     continue;
                 }
 
-                taskModel.setStatus(TaskModel.Status.IN_PROGRESS);
-                if (taskModel.getStartTime() == 0) {
-                    taskModel.setStartTime(System.currentTimeMillis());
-                    Monitors.recordQueueWaitTime(
-                            taskModel.getTaskDefName(), taskModel.getQueueWaitTime());
+                String workflowId = taskModel.getWorkflowInstanceId();
+                executionLockService.waitForLock(workflowId);
+                try {
+                    taskModel = executionDAOFacade.getTaskModel(taskId);
+                    if (taskModel == null || taskModel.getStatus().isTerminal()) {
+                        queueDAO.remove(queueName, taskId);
+                        LOGGER.debug("Removed task: {} from the queue: {}", taskId, queueName);
+                        continue;
+                    }
+
+                    taskModel.setStatus(TaskModel.Status.IN_PROGRESS);
+                    if (taskModel.getStartTime() == 0) {
+                        taskModel.setStartTime(System.currentTimeMillis());
+                        Monitors.recordQueueWaitTime(
+                                taskModel.getTaskDefName(), taskModel.getQueueWaitTime());
+                    }
+                    taskModel.setCallbackAfterSeconds(
+                            0); // reset callbackAfterSeconds when giving the task to the worker
+                    taskModel.setWorkerId(workerId);
+                    taskModel.incrementPollCount();
+                    executionDAOFacade.updateTask(taskModel);
+                    tasks.add(taskModel.toTask());
+                } finally {
+                    executionLockService.releaseLock(workflowId);
                 }
-                taskModel.setCallbackAfterSeconds(
-                        0); // reset callbackAfterSeconds when giving the task to the worker
-                taskModel.setWorkerId(workerId);
-                taskModel.incrementPollCount();
-                executionDAOFacade.updateTask(taskModel);
-                tasks.add(taskModel.toTask());
             } catch (Exception e) {
                 // db operation failed for dequeued message, re-enqueue with a delay
                 LOGGER.warn(

--- a/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
@@ -25,6 +25,7 @@ import com.netflix.conductor.dao.MetadataDAO
 import com.netflix.conductor.dao.QueueDAO
 import com.netflix.conductor.model.TaskModel
 import com.netflix.conductor.model.WorkflowModel
+import com.netflix.conductor.service.ExecutionLockService
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import spock.lang.Specification
@@ -38,6 +39,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
     QueueDAO queueDAO
     MetadataDAO metadataDAO
     WorkflowExecutor workflowExecutor
+    ExecutionLockService executionLockService
 
     @Subject
     AsyncSystemTaskExecutor executor
@@ -50,6 +52,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         queueDAO = Mock(QueueDAO.class)
         metadataDAO = Mock(MetadataDAO.class)
         workflowExecutor = Mock(WorkflowExecutor.class)
+        executionLockService = Mock(ExecutionLockService.class)
 
         workflowSystemTask = Mock(WorkflowSystemTask.class) {
             isTaskRetrievalRequired() >> true
@@ -58,7 +61,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         properties.taskExecutionPostponeDuration = Duration.ofSeconds(1)
         properties.systemTaskWorkerCallbackDuration = Duration.ofSeconds(1)
 
-        executor = new AsyncSystemTaskExecutor(executionDAOFacade, queueDAO, metadataDAO, properties, workflowExecutor)
+        executor = new AsyncSystemTaskExecutor(executionDAOFacade, queueDAO, metadataDAO, properties, workflowExecutor, executionLockService)
     }
 
     // this is not strictly a unit test, but its essential to test AsyncSystemTaskExecutor with SubWorkflow
@@ -88,7 +91,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(subWorkflowTask, task1Id)
 
         then:
-        1 * executionDAOFacade.getTaskModel(task1Id) >> task1
+        2 * executionDAOFacade.getTaskModel(task1Id) >> task1
         1 * executionDAOFacade.getWorkflowModel(workflowId, subWorkflowTask.isTaskRetrievalRequired()) >> workflow
         1 * workflowExecutor.startWorkflow(*_) >> subWorkflowId
         1 * workflowExecutor.getWorkflow(subWorkflowId, false) >> subWorkflow
@@ -154,7 +157,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        2 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         1 * queueDAO.remove(queueName, taskId)
 
@@ -242,7 +245,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        2 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         1 * executionDAOFacade.updateTask(task)
         1 * queueDAO.postpone(queueName, taskId, task.workflowPriority, properties.systemTaskWorkerCallbackDuration.seconds)
@@ -270,7 +273,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        2 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         1 * executionDAOFacade.updateTask(task)
 
@@ -296,7 +299,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        2 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         1 * executionDAOFacade.updateTask(task)
 
@@ -328,7 +331,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        2 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         1 * executionDAOFacade.updateTask(task) // 1st call for pollCount, 2nd call for status update
 
@@ -356,7 +359,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        2 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         1 * executionDAOFacade.updateTask(task) // 1st call for pollCount, 2nd call for status update
 
@@ -380,7 +383,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        2 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         1 * executionDAOFacade.updateTask(task) // only one call since pollCount is not incremented
 

--- a/core/src/test/java/com/netflix/conductor/service/ExecutionServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/ExecutionServiceTest.java
@@ -58,6 +58,7 @@ public class ExecutionServiceTest {
     @Mock private ExternalPayloadStorage externalPayloadStorage;
     @Mock private SystemTaskRegistry systemTaskRegistry;
     @Mock private TaskStatusListener taskStatusListener;
+    @Mock private ExecutionLockService executionLockService;
 
     private ExecutionService executionService;
 
@@ -79,7 +80,8 @@ public class ExecutionServiceTest {
                         conductorProperties,
                         externalPayloadStorage,
                         systemTaskRegistry,
-                        taskStatusListener);
+                        taskStatusListener,
+                        executionLockService);
         WorkflowDef workflowDef = new WorkflowDef();
         workflow1 = new Workflow();
         workflow1.setWorkflowId("wf1");

--- a/redis-configuration/src/main/java/com/netflix/conductor/redis/jedis/JedisProxy.java
+++ b/redis-configuration/src/main/java/com/netflix/conductor/redis/jedis/JedisProxy.java
@@ -367,6 +367,11 @@ public class JedisProxy {
         return jedisCommands.scriptLoad(script, sampleKey);
     }
 
+    public boolean supportsMultiKeyAtomicScripts() {
+        return !(jedisCommands instanceof JedisClusterCommands)
+                && !(jedisCommands instanceof InMemoryJedisCommands);
+    }
+
     public String info(String command) {
         return jedisCommands.info(command);
     }

--- a/redis-persistence/src/main/java/com/netflix/conductor/redis/dao/RedisExecutionDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/redis/dao/RedisExecutionDAO.java
@@ -12,6 +12,7 @@
  */
 package com.netflix.conductor.redis.dao;
 
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -58,7 +59,33 @@ public class RedisExecutionDAO extends BaseDynoDAO
     private static final String WORKFLOW_DEF_TO_WORKFLOWS = "WORKFLOW_DEF_TO_WORKFLOWS";
     private static final String CORR_ID_TO_WORKFLOWS = "CORR_ID_TO_WORKFLOWS";
     private static final String EVENT_EXECUTION = "EVENT_EXECUTION";
+    // Persist the scheduled-task pointer, workflow mapping, in-progress markers, and task payload
+    // together so duplicate decide paths cannot leave Redis in a split state for the same task key.
+    private static final byte[] CREATE_TASK_SCRIPT =
+            String.join(
+                            "\n",
+                            "local created = redis.call('hsetnx', KEYS[1], ARGV[1], ARGV[2])",
+                            "if created == 0 then",
+                            "  return 0",
+                            "end",
+                            "redis.call('sadd', KEYS[2], ARGV[2])",
+                            "redis.call('sadd', KEYS[3], ARGV[2])",
+                            "if ARGV[4] == '1' then",
+                            "  redis.call('sadd', KEYS[5], ARGV[2])",
+                            "else",
+                            "  redis.call('srem', KEYS[5], ARGV[2])",
+                            "end",
+                            "if ARGV[5] == '1' then",
+                            "  redis.call('srem', KEYS[3], ARGV[2])",
+                            "end",
+                            "if ARGV[6] == '1' then",
+                            "  redis.call('zrem', KEYS[6], ARGV[2])",
+                            "end",
+                            "redis.call('set', KEYS[4], ARGV[3])",
+                            "return 1")
+                    .getBytes(StandardCharsets.UTF_8);
     private final int ttlEventExecutionSeconds;
+    private volatile byte[] createTaskScriptSha;
 
     public RedisExecutionDAO(
             JedisProxy jedisProxy,
@@ -143,50 +170,167 @@ public class RedisExecutionDAO extends BaseDynoDAO
 
             recordRedisDaoRequests("createTask", task.getTaskType(), task.getWorkflowType());
 
-            String taskKey = task.getReferenceTaskName() + "" + task.getRetryCount();
-            Long added =
-                    jedisProxy.hset(
-                            nsKey(SCHEDULED_TASKS, task.getWorkflowInstanceId()),
-                            taskKey,
-                            task.getTaskId());
-            if (added < 1) {
-                LOGGER.debug(
-                        "Task already scheduled, skipping the run "
-                                + task.getTaskId()
-                                + ", ref="
-                                + task.getReferenceTaskName()
-                                + ", key="
-                                + taskKey);
-                continue;
-            }
-
             if (task.getStatus() != null
                     && !task.getStatus().isTerminal()
                     && task.getScheduledTime() == 0) {
                 task.setScheduledTime(System.currentTimeMillis());
             }
 
-            correlateTaskToWorkflowInDS(task.getTaskId(), task.getWorkflowInstanceId());
-            LOGGER.debug(
-                    "Scheduled task added to WORKFLOW_TO_TASKS workflowId: {}, taskId: {}, taskType: {} during createTasks",
-                    task.getWorkflowInstanceId(),
-                    task.getTaskId(),
-                    task.getTaskType());
-
-            String inProgressTaskKey = nsKey(IN_PROGRESS_TASKS, task.getTaskDefName());
-            jedisProxy.sadd(inProgressTaskKey, task.getTaskId());
-            LOGGER.debug(
-                    "Scheduled task added to IN_PROGRESS_TASKS with inProgressTaskKey: {}, workflowId: {}, taskId: {}, taskType: {} during createTasks",
-                    inProgressTaskKey,
-                    task.getWorkflowInstanceId(),
-                    task.getTaskId(),
-                    task.getTaskType());
-
-            updateTask(task);
-            tasksCreated.add(task);
+            if (createTask(task)) {
+                tasksCreated.add(task);
+            }
         }
 
         return tasksCreated;
+    }
+
+    private boolean createTask(TaskModel task) {
+        if (jedisProxy.supportsMultiKeyAtomicScripts()) {
+            return createTaskAtomically(task);
+        }
+        // Redis Cluster cannot guarantee atomicity for these multi-key writes with the current key
+        // layout because the keys are not hash-slot aligned. Preserve existing behavior there
+        // until the key model is updated to support cross-structure atomic scripts.
+        return createTaskNonAtomically(task);
+    }
+
+    private boolean createTaskNonAtomically(TaskModel task) {
+        String taskKey = task.getReferenceTaskName() + "" + task.getRetryCount();
+        Long added =
+                jedisProxy.hsetnx(
+                        nsKey(SCHEDULED_TASKS, task.getWorkflowInstanceId()),
+                        taskKey,
+                        task.getTaskId());
+        if (added < 1) {
+            logTaskAlreadyScheduled(task, taskKey);
+            return false;
+        }
+
+        correlateTaskToWorkflowInDS(task.getTaskId(), task.getWorkflowInstanceId());
+        LOGGER.debug(
+                "Scheduled task added to WORKFLOW_TO_TASKS workflowId: {}, taskId: {}, taskType: {} during createTasks",
+                task.getWorkflowInstanceId(),
+                task.getTaskId(),
+                task.getTaskType());
+
+        String inProgressTaskKey = nsKey(IN_PROGRESS_TASKS, task.getTaskDefName());
+        jedisProxy.sadd(inProgressTaskKey, task.getTaskId());
+        LOGGER.debug(
+                "Scheduled task added to IN_PROGRESS_TASKS with inProgressTaskKey: {}, workflowId: {}, taskId: {}, taskType: {} during createTasks",
+                inProgressTaskKey,
+                task.getWorkflowInstanceId(),
+                task.getTaskId(),
+                task.getTaskType());
+
+        updateTask(task);
+        return true;
+    }
+
+    private boolean createTaskAtomically(TaskModel task) {
+        Optional<TaskDef> taskDefinition = task.getTaskDefinition();
+        String payload = toJson(task);
+        String taskKey = task.getReferenceTaskName() + "" + task.getRetryCount();
+
+        List<byte[]> keys =
+                List.of(
+                        nsKey(SCHEDULED_TASKS, task.getWorkflowInstanceId())
+                                .getBytes(StandardCharsets.UTF_8),
+                        nsKey(WORKFLOW_TO_TASKS, task.getWorkflowInstanceId())
+                                .getBytes(StandardCharsets.UTF_8),
+                        nsKey(IN_PROGRESS_TASKS, task.getTaskDefName())
+                                .getBytes(StandardCharsets.UTF_8),
+                        nsKey(TASK, task.getTaskId()).getBytes(StandardCharsets.UTF_8),
+                        nsKey(TASKS_IN_PROGRESS_STATUS, task.getTaskDefName())
+                                .getBytes(StandardCharsets.UTF_8),
+                        nsKey(TASK_LIMIT_BUCKET, task.getTaskDefName())
+                                .getBytes(StandardCharsets.UTF_8));
+        List<byte[]> args =
+                List.of(
+                        taskKey.getBytes(StandardCharsets.UTF_8),
+                        task.getTaskId().getBytes(StandardCharsets.UTF_8),
+                        payload.getBytes(StandardCharsets.UTF_8),
+                        shouldAddTaskInProgressStatus(task, taskDefinition)
+                                ? "1".getBytes(StandardCharsets.UTF_8)
+                                : "0".getBytes(StandardCharsets.UTF_8),
+                        task.getStatus() != null && task.getStatus().isTerminal()
+                                ? "1".getBytes(StandardCharsets.UTF_8)
+                                : "0".getBytes(StandardCharsets.UTF_8),
+                        shouldRemoveTaskLimitBucket(task, taskDefinition)
+                                ? "1".getBytes(StandardCharsets.UTF_8)
+                                : "0".getBytes(StandardCharsets.UTF_8));
+
+        Object response = runCreateTaskScript(keys, args);
+        long added = response instanceof Number ? ((Number) response).longValue() : 0L;
+        if (added < 1) {
+            logTaskAlreadyScheduled(task, taskKey);
+            return false;
+        }
+        recordTaskPayloadPersisted(task, taskDefinition, payload);
+        return true;
+    }
+
+    private Object runCreateTaskScript(List<byte[]> keys, List<byte[]> args) {
+        byte[] sampleKey = keys.get(0);
+        try {
+            return jedisProxy.evalsha(loadCreateTaskScript(sampleKey), keys, args);
+        } catch (RuntimeException e) {
+            if (!isNoScriptError(e)) {
+                throw e;
+            }
+            synchronized (this) {
+                createTaskScriptSha = jedisProxy.scriptLoad(CREATE_TASK_SCRIPT, sampleKey);
+            }
+            return jedisProxy.evalsha(createTaskScriptSha, keys, args);
+        }
+    }
+
+    private void recordTaskPayloadPersisted(
+            TaskModel task, Optional<TaskDef> taskDefinition, String payload) {
+        recordRedisDaoPayloadSize(
+                "updateTask",
+                payload.length(),
+                taskDefinition.map(TaskDef::getName).orElse("n/a"),
+                task.getWorkflowType());
+        recordRedisDaoRequests("updateTask", task.getTaskType(), task.getWorkflowType());
+    }
+
+    private boolean shouldAddTaskInProgressStatus(
+            TaskModel task, Optional<TaskDef> taskDefinition) {
+        return taskDefinition.isPresent()
+                && taskDefinition.get().concurrencyLimit() > 0
+                && task.getStatus() == TaskModel.Status.IN_PROGRESS;
+    }
+
+    private boolean shouldRemoveTaskLimitBucket(TaskModel task, Optional<TaskDef> taskDefinition) {
+        return taskDefinition.isPresent()
+                && taskDefinition.get().concurrencyLimit() > 0
+                && task.getStatus() != TaskModel.Status.IN_PROGRESS;
+    }
+
+    private byte[] loadCreateTaskScript(byte[] sampleKey) {
+        byte[] sha = createTaskScriptSha;
+        if (sha == null || sha.length == 0) {
+            synchronized (this) {
+                sha = createTaskScriptSha;
+                if (sha == null || sha.length == 0) {
+                    sha = jedisProxy.scriptLoad(CREATE_TASK_SCRIPT, sampleKey);
+                    createTaskScriptSha = sha;
+                }
+            }
+        }
+        return sha;
+    }
+
+    private boolean isNoScriptError(RuntimeException e) {
+        return e.getMessage() != null && e.getMessage().contains("NOSCRIPT");
+    }
+
+    private void logTaskAlreadyScheduled(TaskModel task, String taskKey) {
+        LOGGER.debug(
+                "Task already scheduled, skipping the run {}, ref={}, key={}",
+                task.getTaskId(),
+                task.getReferenceTaskName(),
+                taskKey);
     }
 
     @Override

--- a/redis-persistence/src/test/java/com/netflix/conductor/redis/dao/RedisExecutionDAOTest.java
+++ b/redis-persistence/src/test/java/com/netflix/conductor/redis/dao/RedisExecutionDAOTest.java
@@ -152,6 +152,50 @@ public class RedisExecutionDAOTest extends ExecutionDAOTest {
     }
 
     @Test
+    public void testCreateTasksDoesNotOverwriteScheduledTaskOnDuplicateRefAndRetry() {
+        WorkflowModel workflow = createRunningWorkflow();
+        executionDAO.createWorkflow(workflow);
+
+        TaskModel originalTask = new TaskModel();
+        originalTask.setTaskDefName("task_type");
+        originalTask.setTaskType("task_type");
+        originalTask.setStatus(TaskModel.Status.SCHEDULED);
+        originalTask.setTaskId(UUID.randomUUID().toString());
+        originalTask.setWorkflowInstanceId(workflow.getWorkflowId());
+        originalTask.setReferenceTaskName("join_ref");
+        originalTask.setRetryCount(0);
+
+        TaskModel duplicateTask = new TaskModel();
+        duplicateTask.setTaskDefName("task_type");
+        duplicateTask.setTaskType("task_type");
+        duplicateTask.setStatus(TaskModel.Status.SCHEDULED);
+        duplicateTask.setTaskId(UUID.randomUUID().toString());
+        duplicateTask.setWorkflowInstanceId(workflow.getWorkflowId());
+        duplicateTask.setReferenceTaskName("join_ref");
+        duplicateTask.setRetryCount(0);
+
+        List<TaskModel> created = executionDAO.createTasks(List.of(originalTask));
+        assertEquals(1, created.size());
+
+        created = executionDAO.createTasks(List.of(duplicateTask));
+        assertTrue(created.isEmpty());
+
+        try (Jedis jedis = jedisPool.getResource()) {
+            String scheduledTaskId =
+                    jedis.hget("SCHEDULED_TASKS." + workflow.getWorkflowId(), "join_ref0");
+            assertEquals(originalTask.getTaskId(), scheduledTaskId);
+            assertFalse(jedis.exists("TASK." + duplicateTask.getTaskId()));
+            assertEquals(
+                    Collections.singleton(originalTask.getTaskId()),
+                    jedis.smembers("WORKFLOW_TO_TASKS." + workflow.getWorkflowId()));
+        }
+
+        List<TaskModel> retrievedTasks = executionDAO.getTasksForWorkflow(workflow.getWorkflowId());
+        assertEquals(1, retrievedTasks.size());
+        assertEquals(originalTask.getTaskId(), retrievedTasks.get(0).getTaskId());
+    }
+
+    @Test
     public void testPendingWorkflowCount() {
         String workflowName = "count_workflow_" + UUID.randomUUID();
         int workflowCount = 5;


### PR DESCRIPTION
## Problem

Redis-backed workflow execution can leave a workflow permanently stuck when task creation or task mutation state becomes internally inconsistent. The failure mode observed was a running workflow where the logical next task had been scheduled, but Redis contained inconsistent task metadata: `SCHEDULED_TASKS` and `WORKFLOW_TO_TASKS` could point at different task IDs, and the corresponding `TASK.<taskId>` payload could be missing.

When that happens, the decider no longer sees the missing task as part of the workflow task list, but the workflow is still not terminal. Re-running decide or sweep can keep exercising the same state without converging, because the execution backend has already lost the atomic relationship between the scheduled-task marker, workflow-to-task mapping, in-progress tracking, and the task payload.

This is especially visible with Redis as the execution backend because task creation was previously persisted through several independent Redis writes. A crash, timeout, retry, or duplicate scheduling attempt could leave durable partial state behind.

## What changed

### 1. Make duplicate Redis task scheduling non-destructive

`RedisExecutionDAO.createTasks()` now uses a set-if-absent style scheduled-task guard instead of overwriting the existing scheduled-task mapping and then deciding to skip the duplicate.

Previously, a duplicate schedule attempt for the same logical task key could overwrite `SCHEDULED_TASKS` with a new task ID, receive the Redis return value that indicates the field already existed, and then skip the rest of task persistence. That left `SCHEDULED_TASKS` pointing to a task payload that was never written.

With the new behavior, a duplicate schedule attempt is a true no-op: the existing scheduled-task mapping is preserved and the new task ID is discarded before any related task metadata is written.

### 2. Persist Redis task creation atomically for single-primary Redis deployments

Redis task creation now has an atomic path for Redis standalone and sentinel deployments. The atomic write covers the scheduled-task guard, workflow-to-task correlation, in-progress task tracking, concurrency-limit bookkeeping, and the `TASK.<taskId>` payload write as one Redis script execution.

This removes the partial-write window where Conductor could write one Redis structure and fail before writing the others. In the failure mode this PR targets, that partial-write window was enough to make a workflow appear to have no pending task even though its scheduled-task metadata still existed.

Redis Cluster and in-memory Redis continue to use the fallback path because the current Redis key layout is not hash-slot aligned for safe multi-key Lua execution in Redis Cluster.

### 3. Serialize workflow-visible task mutations by owning workflow ID

Task write entry points now acquire the workflow execution lock before mutating task state that is visible to workflow progression. This hardens the read-modify-write paths that can otherwise operate on stale task snapshots while another thread is updating the same workflow.

The lock is applied at the higher-level execution entry points rather than inside `ExecutionDAOFacade`, so the protected section includes the important workflow-visible logic around task state changes, not just the final DAO write. This includes worker task updates, task lease extension, worker poll task claiming, and async system task execution.

## Why these changes fix the issue

Together, these changes address the main ways Redis execution state could become inconsistent:

- Duplicate scheduling can no longer overwrite an existing scheduled-task pointer and then skip task payload creation.
- Task creation in supported Redis deployments can no longer be persisted as a half-written set of Redis structures.
- Concurrent task mutation paths are serialized on the same workflow lock used by workflow progression, reducing stale-state races around task completion, claiming, and system-task execution.

The Redis atomic create change is the primary correctness fix for partial persistence. The workflow-scoped task locking is additional hardening around concurrent execution paths that can otherwise race with decider/sweeper activity.

## Validation

- Ran targeted core tests covering the modified execution paths:
  - `./gradlew :conductor-core:test --tests com.netflix.conductor.core.dal.ExecutionDAOFacadeTest --tests com.netflix.conductor.service.ExecutionServiceTest --tests com.netflix.conductor.core.execution.TestWorkflowExecutor --tests com.netflix.conductor.core.reconciliation.TestWorkflowRepairService --tests com.netflix.conductor.core.execution.AsyncSystemTaskExecutorTest`
- Verified the targeted core test run passed.
- `spotlessApply` was run before opening the PR.
- Manually validated the change in a Redis-backed deployment by checking that a running workflow had matching `WORKFLOW_TO_TASKS` and `SCHEDULED_TASKS` state and no missing `TASK.<taskId>` payloads.

## Notes

This PR does not change the broader cross-backend behavior where reads may tolerate missing task payloads if datastore corruption already exists. The focus here is preventing the Redis execution backend from creating the inconsistent state in the first place and reducing races around task write paths.