### PR TITLE
Improve task retry policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,49 @@ jobs:
         if: always()
         with:
           report_paths: "e2e/build/test-results/test/TEST-*.xml"
+      - name: Generate test summary table
+        if: always()
+        shell: python3 {0}
+        run: |
+          import os, glob, xml.etree.ElementTree as ET
+
+          xml_files = glob.glob("e2e/build/test-results/test/TEST-*.xml")
+          rows = []
+          totals = {"passed": 0, "failed": 0, "skipped": 0}
+
+          for f in sorted(xml_files):
+              try:
+                  root = ET.parse(f).getroot()
+              except ET.ParseError:
+                  continue
+              for tc in root.iter("testcase"):
+                  name = tc.get("name", "?")
+                  classname = tc.get("classname", "").split(".")[-1]
+                  duration = float(tc.get("time", 0))
+                  if tc.find("skipped") is not None:
+                      status, totals["skipped"] = "⏭ skip", totals["skipped"] + 1
+                  elif tc.find("failure") is not None or tc.find("error") is not None:
+                      node = tc.find("failure") or tc.find("error")
+                      msg = (node.get("message") or "")[:120]
+                      status, totals["failed"] = f"❌ `{msg}`", totals["failed"] + 1
+                  else:
+                      status, totals["passed"] = "✅", totals["passed"] + 1
+                  rows.append((classname, name, f"{duration:.1f}s", status))
+
+          backend = "${{ matrix.name }}"
+          lines = [
+              f"## E2E results — {backend}",
+              f"**✅ {totals['passed']} passed · ❌ {totals['failed']} failed · ⏭ {totals['skipped']} skipped**",
+              "",
+              "| Class | Test | Duration | Result |",
+              "|-------|------|----------|--------|",
+          ]
+          for cls, name, dur, status in rows:
+              lines.append(f"| {cls} | {name} | {dur} | {status} |")
+
+          summary = os.environ.get("GITHUB_STEP_SUMMARY", "/dev/null")
+          with open(summary, "a") as fh:
+              fh.write("\n".join(lines) + "\n")
       - name: Upload E2E reports
         uses: actions/upload-artifact@v6
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,32 @@ on:
   pull_request:
     paths-ignore:
       - "conductor-clients/**"
+  workflow_dispatch:
+    inputs:
+      redis_es8:
+        description: "Redis + Elasticsearch 8"
+        type: boolean
+        default: true
+      postgres:
+        description: "PostgreSQL"
+        type: boolean
+        default: false
+      mysql:
+        description: "MySQL"
+        type: boolean
+        default: false
+      redis_os3:
+        description: "Redis + OpenSearch 3"
+        type: boolean
+        default: false
+      redis_es7:
+        description: "Redis + Elasticsearch 7"
+        type: boolean
+        default: false
+      cassandra_es7:
+        description: "Cassandra + Elasticsearch 7"
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -175,16 +201,35 @@ jobs:
         with:
           name: test-harness-coverage-report
           path: "test-harness/build/reports/jacoco"
+  generate-e2e-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            items=""
+            [ "${{ inputs.redis_es8 }}"    = "true" ] && items="${items}{\"name\":\"redis-es8\",\"script\":\"./e2e/run_tests-es8.sh\"},"
+            [ "${{ inputs.postgres }}"     = "true" ] && items="${items}{\"name\":\"postgres\",\"script\":\"./e2e/run_tests-postgres.sh\"},"
+            [ "${{ inputs.mysql }}"        = "true" ] && items="${items}{\"name\":\"mysql\",\"script\":\"./e2e/run_tests-mysql.sh\"},"
+            [ "${{ inputs.redis_os3 }}"    = "true" ] && items="${items}{\"name\":\"redis-os3\",\"script\":\"./e2e/run_tests-redis-os3.sh\"},"
+            [ "${{ inputs.redis_es7 }}"    = "true" ] && items="${items}{\"name\":\"redis-es7\",\"script\":\"./e2e/run_tests-redis-es7.sh\"},"
+            [ "${{ inputs.cassandra_es7 }}" = "true" ] && items="${items}{\"name\":\"cassandra-es7\",\"script\":\"./e2e/run_tests-cassandra-es7.sh\"},"
+            items="${items%,}"
+            echo "matrix={\"include\":[${items}]}" >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix={"include":[{"name":"redis-es8","script":"./e2e/run_tests-es8.sh"}]}' >> "$GITHUB_OUTPUT"
+          fi
+
   e2e:
+    needs: generate-e2e-matrix
+    if: ${{ needs.generate-e2e-matrix.outputs.matrix != '{"include":[]}' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - name: postgres
-            script: ./e2e/run_tests-postgres.sh
-          - name: redis-es8
-            script: ./e2e/run_tests-es8.sh
+      matrix: ${{ fromJson(needs.generate-e2e-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,53 @@ jobs:
         with:
           name: test-harness-coverage-report
           path: "test-harness/build/reports/jacoco"
+  e2e:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: postgres
+            script: ./e2e/run_tests-postgres.sh
+          - name: redis-es8
+            script: ./e2e/run_tests-es8.sh
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+      - name: Set up Zulu JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: "zulu"
+          java-version: "21"
+      - name: Cache Gradle packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+      - name: Run E2E tests (${{ matrix.name }})
+        run: ${{ matrix.script }}
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v6
+        if: always()
+        with:
+          report_paths: "e2e/build/test-results/test/TEST-*.xml"
+      - name: Upload E2E reports
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: e2e-reports-${{ matrix.name }}
+          path: "e2e/build/reports"
+
   build-ui:
     runs-on: ubuntu-latest
     container: cypress/browsers:node-22.11.0-chrome-130.0.6723.116-1-ff-132.0.1-edge-130.0.2849.68-1

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
@@ -128,6 +128,10 @@ public class TaskDef extends Auditable {
     @Min(value = 0, message = "TaskDef maxRetryDelaySeconds: {value} must be >= 0")
     private int maxRetryDelaySeconds = 0;
 
+    @ProtoField(id = 25)
+    @Min(value = 0, message = "TaskDef backoffJitterMs: {value} must be >= 0")
+    private int backoffJitterMs = 0;
+
     @ProtoField(id = 21)
     private String baseType;
 
@@ -459,6 +463,20 @@ public class TaskDef extends Auditable {
         this.maxRetryDelaySeconds = maxRetryDelaySeconds;
     }
 
+    /**
+     * Maximum jitter to add to the retry delay. On each retry a random value in {@code [0,
+     * backoffJitterMs]} milliseconds is added to the computed delay, spreading retries across time
+     * and preventing thundering-herd storms when many tasks fail simultaneously. A value of 0 (the
+     * default) disables jitter.
+     */
+    public int getBackoffJitterMs() {
+        return backoffJitterMs;
+    }
+
+    public void setBackoffJitterMs(int backoffJitterMs) {
+        this.backoffJitterMs = backoffJitterMs;
+    }
+
     public String getBaseType() {
         return baseType;
     }
@@ -542,7 +560,8 @@ public class TaskDef extends Auditable {
                 && Objects.equals(getInputSchema(), taskDef.getInputSchema())
                 && Objects.equals(getOutputSchema(), taskDef.getOutputSchema())
                 && Objects.equals(getTotalTimeoutSeconds(), taskDef.getTotalTimeoutSeconds())
-                && getMaxRetryDelaySeconds() == taskDef.getMaxRetryDelaySeconds();
+                && getMaxRetryDelaySeconds() == taskDef.getMaxRetryDelaySeconds()
+                && getBackoffJitterMs() == taskDef.getBackoffJitterMs();
     }
 
     @Override
@@ -570,6 +589,7 @@ public class TaskDef extends Auditable {
                 getInputSchema(),
                 getOutputSchema(),
                 getTotalTimeoutSeconds(),
-                getMaxRetryDelaySeconds());
+                getMaxRetryDelaySeconds(),
+                getBackoffJitterMs());
     }
 }

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
@@ -136,7 +136,7 @@ public class TaskDef extends Auditable {
     private String baseType;
 
     @ProtoField(id = 22)
-    @NotNull
+    @Min(value = 0, message = "TaskDef totalTimeoutSeconds: {value} must be >= 0")
     private long totalTimeoutSeconds;
 
     @ProtoField(id = 23)

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
@@ -452,8 +452,8 @@ public class TaskDef extends Auditable {
      * delay for {@code EXPONENTIAL_BACKOFF} and {@code LINEAR_BACKOFF} retry logic will be capped
      * at this value. A value of 0 (the default) means no cap is applied.
      *
-     * <p>Example: 20 retries with exponential backoff starting at 1 s and capped at 600 s will
-     * back off as 1, 2, 4, 8, …, 600, 600, 600, … instead of growing unboundedly.
+     * <p>Example: 20 retries with exponential backoff starting at 1 s and capped at 600 s will back
+     * off as 1, 2, 4, 8, …, 600, 600, 600, … instead of growing unboundedly.
      */
     public int getMaxRetryDelaySeconds() {
         return maxRetryDelaySeconds;

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
@@ -124,6 +124,10 @@ public class TaskDef extends Auditable {
     @Min(value = 1, message = "Backoff scale factor. Applicable for LINEAR_BACKOFF")
     private Integer backoffScaleFactor = 1;
 
+    @ProtoField(id = 24)
+    @Min(value = 0, message = "TaskDef maxRetryDelaySeconds: {value} must be >= 0")
+    private int maxRetryDelaySeconds = 0;
+
     @ProtoField(id = 21)
     private String baseType;
 
@@ -439,6 +443,22 @@ public class TaskDef extends Auditable {
         return backoffScaleFactor;
     }
 
+    /**
+     * Maximum delay between retries in seconds. When set to a value greater than 0, the computed
+     * delay for {@code EXPONENTIAL_BACKOFF} and {@code LINEAR_BACKOFF} retry logic will be capped
+     * at this value. A value of 0 (the default) means no cap is applied.
+     *
+     * <p>Example: 20 retries with exponential backoff starting at 1 s and capped at 600 s will
+     * back off as 1, 2, 4, 8, …, 600, 600, 600, … instead of growing unboundedly.
+     */
+    public int getMaxRetryDelaySeconds() {
+        return maxRetryDelaySeconds;
+    }
+
+    public void setMaxRetryDelaySeconds(int maxRetryDelaySeconds) {
+        this.maxRetryDelaySeconds = maxRetryDelaySeconds;
+    }
+
     public String getBaseType() {
         return baseType;
     }
@@ -521,7 +541,8 @@ public class TaskDef extends Auditable {
                 && Objects.equals(getBaseType(), taskDef.getBaseType())
                 && Objects.equals(getInputSchema(), taskDef.getInputSchema())
                 && Objects.equals(getOutputSchema(), taskDef.getOutputSchema())
-                && Objects.equals(getTotalTimeoutSeconds(), taskDef.getTotalTimeoutSeconds());
+                && Objects.equals(getTotalTimeoutSeconds(), taskDef.getTotalTimeoutSeconds())
+                && getMaxRetryDelaySeconds() == taskDef.getMaxRetryDelaySeconds();
     }
 
     @Override
@@ -548,6 +569,7 @@ public class TaskDef extends Auditable {
                 getBaseType(),
                 getInputSchema(),
                 getOutputSchema(),
-                getTotalTimeoutSeconds());
+                getTotalTimeoutSeconds(),
+                getMaxRetryDelaySeconds());
     }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -15,7 +15,6 @@ apply plugin: 'groovy'
 dependencies {
     implementation project(':conductor-common')
     implementation project(':conductor-metrics')
-    implementation ("org.conductoross:conductor-client:4.2.0-rc3")
 
     compileOnly 'org.springframework.boot:spring-boot-starter'
     compileOnly 'org.springframework.boot:spring-boot-starter-validation'

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -201,6 +201,9 @@ public class DeciderService {
             }
 
             if (taskDefinition.isPresent()) {
+                // Total timeout is checked first: if the overall budget is exhausted any
+                // per-attempt timeout check is moot.
+                checkTotalTimeout(taskDefinition.get(), pendingTask);
                 checkTaskTimeout(taskDefinition.get(), pendingTask);
                 checkTaskPollTimeout(taskDefinition.get(), pendingTask);
                 // If the task has not been updated for "responseTimeoutSeconds" then mark task
@@ -602,6 +605,31 @@ public class DeciderService {
             throw new TerminateWorkflowException(errMsg, status, task);
         }
 
+        // Guard: stop retrying if the total time budget across all attempts is exhausted.
+        // This is checked here (not only in checkTotalTimeout) so that a task timed out by a
+        // per-attempt policy with RETRY does not get re-queued once the total budget is gone.
+        if (taskDefinition.getTotalTimeoutSeconds() > 0 && task.getFirstScheduledTime() > 0) {
+            long totalElapsedSeconds =
+                    (System.currentTimeMillis() - task.getFirstScheduledTime()) / 1000;
+            if (totalElapsedSeconds >= taskDefinition.getTotalTimeoutSeconds()) {
+                final String errMsg =
+                        String.format(
+                                "Task %s/%s exceeded total timeout of %d seconds "
+                                        + "(elapsed %d seconds across all attempts). "
+                                        + "No further retries will be attempted.",
+                                task.getTaskId(),
+                                task.getTaskDefName(),
+                                taskDefinition.getTotalTimeoutSeconds(),
+                                totalElapsedSeconds);
+                WorkflowModel.Status totalTimeoutStatus =
+                        task.getStatus() == TaskModel.Status.TIMED_OUT
+                                ? WorkflowModel.Status.TIMED_OUT
+                                : WorkflowModel.Status.FAILED;
+                updateWorkflowOutput(workflow, task);
+                throw new TerminateWorkflowException(errMsg, totalTimeoutStatus, task);
+            }
+        }
+
         // retry... - but not immediately - put a delay...
         int startDelay = taskDefinition.getRetryDelaySeconds();
         switch (taskDefinition.getRetryLogic()) {
@@ -722,7 +750,44 @@ public class DeciderService {
         }
     }
 
+    /**
+     * Enforces {@link TaskDef#getTotalTimeoutSeconds()} — a hard wall-clock budget that spans the
+     * entire lifetime of the task including all retry delays, not just a single attempt.
+     *
+     * <p>When the budget is exceeded the task is timed out via the same {@link
+     * #timeoutTaskWithTimeoutPolicy} path used for per-attempt timeouts, so the configured {@link
+     * TaskDef.TimeoutPolicy} still applies (ALERT_ONLY logs, RETRY sets TIMED_OUT which then
+     * fails permanently in {@link #retry}, TIME_OUT_WF terminates the workflow).
+     *
+     * <p>Tasks created before {@code firstScheduledTime} was introduced (value == 0) are skipped
+     * to preserve backward compatibility.
+     */
     @VisibleForTesting
+    void checkTotalTimeout(TaskDef taskDef, TaskModel task) {
+        if (taskDef == null
+                || taskDef.getTotalTimeoutSeconds() <= 0
+                || task.getStatus().isTerminal()
+                || task.getFirstScheduledTime() <= 0) {
+            return;
+        }
+        long totalElapsedSeconds =
+                (System.currentTimeMillis() - task.getFirstScheduledTime()) / 1000;
+        if (totalElapsedSeconds < taskDef.getTotalTimeoutSeconds()) {
+            return;
+        }
+        String reason =
+                String.format(
+                        "Task %s/%s exceeded total timeout of %d seconds "
+                                + "(elapsed %d seconds across all attempts including retry delays). "
+                                + "Timeout policy: %s",
+                        task.getTaskDefName(),
+                        task.getTaskId(),
+                        taskDef.getTotalTimeoutSeconds(),
+                        totalElapsedSeconds,
+                        taskDef.getTimeoutPolicy().name());
+        timeoutTaskWithTimeoutPolicy(reason, taskDef, task);
+    }
+
     void checkTaskTimeout(TaskDef taskDef, TaskModel task) {
 
         if (taskDef == null) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -662,10 +662,13 @@ public class DeciderService {
 
         task.setRetried(true);
 
-        // Compute ms-precision total delay: base delay in seconds + random jitter in [0, maxJitterMs]
+        // Compute ms-precision total delay: base delay in seconds + random jitter in [0,
+        // maxJitterMs]
         long jitterMs = 0;
         if (taskDefinition.getBackoffJitterMs() > 0) {
-            jitterMs = ThreadLocalRandom.current().nextLong(0, taskDefinition.getBackoffJitterMs() + 1);
+            jitterMs =
+                    ThreadLocalRandom.current()
+                            .nextLong(0, taskDefinition.getBackoffJitterMs() + 1);
         }
         long totalDelayMs = (long) startDelay * 1000 + jitterMs;
 
@@ -756,11 +759,11 @@ public class DeciderService {
      *
      * <p>When the budget is exceeded the task is timed out via the same {@link
      * #timeoutTaskWithTimeoutPolicy} path used for per-attempt timeouts, so the configured {@link
-     * TaskDef.TimeoutPolicy} still applies (ALERT_ONLY logs, RETRY sets TIMED_OUT which then
-     * fails permanently in {@link #retry}, TIME_OUT_WF terminates the workflow).
+     * TaskDef.TimeoutPolicy} still applies (ALERT_ONLY logs, RETRY sets TIMED_OUT which then fails
+     * permanently in {@link #retry}, TIME_OUT_WF terminates the workflow).
      *
-     * <p>Tasks created before {@code firstScheduledTime} was introduced (value == 0) are skipped
-     * to preserve backward compatibility.
+     * <p>Tasks created before {@code firstScheduledTime} was introduced (value == 0) are skipped to
+     * preserve backward compatibility.
      */
     @VisibleForTesting
     void checkTotalTimeout(TaskDef taskDef, TaskModel task) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -14,6 +14,7 @@ package com.netflix.conductor.core.execution;
 
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -606,6 +607,7 @@ public class DeciderService {
         switch (taskDefinition.getRetryLogic()) {
             case FIXED:
                 startDelay = taskDefinition.getRetryDelaySeconds();
+                startDelay = applyMaxRetryDelayCap(startDelay, taskDefinition);
                 break;
             case LINEAR_BACKOFF:
                 int linearRetryDelaySeconds =
@@ -632,9 +634,17 @@ public class DeciderService {
 
         task.setRetried(true);
 
+        // Compute ms-precision total delay: base delay in seconds + random jitter in [0, maxJitterMs]
+        long jitterMs = 0;
+        if (taskDefinition.getBackoffJitterMs() > 0) {
+            jitterMs = ThreadLocalRandom.current().nextLong(0, taskDefinition.getBackoffJitterMs() + 1);
+        }
+        long totalDelayMs = (long) startDelay * 1000 + jitterMs;
+
         TaskModel rescheduled = task.copy();
         rescheduled.setStartDelayInSeconds(startDelay);
         rescheduled.setCallbackAfterSeconds(startDelay);
+        rescheduled.setCallbackAfterMs(totalDelayMs);
         rescheduled.setRetryCount(task.getRetryCount() + 1);
         rescheduled.setRetried(false);
         rescheduled.setTaskId(idGenerator.generate());

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -615,6 +615,7 @@ public class DeciderService {
                 // Reset integer overflow to max value
                 startDelay =
                         linearRetryDelaySeconds < 0 ? Integer.MAX_VALUE : linearRetryDelaySeconds;
+                startDelay = applyMaxRetryDelayCap(startDelay, taskDefinition);
                 break;
             case EXPONENTIAL_BACKOFF:
                 int exponentialRetryDelaySeconds =
@@ -625,6 +626,7 @@ public class DeciderService {
                         exponentialRetryDelaySeconds < 0
                                 ? Integer.MAX_VALUE
                                 : exponentialRetryDelaySeconds;
+                startDelay = applyMaxRetryDelayCap(startDelay, taskDefinition);
                 break;
         }
 
@@ -924,6 +926,11 @@ public class DeciderService {
                 .stream()
                 .filter(task -> !tasksInWorkflow.contains(task.getReferenceTaskName()))
                 .collect(Collectors.toList());
+    }
+
+    private int applyMaxRetryDelayCap(int delaySeconds, TaskDef taskDef) {
+        int cap = taskDef.getMaxRetryDelaySeconds();
+        return (cap > 0 && delaySeconds > cap) ? cap : delaySeconds;
     }
 
     private boolean isTaskSkipped(WorkflowTask taskToSchedule, WorkflowModel workflow) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
@@ -1626,6 +1626,11 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
                 if (task.getSeq() == 0) { // Set only if the seq was not set
                     task.setSeq(++count);
                 }
+                // Stamp the very first time this task enters the queue. Retried tasks carry
+                // this value forward (via TaskModel.copy()), so it is never overwritten here.
+                if (task.getFirstScheduledTime() == 0) {
+                    task.setFirstScheduledTime(System.currentTimeMillis());
+                }
             }
 
             // metric to track the distribution of number of tasks within a workflow

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
@@ -1513,7 +1513,14 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
     private void addTaskToQueue(TaskModel task) {
         // put in queue
         String taskQueueName = QueueUtils.getQueueName(task);
-        if (task.getCallbackAfterSeconds() > 0) {
+        if (task.getCallbackAfterMs() > 0) {
+            // Use ms-precision Duration overload to preserve sub-second jitter
+            queueDAO.push(
+                    taskQueueName,
+                    task.getTaskId(),
+                    task.getWorkflowPriority(),
+                    Duration.ofMillis(task.getCallbackAfterMs()));
+        } else if (task.getCallbackAfterSeconds() > 0) {
             queueDAO.push(
                     taskQueueName,
                     task.getTaskId(),

--- a/core/src/main/java/com/netflix/conductor/dao/QueueDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/QueueDAO.java
@@ -122,6 +122,23 @@ public interface QueueDAO {
     boolean setUnackTimeout(String queueName, String messageId, long unackTimeout);
 
     /**
+     * Updates the unack timeout only if the new value would result in an earlier delivery than the
+     * currently scheduled time — i.e. never postpones further than what is already set.
+     *
+     * <p>Implementations should perform this as an atomic compare-and-set where possible (e.g.
+     * {@code ZADD XX LT} in Redis, {@code LEAST(deliver_on, …)} in SQL). The default falls back to
+     * an unconditional {@link #setUnackTimeout}.
+     *
+     * @param queueName Name of the queue
+     * @param messageId Message Id
+     * @param unackTimeout timeout in milliseconds
+     * @return true if the timeout was updated
+     */
+    default boolean setUnackTimeoutIfShorter(String queueName, String messageId, long unackTimeout) {
+        return setUnackTimeout(queueName, messageId, unackTimeout);
+    }
+
+    /**
      * @param queueName Name of the queue
      */
     void flush(String queueName);

--- a/core/src/main/java/com/netflix/conductor/dao/QueueDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/QueueDAO.java
@@ -134,7 +134,8 @@ public interface QueueDAO {
      * @param unackTimeout timeout in milliseconds
      * @return true if the timeout was updated
      */
-    default boolean setUnackTimeoutIfShorter(String queueName, String messageId, long unackTimeout) {
+    default boolean setUnackTimeoutIfShorter(
+            String queueName, String messageId, long unackTimeout) {
         return setUnackTimeout(queueName, messageId, unackTimeout);
     }
 

--- a/core/src/main/java/com/netflix/conductor/model/TaskModel.java
+++ b/core/src/main/java/com/netflix/conductor/model/TaskModel.java
@@ -119,19 +119,19 @@ public class TaskModel {
     private long callbackAfterSeconds;
 
     /**
-     * Millisecond-precision delay before this task should next be made visible in the queue.
-     * When greater than zero this takes precedence over {@link #callbackAfterSeconds} so that
-     * sub-second jitter added at retry scheduling time is preserved through to the queue push.
-     * Zero (the default) means fall back to {@link #callbackAfterSeconds}.
+     * Millisecond-precision delay before this task should next be made visible in the queue. When
+     * greater than zero this takes precedence over {@link #callbackAfterSeconds} so that sub-second
+     * jitter added at retry scheduling time is preserved through to the queue push. Zero (the
+     * default) means fall back to {@link #callbackAfterSeconds}.
      */
     private long callbackAfterMs;
 
     /**
      * Epoch-millisecond timestamp of when this task was <em>first</em> scheduled, before any
-     * retries. Preserved across all retry attempts (copied but never reset) so that
-     * {@code totalTimeoutSeconds} on the task definition can be enforced as a hard wall-clock
-     * budget spanning the entire lifetime of the task including retry delays.
-     * Zero means the task was created before this field was introduced.
+     * retries. Preserved across all retry attempts (copied but never reset) so that {@code
+     * totalTimeoutSeconds} on the task definition can be enforced as a hard wall-clock budget
+     * spanning the entire lifetime of the task including retry delays. Zero means the task was
+     * created before this field was introduced.
      */
     private long firstScheduledTime;
 

--- a/core/src/main/java/com/netflix/conductor/model/TaskModel.java
+++ b/core/src/main/java/com/netflix/conductor/model/TaskModel.java
@@ -126,6 +126,15 @@ public class TaskModel {
      */
     private long callbackAfterMs;
 
+    /**
+     * Epoch-millisecond timestamp of when this task was <em>first</em> scheduled, before any
+     * retries. Preserved across all retry attempts (copied but never reset) so that
+     * {@code totalTimeoutSeconds} on the task definition can be enforced as a hard wall-clock
+     * budget spanning the entire lifetime of the task including retry delays.
+     * Zero means the task was created before this field was introduced.
+     */
+    private long firstScheduledTime;
+
     private String workerId;
 
     private WorkflowTask workflowTask;
@@ -426,6 +435,14 @@ public class TaskModel {
 
     public void setCallbackAfterMs(long callbackAfterMs) {
         this.callbackAfterMs = callbackAfterMs;
+    }
+
+    public long getFirstScheduledTime() {
+        return firstScheduledTime;
+    }
+
+    public void setFirstScheduledTime(long firstScheduledTime) {
+        this.firstScheduledTime = firstScheduledTime;
     }
 
     public String getWorkerId() {

--- a/core/src/main/java/com/netflix/conductor/model/TaskModel.java
+++ b/core/src/main/java/com/netflix/conductor/model/TaskModel.java
@@ -118,6 +118,14 @@ public class TaskModel {
 
     private long callbackAfterSeconds;
 
+    /**
+     * Millisecond-precision delay before this task should next be made visible in the queue.
+     * When greater than zero this takes precedence over {@link #callbackAfterSeconds} so that
+     * sub-second jitter added at retry scheduling time is preserved through to the queue push.
+     * Zero (the default) means fall back to {@link #callbackAfterSeconds}.
+     */
+    private long callbackAfterMs;
+
     private String workerId;
 
     private WorkflowTask workflowTask;
@@ -410,6 +418,14 @@ public class TaskModel {
 
     public void setCallbackAfterSeconds(long callbackAfterSeconds) {
         this.callbackAfterSeconds = callbackAfterSeconds;
+    }
+
+    public long getCallbackAfterMs() {
+        return callbackAfterMs;
+    }
+
+    public void setCallbackAfterMs(long callbackAfterMs) {
+        this.callbackAfterMs = callbackAfterMs;
     }
 
     public String getWorkerId() {

--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -216,9 +216,9 @@ public class ExecutionService {
      * pollTimeoutSeconds to responseTimeoutSeconds. Advance the decider queue entry to fire at the
      * response timeout so the sweeper doesn't wait for the now-stale poll-based postpone.
      *
-     * <p>Uses {@link QueueDAO#setUnackTimeoutIfShorter} so we never push the evaluation further
-     * out than whatever the sweeper already scheduled (e.g. for another in-flight task with a
-     * shorter remaining timeout).
+     * <p>Uses {@link QueueDAO#setUnackTimeoutIfShorter} so we never push the evaluation further out
+     * than whatever the sweeper already scheduled (e.g. for another in-flight task with a shorter
+     * remaining timeout).
      */
     private void adjustDeciderQueuePostpone(TaskModel taskModel, TaskDef taskDef) {
         long responseTimeoutSeconds =

--- a/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
+++ b/core/src/main/java/com/netflix/conductor/service/ExecutionService.java
@@ -52,6 +52,7 @@ public class ExecutionService {
     private final WorkflowExecutor workflowExecutor;
     private final ExecutionDAOFacade executionDAOFacade;
     private final QueueDAO queueDAO;
+    private final ConductorProperties properties;
     private final ExternalPayloadStorage externalPayloadStorage;
     private final SystemTaskRegistry systemTaskRegistry;
     private final TaskStatusListener taskStatusListener;
@@ -73,6 +74,7 @@ public class ExecutionService {
         this.workflowExecutor = workflowExecutor;
         this.executionDAOFacade = executionDAOFacade;
         this.queueDAO = queueDAO;
+        this.properties = properties;
         this.externalPayloadStorage = externalPayloadStorage;
 
         this.queueTaskMessagePostponeSecs =
@@ -177,6 +179,7 @@ public class ExecutionService {
                 taskModel.setWorkerId(workerId);
                 taskModel.incrementPollCount();
                 executionDAOFacade.updateTask(taskModel);
+                adjustDeciderQueuePostpone(taskModel, taskDef);
                 tasks.add(taskModel.toTask());
             } catch (Exception e) {
                 // db operation failed for dequeued message, re-enqueue with a delay
@@ -206,6 +209,37 @@ public class ExecutionService {
         Monitors.recordTaskPoll(queueName);
         tasks.forEach(this::ackTaskReceived);
         return tasks;
+    }
+
+    /**
+     * When a task transitions SCHEDULED → IN_PROGRESS the relevant deadline changes from
+     * pollTimeoutSeconds to responseTimeoutSeconds. Advance the decider queue entry to fire at the
+     * response timeout so the sweeper doesn't wait for the now-stale poll-based postpone.
+     *
+     * <p>Uses {@link QueueDAO#setUnackTimeoutIfShorter} so we never push the evaluation further
+     * out than whatever the sweeper already scheduled (e.g. for another in-flight task with a
+     * shorter remaining timeout).
+     */
+    private void adjustDeciderQueuePostpone(TaskModel taskModel, TaskDef taskDef) {
+        long responseTimeoutSeconds =
+                (taskDef != null && taskDef.getResponseTimeoutSeconds() != 0)
+                        ? taskDef.getResponseTimeoutSeconds()
+                        : taskModel.getResponseTimeoutSeconds();
+        if (responseTimeoutSeconds == 0) {
+            return; // no response timeout — nothing to adjust
+        }
+        try {
+            queueDAO.setUnackTimeoutIfShorter(
+                    Utils.DECIDER_QUEUE,
+                    taskModel.getWorkflowInstanceId(),
+                    responseTimeoutSeconds * 1000);
+        } catch (Exception e) {
+            LOGGER.warn(
+                    "Failed to adjust decider queue postpone for workflow: {} after polling task: {}",
+                    taskModel.getWorkflowInstanceId(),
+                    taskModel.getTaskId(),
+                    e);
+        }
     }
 
     public Task getLastPollTask(String taskType, String workerId, String domain) {

--- a/core/src/main/java/org/conductoross/conductor/core/execution/ExecutorUtils.java
+++ b/core/src/main/java/org/conductoross/conductor/core/execution/ExecutorUtils.java
@@ -26,6 +26,60 @@ import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_WAI
 @Slf4j
 public class ExecutorUtils {
 
+    /**
+     * Computes how long to postpone the next sweep/re-check of a workflow so that the scheduler
+     * does not poll more frequently than necessary.
+     *
+     * <p>Algorithm:
+     *
+     * <ol>
+     *   <li>Iterate over every task in the workflow and derive a <em>candidate</em> postpone
+     *       duration based on the task's status and type:
+     *       <ul>
+     *         <li><b>SCHEDULED</b> – the worker has not polled yet.
+     *             <ul>
+     *               <li>If the task definition has a non-zero {@code pollTimeoutSeconds}: candidate
+     *                   = remaining seconds until the poll window expires ({@code pollTimeoutSeconds
+     *                   - elapsedSecondsSinceScheduled + 1}), floored at 0.
+     *               <li>Else if the workflow definition has a non-zero {@code timeoutSeconds}:
+     *                   candidate = {@code workflowTimeoutSeconds + 1}.
+     *               <li>Otherwise: candidate = {@code workflowOffsetTimeout}.
+     *             </ul>
+     *         <li><b>IN_PROGRESS / WAIT task</b>
+     *             <ul>
+     *               <li>{@code waitTimeout == 0} (indefinite wait): candidate = {@code
+     *                   workflowOffsetTimeout}.
+     *               <li>{@code waitTimeout > 0}: candidate = remaining milliseconds until {@code
+     *                   waitTimeout} converted to seconds, floored at 0.
+     *             </ul>
+     *         <li><b>IN_PROGRESS / HUMAN task</b>: candidate = {@code workflowOffsetTimeout}.
+     *         <li><b>IN_PROGRESS / all other tasks</b>
+     *             <ul>
+     *               <li>The effective {@code responseTimeoutSeconds} is the task definition value
+     *                   when non-zero, otherwise the task model value (allowing workflow-task-level
+     *                   overrides to be honoured even when the task def has no timeout).
+     *               <li>If the effective {@code responseTimeoutSeconds} is non-zero: candidate =
+     *                   {@code responseTimeoutSeconds - elapsedSeconds + 1}, floored at 0 (the
+     *                   +1 gives a one-second buffer past the deadline before re-evaluating).
+     *               <li>Otherwise: candidate = {@code workflowOffsetTimeout}.
+     *             </ul>
+     *         <li><b>Any other status</b> (COMPLETED, FAILED, …): skipped — no candidate
+     *             produced.
+     *       </ul>
+     *   <li>Each candidate is clamped to 0 if negative, then capped at {@code maxPostponeDuration}
+     *       when {@code maxPostponeDuration > 0}.
+     *   <li>The final postpone duration is the <em>minimum</em> of all candidates, so the workflow
+     *       is re-checked as soon as the soonest task needs attention.
+     *   <li>If no eligible tasks produced a candidate (e.g. all tasks are terminal), fall back to
+     *       {@code workflowOffsetTimeout}.
+     * </ol>
+     *
+     * @param workflowModel the workflow whose tasks are inspected
+     * @param workflowOffsetTimeout default postpone used when no task-level deadline is available
+     * @param maxPostponeDuration hard upper bound on the returned duration (ignored when zero or
+     *     negative)
+     * @return the duration to wait before the next workflow sweep, never negative
+     */
     public static Duration computePostpone(
             WorkflowModel workflowModel,
             Duration workflowOffsetTimeout,
@@ -51,7 +105,7 @@ public class ExecutorUtils {
                 } else {
                     TaskDef taskDef = taskModel.getTaskDefinition().orElse(null);
                     long responseTimeoutSeconds =
-                            taskDef != null
+                            (taskDef != null && taskDef.getResponseTimeoutSeconds() != 0)
                                     ? taskDef.getResponseTimeoutSeconds()
                                     : taskModel.getResponseTimeoutSeconds();
                     if (responseTimeoutSeconds != 0) {
@@ -68,7 +122,11 @@ public class ExecutorUtils {
                 if (taskDef != null
                         && taskDef.getPollTimeoutSeconds() != null
                         && taskDef.getPollTimeoutSeconds() != 0) {
-                    candidateSeconds = taskDef.getPollTimeoutSeconds().longValue() + 1;
+                    long scheduledElapsedSeconds =
+                            Math.max(0, (currentTimeMillis - taskModel.getScheduledTime()) / 1000);
+                    long remainingPollSeconds =
+                            taskDef.getPollTimeoutSeconds() - scheduledElapsedSeconds + 1;
+                    candidateSeconds = Math.max(0, remainingPollSeconds);
                 } else {
                     long workflowTimeoutSeconds =
                             workflowModel.getWorkflowDefinition() != null

--- a/core/src/main/java/org/conductoross/conductor/core/execution/ExecutorUtils.java
+++ b/core/src/main/java/org/conductoross/conductor/core/execution/ExecutorUtils.java
@@ -39,8 +39,8 @@ public class ExecutorUtils {
      *         <li><b>SCHEDULED</b> – the worker has not polled yet.
      *             <ul>
      *               <li>If the task definition has a non-zero {@code pollTimeoutSeconds}: candidate
-     *                   = remaining seconds until the poll window expires ({@code pollTimeoutSeconds
-     *                   - elapsedSecondsSinceScheduled + 1}), floored at 0.
+     *                   = remaining seconds until the poll window expires ({@code
+     *                   pollTimeoutSeconds - elapsedSecondsSinceScheduled + 1}), floored at 0.
      *               <li>Else if the workflow definition has a non-zero {@code timeoutSeconds}:
      *                   candidate = {@code workflowTimeoutSeconds + 1}.
      *               <li>Otherwise: candidate = {@code workflowOffsetTimeout}.
@@ -59,12 +59,11 @@ public class ExecutorUtils {
      *                   when non-zero, otherwise the task model value (allowing workflow-task-level
      *                   overrides to be honoured even when the task def has no timeout).
      *               <li>If the effective {@code responseTimeoutSeconds} is non-zero: candidate =
-     *                   {@code responseTimeoutSeconds - elapsedSeconds + 1}, floored at 0 (the
-     *                   +1 gives a one-second buffer past the deadline before re-evaluating).
+     *                   {@code responseTimeoutSeconds - elapsedSeconds + 1}, floored at 0 (the +1
+     *                   gives a one-second buffer past the deadline before re-evaluating).
      *               <li>Otherwise: candidate = {@code workflowOffsetTimeout}.
      *             </ul>
-     *         <li><b>Any other status</b> (COMPLETED, FAILED, …): skipped — no candidate
-     *             produced.
+     *         <li><b>Any other status</b> (COMPLETED, FAILED, …): skipped — no candidate produced.
      *       </ul>
      *   <li>Each candidate is clamped to 0 if negative, then capped at {@code maxPostponeDuration}
      *       when {@code maxPostponeDuration > 0}.

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -1083,6 +1083,164 @@ public class TestDeciderService {
                 distinctMs.size() > 1);
     }
 
+    // -------------------------------------------------------------------------
+    // totalTimeoutSeconds
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCheckTotalTimeout_notExceeded_noTimeout() {
+        WorkflowModel workflow = createDefaultWorkflow();
+        TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.IN_PROGRESS);
+        task.setTaskId("t1");
+        task.setTaskDefName("test");
+        task.setWorkflowInstanceId(workflow.getWorkflowId());
+        task.setFirstScheduledTime(System.currentTimeMillis()); // just now — not exceeded
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setTotalTimeoutSeconds(60);
+
+        // Should be a no-op; task status must remain IN_PROGRESS
+        deciderService.checkTotalTimeout(taskDef, task);
+        assertEquals(TaskModel.Status.IN_PROGRESS, task.getStatus());
+    }
+
+    @Test
+    public void testCheckTotalTimeout_exceeded_timesOutTask() {
+        WorkflowModel workflow = createDefaultWorkflow();
+        TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.IN_PROGRESS);
+        task.setTaskId("t1");
+        task.setTaskDefName("test");
+        task.setWorkflowInstanceId(workflow.getWorkflowId());
+        // Push firstScheduledTime far into the past so the budget is exhausted
+        task.setFirstScheduledTime(System.currentTimeMillis() - 120_000); // 120s ago
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setTotalTimeoutSeconds(60); // budget = 60s, elapsed > 60s
+        taskDef.setTimeoutPolicy(TaskDef.TimeoutPolicy.RETRY);
+
+        deciderService.checkTotalTimeout(taskDef, task);
+        assertEquals("RETRY policy sets task to TIMED_OUT",
+                TaskModel.Status.TIMED_OUT, task.getStatus());
+    }
+
+    @Test(expected = com.netflix.conductor.core.exception.TerminateWorkflowException.class)
+    public void testCheckTotalTimeout_exceeded_timeOutWfPolicy_terminatesWorkflow() {
+        WorkflowModel workflow = createDefaultWorkflow();
+        TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.IN_PROGRESS);
+        task.setTaskId("t1");
+        task.setTaskDefName("test");
+        task.setWorkflowInstanceId(workflow.getWorkflowId());
+        task.setFirstScheduledTime(System.currentTimeMillis() - 120_000);
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setTotalTimeoutSeconds(60);
+        taskDef.setTimeoutPolicy(TaskDef.TimeoutPolicy.TIME_OUT_WF);
+
+        deciderService.checkTotalTimeout(taskDef, task); // must throw
+    }
+
+    @Test
+    public void testCheckTotalTimeout_zeroDisabled_noTimeout() {
+        WorkflowModel workflow = createDefaultWorkflow();
+        TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.IN_PROGRESS);
+        task.setTaskId("t1");
+        task.setTaskDefName("test");
+        task.setWorkflowInstanceId(workflow.getWorkflowId());
+        task.setFirstScheduledTime(System.currentTimeMillis() - 120_000); // way past any sane limit
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setTotalTimeoutSeconds(0); // disabled
+
+        deciderService.checkTotalTimeout(taskDef, task);
+        assertEquals("totalTimeoutSeconds=0 means disabled; status must be unchanged",
+                TaskModel.Status.IN_PROGRESS, task.getStatus());
+    }
+
+    @Test
+    public void testCheckTotalTimeout_firstScheduledTimeZero_skipped() {
+        // Tasks created before firstScheduledTime was introduced have value 0 —
+        // the check must be skipped for backward compatibility.
+        WorkflowModel workflow = createDefaultWorkflow();
+        TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.IN_PROGRESS);
+        task.setTaskId("t1");
+        task.setTaskDefName("test");
+        task.setWorkflowInstanceId(workflow.getWorkflowId());
+        task.setFirstScheduledTime(0); // pre-feature task
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setTotalTimeoutSeconds(1); // very tight budget
+
+        deciderService.checkTotalTimeout(taskDef, task);
+        assertEquals("firstScheduledTime=0 must be skipped for backward compat",
+                TaskModel.Status.IN_PROGRESS, task.getStatus());
+    }
+
+    @Test(expected = com.netflix.conductor.core.exception.TerminateWorkflowException.class)
+    public void testRetry_totalTimeoutExceeded_preventsRetry() {
+        WorkflowModel workflow = createDefaultWorkflow();
+        TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.FAILED);
+        task.setTaskId("t1");
+        task.setReasonForIncompletion("test failure");
+        task.setFirstScheduledTime(System.currentTimeMillis() - 200_000); // 200s ago
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setRetryCount(10); // plenty of retries left
+        taskDef.setRetryDelaySeconds(1);
+        taskDef.setRetryLogic(TaskDef.RetryLogic.FIXED);
+        taskDef.setTotalTimeoutSeconds(60); // budget = 60s, elapsed = 200s → exceeded
+        WorkflowTask workflowTask = new WorkflowTask();
+
+        // Must throw TerminateWorkflowException — total timeout exceeded, no retry
+        deciderService.retry(taskDef, workflowTask, task, workflow);
+    }
+
+    @Test
+    public void testRetry_totalTimeoutNotYetExceeded_retriesNormally() {
+        WorkflowModel workflow = createDefaultWorkflow();
+        TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.FAILED);
+        task.setTaskId("t1");
+        task.setReasonForIncompletion("test failure");
+        task.setFirstScheduledTime(System.currentTimeMillis()); // just now — budget not exhausted
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setRetryCount(10);
+        taskDef.setRetryDelaySeconds(1);
+        taskDef.setRetryLogic(TaskDef.RetryLogic.FIXED);
+        taskDef.setTotalTimeoutSeconds(3600); // 1 hour budget — far from exceeded
+        WorkflowTask workflowTask = new WorkflowTask();
+
+        Optional<TaskModel> retried = deciderService.retry(taskDef, workflowTask, task, workflow);
+        assertTrue("retry must succeed when total budget is not exhausted", retried.isPresent());
+        assertEquals(1, retried.get().getRetryCount());
+    }
+
+    @Test(expected = com.netflix.conductor.core.exception.TerminateWorkflowException.class)
+    public void testRetry_totalTimeoutZero_doesNotPreventRetry() {
+        // totalTimeoutSeconds=0 means disabled — retries must still be allowed (up to retryCount).
+        // When retryCount is 0, the task fails terminally as usual (TerminateWorkflowException),
+        // but NOT because of total timeout.
+        WorkflowModel workflow = createDefaultWorkflow();
+        TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.FAILED);
+        task.setTaskId("t1");
+        task.setReasonForIncompletion("failure");
+        task.setFirstScheduledTime(System.currentTimeMillis() - 200_000);
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setRetryCount(0); // no retries — will throw, but due to retryCount=0, not total timeout
+        taskDef.setTotalTimeoutSeconds(0); // disabled
+        WorkflowTask workflowTask = new WorkflowTask();
+
+        deciderService.retry(taskDef, workflowTask, task, workflow);
+    }
+
     @Test
     public void testFork() throws IOException {
         InputStream stream = TestDeciderService.class.getResourceAsStream("/test.json");

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -1221,6 +1221,54 @@ public class TestDeciderService {
         assertEquals(1, retried.get().getRetryCount());
     }
 
+    /** ALERT_ONLY policy: checkTotalTimeout should only log — task must remain unchanged. */
+    @Test
+    public void testCheckTotalTimeout_alertOnlyPolicy_onlyLogs() {
+        WorkflowModel workflow = createDefaultWorkflow();
+        TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.IN_PROGRESS);
+        task.setTaskId("t1");
+        task.setTaskDefName("test");
+        task.setWorkflowInstanceId(workflow.getWorkflowId());
+        task.setFirstScheduledTime(System.currentTimeMillis() - 120_000);
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setTotalTimeoutSeconds(60);
+        taskDef.setTimeoutPolicy(TaskDef.TimeoutPolicy.ALERT_ONLY);
+
+        deciderService.checkTotalTimeout(taskDef, task);
+        // ALERT_ONLY must NOT change task status — it only logs
+        assertEquals("ALERT_ONLY must not change task status",
+                TaskModel.Status.IN_PROGRESS, task.getStatus());
+    }
+
+    /**
+     * When a worker explicitly fails a task and the total budget is already exhausted,
+     * the retry() guard throws TerminateWorkflowException regardless of the per-attempt policy.
+     * This documents the intended behavior: totalTimeoutSeconds is a hard budget; the
+     * per-attempt timeoutPolicy controls single-attempt timeouts, not the total limit.
+     */
+    @Test(expected = com.netflix.conductor.core.exception.TerminateWorkflowException.class)
+    public void testRetry_totalTimeoutExceeded_alertOnlyPolicy_stillTerminates() {
+        WorkflowModel workflow = createDefaultWorkflow();
+        TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.FAILED); // worker explicitly failed it
+        task.setTaskId("t1");
+        task.setReasonForIncompletion("worker failure");
+        task.setFirstScheduledTime(System.currentTimeMillis() - 200_000);
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setRetryCount(10);
+        taskDef.setRetryDelaySeconds(1);
+        taskDef.setRetryLogic(TaskDef.RetryLogic.FIXED);
+        taskDef.setTotalTimeoutSeconds(60);
+        taskDef.setTimeoutPolicy(TaskDef.TimeoutPolicy.ALERT_ONLY);
+        WorkflowTask workflowTask = new WorkflowTask();
+
+        // Must throw — total budget exhausted regardless of ALERT_ONLY policy
+        deciderService.retry(taskDef, workflowTask, task, workflow);
+    }
+
     @Test(expected = com.netflix.conductor.core.exception.TerminateWorkflowException.class)
     public void testRetry_totalTimeoutZero_doesNotPreventRetry() {
         // totalTimeoutSeconds=0 means disabled — retries must still be allowed (up to retryCount).

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -824,6 +824,77 @@ public class TestDeciderService {
     }
 
     @Test
+    public void testExponentialBackoffWithMaxDelayCap() {
+        WorkflowModel workflow = createDefaultWorkflow();
+
+        TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.FAILED);
+        task.setTaskId("t1");
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setRetryCount(10);
+        taskDef.setRetryDelaySeconds(60);
+        taskDef.setRetryLogic(TaskDef.RetryLogic.EXPONENTIAL_BACKOFF);
+        taskDef.setMaxRetryDelaySeconds(200); // cap at 200 s
+        WorkflowTask workflowTask = new WorkflowTask();
+
+        // retry 0: 60 * 2^0 = 60 — below cap
+        Optional<TaskModel> task2 = deciderService.retry(taskDef, workflowTask, task, workflow);
+        assertEquals(60, task2.get().getCallbackAfterSeconds());
+
+        // retry 1: 60 * 2^1 = 120 — below cap
+        Optional<TaskModel> task3 =
+                deciderService.retry(taskDef, workflowTask, task2.get(), workflow);
+        assertEquals(120, task3.get().getCallbackAfterSeconds());
+
+        // retry 2: 60 * 2^2 = 240 — exceeds cap, should be clamped to 200
+        Optional<TaskModel> task4 =
+                deciderService.retry(taskDef, workflowTask, task3.get(), workflow);
+        assertEquals(200, task4.get().getCallbackAfterSeconds());
+
+        // retry 3: 60 * 2^3 = 480 — still capped at 200
+        Optional<TaskModel> task5 =
+                deciderService.retry(taskDef, workflowTask, task4.get(), workflow);
+        assertEquals(200, task5.get().getCallbackAfterSeconds());
+    }
+
+    @Test
+    public void testLinearBackoffWithMaxDelayCap() {
+        WorkflowModel workflow = createDefaultWorkflow();
+
+        TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.FAILED);
+        task.setTaskId("t1");
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setRetryCount(10);
+        taskDef.setRetryDelaySeconds(60);
+        taskDef.setRetryLogic(TaskDef.RetryLogic.LINEAR_BACKOFF);
+        taskDef.setBackoffScaleFactor(2);
+        taskDef.setMaxRetryDelaySeconds(250); // cap at 250 s
+        WorkflowTask workflowTask = new WorkflowTask();
+
+        // retry 0: 60 * 2 * 1 = 120 — below cap
+        Optional<TaskModel> task2 = deciderService.retry(taskDef, workflowTask, task, workflow);
+        assertEquals(120, task2.get().getCallbackAfterSeconds());
+
+        // retry 1: 60 * 2 * 2 = 240 — below cap
+        Optional<TaskModel> task3 =
+                deciderService.retry(taskDef, workflowTask, task2.get(), workflow);
+        assertEquals(240, task3.get().getCallbackAfterSeconds());
+
+        // retry 2: 60 * 2 * 3 = 360 — exceeds cap, should be clamped to 250
+        Optional<TaskModel> task4 =
+                deciderService.retry(taskDef, workflowTask, task3.get(), workflow);
+        assertEquals(250, task4.get().getCallbackAfterSeconds());
+
+        // retry 3: 60 * 2 * 4 = 480 — still capped at 250
+        Optional<TaskModel> task5 =
+                deciderService.retry(taskDef, workflowTask, task4.get(), workflow);
+        assertEquals(250, task5.get().getCallbackAfterSeconds());
+    }
+
+    @Test
     public void testFork() throws IOException {
         InputStream stream = TestDeciderService.class.getResourceAsStream("/test.json");
         WorkflowModel workflow = objectMapper.readValue(stream, WorkflowModel.class);

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -909,19 +909,15 @@ public class TestDeciderService {
         taskDef.setBackoffJitterMs(5000); // up to 5 000 ms of jitter
         WorkflowTask workflowTask = new WorkflowTask();
 
-        Optional<TaskModel> retried =
-                deciderService.retry(taskDef, workflowTask, task, workflow);
+        Optional<TaskModel> retried = deciderService.retry(taskDef, workflowTask, task, workflow);
 
         // callbackAfterSeconds stays at the base delay
         assertEquals(60, retried.get().getCallbackAfterSeconds());
         // callbackAfterMs must be in [60_000, 65_000]
         long callbackMs = retried.get().getCallbackAfterMs();
+        assertTrue("callbackAfterMs should be >= base delay ms", callbackMs >= 60_000);
         assertTrue(
-                "callbackAfterMs should be >= base delay ms",
-                callbackMs >= 60_000);
-        assertTrue(
-                "callbackAfterMs should be <= base delay ms + maxJitterMs",
-                callbackMs <= 65_000);
+                "callbackAfterMs should be <= base delay ms + maxJitterMs", callbackMs <= 65_000);
     }
 
     @Test
@@ -939,8 +935,7 @@ public class TestDeciderService {
         taskDef.setBackoffJitterMs(0); // no jitter
         WorkflowTask workflowTask = new WorkflowTask();
 
-        Optional<TaskModel> retried =
-                deciderService.retry(taskDef, workflowTask, task, workflow);
+        Optional<TaskModel> retried = deciderService.retry(taskDef, workflowTask, task, workflow);
 
         assertEquals(60, retried.get().getCallbackAfterSeconds());
         assertEquals(60_000, retried.get().getCallbackAfterMs());
@@ -998,8 +993,10 @@ public class TestDeciderService {
         assertEquals(20, t2.get().getCallbackAfterSeconds());
 
         Optional<TaskModel> t3 = deciderService.retry(taskDef, workflowTask, t2.get(), workflow);
-        assertEquals("cap=0 must be treated as disabled: 10*2^2=40s is NOT capped",
-                40, t3.get().getCallbackAfterSeconds());
+        assertEquals(
+                "cap=0 must be treated as disabled: 10*2^2=40s is NOT capped",
+                40,
+                t3.get().getCallbackAfterSeconds());
     }
 
     /** Boundary: cap < retryDelaySeconds — cap fires immediately from the first retry. */
@@ -1018,12 +1015,16 @@ public class TestDeciderService {
         WorkflowTask workflowTask = new WorkflowTask();
 
         Optional<TaskModel> t1 = deciderService.retry(taskDef, workflowTask, task, workflow);
-        assertEquals("FIXED base=60s must be capped to 10s immediately",
-                10, t1.get().getCallbackAfterSeconds());
+        assertEquals(
+                "FIXED base=60s must be capped to 10s immediately",
+                10,
+                t1.get().getCallbackAfterSeconds());
 
         Optional<TaskModel> t2 = deciderService.retry(taskDef, workflowTask, t1.get(), workflow);
-        assertEquals("All subsequent retries must also be capped at 10s",
-                10, t2.get().getCallbackAfterSeconds());
+        assertEquals(
+                "All subsequent retries must also be capped at 10s",
+                10,
+                t2.get().getCallbackAfterSeconds());
     }
 
     /** Boundary: jitterMs=1 (minimum non-zero) — callbackAfterMs is base or base+1. */
@@ -1045,7 +1046,8 @@ public class TestDeciderService {
         assertEquals(30, retried.get().getCallbackAfterSeconds());
         // callbackAfterMs must be in [30_000, 30_001]
         assertTrue(retried.get().getCallbackAfterMs() >= 30_000);
-        assertTrue("With jitter=1ms, callbackAfterMs must be in [30000, 30001]; was "
+        assertTrue(
+                "With jitter=1ms, callbackAfterMs must be in [30000, 30001]; was "
                         + retried.get().getCallbackAfterMs(),
                 retried.get().getCallbackAfterMs() <= 30_001);
     }
@@ -1074,12 +1076,17 @@ public class TestDeciderService {
             t.setStatus(TaskModel.Status.FAILED);
             t.setTaskId("t-" + i);
             t.setRetryCount(0);
-            distinctMs.add(deciderService.retry(taskDef, workflowTask, t, workflow)
-                    .get().getCallbackAfterMs());
+            distinctMs.add(
+                    deciderService
+                            .retry(taskDef, workflowTask, t, workflow)
+                            .get()
+                            .getCallbackAfterMs());
         }
 
-        // With 2000ms jitter over 10 retries, getting 10 identical values is astronomically unlikely
-        assertTrue("jitter must produce variance across multiple retries; all 10 had same callbackAfterMs",
+        // With 2000ms jitter over 10 retries, getting 10 identical values is astronomically
+        // unlikely
+        assertTrue(
+                "jitter must produce variance across multiple retries; all 10 had same callbackAfterMs",
                 distinctMs.size() > 1);
     }
 
@@ -1121,8 +1128,10 @@ public class TestDeciderService {
         taskDef.setTimeoutPolicy(TaskDef.TimeoutPolicy.RETRY);
 
         deciderService.checkTotalTimeout(taskDef, task);
-        assertEquals("RETRY policy sets task to TIMED_OUT",
-                TaskModel.Status.TIMED_OUT, task.getStatus());
+        assertEquals(
+                "RETRY policy sets task to TIMED_OUT",
+                TaskModel.Status.TIMED_OUT,
+                task.getStatus());
     }
 
     @Test(expected = com.netflix.conductor.core.exception.TerminateWorkflowException.class)
@@ -1156,8 +1165,10 @@ public class TestDeciderService {
         taskDef.setTotalTimeoutSeconds(0); // disabled
 
         deciderService.checkTotalTimeout(taskDef, task);
-        assertEquals("totalTimeoutSeconds=0 means disabled; status must be unchanged",
-                TaskModel.Status.IN_PROGRESS, task.getStatus());
+        assertEquals(
+                "totalTimeoutSeconds=0 means disabled; status must be unchanged",
+                TaskModel.Status.IN_PROGRESS,
+                task.getStatus());
     }
 
     @Test
@@ -1176,8 +1187,10 @@ public class TestDeciderService {
         taskDef.setTotalTimeoutSeconds(1); // very tight budget
 
         deciderService.checkTotalTimeout(taskDef, task);
-        assertEquals("firstScheduledTime=0 must be skipped for backward compat",
-                TaskModel.Status.IN_PROGRESS, task.getStatus());
+        assertEquals(
+                "firstScheduledTime=0 must be skipped for backward compat",
+                TaskModel.Status.IN_PROGRESS,
+                task.getStatus());
     }
 
     @Test(expected = com.netflix.conductor.core.exception.TerminateWorkflowException.class)
@@ -1238,15 +1251,17 @@ public class TestDeciderService {
 
         deciderService.checkTotalTimeout(taskDef, task);
         // ALERT_ONLY must NOT change task status — it only logs
-        assertEquals("ALERT_ONLY must not change task status",
-                TaskModel.Status.IN_PROGRESS, task.getStatus());
+        assertEquals(
+                "ALERT_ONLY must not change task status",
+                TaskModel.Status.IN_PROGRESS,
+                task.getStatus());
     }
 
     /**
-     * When a worker explicitly fails a task and the total budget is already exhausted,
-     * the retry() guard throws TerminateWorkflowException regardless of the per-attempt policy.
-     * This documents the intended behavior: totalTimeoutSeconds is a hard budget; the
-     * per-attempt timeoutPolicy controls single-attempt timeouts, not the total limit.
+     * When a worker explicitly fails a task and the total budget is already exhausted, the retry()
+     * guard throws TerminateWorkflowException regardless of the per-attempt policy. This documents
+     * the intended behavior: totalTimeoutSeconds is a hard budget; the per-attempt timeoutPolicy
+     * controls single-attempt timeouts, not the total limit.
      */
     @Test(expected = com.netflix.conductor.core.exception.TerminateWorkflowException.class)
     public void testRetry_totalTimeoutExceeded_alertOnlyPolicy_stillTerminates() {
@@ -1282,7 +1297,8 @@ public class TestDeciderService {
         task.setFirstScheduledTime(System.currentTimeMillis() - 200_000);
 
         TaskDef taskDef = new TaskDef();
-        taskDef.setRetryCount(0); // no retries — will throw, but due to retryCount=0, not total timeout
+        taskDef.setRetryCount(
+                0); // no retries — will throw, but due to retryCount=0, not total timeout
         taskDef.setTotalTimeoutSeconds(0); // disabled
         WorkflowTask workflowTask = new WorkflowTask();
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -895,6 +895,195 @@ public class TestDeciderService {
     }
 
     @Test
+    public void testJitterAddedToRetryDelay() {
+        WorkflowModel workflow = createDefaultWorkflow();
+
+        TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.FAILED);
+        task.setTaskId("t1");
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setRetryCount(10);
+        taskDef.setRetryDelaySeconds(60);
+        taskDef.setRetryLogic(TaskDef.RetryLogic.FIXED);
+        taskDef.setBackoffJitterMs(5000); // up to 5 000 ms of jitter
+        WorkflowTask workflowTask = new WorkflowTask();
+
+        Optional<TaskModel> retried =
+                deciderService.retry(taskDef, workflowTask, task, workflow);
+
+        // callbackAfterSeconds stays at the base delay
+        assertEquals(60, retried.get().getCallbackAfterSeconds());
+        // callbackAfterMs must be in [60_000, 65_000]
+        long callbackMs = retried.get().getCallbackAfterMs();
+        assertTrue(
+                "callbackAfterMs should be >= base delay ms",
+                callbackMs >= 60_000);
+        assertTrue(
+                "callbackAfterMs should be <= base delay ms + maxJitterMs",
+                callbackMs <= 65_000);
+    }
+
+    @Test
+    public void testJitterZeroMeansNoJitter() {
+        WorkflowModel workflow = createDefaultWorkflow();
+
+        TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.FAILED);
+        task.setTaskId("t1");
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setRetryCount(10);
+        taskDef.setRetryDelaySeconds(60);
+        taskDef.setRetryLogic(TaskDef.RetryLogic.FIXED);
+        taskDef.setBackoffJitterMs(0); // no jitter
+        WorkflowTask workflowTask = new WorkflowTask();
+
+        Optional<TaskModel> retried =
+                deciderService.retry(taskDef, workflowTask, task, workflow);
+
+        assertEquals(60, retried.get().getCallbackAfterSeconds());
+        assertEquals(60_000, retried.get().getCallbackAfterMs());
+    }
+
+    @Test
+    public void testJitterWithExponentialBackoff() {
+        WorkflowModel workflow = createDefaultWorkflow();
+
+        TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.FAILED);
+        task.setTaskId("t1");
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setRetryCount(10);
+        taskDef.setRetryDelaySeconds(10);
+        taskDef.setRetryLogic(TaskDef.RetryLogic.EXPONENTIAL_BACKOFF);
+        taskDef.setBackoffJitterMs(2000); // up to 2 000 ms of jitter
+        WorkflowTask workflowTask = new WorkflowTask();
+
+        // retry 0: base = 10 * 2^0 = 10 s → callbackAfterMs in [10_000, 12_000]
+        Optional<TaskModel> task2 = deciderService.retry(taskDef, workflowTask, task, workflow);
+        assertEquals(10, task2.get().getCallbackAfterSeconds());
+        assertTrue(task2.get().getCallbackAfterMs() >= 10_000);
+        assertTrue(task2.get().getCallbackAfterMs() <= 12_000);
+
+        // retry 1: base = 10 * 2^1 = 20 s → callbackAfterMs in [20_000, 22_000]
+        Optional<TaskModel> task3 =
+                deciderService.retry(taskDef, workflowTask, task2.get(), workflow);
+        assertEquals(20, task3.get().getCallbackAfterSeconds());
+        assertTrue(task3.get().getCallbackAfterMs() >= 20_000);
+        assertTrue(task3.get().getCallbackAfterMs() <= 22_000);
+    }
+
+    /** Boundary: maxRetryDelaySeconds=0 means cap is disabled — delays grow uncapped. */
+    @Test
+    public void testMaxRetryDelaySeconds_zeroMeansNoCap() {
+        WorkflowModel workflow = createDefaultWorkflow();
+        TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.FAILED);
+        task.setTaskId("t1");
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setRetryCount(10);
+        taskDef.setRetryDelaySeconds(10);
+        taskDef.setRetryLogic(TaskDef.RetryLogic.EXPONENTIAL_BACKOFF);
+        taskDef.setMaxRetryDelaySeconds(0); // disabled
+        WorkflowTask workflowTask = new WorkflowTask();
+
+        // retry 0: 10s; retry 1: 20s; retry 2: 40s — all uncapped
+        Optional<TaskModel> t1 = deciderService.retry(taskDef, workflowTask, task, workflow);
+        assertEquals(10, t1.get().getCallbackAfterSeconds());
+
+        Optional<TaskModel> t2 = deciderService.retry(taskDef, workflowTask, t1.get(), workflow);
+        assertEquals(20, t2.get().getCallbackAfterSeconds());
+
+        Optional<TaskModel> t3 = deciderService.retry(taskDef, workflowTask, t2.get(), workflow);
+        assertEquals("cap=0 must be treated as disabled: 10*2^2=40s is NOT capped",
+                40, t3.get().getCallbackAfterSeconds());
+    }
+
+    /** Boundary: cap < retryDelaySeconds — cap fires immediately from the first retry. */
+    @Test
+    public void testMaxRetryDelaySeconds_capLessThanBaseDelay() {
+        WorkflowModel workflow = createDefaultWorkflow();
+        TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.FAILED);
+        task.setTaskId("t1");
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setRetryCount(10);
+        taskDef.setRetryDelaySeconds(60);
+        taskDef.setRetryLogic(TaskDef.RetryLogic.FIXED);
+        taskDef.setMaxRetryDelaySeconds(10); // cap < base
+        WorkflowTask workflowTask = new WorkflowTask();
+
+        Optional<TaskModel> t1 = deciderService.retry(taskDef, workflowTask, task, workflow);
+        assertEquals("FIXED base=60s must be capped to 10s immediately",
+                10, t1.get().getCallbackAfterSeconds());
+
+        Optional<TaskModel> t2 = deciderService.retry(taskDef, workflowTask, t1.get(), workflow);
+        assertEquals("All subsequent retries must also be capped at 10s",
+                10, t2.get().getCallbackAfterSeconds());
+    }
+
+    /** Boundary: jitterMs=1 (minimum non-zero) — callbackAfterMs is base or base+1. */
+    @Test
+    public void testJitterMs_minimumOneMs() {
+        WorkflowModel workflow = createDefaultWorkflow();
+        TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.FAILED);
+        task.setTaskId("t1");
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setRetryCount(10);
+        taskDef.setRetryDelaySeconds(30);
+        taskDef.setRetryLogic(TaskDef.RetryLogic.FIXED);
+        taskDef.setBackoffJitterMs(1);
+        WorkflowTask workflowTask = new WorkflowTask();
+
+        Optional<TaskModel> retried = deciderService.retry(taskDef, workflowTask, task, workflow);
+        assertEquals(30, retried.get().getCallbackAfterSeconds());
+        // callbackAfterMs must be in [30_000, 30_001]
+        assertTrue(retried.get().getCallbackAfterMs() >= 30_000);
+        assertTrue("With jitter=1ms, callbackAfterMs must be in [30000, 30001]; was "
+                        + retried.get().getCallbackAfterMs(),
+                retried.get().getCallbackAfterMs() <= 30_001);
+    }
+
+    /** Statistical: multiple retries with jitter produce different callbackAfterMs values. */
+    @Test
+    public void testJitter_producesVariance() {
+        WorkflowModel workflow = createDefaultWorkflow();
+
+        TaskDef taskDef = new TaskDef();
+        taskDef.setRetryCount(20);
+        taskDef.setRetryDelaySeconds(10);
+        taskDef.setRetryLogic(TaskDef.RetryLogic.FIXED);
+        taskDef.setBackoffJitterMs(2000);
+        WorkflowTask workflowTask = new WorkflowTask();
+
+        // Collect callbackAfterMs from 10 independent retry calls
+        java.util.Set<Long> distinctMs = new java.util.HashSet<>();
+        TaskModel task = new TaskModel();
+        task.setStatus(TaskModel.Status.FAILED);
+        task.setTaskId("t0");
+        task.setRetryCount(0);
+
+        for (int i = 0; i < 10; i++) {
+            TaskModel t = new TaskModel();
+            t.setStatus(TaskModel.Status.FAILED);
+            t.setTaskId("t-" + i);
+            t.setRetryCount(0);
+            distinctMs.add(deciderService.retry(taskDef, workflowTask, t, workflow)
+                    .get().getCallbackAfterMs());
+        }
+
+        // With 2000ms jitter over 10 retries, getting 10 identical values is astronomically unlikely
+        assertTrue("jitter must produce variance across multiple retries; all 10 had same callbackAfterMs",
+                distinctMs.size() > 1);
+    }
+
+    @Test
     public void testFork() throws IOException {
         InputStream stream = TestDeciderService.class.getResourceAsStream("/test.json");
         WorkflowModel workflow = objectMapper.readValue(stream, WorkflowModel.class);

--- a/core/src/test/java/org/conductoross/conductor/core/execution/ExecutorUtilsTest.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/ExecutorUtilsTest.java
@@ -26,6 +26,7 @@ import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ExecutorUtilsTest {
 
@@ -112,6 +113,68 @@ public class ExecutorUtilsTest {
                         workflow, Duration.ofSeconds(30), Duration.ofSeconds(3600));
 
         assertEquals(30, result.getSeconds());
+    }
+
+    /** Boundary: SCHEDULED task whose poll window has already elapsed → remaining = 0. */
+    @Test
+    public void computePostponeScheduledElapsedExceedsTimeout() {
+        TaskModel task = newTask(TaskType.TASK_TYPE_SIMPLE, TaskModel.Status.SCHEDULED);
+        TaskDef taskDef = new TaskDef();
+        taskDef.setPollTimeoutSeconds(1); // 1-second poll window
+        WorkflowTask workflowTask = new WorkflowTask();
+        workflowTask.setTaskDefinition(taskDef);
+        task.setWorkflowTask(workflowTask);
+        // Push scheduledTime far into the past so elapsed >> pollTimeout
+        task.setScheduledTime(System.currentTimeMillis() - 60_000);
+
+        WorkflowModel workflow = newWorkflow(Arrays.asList(task), 0);
+        Duration result =
+                ExecutorUtils.computePostpone(workflow, Duration.ofSeconds(30), Duration.ofSeconds(3600));
+
+        // Elapsed >> pollTimeout: remaining = 0, clamped to 0
+        assertEquals("When poll window is already elapsed, postpone should be 0",
+                0L, result.getSeconds());
+    }
+
+    /** Boundary: IN_PROGRESS task whose response window has already elapsed → remaining = 0. */
+    @Test
+    public void computePostponeInProgressElapsedExceedsResponseTimeout() {
+        TaskModel task = newTask(TaskType.TASK_TYPE_SIMPLE, TaskModel.Status.IN_PROGRESS);
+        task.setResponseTimeoutSeconds(1); // 1-second response window
+        // Push startTime far into the past so elapsed >> responseTimeout
+        task.setStartTime(System.currentTimeMillis() - 60_000);
+
+        WorkflowModel workflow = newWorkflow(Arrays.asList(task), 0);
+        Duration result =
+                ExecutorUtils.computePostpone(workflow, Duration.ofSeconds(30), Duration.ofSeconds(3600));
+
+        assertEquals("When response window is already elapsed, postpone should be 0",
+                0L, result.getSeconds());
+    }
+
+    /** Boundary: taskDef.responseTimeout=0 but taskModel.responseTimeout is non-zero — model wins. */
+    @Test
+    public void computePostponeUsesTaskModelResponseTimeoutWhenTaskDefIsZero() {
+        TaskModel task = newTask(TaskType.TASK_TYPE_SIMPLE, TaskModel.Status.IN_PROGRESS);
+        // taskDef has responseTimeoutSeconds=0 (not set), taskModel has 120s
+        TaskDef taskDef = new TaskDef();
+        taskDef.setResponseTimeoutSeconds(0); // explicitly zero
+        WorkflowTask workflowTask = new WorkflowTask();
+        workflowTask.setTaskDefinition(taskDef);
+        task.setWorkflowTask(workflowTask);
+        task.setResponseTimeoutSeconds(120);
+        task.setStartTime(System.currentTimeMillis());
+
+        WorkflowModel workflow = newWorkflow(Arrays.asList(task), 0);
+        Duration result =
+                ExecutorUtils.computePostpone(workflow, Duration.ofSeconds(30), Duration.ofSeconds(3600));
+
+        // Should use task model's 120s, not fall back to workflow offset (30s)
+        assertTrue("When taskDef.responseTimeout=0, taskModel.responseTimeout (120s) should be used; "
+                        + "result=" + result.getSeconds(),
+                result.getSeconds() > 30);
+        assertTrue("Result should be ~120s remaining; got " + result.getSeconds(),
+                result.getSeconds() <= 121);
     }
 
     private WorkflowModel newWorkflow(List<TaskModel> tasks, long timeoutSeconds) {

--- a/core/src/test/java/org/conductoross/conductor/core/execution/ExecutorUtilsTest.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/ExecutorUtilsTest.java
@@ -129,6 +129,7 @@ public class ExecutorUtilsTest {
         task.setTaskType(taskType);
         task.setStatus(status);
         task.setTaskId("taskId-" + taskType + "-" + status);
+        task.setScheduledTime(System.currentTimeMillis());
         return task;
     }
 }

--- a/core/src/test/java/org/conductoross/conductor/core/execution/ExecutorUtilsTest.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/ExecutorUtilsTest.java
@@ -129,11 +129,14 @@ public class ExecutorUtilsTest {
 
         WorkflowModel workflow = newWorkflow(Arrays.asList(task), 0);
         Duration result =
-                ExecutorUtils.computePostpone(workflow, Duration.ofSeconds(30), Duration.ofSeconds(3600));
+                ExecutorUtils.computePostpone(
+                        workflow, Duration.ofSeconds(30), Duration.ofSeconds(3600));
 
         // Elapsed >> pollTimeout: remaining = 0, clamped to 0
-        assertEquals("When poll window is already elapsed, postpone should be 0",
-                0L, result.getSeconds());
+        assertEquals(
+                "When poll window is already elapsed, postpone should be 0",
+                0L,
+                result.getSeconds());
     }
 
     /** Boundary: IN_PROGRESS task whose response window has already elapsed → remaining = 0. */
@@ -146,13 +149,18 @@ public class ExecutorUtilsTest {
 
         WorkflowModel workflow = newWorkflow(Arrays.asList(task), 0);
         Duration result =
-                ExecutorUtils.computePostpone(workflow, Duration.ofSeconds(30), Duration.ofSeconds(3600));
+                ExecutorUtils.computePostpone(
+                        workflow, Duration.ofSeconds(30), Duration.ofSeconds(3600));
 
-        assertEquals("When response window is already elapsed, postpone should be 0",
-                0L, result.getSeconds());
+        assertEquals(
+                "When response window is already elapsed, postpone should be 0",
+                0L,
+                result.getSeconds());
     }
 
-    /** Boundary: taskDef.responseTimeout=0 but taskModel.responseTimeout is non-zero — model wins. */
+    /**
+     * Boundary: taskDef.responseTimeout=0 but taskModel.responseTimeout is non-zero — model wins.
+     */
     @Test
     public void computePostponeUsesTaskModelResponseTimeoutWhenTaskDefIsZero() {
         TaskModel task = newTask(TaskType.TASK_TYPE_SIMPLE, TaskModel.Status.IN_PROGRESS);
@@ -167,13 +175,17 @@ public class ExecutorUtilsTest {
 
         WorkflowModel workflow = newWorkflow(Arrays.asList(task), 0);
         Duration result =
-                ExecutorUtils.computePostpone(workflow, Duration.ofSeconds(30), Duration.ofSeconds(3600));
+                ExecutorUtils.computePostpone(
+                        workflow, Duration.ofSeconds(30), Duration.ofSeconds(3600));
 
         // Should use task model's 120s, not fall back to workflow offset (30s)
-        assertTrue("When taskDef.responseTimeout=0, taskModel.responseTimeout (120s) should be used; "
-                        + "result=" + result.getSeconds(),
+        assertTrue(
+                "When taskDef.responseTimeout=0, taskModel.responseTimeout (120s) should be used; "
+                        + "result="
+                        + result.getSeconds(),
                 result.getSeconds() > 30);
-        assertTrue("Result should be ~120s remaining; got " + result.getSeconds(),
+        assertTrue(
+                "Result should be ~120s remaining; got " + result.getSeconds(),
                 result.getSeconds() <= 121);
     }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -86,7 +86,7 @@ ext {
     revNats = '2.16.14'
     revStan = '2.2.3'
     revFlyway = '10.15.2'
-    revConductorClient = '4.0.10'
+    revConductorClient = '5.0.1'
     revReactor = '1.3.1'
     revSpringAI = '1.1.2'
     revJSonSchemaValidator  = '1.0.73'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -63,7 +63,7 @@ ext {
     revJsr311Api = '1.1.1'
     revMockServerClient = '5.12.0'
     revSpringDoc = '2.1.0'
-    revOrkesQueues = '2.0.0.rc1'
+    revOrkesQueues = '2.0.0.rc2'
     revPowerMock = '2.0.9'
     revProtogenAnnotations = '1.0.0'
     revProtogenCodegen = '1.4.0'

--- a/docker/docker-compose-cassandra-es7.yaml
+++ b/docker/docker-compose-cassandra-es7.yaml
@@ -1,0 +1,90 @@
+services:
+  conductor-server:
+    environment:
+      - CONFIG_PROP=config-cassandra-es7.properties
+      - JAVA_OPTS=-Dpolyglot.engine.WarnInterpreterOnly=false
+      - conductor.app.ownerEmailMandatory=false
+    image: conductor:server
+    container_name: conductor-server
+    build:
+      context: ../
+      dockerfile: docker/server/Dockerfile
+      args:
+        YARN_OPTS: ${YARN_OPTS}
+    networks:
+      - internal
+    ports:
+      - 8000:8080
+      - 8127:5000
+    healthcheck:
+      test: ["CMD", "curl", "-I", "-XGET", "http://localhost:8080/health"]
+      interval: 60s
+      timeout: 30s
+      retries: 12
+    links:
+      - conductor-cassandra:cassandradb
+      - conductor-redis:rs
+      - conductor-elasticsearch:es
+    depends_on:
+      conductor-cassandra:
+        condition: service_healthy
+      conductor-redis:
+        condition: service_healthy
+      conductor-elasticsearch:
+        condition: service_healthy
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1k"
+        max-file: "3"
+
+  conductor-cassandra:
+    image: cassandra:4
+    environment:
+      - CASSANDRA_CLUSTER_NAME=conductor
+      - CASSANDRA_NUM_TOKENS=4
+      - MAX_HEAP_SIZE=512M
+      - HEAP_NEWSIZE=128M
+    networks:
+      - internal
+    healthcheck:
+      test: ["CMD", "cqlsh", "-e", "describe keyspaces"]
+      interval: 10s
+      timeout: 10s
+      retries: 20
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1k"
+        max-file: "3"
+
+  conductor-redis:
+    image: redis:6.2.3-alpine
+    volumes:
+      - ../server/config/redis.conf:/usr/local/etc/redis/redis.conf
+    networks:
+      - internal
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+
+  conductor-elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.11
+    environment:
+      - "ES_JAVA_OPTS=-Xms512m -Xmx1024m"
+      - xpack.security.enabled=false
+      - discovery.type=single-node
+    networks:
+      - internal
+    healthcheck:
+      test: curl http://localhost:9200/_cluster/health -o /dev/null
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1k"
+        max-file: "3"
+
+networks:
+  internal:

--- a/docker/docker-compose-redis-os3.yaml
+++ b/docker/docker-compose-redis-os3.yaml
@@ -12,7 +12,7 @@ services:
       dockerfile: docker/server/Dockerfile
       args:
         YARN_OPTS: ${YARN_OPTS}
-        INDEXING_BACKEND: opensearch
+        INDEXING_BACKEND: opensearch3
     networks:
       - internal
     ports:

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -24,7 +24,7 @@ RUN if [ "$PREBUILT" = "true" ]; then \
       cp docker/server/libs/conductor-server.jar server/build/libs/conductor-server-boot.jar && \
       echo "Using pre-built server JAR"; \
     else \
-      ./gradlew build -x test -x spotlessCheck -x shadowJar -x :conductor-os-persistence-v3:build \
+      ./gradlew build -x test -x spotlessCheck -x shadowJar \
         -PindexingBackend=${INDEXING_BACKEND} \
         -Dorg.gradle.jvmargs=-Xmx2g \
         --no-daemon --no-parallel; \

--- a/docker/server/config/config-cassandra-es7.properties
+++ b/docker/server/config/config-cassandra-es7.properties
@@ -1,0 +1,39 @@
+# Database persistence: Cassandra
+conductor.db.type=cassandra
+conductor.cassandra.hostAddress=cassandradb
+conductor.cassandra.port=9042
+conductor.cassandra.replicationFactorValue=1
+conductor.cassandra.readConsistencyLevel=ONE
+conductor.cassandra.writeConsistencyLevel=ONE
+
+# Task queue: Redis (Cassandra has no native queue implementation)
+conductor.queue.type=redis_standalone
+conductor.redis.hosts=rs:6379:us-east-1c
+conductor.redis-lock.serverAddress=redis://rs:6379
+conductor.redis.taskDefCacheRefreshInterval=1
+conductor.redis.workflowNamespacePrefix=conductor
+conductor.redis.queueNamespacePrefix=conductor_queues
+
+conductor.workflow-execution-lock.type=redis
+conductor.app.workflowExecutionLockEnabled=true
+conductor.app.lockTimeToTry=500
+
+conductor.app.systemTaskWorkerThreadCount=20
+conductor.app.systemTaskMaxPollCount=20
+
+# Elasticsearch 7 indexing
+conductor.indexing.enabled=true
+conductor.indexing.type=elasticsearch
+conductor.elasticsearch.url=http://es:9200
+conductor.elasticsearch.indexName=conductor
+conductor.elasticsearch.version=7
+conductor.elasticsearch.clusterHealthColor=yellow
+
+# Metrics
+conductor.metrics-prometheus.enabled=true
+management.endpoints.web.exposure.include=health,prometheus
+
+# Redis health indicator
+management.health.redis.enabled=true
+
+loadSample=true

--- a/docker/server/config/config-redis-es8.properties
+++ b/docker/server/config/config-redis-es8.properties
@@ -22,6 +22,7 @@ conductor.indexing.type=elasticsearch8
 conductor.elasticsearch.url=http://es:9200
 conductor.elasticsearch.indexName=conductor
 conductor.elasticsearch.clusterHealthColor=yellow
+conductor.elasticsearch.indexRefreshInterval=1s
 
 # Additional modules for metrics collection exposed to Prometheus (optional)
 conductor.metrics-prometheus.enabled=true

--- a/docs/devguide/architecture/tasklifecycle.md
+++ b/docs/devguide/architecture/tasklifecycle.md
@@ -23,9 +23,9 @@ stateDiagram-v2
     FAILED --> SCHEDULED : Retry (after delay)
     TIMED_OUT --> SCHEDULED : Retry (after delay)
     COMPLETED --> [*]
-    FAILED --> [*] : Retries exhausted
+    FAILED --> [*] : Retries exhausted or totalTimeoutSeconds exceeded
     FAILED_WITH_TERMINAL_ERROR --> [*]
-    TIMED_OUT --> [*] : Retries exhausted
+    TIMED_OUT --> [*] : Retries exhausted or totalTimeoutSeconds exceeded
     CANCELED --> [*]
     SKIPPED --> [*]
     COMPLETED_WITH_ERRORS --> [*]
@@ -75,8 +75,11 @@ Retry behavior is controlled by the task definition:
 | Parameter | Description |
 | :--- | :--- |
 | `retryCount` | Maximum number of retry attempts. |
-| `retryLogic` | `FIXED` (constant delay) or `EXPONENTIAL_BACKOFF`. |
-| `retryDelaySeconds` | Delay between retries. For exponential backoff, this is the base delay. |
+| `retryLogic` | `FIXED`, `EXPONENTIAL_BACKOFF`, or `LINEAR_BACKOFF`. See [Retry Logic](../../../documentation/configuration/taskdef.md#retry-logic). |
+| `retryDelaySeconds` | Base delay between retries. |
+| `maxRetryDelaySeconds` | Caps the computed delay. Prevents exponential growth from becoming arbitrarily large. |
+| `backoffJitterMs` | Adds random milliseconds to each delay to spread concurrent retries over time. |
+| `totalTimeoutSeconds` | Hard wall-clock budget across all attempts. See [Total timeout](#total-timeout). |
 
 
 ## Timeout scenarios
@@ -145,11 +148,36 @@ sequenceDiagram
     Note over C: Ignored — T1 already terminal
 ```
 
+### Total timeout
+
+`totalTimeoutSeconds` limits the total wall-clock time across **all** retry attempts. Once this budget is consumed, no further retries are scheduled regardless of how many remain in `retryCount`.
+
+```mermaid
+sequenceDiagram
+    participant W as Worker
+    participant C as Conductor Server
+
+    Note over C: totalTimeoutSeconds = 30s
+    C->>W: Task T1 (attempt 1)
+    W->>C: FAILED (at t=5s)
+    Note over C: Retry delay 5s
+    C->>W: Task T1 (attempt 2, at t=10s)
+    W->>C: FAILED (at t=20s)
+    Note over C: Retry delay 5s
+    C->>W: Task T1 (attempt 3, at t=25s)
+    W->>C: FAILED (at t=28s)
+    Note over C: t=28s ≥ 30s → total budget exhausted
+    C->>C: Mark workflow FAILED — no more retries
+```
+
+This is useful when you need a hard SLA on how long a task can run across all its attempts, independent of how many retries are configured.
+
 ## Timeout configuration summary
 
 | Parameter | Description | Default |
 | :--- | :--- | :--- |
 | `pollTimeoutSeconds` | Max time for a worker to poll the task. | No timeout |
-| `responseTimeoutSeconds` | Max time for a worker to respond after polling. | No timeout |
-| `timeoutSeconds` | Overall SLA for the task to reach a terminal state. | No timeout |
+| `responseTimeoutSeconds` | Max time for a worker to respond after polling. | 600s |
+| `timeoutSeconds` | SLA per individual attempt (from first `IN_PROGRESS` to terminal). | No timeout |
+| `totalTimeoutSeconds` | Hard budget across all attempts combined. Overrides `retryCount`. | No timeout |
 | `timeoutPolicy` | Action on timeout: `RETRY`, `TIME_OUT_WF` (fail workflow), or `ALERT_ONLY`. | `TIME_OUT_WF` |

--- a/docs/devguide/concepts/tasks.md
+++ b/docs/devguide/concepts/tasks.md
@@ -64,6 +64,9 @@ def process_payment(orderId: str, amount: float) -> dict:
   "retryCount": 3,
   "retryLogic": "EXPONENTIAL_BACKOFF",
   "retryDelaySeconds": 5,
+  "maxRetryDelaySeconds": 60,
+  "backoffJitterMs": 2000,
+  "totalTimeoutSeconds": 300,
   "timeoutSeconds": 120,
   "responseTimeoutSeconds": 60,
   "pollTimeoutSeconds": 30
@@ -71,7 +74,10 @@ def process_payment(orderId: str, amount: float) -> dict:
 ```
 
 - **retryCount / retryLogic / retryDelaySeconds** — How many times to retry a failed task, the backoff strategy, and the initial delay between retries.
-- **timeoutSeconds** — Maximum wall-clock time before the task is marked `TIMED_OUT`.
+- **maxRetryDelaySeconds** — Caps the computed backoff delay. Prevents exponential growth from becoming arbitrarily large.
+- **backoffJitterMs** — Adds random milliseconds to each retry delay to spread concurrent retries over time (thundering herd prevention).
+- **totalTimeoutSeconds** — Hard wall-clock budget across all retry attempts combined. Once exceeded, no further retries are attempted regardless of `retryCount`.
+- **timeoutSeconds** — Maximum wall-clock time per individual attempt before the task is marked `TIMED_OUT`.
 - **responseTimeoutSeconds** — Maximum time to wait for a worker to respond after picking up a task. Useful for detecting unresponsive workers.
 - **pollTimeoutSeconds** — Maximum time a worker can hold a long-poll connection before the server releases it.
 

--- a/docs/devguide/cookbook/index.md
+++ b/docs/devguide/cookbook/index.md
@@ -20,6 +20,10 @@ Production-ready workflow recipes. Each recipe includes the complete JSON workfl
 
     Fixed delays, scheduled execution, external signals, and human-in-the-loop approvals.
 
+-   **[Task timeouts and retries](task-timeouts-and-retries.md)**
+
+    Exponential backoff with cap and jitter, lease extension for long-running workers, hard SLA with totalTimeoutSeconds, and thundering herd prevention.
+
 -   **[Event-driven recipes](event-driven.md)**
 
     Publish to Kafka/NATS/RabbitMQ/SQS, event handlers to trigger workflows, complete tasks from events.

--- a/docs/devguide/cookbook/task-timeouts-and-retries.md
+++ b/docs/devguide/cookbook/task-timeouts-and-retries.md
@@ -1,0 +1,187 @@
+---
+description: "Conductor cookbook — task timeout and retry recipes covering responseTimeout with lease extension, totalTimeoutSeconds, exponential backoff with cap and jitter, and thundering herd prevention."
+---
+
+# Task timeouts and retries
+
+Practical recipes for making workers resilient. Each recipe is a complete task definition you can register with `POST /api/metadata/taskdefs`.
+
+---
+
+### Exponential backoff with a cap
+
+Retries with exponential backoff for a task that calls an external API. The cap prevents the delay from growing indefinitely; jitter prevents multiple failing workers from hammering the API at the same time.
+
+```json
+{
+  "name": "call_payment_api",
+  "ownerEmail": "payments@example.com",
+  "retryCount": 6,
+  "retryLogic": "EXPONENTIAL_BACKOFF",
+  "retryDelaySeconds": 2,
+  "maxRetryDelaySeconds": 60,
+  "backoffJitterMs": 3000,
+  "responseTimeoutSeconds": 30,
+  "timeoutSeconds": 600,
+  "timeoutPolicy": "RETRY"
+}
+```
+
+**Delay schedule** (`retryDelaySeconds=2`, `maxRetryDelaySeconds=60`, `backoffJitterMs=3000`):
+
+| Attempt | Base delay | After cap | Actual range |
+| :--- | :--- | :--- | :--- |
+| 1 | 2s | 2s | 2.0 – 5.0s |
+| 2 | 4s | 4s | 4.0 – 7.0s |
+| 3 | 8s | 8s | 8.0 – 11.0s |
+| 4 | 16s | 16s | 16.0 – 19.0s |
+| 5 | 32s | 32s | 32.0 – 35.0s |
+| 6 | 64s | **60s** | 60.0 – 63.0s |
+
+---
+
+### Lease extension for long-running workers
+
+`responseTimeoutSeconds` is the heartbeat window: if the worker doesn't report back within this duration, Conductor marks the task `TIMED_OUT` and retries it. For tasks that take longer than the heartbeat window, workers extend the lease by posting an `IN_PROGRESS` update with `callbackAfterSeconds`.
+
+**Task definition**
+
+```json
+{
+  "name": "transcode_video",
+  "ownerEmail": "media@example.com",
+  "retryCount": 2,
+  "retryLogic": "FIXED",
+  "retryDelaySeconds": 10,
+  "responseTimeoutSeconds": 30,
+  "timeoutSeconds": 3600,
+  "timeoutPolicy": "RETRY"
+}
+```
+
+`responseTimeoutSeconds: 30` — Conductor will reschedule the task if the worker is silent for 30 seconds.
+`timeoutSeconds: 3600` — the task itself can take up to 1 hour across all heartbeats.
+
+**Worker: extend the lease every 25 seconds**
+
+```python
+import time
+from conductor.client.http.models import TaskResult
+
+def transcode_video(task):
+    task_id = task.task_id
+    workflow_id = task.workflow_instance_id
+
+    for chunk in video_chunks(task.input_data["file_url"]):
+        transcode_chunk(chunk)
+
+        # Extend the lease before responseTimeoutSeconds (30s) expires.
+        # callbackAfterSeconds tells Conductor to leave this task invisible
+        # in the queue for another 25s — resetting the response clock.
+        heartbeat = TaskResult(
+            task_id=task_id,
+            workflow_instance_id=workflow_id,
+            status="IN_PROGRESS",
+            callback_after_seconds=25,
+            output_data={"progress": chunk.index / len(video_chunks)}
+        )
+        conductor_client.update_task(heartbeat)
+
+    return TaskResult(
+        task_id=task_id,
+        workflow_instance_id=workflow_id,
+        status="COMPLETED",
+        output_data={"output_url": upload_result.url}
+    )
+```
+
+**What happens without a heartbeat:**
+
+```
+t=0s   Worker polls task → IN_PROGRESS
+t=30s  responseTimeoutSeconds expires → TIMED_OUT → retry scheduled
+t=40s  Worker finishes (too late, task already terminated)
+```
+
+**What happens with a heartbeat every 25s:**
+
+```
+t=0s   Worker polls task → IN_PROGRESS
+t=25s  Worker: POST IN_PROGRESS, callbackAfterSeconds=25 → clock resets
+t=50s  Worker: POST IN_PROGRESS, callbackAfterSeconds=25 → clock resets
+...
+t=90s  Worker: POST COMPLETED → task done
+```
+
+---
+
+### Hard SLA with `totalTimeoutSeconds`
+
+Use `totalTimeoutSeconds` when you need a guaranteed upper bound on how long a task can take across all of its retries. This is independent of `retryCount` — whichever limit is hit first wins.
+
+```json
+{
+  "name": "sync_crm_record",
+  "ownerEmail": "crm@example.com",
+  "retryCount": 20,
+  "retryLogic": "FIXED",
+  "retryDelaySeconds": 5,
+  "totalTimeoutSeconds": 120,
+  "responseTimeoutSeconds": 15,
+  "timeoutPolicy": "TIME_OUT_WF"
+}
+```
+
+`retryCount: 20` — would normally allow 20 retries.
+`totalTimeoutSeconds: 120` — but if the 2-minute wall-clock budget is consumed first, no more retries are queued and the workflow is failed.
+
+This is useful for SLA-sensitive tasks where you need to know that, regardless of transient failures, the workflow will either succeed or surface as failed within a bounded time window.
+
+**Timeline example** (`retryDelaySeconds=5`, `totalTimeoutSeconds=30`):
+
+```
+t=0s   Attempt 1 → FAILED
+t=5s   Attempt 2 → FAILED
+t=10s  Attempt 3 → FAILED
+t=15s  Attempt 4 → FAILED
+t=20s  Attempt 5 → FAILED
+t=25s  Attempt 6 → FAILED
+t=30s  totalTimeoutSeconds exceeded → workflow FAILED, no more retries
+        (10 retries still remained in retryCount)
+```
+
+---
+
+### Thundering herd prevention
+
+When hundreds of tasks fail simultaneously (e.g., a downstream service goes down), all retries are scheduled at the same time. Without jitter, they all hit the recovering service at once. `backoffJitterMs` spreads them across a time window.
+
+```json
+{
+  "name": "send_webhook",
+  "ownerEmail": "platform@example.com",
+  "retryCount": 5,
+  "retryLogic": "EXPONENTIAL_BACKOFF",
+  "retryDelaySeconds": 1,
+  "maxRetryDelaySeconds": 30,
+  "backoffJitterMs": 5000,
+  "responseTimeoutSeconds": 10,
+  "concurrentExecLimit": 200
+}
+```
+
+With `backoffJitterMs: 5000`, 500 tasks that all fail at `t=0` will retry at uniformly random times between `t=1s` and `t=6s` — spreading the retry load across 5 seconds instead of hitting the service in a single burst.
+
+---
+
+### Choosing the right combination
+
+| Scenario | Recommended config |
+| :--- | :--- |
+| External API with rate limits | `EXPONENTIAL_BACKOFF` + `maxRetryDelaySeconds` + `backoffJitterMs` |
+| Long-running processing job | `responseTimeoutSeconds` (short) + heartbeats from worker + `timeoutSeconds` (long) |
+| SLA-bounded task | `totalTimeoutSeconds` + `FIXED` or `EXPONENTIAL_BACKOFF` |
+| High fan-out with many concurrent failures | `backoffJitterMs` + `concurrentExecLimit` |
+| Non-retryable error | Return `FAILED_WITH_TERMINAL_ERROR` from the worker |
+
+See the [Task Definition reference](../../documentation/configuration/taskdef.md) for all available parameters.

--- a/docs/documentation/configuration/taskdef.md
+++ b/docs/documentation/configuration/taskdef.md
@@ -17,7 +17,10 @@ This should not be confused with [*Task Configurations*](workflowdef/index.md#ta
 | description                 | string             | Description of the task.                                                                                                                                                                                       | Optional                                                                         |
 | retryCount                  | number             | Number of retries to attempt when a Task is marked as failure.                                                                                                                                                 | Defaults to 3 with maximum allowed capped at 10                                  |
 | retryLogic                  | string (enum)      | Mechanism for the retries.                                                                                                                                                                                     | See [Retry Logic](#retry-logic)                                                  |
-| retryDelaySeconds           | number             | Time to wait before retries.                                                                                                                                                                                   | Defaults to 60 seconds                                                           |
+| retryDelaySeconds           | number             | Base delay before the first retry. The meaning varies by `retryLogic`.                                                                                                                                        | Defaults to 60 seconds                                                           |
+| maxRetryDelaySeconds        | number             | Maximum delay between retries, in seconds. Caps the computed delay for `EXPONENTIAL_BACKOFF` and `LINEAR_BACKOFF` so delays never grow beyond this value. `0` disables the cap.                              | Defaults to 0 (no cap). See [Retry Logic](#retry-logic)                          |
+| backoffJitterMs             | number             | Adds a random jitter of up to this many milliseconds to each retry delay. Spreads simultaneous retries across time to prevent thundering herd. `0` disables jitter.                                          | Defaults to 0 (no jitter). See [Retry Logic](#retry-logic)                       |
+| totalTimeoutSeconds         | number             | Maximum wall-clock time (in seconds) across all retry attempts combined. Once exceeded, the task fails immediately with no further retries, regardless of `retryCount`. `0` disables this limit.             | Defaults to 0 (no limit). See [Timeout scenarios](../../../devguide/architecture/tasklifecycle.md#total-timeout)  |
 | timeoutPolicy               | string (enum)      | Task's timeout policy.                                                                                                                                                                                         | Defaults to `TIME_OUT_WF`; See [Timeout Policy](#timeout-policy)                 |
 | timeoutSeconds              | number             | Time in seconds, after which the task is marked as `TIMED_OUT` if it has not reached a terminal state after transitioning to `IN_PROGRESS` status for the first time.                                                                | No timeouts if set to 0                                                          |
 | responseTimeoutSeconds      | number             | If greater than 0, the task is rescheduled if not updated with a status after this time (heartbeat mechanism). Useful when the worker polls for the task but fails to complete due to errors/network failure. | Defaults to 600                                                                 |
@@ -32,21 +35,42 @@ This should not be confused with [*Task Configurations*](workflowdef/index.md#ta
 
 ### Retry Logic
 
-* FIXED: Reschedule the task after `retryDelaySeconds`
-* EXPONENTIAL_BACKOFF: Reschedule the task after `retryDelaySeconds * (2 ^ attemptNumber)`
-* LINEAR_BACKOFF: Reschedule after `retryDelaySeconds * backoffRate * attemptNumber`
- 
+The `retryLogic` field controls how the delay between retries is computed. The final delay applied is:
+
+```
+delay = clamp(computedDelay, 0, maxRetryDelaySeconds)  +  random(0, backoffJitterMs) ms
+```
+
+where `clamp` only applies when `maxRetryDelaySeconds > 0`.
+
+| Value | Delay formula | Notes |
+| :--- | :--- | :--- |
+| `FIXED` | `retryDelaySeconds` | Constant delay every retry. |
+| `EXPONENTIAL_BACKOFF` | `retryDelaySeconds × 2^attemptNumber` | Doubles each attempt. Cap with `maxRetryDelaySeconds` to avoid runaway delays. |
+| `LINEAR_BACKOFF` | `retryDelaySeconds × backoffScaleFactor × attemptNumber` | Grows linearly. `backoffScaleFactor` defaults to 1. |
+
+**`maxRetryDelaySeconds`** — caps the computed delay so it never exceeds this value. Example with `EXPONENTIAL_BACKOFF`, `retryDelaySeconds=1`, `maxRetryDelaySeconds=3`:
+
+| Attempt | Raw delay | After cap |
+| :--- | :--- | :--- |
+| 0 | 1s | 1s |
+| 1 | 2s | 2s |
+| 2 | 4s | 3s |
+| 3+ | 8s+ | 3s |
+
+**`backoffJitterMs`** — adds a uniform random value in `[0, backoffJitterMs]` milliseconds to the final delay. This spreads retries from multiple failing workers across time (thundering herd prevention). Example: `retryDelaySeconds=2`, `backoffJitterMs=1000` → each retry fires between 2 000 ms and 3 000 ms after failure.
+
 ### Timeout Policy
 
-* RETRY: Retries the task again
-* TIME_OUT_WF: Workflow is marked as TIMED_OUT and terminated. This is the default value.
-* ALERT_ONLY: Registers a counter (task_timeout)
+* `RETRY`: Retries the task again
+* `TIME_OUT_WF`: Workflow is marked as TIMED_OUT and terminated. This is the default value.
+* `ALERT_ONLY`: Registers a counter (task_timeout)
 
 ### Task Concurrent Execution Limits
 
 `concurrentExecLimit` limits the number of simultaneous Task executions at any point.
 
-**Example** 
+**Example**
 You have 1000 task executions waiting in the queue, and 1000 workers polling this queue for tasks, but if you have set `concurrentExecLimit` to 10, only 10 tasks would be given to workers (which would lead to starvation). If any of the workers finishes execution, a new task(s) will be removed from the queue, while still keeping the current execution count to 10.
 
 ### Task Rate Limits
@@ -58,10 +82,10 @@ You have 1000 task executions waiting in the queue, and 1000 workers polling thi
 * `rateLimitFrequencyInSeconds` sets the "frequency window", i.e the `duration` to be used in `events per duration`. Eg: 1s, 5s, 60s, 300s etc.
 * `rateLimitPerFrequency`defines the number of Tasks that can be given to Workers per given "frequency window". No rate limit if set to 0.
 
-**Example**  
-Let's set `rateLimitFrequencyInSeconds = 5`, and `rateLimitPerFrequency = 12`. This means our frequency window is of 5 seconds duration, and for each frequency window, Conductor would only give 12 tasks to workers. So, in a given minute, Conductor would only give 12*(60/5) = 144 tasks to workers irrespective of the number of workers that are polling for the task.  
+**Example**
+Let's set `rateLimitFrequencyInSeconds = 5`, and `rateLimitPerFrequency = 12`. This means our frequency window is of 5 seconds duration, and for each frequency window, Conductor would only give 12 tasks to workers. So, in a given minute, Conductor would only give 12*(60/5) = 144 tasks to workers irrespective of the number of workers that are polling for the task.
 
-Note that unlike `concurrentExecLimit`, rate limiting doesn't take into account tasks already in progress or a terminal state. Even if all the previous tasks are executed within 1 sec, or would take a few days, the new tasks are still given to workers at configured frequency, 144 tasks per minute in above example.   
+Note that unlike `concurrentExecLimit`, rate limiting doesn't take into account tasks already in progress or a terminal state. Even if all the previous tasks are executed within 1 sec, or would take a few days, the new tasks are still given to workers at configured frequency, 144 tasks per minute in above example.
 
 
 ### Using `inputKeys` and `outputKeys`
@@ -90,14 +114,74 @@ Note that unlike `concurrentExecLimit`, rate limiting doesn't take into account 
 }
 ```
 
+## Retry configuration examples
+
+### Retrying a flaky external API call
+
+```json
+{
+  "name": "call_payment_api",
+  "retryCount": 5,
+  "retryLogic": "EXPONENTIAL_BACKOFF",
+  "retryDelaySeconds": 2,
+  "maxRetryDelaySeconds": 60,
+  "backoffJitterMs": 2000,
+  "responseTimeoutSeconds": 30,
+  "timeoutSeconds": 300,
+  "timeoutPolicy": "RETRY",
+  "ownerEmail": "payments@example.com"
+}
+```
+
+Retries up to 5 times with delays 2s, 4s, 8s, 16s, 32s — capped at 60s — plus up to 2 seconds of random jitter on each attempt. Prevents hammering a degraded payment provider.
+
+### Bounded retry budget with `totalTimeoutSeconds`
+
+```json
+{
+  "name": "process_order",
+  "retryCount": 10,
+  "retryLogic": "FIXED",
+  "retryDelaySeconds": 5,
+  "totalTimeoutSeconds": 120,
+  "timeoutPolicy": "TIME_OUT_WF",
+  "ownerEmail": "orders@example.com"
+}
+```
+
+Retries every 5 seconds, but the entire sequence — all attempts combined — must finish within 2 minutes. Even if `retryCount` isn't exhausted, the task fails once the 2-minute budget is consumed.
+
+### High-throughput worker with jitter
+
+```json
+{
+  "name": "send_notification",
+  "retryCount": 3,
+  "retryLogic": "FIXED",
+  "retryDelaySeconds": 1,
+  "backoffJitterMs": 3000,
+  "concurrentExecLimit": 500,
+  "ownerEmail": "notifications@example.com"
+}
+```
+
+When thousands of notifications fail simultaneously (e.g., downstream outage), jitter spreads the retries across a 3-second window instead of all hammering the service at once.
+
 ## Complete Example
-This is an example of a Task Definition for a worker implementation named `encode_task`.
 
 ``` json
 {
   "name": "encode_task",
   "retryCount": 3,
+  "retryLogic": "EXPONENTIAL_BACKOFF",
+  "retryDelaySeconds": 10,
+  "maxRetryDelaySeconds": 120,
+  "backoffJitterMs": 5000,
+  "totalTimeoutSeconds": 600,
   "timeoutSeconds": 1200,
+  "timeoutPolicy": "TIME_OUT_WF",
+  "responseTimeoutSeconds": 3600,
+  "pollTimeoutSeconds": 3600,
   "inputKeys": [
     "sourceRequestId",
     "qcElementType"
@@ -107,11 +191,6 @@ This is an example of a Task Definition for a worker implementation named `encod
     "skipped",
     "result"
   ],
-  "timeoutPolicy": "TIME_OUT_WF",
-  "retryLogic": "FIXED",
-  "retryDelaySeconds": 600,
-  "responseTimeoutSeconds": 3600,
-  "pollTimeoutSeconds": 3600,
   "concurrentExecLimit": 100,
   "rateLimitFrequencyInSeconds": 60,
   "rateLimitPerFrequency": 50,

--- a/e2e/run_tests-cassandra-es7.sh
+++ b/e2e/run_tests-cassandra-es7.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="$SCRIPT_DIR/../docker/docker-compose-cassandra-es7.yaml"
+export SERVER_ROOT_URI="${SERVER_ROOT_URI:-http://localhost:8000}"
+
+echo "Starting Conductor (Cassandra + Elasticsearch 7)..."
+docker compose -f "$COMPOSE_FILE" build conductor-server
+docker compose -f "$COMPOSE_FILE" up -d
+
+echo "Waiting for Conductor server at $SERVER_ROOT_URI/health ..."
+for i in $(seq 1 60); do
+    if curl -sf "$SERVER_ROOT_URI/health" > /dev/null 2>&1; then
+        echo "Conductor is up after ${i} attempt(s)!"
+        break
+    fi
+    if [ "$i" -eq 60 ]; then
+        echo "ERROR: Conductor did not start in time"
+        docker compose -f "$COMPOSE_FILE" logs conductor-server 2>/dev/null || docker compose -f "$COMPOSE_FILE" logs
+        docker compose -f "$COMPOSE_FILE" down -v
+        exit 1
+    fi
+    echo "  Attempt $i/60 — waiting 5s..."
+    sleep 5
+done
+
+cd "$SCRIPT_DIR/.."
+./gradlew :conductor-e2e:test -PrunE2E -DSERVER_ROOT_URI="$SERVER_ROOT_URI" "$@"
+EXIT_CODE=$?
+
+docker compose -f "$COMPOSE_FILE" down -v
+exit $EXIT_CODE

--- a/e2e/run_tests-redis-es7.sh
+++ b/e2e/run_tests-redis-es7.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="$SCRIPT_DIR/../docker/docker-compose.yaml"
+export SERVER_ROOT_URI="${SERVER_ROOT_URI:-http://localhost:8000}"
+
+echo "Starting Conductor (Redis + Elasticsearch 7)..."
+docker compose -f "$COMPOSE_FILE" build conductor-server
+docker compose -f "$COMPOSE_FILE" up -d
+
+echo "Waiting for Conductor server at $SERVER_ROOT_URI/health ..."
+for i in $(seq 1 60); do
+    if curl -sf "$SERVER_ROOT_URI/health" > /dev/null 2>&1; then
+        echo "Conductor is up after ${i} attempt(s)!"
+        break
+    fi
+    if [ "$i" -eq 60 ]; then
+        echo "ERROR: Conductor did not start in time"
+        docker compose -f "$COMPOSE_FILE" logs conductor-server 2>/dev/null || docker compose -f "$COMPOSE_FILE" logs
+        docker compose -f "$COMPOSE_FILE" down -v
+        exit 1
+    fi
+    echo "  Attempt $i/60 — waiting 5s..."
+    sleep 5
+done
+
+cd "$SCRIPT_DIR/.."
+./gradlew :conductor-e2e:test -PrunE2E -DSERVER_ROOT_URI="$SERVER_ROOT_URI" "$@"
+EXIT_CODE=$?
+
+docker compose -f "$COMPOSE_FILE" down -v
+exit $EXIT_CODE

--- a/e2e/src/test/java/io/conductor/e2e/processing/SetVariableTests.java
+++ b/e2e/src/test/java/io/conductor/e2e/processing/SetVariableTests.java
@@ -75,7 +75,7 @@ public class SetVariableTests {
         Map<String, String> expectedValues = new ConcurrentHashMap<>();
         List<CompletableFuture<WorkflowRun>> futureRuns = new ArrayList<>();
 
-        final int TOTAL_TO_CREATE = 10_000;
+        final int TOTAL_TO_CREATE = 2_000;
         final int LOG_EVERY_N = 250;
 
         // i think this is why there is 50k+ workflows in the e2e-aws cluster
@@ -145,7 +145,7 @@ public class SetVariableTests {
         List<Future<String>> futures = new ArrayList<>();
         Map<String, String> expectedValues = new ConcurrentHashMap<>();
 
-        final int TOTAL_TO_CREATE = 10_000;
+        final int TOTAL_TO_CREATE = 2_000;
         final int LOG_EVERY_N = 250;
 
         for (int i = 0; i < TOTAL_TO_CREATE; i++) {

--- a/e2e/src/test/java/io/conductor/e2e/task/RetryPolicyTests.java
+++ b/e2e/src/test/java/io/conductor/e2e/task/RetryPolicyTests.java
@@ -582,11 +582,11 @@ public class RetryPolicyTests {
         final int N = 5;
         String tt = "e2e-concurrent-jitter-task", wf = "e2e-concurrent-jitter-wf";
 
-        // base=1s, jitter=2000ms — large jitter relative to base to make spread observable
+        // base=1s, jitter=3000ms — large jitter relative to base to make spread observable
         Map<String, Object> def = taskDefBase(tt);
         def.put("retryDelaySeconds", 1);
         def.put("retryLogic", "FIXED");
-        def.put("backoffJitterMs", 1000);
+        def.put("backoffJitterMs", 3000);
         registerTaskDef(def);
         registerWorkflow(wf, tt);
 
@@ -635,16 +635,15 @@ public class RetryPolicyTests {
 
         assertEquals(N, tasksPolled, "All " + N + " retry tasks must eventually be polled");
 
-        // With 1s jitter and N=5 tasks, it's statistically very unlikely that all tasks become
+        // With 3s jitter and N=5 tasks, it's statistically very unlikely that all tasks become
         // available in the exact same second bucket if jitter is truly random.
         // We assert that tasks spread across at least 2 distinct second-buckets.
-        // (P(all same bucket) ≈ (1/2)^4 = 6.25% with uniform jitter over 1s — acceptable flakiness
-        //  threshold given that test failures prompt investigation rather than automatic re-run.)
+        // (P(all same bucket) ≈ (1/3)^4 ≈ 1.2% with uniform jitter over 3s)
         assertTrue(
                 pollTimestampsSeconds.size() >= 2 || N == 1,
                 "With "
                         + N
-                        + " tasks and 1s jitter, retries must spread across ≥2 second-buckets. "
+                        + " tasks and 3s jitter, retries must spread across ≥2 second-buckets. "
                         + "All "
                         + N
                         + " tasks appeared in the same second — jitter may not be applied.");
@@ -1169,7 +1168,7 @@ public class RetryPolicyTests {
     @DisplayName("Concurrent workflows: totalTimeoutSeconds independent per workflow instance")
     void testTotalTimeoutSeconds_concurrentWorkflows_eachInstanceIndependent()
             throws InterruptedException {
-        final int N = 3;
+        final int N = 2;
         String tt = "e2e-total-timeout-concurrent-task", wf = "e2e-total-timeout-concurrent-wf";
 
         // Generous 30 s total budget — all N workflows complete well within it

--- a/e2e/src/test/java/io/conductor/e2e/task/RetryPolicyTests.java
+++ b/e2e/src/test/java/io/conductor/e2e/task/RetryPolicyTests.java
@@ -1,0 +1,722 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.conductor.e2e.task;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.netflix.conductor.client.http.MetadataClient;
+import com.netflix.conductor.client.http.TaskClient;
+import com.netflix.conductor.client.http.WorkflowClient;
+import com.netflix.conductor.common.config.ObjectMapperProvider;
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.TaskResult;
+import com.netflix.conductor.common.metadata.tasks.TaskType;
+import com.netflix.conductor.common.metadata.workflow.StartWorkflowRequest;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.common.run.Workflow;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.conductor.e2e.util.ApiUtil;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * End-to-end tests for retry policy features:
+ *
+ * <ul>
+ *   <li>{@code maxRetryDelaySeconds} — caps the computed backoff; cap=0 means disabled
+ *   <li>{@code backoffJitterMs} — random [0, max] ms added per retry to spread thundering herds
+ *   <li>Poll gap fix — decider queue updated on SCHEDULED→IN_PROGRESS to reflect response timeout
+ * </ul>
+ *
+ * <p>Task defs are registered via raw HTTP JSON because the published conductor-client SDK predates
+ * these fields. All workflow/task operations use the standard SDK clients.
+ *
+ * <p>Inspection strategy: {@code callbackAfterSeconds} is read from a SCHEDULED retry task before
+ * it is polled (polling resets the field to 0). Actual queue timing verifies jitter and poll-gap
+ * behavior.
+ */
+@Slf4j
+public class RetryPolicyTests {
+
+    static WorkflowClient workflowClient;
+    static TaskClient taskClient;
+    static MetadataClient metadataClient;
+    static HttpClient httpClient;
+    static ObjectMapper objectMapper;
+
+    @BeforeAll
+    static void init() {
+        workflowClient = ApiUtil.WORKFLOW_CLIENT;
+        taskClient = ApiUtil.TASK_CLIENT;
+        metadataClient = ApiUtil.METADATA_CLIENT;
+        httpClient = HttpClient.newHttpClient();
+        objectMapper = new ObjectMapperProvider().getObjectMapper();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    @SneakyThrows
+    private void registerTaskDef(Map<String, Object> fields) {
+        String json = objectMapper.writeValueAsString(List.of(fields));
+        HttpRequest req =
+                HttpRequest.newBuilder()
+                        .uri(URI.create(ApiUtil.SERVER_ROOT_URI + "/metadata/taskdefs"))
+                        .header("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(json))
+                        .build();
+        HttpResponse<String> res = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
+        assertTrue(res.statusCode() < 300,
+                "Task def registration failed " + res.statusCode() + ": " + res.body());
+    }
+
+    private Map<String, Object> taskDefBase(String name) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("name", name);
+        m.put("ownerEmail", "test@conductor.io");
+        m.put("timeoutSeconds", 600);
+        m.put("responseTimeoutSeconds", 600);
+        m.put("retryCount", 5);
+        return m;
+    }
+
+    private void registerWorkflow(String workflowName, String taskType) {
+        WorkflowTask wfTask = new WorkflowTask();
+        wfTask.setName(taskType);
+        wfTask.setTaskReferenceName(taskType + "_ref");
+        wfTask.setWorkflowTaskType(TaskType.SIMPLE);
+
+        WorkflowDef wfDef = new WorkflowDef();
+        wfDef.setName(workflowName);
+        wfDef.setVersion(1);
+        wfDef.setOwnerEmail("test@conductor.io");
+        wfDef.setTimeoutSeconds(600);
+        wfDef.setTimeoutPolicy(WorkflowDef.TimeoutPolicy.ALERT_ONLY);
+        wfDef.setTasks(List.of(wfTask));
+        metadataClient.updateWorkflowDefs(List.of(wfDef));
+    }
+
+    private String startWorkflow(String name) {
+        return workflowClient.startWorkflow(
+                new StartWorkflowRequest().withName(name).withVersion(1).withInput(Map.of()));
+    }
+
+    /** Polls until one task is available; blocks up to 20 s. */
+    private Task pollTask(String taskType) {
+        return await().atMost(20, TimeUnit.SECONDS)
+                .pollInterval(200, TimeUnit.MILLISECONDS)
+                .until(
+                        () -> {
+                            List<Task> t =
+                                    taskClient.batchPollTasksByTaskType(taskType, "e2e-worker", 1, 500);
+                            return t.isEmpty() ? null : t.get(0);
+                        },
+                        t -> t != null);
+    }
+
+    private void failTask(String wfId, String taskId) {
+        TaskResult r = new TaskResult();
+        r.setWorkflowInstanceId(wfId);
+        r.setTaskId(taskId);
+        r.setStatus(TaskResult.Status.FAILED);
+        r.setReasonForIncompletion("e2e retry policy test");
+        taskClient.updateTask(r);
+    }
+
+    private void completeTask(String wfId, String taskId) {
+        TaskResult r = new TaskResult();
+        r.setWorkflowInstanceId(wfId);
+        r.setTaskId(taskId);
+        r.setStatus(TaskResult.Status.COMPLETED);
+        taskClient.updateTask(r);
+    }
+
+    /** Returns the first SCHEDULED task in the workflow once it has ≥ minCount tasks. */
+    private Task awaitScheduledRetry(String wfId, int minCount) {
+        return await().atMost(10, TimeUnit.SECONDS)
+                .pollInterval(200, TimeUnit.MILLISECONDS)
+                .until(
+                        () -> {
+                            Workflow wf = workflowClient.getWorkflow(wfId, true);
+                            if (wf.getTasks().size() < minCount) return null;
+                            return wf.getTasks().stream()
+                                    .filter(t -> t.getStatus() == Task.Status.SCHEDULED)
+                                    .findFirst()
+                                    .orElse(null);
+                        },
+                        t -> t != null);
+    }
+
+    private void awaitCompleted(String wfId) {
+        await().atMost(20, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> assertEquals(
+                                Workflow.WorkflowStatus.COMPLETED,
+                                workflowClient.getWorkflow(wfId, false).getStatus(),
+                                "workflow " + wfId + " did not complete"));
+    }
+
+    // =========================================================================
+    // maxRetryDelaySeconds
+    // =========================================================================
+
+    @Test
+    @DisplayName("EXPONENTIAL_BACKOFF: delays grow then are capped by maxRetryDelaySeconds")
+    void testMaxRetryDelaySeconds_exponential() {
+        String tt = "e2e-exp-cap-task", wf = "e2e-exp-cap-wf";
+        // base=1s, cap=3s: retry1=1s, retry2=2s, retry3=4s→3s
+        Map<String, Object> def = taskDefBase(tt);
+        def.put("retryDelaySeconds", 1);
+        def.put("retryLogic", "EXPONENTIAL_BACKOFF");
+        def.put("maxRetryDelaySeconds", 3);
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        String wfId = startWorkflow(wf);
+
+        failTask(wfId, pollTask(tt).getTaskId());
+        assertEquals(1L, awaitScheduledRetry(wfId, 2).getCallbackAfterSeconds(),
+                "retry1: 1×2⁰=1s (below cap 3s)");
+
+        failTask(wfId, pollTask(tt).getTaskId());
+        assertEquals(2L, awaitScheduledRetry(wfId, 3).getCallbackAfterSeconds(),
+                "retry2: 1×2¹=2s (below cap 3s)");
+
+        failTask(wfId, pollTask(tt).getTaskId());
+        assertEquals(3L, awaitScheduledRetry(wfId, 4).getCallbackAfterSeconds(),
+                "retry3: 1×2²=4s → capped to 3s");
+
+        completeTask(wfId, pollTask(tt).getTaskId());
+        awaitCompleted(wfId);
+    }
+
+    @Test
+    @DisplayName("LINEAR_BACKOFF: delays grow then are capped by maxRetryDelaySeconds")
+    void testMaxRetryDelaySeconds_linear() {
+        String tt = "e2e-lin-cap-task", wf = "e2e-lin-cap-wf";
+        // base=1s, scale=2, cap=3s: retry1=2s, retry2=4s→3s
+        Map<String, Object> def = taskDefBase(tt);
+        def.put("retryDelaySeconds", 1);
+        def.put("retryLogic", "LINEAR_BACKOFF");
+        def.put("backoffScaleFactor", 2);
+        def.put("maxRetryDelaySeconds", 3);
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        String wfId = startWorkflow(wf);
+
+        failTask(wfId, pollTask(tt).getTaskId());
+        assertEquals(2L, awaitScheduledRetry(wfId, 2).getCallbackAfterSeconds(),
+                "retry1: 1×2×1=2s (below cap 3s)");
+
+        failTask(wfId, pollTask(tt).getTaskId());
+        assertEquals(3L, awaitScheduledRetry(wfId, 3).getCallbackAfterSeconds(),
+                "retry2: 1×2×2=4s → capped to 3s");
+
+        completeTask(wfId, pollTask(tt).getTaskId());
+        awaitCompleted(wfId);
+    }
+
+    // --- Boundary: cap = 0 means no cap (backward compat) ---
+
+    @Test
+    @DisplayName("cap=0 means no cap: delays grow without bound (backward compat)")
+    void testMaxRetryDelaySeconds_zeroMeansNoCapApplied() {
+        String tt = "e2e-no-cap-task", wf = "e2e-no-cap-wf";
+        // base=1s, no cap: retry1=1s, retry2=2s, retry3=4s (all uncapped)
+        Map<String, Object> def = taskDefBase(tt);
+        def.put("retryDelaySeconds", 1);
+        def.put("retryLogic", "EXPONENTIAL_BACKOFF");
+        def.put("maxRetryDelaySeconds", 0); // disabled
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        String wfId = startWorkflow(wf);
+
+        failTask(wfId, pollTask(tt).getTaskId());
+        assertEquals(1L, awaitScheduledRetry(wfId, 2).getCallbackAfterSeconds());
+
+        failTask(wfId, pollTask(tt).getTaskId());
+        assertEquals(2L, awaitScheduledRetry(wfId, 3).getCallbackAfterSeconds());
+
+        failTask(wfId, pollTask(tt).getTaskId());
+        // Without cap, retry3 = 1×2²=4s (not capped to any lower value)
+        assertEquals(4L, awaitScheduledRetry(wfId, 4).getCallbackAfterSeconds(),
+                "cap=0 must be treated as disabled: delay should be uncapped 4s");
+
+        completeTask(wfId, pollTask(tt).getTaskId());
+        awaitCompleted(wfId);
+    }
+
+    // --- Boundary: cap < retryDelaySeconds → cap fires immediately from retry 0 ---
+
+    @Test
+    @DisplayName("cap < retryDelaySeconds: cap applied from the very first retry")
+    void testMaxRetryDelaySeconds_capLessThanBaseDelay() {
+        String tt = "e2e-cap-lt-base-task", wf = "e2e-cap-lt-base-wf";
+        // base=5s, cap=2s: every retry is capped to 2s even FIXED
+        Map<String, Object> def = taskDefBase(tt);
+        def.put("retryDelaySeconds", 5);
+        def.put("retryLogic", "FIXED");
+        def.put("maxRetryDelaySeconds", 2);
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        String wfId = startWorkflow(wf);
+
+        failTask(wfId, pollTask(tt).getTaskId());
+        assertEquals(2L, awaitScheduledRetry(wfId, 2).getCallbackAfterSeconds(),
+                "FIXED base=5s capped immediately to 2s");
+
+        failTask(wfId, pollTask(tt).getTaskId());
+        assertEquals(2L, awaitScheduledRetry(wfId, 3).getCallbackAfterSeconds(),
+                "All retries capped at 2s");
+
+        completeTask(wfId, pollTask(tt).getTaskId());
+        awaitCompleted(wfId);
+    }
+
+    // --- Boundary: cap = retryDelaySeconds → effective from retry 0 ---
+
+    @Test
+    @DisplayName("cap=retryDelaySeconds: cap matches base, all retries at ceiling from start")
+    void testMaxRetryDelaySeconds_capEqualsBase() {
+        String tt = "e2e-cap-eq-base-task", wf = "e2e-cap-eq-base-wf";
+        // base=2s, scale=2, LINEAR, cap=2s: retry1=2s(capped), retry2=4s→2s, etc.
+        Map<String, Object> def = taskDefBase(tt);
+        def.put("retryDelaySeconds", 2);
+        def.put("retryLogic", "LINEAR_BACKOFF");
+        def.put("backoffScaleFactor", 2);
+        def.put("maxRetryDelaySeconds", 2); // equals first retry raw value
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        String wfId = startWorkflow(wf);
+
+        failTask(wfId, pollTask(tt).getTaskId());
+        // retry1 raw=2×2×1=4s → capped to 2s
+        assertEquals(2L, awaitScheduledRetry(wfId, 2).getCallbackAfterSeconds());
+
+        failTask(wfId, pollTask(tt).getTaskId());
+        // retry2 raw=2×2×2=8s → capped to 2s
+        assertEquals(2L, awaitScheduledRetry(wfId, 3).getCallbackAfterSeconds());
+
+        completeTask(wfId, pollTask(tt).getTaskId());
+        awaitCompleted(wfId);
+    }
+
+    // =========================================================================
+    // backoffJitterMs
+    // =========================================================================
+
+    @Test
+    @DisplayName("FIXED backoff: callbackAfterSeconds=base; queue delay in [base, base+jitter]")
+    void testBackoffJitterMs_fixed() {
+        String tt = "e2e-jitter-fixed-task", wf = "e2e-jitter-fixed-wf";
+        Map<String, Object> def = taskDefBase(tt);
+        def.put("retryDelaySeconds", 2);
+        def.put("retryLogic", "FIXED");
+        def.put("backoffJitterMs", 1000);
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        String wfId = startWorkflow(wf);
+        failTask(wfId, pollTask(tt).getTaskId());
+
+        Task retry = awaitScheduledRetry(wfId, 2);
+        assertEquals(2L, retry.getCallbackAfterSeconds(),
+                "callbackAfterSeconds must equal the base delay; jitter lives in callbackAfterMs");
+
+        long scheduledAt = retry.getScheduledTime();
+        Task retried = pollTask(tt);
+        long queueDelay = System.currentTimeMillis() - scheduledAt;
+        assertTrue(queueDelay >= 2000, "Must wait at least base 2s; was " + queueDelay + "ms");
+        assertTrue(queueDelay < 5000, "Must not exceed base+jitter+overhead; was " + queueDelay + "ms");
+
+        completeTask(wfId, retried.getTaskId());
+        awaitCompleted(wfId);
+    }
+
+    @Test
+    @DisplayName("EXPONENTIAL_BACKOFF: jitter adds on top of each exponentially growing delay")
+    void testBackoffJitterMs_exponential() {
+        String tt = "e2e-jitter-exp-task", wf = "e2e-jitter-exp-wf";
+        // base=1s, jitter=500ms, exponential: retry1=1s±500ms, retry2=2s±500ms
+        Map<String, Object> def = taskDefBase(tt);
+        def.put("retryDelaySeconds", 1);
+        def.put("retryLogic", "EXPONENTIAL_BACKOFF");
+        def.put("backoffJitterMs", 500);
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        String wfId = startWorkflow(wf);
+
+        // retry 0 → retry 1 (base=1s, jitter up to 500ms)
+        failTask(wfId, pollTask(tt).getTaskId());
+        Task retry1 = awaitScheduledRetry(wfId, 2);
+        assertEquals(1L, retry1.getCallbackAfterSeconds());
+
+        long scheduledAt1 = retry1.getScheduledTime();
+        Task task1 = pollTask(tt);
+        long delay1 = System.currentTimeMillis() - scheduledAt1;
+        assertTrue(delay1 >= 1000, "retry1 queue delay must be >= 1s; was " + delay1 + "ms");
+        assertTrue(delay1 < 3000, "retry1 delay must be < 3s; was " + delay1 + "ms");
+
+        // retry 1 → retry 2 (base=2s, jitter up to 500ms)
+        failTask(wfId, task1.getTaskId());
+        Task retry2 = awaitScheduledRetry(wfId, 3);
+        assertEquals(2L, retry2.getCallbackAfterSeconds());
+
+        long scheduledAt2 = retry2.getScheduledTime();
+        Task task2 = pollTask(tt);
+        long delay2 = System.currentTimeMillis() - scheduledAt2;
+        assertTrue(delay2 >= 2000, "retry2 queue delay must be >= 2s; was " + delay2 + "ms");
+        assertTrue(delay2 < 4000, "retry2 delay must be < 4s; was " + delay2 + "ms");
+
+        completeTask(wfId, task2.getTaskId());
+        awaitCompleted(wfId);
+    }
+
+    @Test
+    @DisplayName("LINEAR_BACKOFF: jitter adds on top of each linearly growing delay")
+    void testBackoffJitterMs_linear() {
+        String tt = "e2e-jitter-lin-task", wf = "e2e-jitter-lin-wf";
+        // base=1s, scale=2, jitter=500ms: retry1=2s±500ms, retry2=4s±500ms
+        Map<String, Object> def = taskDefBase(tt);
+        def.put("retryDelaySeconds", 1);
+        def.put("retryLogic", "LINEAR_BACKOFF");
+        def.put("backoffScaleFactor", 2);
+        def.put("backoffJitterMs", 500);
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        String wfId = startWorkflow(wf);
+
+        failTask(wfId, pollTask(tt).getTaskId());
+        Task retry1 = awaitScheduledRetry(wfId, 2);
+        assertEquals(2L, retry1.getCallbackAfterSeconds());
+
+        long s1 = retry1.getScheduledTime();
+        Task t1 = pollTask(tt);
+        long d1 = System.currentTimeMillis() - s1;
+        assertTrue(d1 >= 2000 && d1 < 4000,
+                "retry1 queue delay should be in [2s, 4s]; was " + d1 + "ms");
+
+        completeTask(wfId, t1.getTaskId());
+        awaitCompleted(wfId);
+    }
+
+    @Test
+    @DisplayName("jitter=0: exact base delay, no random spread")
+    void testBackoffJitterMs_zero() {
+        String tt = "e2e-no-jitter-task", wf = "e2e-no-jitter-wf";
+        Map<String, Object> def = taskDefBase(tt);
+        def.put("retryDelaySeconds", 2);
+        def.put("retryLogic", "FIXED");
+        def.put("backoffJitterMs", 0);
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        String wfId = startWorkflow(wf);
+        failTask(wfId, pollTask(tt).getTaskId());
+
+        Task retry = awaitScheduledRetry(wfId, 2);
+        assertEquals(2L, retry.getCallbackAfterSeconds());
+
+        long s = retry.getScheduledTime();
+        Task t = pollTask(tt);
+        long d = System.currentTimeMillis() - s;
+        assertTrue(d >= 2000, "Must wait at least 2s base; was " + d + "ms");
+        assertTrue(d < 4000, "With zero jitter should be close to 2s; was " + d + "ms");
+
+        completeTask(wfId, t.getTaskId());
+        awaitCompleted(wfId);
+    }
+
+    // --- Boundary: minimum positive jitter ---
+
+    @Test
+    @DisplayName("jitter=1ms (minimum): task still retried correctly, minimal spread")
+    void testBackoffJitterMs_minimumOnems() {
+        String tt = "e2e-jitter-1ms-task", wf = "e2e-jitter-1ms-wf";
+        Map<String, Object> def = taskDefBase(tt);
+        def.put("retryDelaySeconds", 2);
+        def.put("retryLogic", "FIXED");
+        def.put("backoffJitterMs", 1); // 1 ms jitter — barely above zero
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        String wfId = startWorkflow(wf);
+        failTask(wfId, pollTask(tt).getTaskId());
+
+        Task retry = awaitScheduledRetry(wfId, 2);
+        assertEquals(2L, retry.getCallbackAfterSeconds());
+
+        // queue delay: base 2s ± 1ms → effectively 2s
+        long s = retry.getScheduledTime();
+        Task t = pollTask(tt);
+        long d = System.currentTimeMillis() - s;
+        assertTrue(d >= 2000 && d < 4000,
+                "1ms jitter should not significantly change timing; was " + d + "ms");
+
+        completeTask(wfId, t.getTaskId());
+        awaitCompleted(wfId);
+    }
+
+    // --- Combined cap + jitter ---
+
+    @Test
+    @DisplayName("Cap applied before jitter: callbackAfterSeconds=cap; queue delay in [cap, cap+jitter]")
+    void testMaxRetryDelaySeconds_withJitter() {
+        String tt = "e2e-cap-jitter-task", wf = "e2e-cap-jitter-wf";
+        // base=1s, cap=3s, jitter=500ms; at retry3: 4s→3s, queue delay in [3s, 3.5s]
+        Map<String, Object> def = taskDefBase(tt);
+        def.put("retryDelaySeconds", 1);
+        def.put("retryLogic", "EXPONENTIAL_BACKOFF");
+        def.put("maxRetryDelaySeconds", 3);
+        def.put("backoffJitterMs", 500);
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        String wfId = startWorkflow(wf);
+
+        failTask(wfId, pollTask(tt).getTaskId());
+        assertEquals(1L, awaitScheduledRetry(wfId, 2).getCallbackAfterSeconds());
+
+        failTask(wfId, pollTask(tt).getTaskId());
+        assertEquals(2L, awaitScheduledRetry(wfId, 3).getCallbackAfterSeconds());
+
+        // retry 2 → retry 3: raw=4s → capped=3s; queue delay in [3000, 3500]ms
+        failTask(wfId, pollTask(tt).getTaskId());
+        Task retry3 = awaitScheduledRetry(wfId, 4);
+        assertEquals(3L, retry3.getCallbackAfterSeconds(),
+                "callbackAfterSeconds reflects cap (3s), not raw (4s)");
+
+        long s = retry3.getScheduledTime();
+        Task t = pollTask(tt);
+        long d = System.currentTimeMillis() - s;
+        assertTrue(d >= 3000, "Queue delay must be ≥ cap 3s; was " + d + "ms");
+        assertTrue(d < 5000, "Queue delay must be < cap+jitter+overhead; was " + d + "ms");
+
+        completeTask(wfId, t.getTaskId());
+        awaitCompleted(wfId);
+    }
+
+    // =========================================================================
+    // Concurrency: jitter spreads retries across time
+    //
+    // The core thundering-herd protection test: N workflows fail their tasks
+    // simultaneously. With jitter, each retry task should become available at a
+    // different time. We verify this by recording poll timestamps — if all tasks
+    // were delivered at the same moment (no jitter), they would all be polled in
+    // the same batch; with jitter they must spread across multiple batches.
+    // =========================================================================
+
+    @Test
+    @DisplayName("Concurrency: jitter spreads N simultaneous retries across the jitter window")
+    void testConcurrentRetries_jitterSpreadsRetryTimes() throws InterruptedException {
+        final int N = 5;
+        String tt = "e2e-concurrent-jitter-task", wf = "e2e-concurrent-jitter-wf";
+
+        // base=1s, jitter=2000ms — large jitter relative to base to make spread observable
+        Map<String, Object> def = taskDefBase(tt);
+        def.put("retryDelaySeconds", 1);
+        def.put("retryLogic", "FIXED");
+        def.put("backoffJitterMs", 2000);
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        // Start N workflows simultaneously
+        List<String> wfIds = new ArrayList<>();
+        for (int i = 0; i < N; i++) wfIds.add(startWorkflow(wf));
+
+        // Poll and fail all initial tasks concurrently so retries are scheduled at the same instant
+        ExecutorService pool = Executors.newFixedThreadPool(N);
+        CountDownLatch allFailed = new CountDownLatch(N);
+        for (String id : wfIds) {
+            pool.submit(() -> {
+                try {
+                    failTask(id, pollTask(tt).getTaskId());
+                } finally {
+                    allFailed.countDown();
+                }
+            });
+        }
+        assertTrue(allFailed.await(30, TimeUnit.SECONDS), "All tasks failed within timeout");
+        pool.shutdown();
+
+        // Collect timestamps of when each retry task first becomes poppable
+        Set<Long> pollTimestampsSeconds = ConcurrentHashMap.newKeySet();
+        long start = System.currentTimeMillis();
+        while (pollTimestampsSeconds.size() < N && System.currentTimeMillis() - start < 15_000) {
+            List<Task> batch = taskClient.batchPollTasksByTaskType(tt, "e2e-concurrency-worker", N, 500);
+            long nowSec = System.currentTimeMillis() / 1000;
+            for (Task t : batch) {
+                pollTimestampsSeconds.add(nowSec);
+                completeTask(t.getWorkflowInstanceId(), t.getTaskId());
+            }
+            if (batch.isEmpty()) Thread.sleep(200);
+        }
+
+        assertEquals(N, pollTimestampsSeconds.size() + /* could be in same second with low N */ 0,
+                "All " + N + " retry tasks must eventually be polled");
+
+        // With 2s jitter and N=5 tasks, it's statistically very unlikely that all tasks become
+        // available in the exact same second bucket if jitter is truly random.
+        // We assert that tasks spread across at least 2 distinct second-buckets.
+        // (P(all same bucket) ≈ (1/2)^4 = 6.25% with uniform jitter over 2s — acceptable flakiness
+        //  threshold given that test failures prompt investigation rather than automatic re-run.)
+        assertTrue(pollTimestampsSeconds.size() >= 2 || N == 1,
+                "With " + N + " tasks and 2s jitter, retries must spread across ≥2 second-buckets. "
+                        + "All " + N + " tasks appeared in the same second — jitter may not be applied.");
+    }
+
+    @Test
+    @DisplayName("Concurrency: N workflows with cap+jitter all complete correctly")
+    void testConcurrentRetries_capAndJitter_allWorkflowsComplete() throws InterruptedException {
+        final int N = 4;
+        String tt = "e2e-concurrent-cap-jitter-task", wf = "e2e-concurrent-cap-jitter-wf";
+
+        // base=1s, cap=2s, jitter=500ms
+        Map<String, Object> def = taskDefBase(tt);
+        def.put("retryDelaySeconds", 1);
+        def.put("retryLogic", "EXPONENTIAL_BACKOFF");
+        def.put("maxRetryDelaySeconds", 2);
+        def.put("backoffJitterMs", 500);
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        List<String> wfIds = new ArrayList<>();
+        for (int i = 0; i < N; i++) wfIds.add(startWorkflow(wf));
+
+        // Fail each initial task, then complete each retry — all under concurrent conditions
+        ExecutorService pool = Executors.newFixedThreadPool(N);
+        CountDownLatch done = new CountDownLatch(N);
+        for (String id : wfIds) {
+            pool.submit(() -> {
+                try {
+                    failTask(id, pollTask(tt).getTaskId());
+                    // await and complete the retry
+                    Task retry = awaitScheduledRetry(id, 2);
+                    assertNotNull(retry, "retry task must be scheduled for wf " + id);
+                    // cap applied: base=1s (retry0), raw retry1=2s (2^1 * 1) → capped to 2s
+                    assertTrue(retry.getCallbackAfterSeconds() <= 2,
+                            "callbackAfterSeconds must be ≤ cap (2s); was "
+                                    + retry.getCallbackAfterSeconds());
+                    completeTask(id, pollTask(tt).getTaskId());
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+        assertTrue(done.await(60, TimeUnit.SECONDS), "All " + N + " retry cycles completed");
+        pool.shutdown();
+
+        // Verify all N workflows completed successfully
+        for (String id : wfIds) {
+            Workflow w = workflowClient.getWorkflow(id, false);
+            assertEquals(Workflow.WorkflowStatus.COMPLETED, w.getStatus(),
+                    "Workflow " + id + " must be COMPLETED");
+        }
+    }
+
+    // =========================================================================
+    // Poll gap fix: responseTimeout < pollTimeout
+    //
+    // Before the fix: when a task transitions SCHEDULED→IN_PROGRESS the decider
+    // queue kept the old poll-based postpone. If pollTimeout=30s and
+    // responseTimeout=3s, the sweeper would not re-evaluate until ~30s, missing
+    // the response timeout by ~27s.
+    //
+    // After the fix: `adjustDeciderQueuePostpone()` calls
+    // `setUnackTimeoutIfShorter()` with the response timeout, advancing the
+    // sweep to ~responseTimeout.
+    //
+    // We observe this by measuring how quickly the task transitions to TIMED_OUT
+    // after being polled (left IN_PROGRESS without a response).
+    // =========================================================================
+
+    @Test
+    @DisplayName("Poll gap fix: response timeout is detected promptly after polling "
+            + "(not delayed until poll timeout expires)")
+    void testPollGapFix_responseTimeoutDetectedBeforePollTimeout() {
+        String tt = "e2e-poll-gap-task", wf = "e2e-poll-gap-wf";
+
+        // pollTimeout=30s, responseTimeout=3s.
+        // Without fix: TIMED_OUT after ~30s.  With fix: TIMED_OUT after ~3s.
+        Map<String, Object> def = taskDefBase(tt);
+        def.put("retryCount", 0); // no retries — task goes straight to TIMED_OUT
+        def.put("retryLogic", "FIXED");
+        def.put("pollTimeoutSeconds", 30);   // long poll window
+        def.put("responseTimeoutSeconds", 3); // short response window
+        def.put("timeoutSeconds", 600);
+        def.put("timeoutPolicy", "TIME_OUT_WF");
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        String wfId = startWorkflow(wf);
+
+        // Poll the task (SCHEDULED → IN_PROGRESS) — but do NOT respond.
+        // The poll gap fix must update the decider queue to fire after responseTimeout (3s),
+        // not after the old poll-based postpone (~30s).
+        Task task = pollTask(tt);
+        assertNotNull(task, "Task must be pollable");
+        long polledAt = System.currentTimeMillis();
+
+        // Wait for the sweeper to fire and time out the task.
+        // With fix:    detectable within ~5s (3s response timeout + small sweep lag).
+        // Without fix: would take ~30s (poll timeout) — test would fail at 10s.
+        await().atMost(10, TimeUnit.SECONDS)
+                .pollInterval(500, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    Workflow w = workflowClient.getWorkflow(wfId, true);
+                    Task t = w.getTasks().stream()
+                            .filter(tk -> tk.getTaskId().equals(task.getTaskId()))
+                            .findFirst()
+                            .orElseThrow();
+                    assertEquals(Task.Status.TIMED_OUT, t.getStatus(),
+                            "Task must be TIMED_OUT within response timeout window");
+                });
+
+        long elapsed = System.currentTimeMillis() - polledAt;
+        log.info("Task timed out {}ms after being polled (responseTimeout=3s, pollTimeout=30s)", elapsed);
+
+        // The key assertion: timed out well before the poll timeout would have fired.
+        assertTrue(elapsed < 20_000,
+                "Task timed out " + elapsed + "ms after polling — poll gap fix must advance the"
+                        + " sweep to responseTimeout (~3s), not pollTimeout (~30s)");
+    }
+}

--- a/e2e/src/test/java/io/conductor/e2e/task/RetryPolicyTests.java
+++ b/e2e/src/test/java/io/conductor/e2e/task/RetryPolicyTests.java
@@ -879,6 +879,179 @@ public class RetryPolicyTests {
         }
     }
 
+    // --- interaction: totalTimeout + maxRetryDelayCap ---
+
+    @Test
+    @DisplayName("totalTimeout + maxRetryDelayCap: cap applied to retry delay; hard budget still enforced")
+    void testTotalTimeoutSeconds_withMaxRetryDelayCap() {
+        String tt = "e2e-total-cap-combo-task", wf = "e2e-total-cap-combo-wf";
+
+        // base=1s, cap=2s, totalBudget=60s: retries are delayed by at most 2s; budget never hit
+        Map<String, Object> def = new HashMap<>();
+        def.put("name", tt);
+        def.put("ownerEmail", "test@conductor.io");
+        def.put("retryCount", 5);
+        def.put("retryDelaySeconds", 1);
+        def.put("retryLogic", "EXPONENTIAL_BACKOFF");
+        def.put("maxRetryDelaySeconds", 2);
+        def.put("totalTimeoutSeconds", 60);
+        def.put("timeoutSeconds", 0);
+        def.put("responseTimeoutSeconds", 1);
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        String wfId = startWorkflow(wf);
+
+        // Fail twice, verify cap is applied AND retries are scheduled (total budget not hit)
+        failTask(wfId, pollTask(tt).getTaskId());
+        Task retry1 = awaitScheduledRetry(wfId, 2);
+        assertEquals(1L, retry1.getCallbackAfterSeconds(),
+                "retry1: 1×2⁰=1s (below cap 2s, well within totalTimeout 60s)");
+
+        failTask(wfId, pollTask(tt).getTaskId());
+        Task retry2 = awaitScheduledRetry(wfId, 3);
+        assertEquals(2L, retry2.getCallbackAfterSeconds(),
+                "retry2: 1×2¹=2s = cap, still within totalTimeout 60s");
+
+        completeTask(wfId, pollTask(tt).getTaskId());
+        awaitCompleted(wfId);
+    }
+
+    // --- interaction: totalTimeout + backoffJitterMs ---
+
+    @Test
+    @DisplayName("totalTimeout + backoffJitterMs: jitter applies per retry; hard budget still enforced")
+    void testTotalTimeoutSeconds_withJitter() {
+        String tt = "e2e-total-jitter-combo-task", wf = "e2e-total-jitter-combo-wf";
+
+        // base=1s, jitter=500ms, totalBudget=60s: retries get jitter; budget never hit
+        Map<String, Object> def = new HashMap<>();
+        def.put("name", tt);
+        def.put("ownerEmail", "test@conductor.io");
+        def.put("retryCount", 5);
+        def.put("retryDelaySeconds", 1);
+        def.put("retryLogic", "FIXED");
+        def.put("backoffJitterMs", 500);
+        def.put("totalTimeoutSeconds", 60);
+        def.put("timeoutSeconds", 0);
+        def.put("responseTimeoutSeconds", 1);
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        String wfId = startWorkflow(wf);
+
+        failTask(wfId, pollTask(tt).getTaskId());
+        Task retry1 = awaitScheduledRetry(wfId, 2);
+        // callbackAfterSeconds = base delay (jitter is in callbackAfterMs, not visible via HTTP API)
+        assertEquals(1L, retry1.getCallbackAfterSeconds(),
+                "callbackAfterSeconds must equal base delay regardless of jitter");
+
+        long scheduledAt = retry1.getScheduledTime();
+        Task retried = pollTask(tt);
+        long queueDelay = System.currentTimeMillis() - scheduledAt;
+        assertTrue(queueDelay >= 1000, "Must wait at least base 1s; was " + queueDelay + "ms");
+        assertTrue(queueDelay < 3000, "Must be < base+jitter+overhead; was " + queueDelay + "ms");
+
+        completeTask(wfId, retried.getTaskId());
+        awaitCompleted(wfId);
+    }
+
+    // --- firstScheduledTime preserved across multiple retries ---
+
+    @Test
+    @DisplayName("firstScheduledTime preserved: budget measured from first schedule, not each retry")
+    void testTotalTimeoutSeconds_firstScheduledTimePreservedAcrossRetries() {
+        String tt = "e2e-total-preserve-task", wf = "e2e-total-preserve-wf";
+
+        // Generous 60s budget, multiple retries — verify that budget is not reset on each retry
+        Map<String, Object> def = new HashMap<>();
+        def.put("name", tt);
+        def.put("ownerEmail", "test@conductor.io");
+        def.put("retryCount", 10);
+        def.put("retryDelaySeconds", 0);
+        def.put("retryLogic", "FIXED");
+        def.put("totalTimeoutSeconds", 60);
+        def.put("timeoutSeconds", 0);
+        def.put("responseTimeoutSeconds", 1);
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        String wfId = startWorkflow(wf);
+        long testStart = System.currentTimeMillis();
+
+        // Fail 3 times in rapid succession — each retry must use the original firstScheduledTime
+        for (int i = 0; i < 3; i++) {
+            failTask(wfId, pollTask(tt).getTaskId());
+            awaitScheduledRetry(wfId, i + 2);
+        }
+
+        // All 3 retries should have been scheduled — total elapsed is << 60s
+        Workflow wf2 = workflowClient.getWorkflow(wfId, true);
+        long elapsed = System.currentTimeMillis() - testStart;
+        assertEquals(4, wf2.getTasks().size(),
+                "Should have 4 tasks (original + 3 retries) after 3 failures; "
+                        + "elapsed=" + elapsed + "ms");
+        assertTrue(elapsed < 10_000,
+                "Test must complete in << 60s totalTimeout; elapsed=" + elapsed + "ms");
+
+        completeTask(wfId, pollTask(tt).getTaskId());
+        awaitCompleted(wfId);
+    }
+
+    // --- ALERT_ONLY policy behavior ---
+
+    @Test
+    @DisplayName("ALERT_ONLY policy + totalTimeout exceeded: workflow terminates when task explicitly fails")
+    void testTotalTimeoutSeconds_alertOnlyPolicy_terminatesOnWorkerFailure() {
+        // When a worker explicitly fails a task and the total budget is already exhausted,
+        // the retry() guard fires and terminates the workflow.
+        // This is intentional: totalTimeoutSeconds is a hard budget regardless of per-attempt policy.
+        // (ALERT_ONLY controls single-attempt timeouts; the total limit is absolute.)
+        String tt = "e2e-total-alert-only-task", wf = "e2e-total-alert-only-wf";
+
+        TaskRunnerConfigurer workerConfigurer = null;
+        try {
+            // 4s budget, ALERT_ONLY, always-failing worker
+            Map<String, Object> def = new HashMap<>();
+            def.put("name", tt);
+            def.put("ownerEmail", "test@conductor.io");
+            def.put("retryCount", 100);
+            def.put("retryDelaySeconds", 0);
+            def.put("retryLogic", "FIXED");
+            def.put("totalTimeoutSeconds", 4);
+            def.put("timeoutSeconds", 0);
+            def.put("responseTimeoutSeconds", 1);
+            def.put("timeoutPolicy", "ALERT_ONLY");
+            registerTaskDef(def);
+            registerWorkflow(wf, tt);
+
+            workerConfigurer = startAlwaysFailingWorker(tt);
+            String wfId = startWorkflow(wf);
+
+            // Workflow must terminate even with ALERT_ONLY, because the retry() guard is a hard stop
+            await().atMost(30, TimeUnit.SECONDS)
+                    .pollInterval(500, TimeUnit.MILLISECONDS)
+                    .untilAsserted(() -> {
+                        Workflow w = workflowClient.getWorkflow(wfId, false);
+                        assertTrue(
+                                w.getStatus() == Workflow.WorkflowStatus.FAILED
+                                        || w.getStatus() == Workflow.WorkflowStatus.TIMED_OUT,
+                                "ALERT_ONLY with totalTimeout must still terminate after budget exhausted; "
+                                        + "status=" + w.getStatus());
+                    });
+
+            // Fewer tasks than retryCount — proves totalTimeout, not retry exhaustion, stopped it
+            Workflow wfFinal = workflowClient.getWorkflow(wfId, true);
+            assertTrue(wfFinal.getTasks().size() < 100,
+                    "Must have terminated before retryCount=100 is exhausted");
+
+        } finally {
+            if (workerConfigurer != null) {
+                try { workerConfigurer.shutdown(); } catch (Exception ignored) {}
+            }
+        }
+    }
+
     @Test
     @DisplayName("Concurrent workflows: totalTimeoutSeconds independent per workflow instance")
     void testTotalTimeoutSeconds_concurrentWorkflows_eachInstanceIndependent()

--- a/e2e/src/test/java/io/conductor/e2e/task/RetryPolicyTests.java
+++ b/e2e/src/test/java/io/conductor/e2e/task/RetryPolicyTests.java
@@ -102,7 +102,8 @@ public class RetryPolicyTests {
                         .POST(HttpRequest.BodyPublishers.ofString(json))
                         .build();
         HttpResponse<String> res = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
-        assertTrue(res.statusCode() < 300,
+        assertTrue(
+                res.statusCode() < 300,
                 "Task def registration failed " + res.statusCode() + ": " + res.body());
     }
 
@@ -144,7 +145,8 @@ public class RetryPolicyTests {
                 .until(
                         () -> {
                             List<Task> t =
-                                    taskClient.batchPollTasksByTaskType(taskType, "e2e-worker", 1, 500);
+                                    taskClient.batchPollTasksByTaskType(
+                                            taskType, "e2e-worker", 1, 500);
                             return t.isEmpty() ? null : t.get(0);
                         },
                         t -> t != null);
@@ -186,10 +188,11 @@ public class RetryPolicyTests {
     private void awaitCompleted(String wfId) {
         await().atMost(20, TimeUnit.SECONDS)
                 .untilAsserted(
-                        () -> assertEquals(
-                                Workflow.WorkflowStatus.COMPLETED,
-                                workflowClient.getWorkflow(wfId, false).getStatus(),
-                                "workflow " + wfId + " did not complete"));
+                        () ->
+                                assertEquals(
+                                        Workflow.WorkflowStatus.COMPLETED,
+                                        workflowClient.getWorkflow(wfId, false).getStatus(),
+                                        "workflow " + wfId + " did not complete"));
     }
 
     // =========================================================================
@@ -211,15 +214,21 @@ public class RetryPolicyTests {
         String wfId = startWorkflow(wf);
 
         failTask(wfId, pollTask(tt).getTaskId());
-        assertEquals(1L, awaitScheduledRetry(wfId, 2).getCallbackAfterSeconds(),
+        assertEquals(
+                1L,
+                awaitScheduledRetry(wfId, 2).getCallbackAfterSeconds(),
                 "retry1: 1×2⁰=1s (below cap 3s)");
 
         failTask(wfId, pollTask(tt).getTaskId());
-        assertEquals(2L, awaitScheduledRetry(wfId, 3).getCallbackAfterSeconds(),
+        assertEquals(
+                2L,
+                awaitScheduledRetry(wfId, 3).getCallbackAfterSeconds(),
                 "retry2: 1×2¹=2s (below cap 3s)");
 
         failTask(wfId, pollTask(tt).getTaskId());
-        assertEquals(3L, awaitScheduledRetry(wfId, 4).getCallbackAfterSeconds(),
+        assertEquals(
+                3L,
+                awaitScheduledRetry(wfId, 4).getCallbackAfterSeconds(),
                 "retry3: 1×2²=4s → capped to 3s");
 
         completeTask(wfId, pollTask(tt).getTaskId());
@@ -242,11 +251,15 @@ public class RetryPolicyTests {
         String wfId = startWorkflow(wf);
 
         failTask(wfId, pollTask(tt).getTaskId());
-        assertEquals(2L, awaitScheduledRetry(wfId, 2).getCallbackAfterSeconds(),
+        assertEquals(
+                2L,
+                awaitScheduledRetry(wfId, 2).getCallbackAfterSeconds(),
                 "retry1: 1×2×1=2s (below cap 3s)");
 
         failTask(wfId, pollTask(tt).getTaskId());
-        assertEquals(3L, awaitScheduledRetry(wfId, 3).getCallbackAfterSeconds(),
+        assertEquals(
+                3L,
+                awaitScheduledRetry(wfId, 3).getCallbackAfterSeconds(),
                 "retry2: 1×2×2=4s → capped to 3s");
 
         completeTask(wfId, pollTask(tt).getTaskId());
@@ -277,7 +290,9 @@ public class RetryPolicyTests {
 
         failTask(wfId, pollTask(tt).getTaskId());
         // Without cap, retry3 = 1×2²=4s (not capped to any lower value)
-        assertEquals(4L, awaitScheduledRetry(wfId, 4).getCallbackAfterSeconds(),
+        assertEquals(
+                4L,
+                awaitScheduledRetry(wfId, 4).getCallbackAfterSeconds(),
                 "cap=0 must be treated as disabled: delay should be uncapped 4s");
 
         completeTask(wfId, pollTask(tt).getTaskId());
@@ -301,11 +316,15 @@ public class RetryPolicyTests {
         String wfId = startWorkflow(wf);
 
         failTask(wfId, pollTask(tt).getTaskId());
-        assertEquals(2L, awaitScheduledRetry(wfId, 2).getCallbackAfterSeconds(),
+        assertEquals(
+                2L,
+                awaitScheduledRetry(wfId, 2).getCallbackAfterSeconds(),
                 "FIXED base=5s capped immediately to 2s");
 
         failTask(wfId, pollTask(tt).getTaskId());
-        assertEquals(2L, awaitScheduledRetry(wfId, 3).getCallbackAfterSeconds(),
+        assertEquals(
+                2L,
+                awaitScheduledRetry(wfId, 3).getCallbackAfterSeconds(),
                 "All retries capped at 2s");
 
         completeTask(wfId, pollTask(tt).getTaskId());
@@ -360,14 +379,18 @@ public class RetryPolicyTests {
         failTask(wfId, pollTask(tt).getTaskId());
 
         Task retry = awaitScheduledRetry(wfId, 2);
-        assertEquals(2L, retry.getCallbackAfterSeconds(),
+        assertEquals(
+                2L,
+                retry.getCallbackAfterSeconds(),
                 "callbackAfterSeconds must equal the base delay; jitter lives in callbackAfterMs");
 
         long scheduledAt = retry.getScheduledTime();
         Task retried = pollTask(tt);
         long queueDelay = System.currentTimeMillis() - scheduledAt;
         assertTrue(queueDelay >= 2000, "Must wait at least base 2s; was " + queueDelay + "ms");
-        assertTrue(queueDelay < 5000, "Must not exceed base+jitter+overhead; was " + queueDelay + "ms");
+        assertTrue(
+                queueDelay < 5000,
+                "Must not exceed base+jitter+overhead; was " + queueDelay + "ms");
 
         completeTask(wfId, retried.getTaskId());
         awaitCompleted(wfId);
@@ -435,7 +458,8 @@ public class RetryPolicyTests {
         long s1 = retry1.getScheduledTime();
         Task t1 = pollTask(tt);
         long d1 = System.currentTimeMillis() - s1;
-        assertTrue(d1 >= 2000 && d1 < 4000,
+        assertTrue(
+                d1 >= 2000 && d1 < 4000,
                 "retry1 queue delay should be in [2s, 4s]; was " + d1 + "ms");
 
         completeTask(wfId, t1.getTaskId());
@@ -492,7 +516,8 @@ public class RetryPolicyTests {
         long s = retry.getScheduledTime();
         Task t = pollTask(tt);
         long d = System.currentTimeMillis() - s;
-        assertTrue(d >= 2000 && d < 4000,
+        assertTrue(
+                d >= 2000 && d < 4000,
                 "1ms jitter should not significantly change timing; was " + d + "ms");
 
         completeTask(wfId, t.getTaskId());
@@ -502,7 +527,8 @@ public class RetryPolicyTests {
     // --- Combined cap + jitter ---
 
     @Test
-    @DisplayName("Cap applied before jitter: callbackAfterSeconds=cap; queue delay in [cap, cap+jitter]")
+    @DisplayName(
+            "Cap applied before jitter: callbackAfterSeconds=cap; queue delay in [cap, cap+jitter]")
     void testMaxRetryDelaySeconds_withJitter() {
         String tt = "e2e-cap-jitter-task", wf = "e2e-cap-jitter-wf";
         // base=1s, cap=3s, jitter=500ms; at retry3: 4s→3s, queue delay in [3s, 3.5s]
@@ -525,7 +551,9 @@ public class RetryPolicyTests {
         // retry 2 → retry 3: raw=4s → capped=3s; queue delay in [3000, 3500]ms
         failTask(wfId, pollTask(tt).getTaskId());
         Task retry3 = awaitScheduledRetry(wfId, 4);
-        assertEquals(3L, retry3.getCallbackAfterSeconds(),
+        assertEquals(
+                3L,
+                retry3.getCallbackAfterSeconds(),
                 "callbackAfterSeconds reflects cap (3s), not raw (4s)");
 
         long s = retry3.getScheduledTime();
@@ -570,13 +598,14 @@ public class RetryPolicyTests {
         ExecutorService pool = Executors.newFixedThreadPool(N);
         CountDownLatch allFailed = new CountDownLatch(N);
         for (String id : wfIds) {
-            pool.submit(() -> {
-                try {
-                    failTask(id, pollTask(tt).getTaskId());
-                } finally {
-                    allFailed.countDown();
-                }
-            });
+            pool.submit(
+                    () -> {
+                        try {
+                            failTask(id, pollTask(tt).getTaskId());
+                        } finally {
+                            allFailed.countDown();
+                        }
+                    });
         }
         assertTrue(allFailed.await(30, TimeUnit.SECONDS), "All tasks failed within timeout");
         pool.shutdown();
@@ -585,7 +614,8 @@ public class RetryPolicyTests {
         Set<Long> pollTimestampsSeconds = ConcurrentHashMap.newKeySet();
         long start = System.currentTimeMillis();
         while (pollTimestampsSeconds.size() < N && System.currentTimeMillis() - start < 15_000) {
-            List<Task> batch = taskClient.batchPollTasksByTaskType(tt, "e2e-concurrency-worker", N, 500);
+            List<Task> batch =
+                    taskClient.batchPollTasksByTaskType(tt, "e2e-concurrency-worker", N, 500);
             long nowSec = System.currentTimeMillis() / 1000;
             for (Task t : batch) {
                 pollTimestampsSeconds.add(nowSec);
@@ -594,7 +624,9 @@ public class RetryPolicyTests {
             if (batch.isEmpty()) Thread.sleep(200);
         }
 
-        assertEquals(N, pollTimestampsSeconds.size() + /* could be in same second with low N */ 0,
+        assertEquals(
+                N,
+                pollTimestampsSeconds.size() + /* could be in same second with low N */ 0,
                 "All " + N + " retry tasks must eventually be polled");
 
         // With 2s jitter and N=5 tasks, it's statistically very unlikely that all tasks become
@@ -602,9 +634,14 @@ public class RetryPolicyTests {
         // We assert that tasks spread across at least 2 distinct second-buckets.
         // (P(all same bucket) ≈ (1/2)^4 = 6.25% with uniform jitter over 2s — acceptable flakiness
         //  threshold given that test failures prompt investigation rather than automatic re-run.)
-        assertTrue(pollTimestampsSeconds.size() >= 2 || N == 1,
-                "With " + N + " tasks and 2s jitter, retries must spread across ≥2 second-buckets. "
-                        + "All " + N + " tasks appeared in the same second — jitter may not be applied.");
+        assertTrue(
+                pollTimestampsSeconds.size() >= 2 || N == 1,
+                "With "
+                        + N
+                        + " tasks and 2s jitter, retries must spread across ≥2 second-buckets. "
+                        + "All "
+                        + N
+                        + " tasks appeared in the same second — jitter may not be applied.");
     }
 
     @Test
@@ -629,21 +666,23 @@ public class RetryPolicyTests {
         ExecutorService pool = Executors.newFixedThreadPool(N);
         CountDownLatch done = new CountDownLatch(N);
         for (String id : wfIds) {
-            pool.submit(() -> {
-                try {
-                    failTask(id, pollTask(tt).getTaskId());
-                    // await and complete the retry
-                    Task retry = awaitScheduledRetry(id, 2);
-                    assertNotNull(retry, "retry task must be scheduled for wf " + id);
-                    // cap applied: base=1s (retry0), raw retry1=2s (2^1 * 1) → capped to 2s
-                    assertTrue(retry.getCallbackAfterSeconds() <= 2,
-                            "callbackAfterSeconds must be ≤ cap (2s); was "
-                                    + retry.getCallbackAfterSeconds());
-                    completeTask(id, pollTask(tt).getTaskId());
-                } finally {
-                    done.countDown();
-                }
-            });
+            pool.submit(
+                    () -> {
+                        try {
+                            failTask(id, pollTask(tt).getTaskId());
+                            // await and complete the retry
+                            Task retry = awaitScheduledRetry(id, 2);
+                            assertNotNull(retry, "retry task must be scheduled for wf " + id);
+                            // cap applied: base=1s (retry0), raw retry1=2s (2^1 * 1) → capped to 2s
+                            assertTrue(
+                                    retry.getCallbackAfterSeconds() <= 2,
+                                    "callbackAfterSeconds must be ≤ cap (2s); was "
+                                            + retry.getCallbackAfterSeconds());
+                            completeTask(id, pollTask(tt).getTaskId());
+                        } finally {
+                            done.countDown();
+                        }
+                    });
         }
         assertTrue(done.await(60, TimeUnit.SECONDS), "All " + N + " retry cycles completed");
         pool.shutdown();
@@ -651,7 +690,9 @@ public class RetryPolicyTests {
         // Verify all N workflows completed successfully
         for (String id : wfIds) {
             Workflow w = workflowClient.getWorkflow(id, false);
-            assertEquals(Workflow.WorkflowStatus.COMPLETED, w.getStatus(),
+            assertEquals(
+                    Workflow.WorkflowStatus.COMPLETED,
+                    w.getStatus(),
                     "Workflow " + id + " must be COMPLETED");
         }
     }
@@ -673,8 +714,9 @@ public class RetryPolicyTests {
     // =========================================================================
 
     @Test
-    @DisplayName("Poll gap fix: response timeout is detected promptly after polling "
-            + "(not delayed until poll timeout expires)")
+    @DisplayName(
+            "Poll gap fix: response timeout is detected promptly after polling "
+                    + "(not delayed until poll timeout expires)")
     void testPollGapFix_responseTimeoutDetectedBeforePollTimeout() {
         String tt = "e2e-poll-gap-task", wf = "e2e-poll-gap-wf";
 
@@ -683,7 +725,7 @@ public class RetryPolicyTests {
         Map<String, Object> def = taskDefBase(tt);
         def.put("retryCount", 0); // no retries — task goes straight to TIMED_OUT
         def.put("retryLogic", "FIXED");
-        def.put("pollTimeoutSeconds", 30);   // long poll window
+        def.put("pollTimeoutSeconds", 30); // long poll window
         def.put("responseTimeoutSeconds", 3); // short response window
         def.put("timeoutSeconds", 600);
         def.put("timeoutPolicy", "TIME_OUT_WF");
@@ -704,22 +746,31 @@ public class RetryPolicyTests {
         // Without fix: would take ~30s (poll timeout) — test would fail at 10s.
         await().atMost(10, TimeUnit.SECONDS)
                 .pollInterval(500, TimeUnit.MILLISECONDS)
-                .untilAsserted(() -> {
-                    Workflow w = workflowClient.getWorkflow(wfId, true);
-                    Task t = w.getTasks().stream()
-                            .filter(tk -> tk.getTaskId().equals(task.getTaskId()))
-                            .findFirst()
-                            .orElseThrow();
-                    assertEquals(Task.Status.TIMED_OUT, t.getStatus(),
-                            "Task must be TIMED_OUT within response timeout window");
-                });
+                .untilAsserted(
+                        () -> {
+                            Workflow w = workflowClient.getWorkflow(wfId, true);
+                            Task t =
+                                    w.getTasks().stream()
+                                            .filter(tk -> tk.getTaskId().equals(task.getTaskId()))
+                                            .findFirst()
+                                            .orElseThrow();
+                            assertEquals(
+                                    Task.Status.TIMED_OUT,
+                                    t.getStatus(),
+                                    "Task must be TIMED_OUT within response timeout window");
+                        });
 
         long elapsed = System.currentTimeMillis() - polledAt;
-        log.info("Task timed out {}ms after being polled (responseTimeout=3s, pollTimeout=30s)", elapsed);
+        log.info(
+                "Task timed out {}ms after being polled (responseTimeout=3s, pollTimeout=30s)",
+                elapsed);
 
         // The key assertion: timed out well before the poll timeout would have fired.
-        assertTrue(elapsed < 20_000,
-                "Task timed out " + elapsed + "ms after polling — poll gap fix must advance the"
+        assertTrue(
+                elapsed < 20_000,
+                "Task timed out "
+                        + elapsed
+                        + "ms after polling — poll gap fix must advance the"
                         + " sweep to responseTimeout (~3s), not pollTimeout (~30s)");
     }
 
@@ -737,16 +788,26 @@ public class RetryPolicyTests {
 
     /** Helper: starts a background worker that always fails every task of the given type. */
     private TaskRunnerConfigurer startAlwaysFailingWorker(String taskType) {
-        Worker worker = new Worker() {
-            @Override public String getTaskDefName() { return taskType; }
-            @Override public TaskResult execute(Task task) {
-                TaskResult r = new TaskResult(task);
-                r.setStatus(TaskResult.Status.FAILED);
-                r.setReasonForIncompletion("e2e totalTimeout stress test");
-                return r;
-            }
-            @Override public int getPollingInterval() { return 100; }
-        };
+        Worker worker =
+                new Worker() {
+                    @Override
+                    public String getTaskDefName() {
+                        return taskType;
+                    }
+
+                    @Override
+                    public TaskResult execute(Task task) {
+                        TaskResult r = new TaskResult(task);
+                        r.setStatus(TaskResult.Status.FAILED);
+                        r.setReasonForIncompletion("e2e totalTimeout stress test");
+                        return r;
+                    }
+
+                    @Override
+                    public int getPollingInterval() {
+                        return 100;
+                    }
+                };
         TaskRunnerConfigurer configurer =
                 new TaskRunnerConfigurer.Builder(taskClient, List.of(worker))
                         .withThreadCount(2)
@@ -818,7 +879,9 @@ public class RetryPolicyTests {
 
         awaitCompleted(wfId);
         Workflow workflow = workflowClient.getWorkflow(wfId, false);
-        assertEquals(Workflow.WorkflowStatus.COMPLETED, workflow.getStatus(),
+        assertEquals(
+                Workflow.WorkflowStatus.COMPLETED,
+                workflow.getStatus(),
                 "Workflow must complete when total budget is not exhausted");
     }
 
@@ -852,15 +915,17 @@ public class RetryPolicyTests {
             AtomicReference<Workflow> finalWorkflow = new AtomicReference<>();
             await().atMost(30, TimeUnit.SECONDS)
                     .pollInterval(500, TimeUnit.MILLISECONDS)
-                    .untilAsserted(() -> {
-                        Workflow w = workflowClient.getWorkflow(wfId, false);
-                        assertTrue(
-                                w.getStatus() == Workflow.WorkflowStatus.FAILED
-                                        || w.getStatus() == Workflow.WorkflowStatus.TIMED_OUT,
-                                "Workflow must terminate once total timeout is exceeded; status="
-                                        + w.getStatus());
-                        finalWorkflow.set(w);
-                    });
+                    .untilAsserted(
+                            () -> {
+                                Workflow w = workflowClient.getWorkflow(wfId, false);
+                                assertTrue(
+                                        w.getStatus() == Workflow.WorkflowStatus.FAILED
+                                                || w.getStatus()
+                                                        == Workflow.WorkflowStatus.TIMED_OUT,
+                                        "Workflow must terminate once total timeout is exceeded; status="
+                                                + w.getStatus());
+                                finalWorkflow.set(w);
+                            });
 
             // The key assertion: far fewer than 100 tasks were scheduled.
             // If total timeout is enforced, the workflow terminates in a handful of retries.
@@ -868,21 +933,28 @@ public class RetryPolicyTests {
             // but the workflow would only fail at retry exhaustion, not after 4 s.
             Workflow wf2 = workflowClient.getWorkflow(wfId, true);
             int taskCount = wf2.getTasks().size();
-            log.info("Workflow terminated after {} task attempts (totalTimeoutSeconds=4, retryCount=100)",
+            log.info(
+                    "Workflow terminated after {} task attempts (totalTimeoutSeconds=4, retryCount=100)",
                     taskCount);
-            assertTrue(taskCount < 100,
+            assertTrue(
+                    taskCount < 100,
                     "Workflow must terminate before exhausting all 100 retries — "
-                            + "total timeout (4s) should fire first. taskCount=" + taskCount);
+                            + "total timeout (4s) should fire first. taskCount="
+                            + taskCount);
 
         } finally {
-            try { workerConfigurer.shutdown(); } catch (Exception ignored) {}
+            try {
+                workerConfigurer.shutdown();
+            } catch (Exception ignored) {
+            }
         }
     }
 
     // --- interaction: totalTimeout + maxRetryDelayCap ---
 
     @Test
-    @DisplayName("totalTimeout + maxRetryDelayCap: cap applied to retry delay; hard budget still enforced")
+    @DisplayName(
+            "totalTimeout + maxRetryDelayCap: cap applied to retry delay; hard budget still enforced")
     void testTotalTimeoutSeconds_withMaxRetryDelayCap() {
         String tt = "e2e-total-cap-combo-task", wf = "e2e-total-cap-combo-wf";
 
@@ -905,12 +977,16 @@ public class RetryPolicyTests {
         // Fail twice, verify cap is applied AND retries are scheduled (total budget not hit)
         failTask(wfId, pollTask(tt).getTaskId());
         Task retry1 = awaitScheduledRetry(wfId, 2);
-        assertEquals(1L, retry1.getCallbackAfterSeconds(),
+        assertEquals(
+                1L,
+                retry1.getCallbackAfterSeconds(),
                 "retry1: 1×2⁰=1s (below cap 2s, well within totalTimeout 60s)");
 
         failTask(wfId, pollTask(tt).getTaskId());
         Task retry2 = awaitScheduledRetry(wfId, 3);
-        assertEquals(2L, retry2.getCallbackAfterSeconds(),
+        assertEquals(
+                2L,
+                retry2.getCallbackAfterSeconds(),
                 "retry2: 1×2¹=2s = cap, still within totalTimeout 60s");
 
         completeTask(wfId, pollTask(tt).getTaskId());
@@ -920,7 +996,8 @@ public class RetryPolicyTests {
     // --- interaction: totalTimeout + backoffJitterMs ---
 
     @Test
-    @DisplayName("totalTimeout + backoffJitterMs: jitter applies per retry; hard budget still enforced")
+    @DisplayName(
+            "totalTimeout + backoffJitterMs: jitter applies per retry; hard budget still enforced")
     void testTotalTimeoutSeconds_withJitter() {
         String tt = "e2e-total-jitter-combo-task", wf = "e2e-total-jitter-combo-wf";
 
@@ -942,8 +1019,11 @@ public class RetryPolicyTests {
 
         failTask(wfId, pollTask(tt).getTaskId());
         Task retry1 = awaitScheduledRetry(wfId, 2);
-        // callbackAfterSeconds = base delay (jitter is in callbackAfterMs, not visible via HTTP API)
-        assertEquals(1L, retry1.getCallbackAfterSeconds(),
+        // callbackAfterSeconds = base delay (jitter is in callbackAfterMs, not visible via HTTP
+        // API)
+        assertEquals(
+                1L,
+                retry1.getCallbackAfterSeconds(),
                 "callbackAfterSeconds must equal base delay regardless of jitter");
 
         long scheduledAt = retry1.getScheduledTime();
@@ -959,7 +1039,8 @@ public class RetryPolicyTests {
     // --- firstScheduledTime preserved across multiple retries ---
 
     @Test
-    @DisplayName("firstScheduledTime preserved: budget measured from first schedule, not each retry")
+    @DisplayName(
+            "firstScheduledTime preserved: budget measured from first schedule, not each retry")
     void testTotalTimeoutSeconds_firstScheduledTimePreservedAcrossRetries() {
         String tt = "e2e-total-preserve-task", wf = "e2e-total-preserve-wf";
 
@@ -988,10 +1069,15 @@ public class RetryPolicyTests {
         // All 3 retries should have been scheduled — total elapsed is << 60s
         Workflow wf2 = workflowClient.getWorkflow(wfId, true);
         long elapsed = System.currentTimeMillis() - testStart;
-        assertEquals(4, wf2.getTasks().size(),
+        assertEquals(
+                4,
+                wf2.getTasks().size(),
                 "Should have 4 tasks (original + 3 retries) after 3 failures; "
-                        + "elapsed=" + elapsed + "ms");
-        assertTrue(elapsed < 10_000,
+                        + "elapsed="
+                        + elapsed
+                        + "ms");
+        assertTrue(
+                elapsed < 10_000,
                 "Test must complete in << 60s totalTimeout; elapsed=" + elapsed + "ms");
 
         completeTask(wfId, pollTask(tt).getTaskId());
@@ -1001,11 +1087,13 @@ public class RetryPolicyTests {
     // --- ALERT_ONLY policy behavior ---
 
     @Test
-    @DisplayName("ALERT_ONLY policy + totalTimeout exceeded: workflow terminates when task explicitly fails")
+    @DisplayName(
+            "ALERT_ONLY policy + totalTimeout exceeded: workflow terminates when task explicitly fails")
     void testTotalTimeoutSeconds_alertOnlyPolicy_terminatesOnWorkerFailure() {
         // When a worker explicitly fails a task and the total budget is already exhausted,
         // the retry() guard fires and terminates the workflow.
-        // This is intentional: totalTimeoutSeconds is a hard budget regardless of per-attempt policy.
+        // This is intentional: totalTimeoutSeconds is a hard budget regardless of per-attempt
+        // policy.
         // (ALERT_ONLY controls single-attempt timeouts; the total limit is absolute.)
         String tt = "e2e-total-alert-only-task", wf = "e2e-total-alert-only-wf";
 
@@ -1028,26 +1116,34 @@ public class RetryPolicyTests {
             workerConfigurer = startAlwaysFailingWorker(tt);
             String wfId = startWorkflow(wf);
 
-            // Workflow must terminate even with ALERT_ONLY, because the retry() guard is a hard stop
+            // Workflow must terminate even with ALERT_ONLY, because the retry() guard is a hard
+            // stop
             await().atMost(30, TimeUnit.SECONDS)
                     .pollInterval(500, TimeUnit.MILLISECONDS)
-                    .untilAsserted(() -> {
-                        Workflow w = workflowClient.getWorkflow(wfId, false);
-                        assertTrue(
-                                w.getStatus() == Workflow.WorkflowStatus.FAILED
-                                        || w.getStatus() == Workflow.WorkflowStatus.TIMED_OUT,
-                                "ALERT_ONLY with totalTimeout must still terminate after budget exhausted; "
-                                        + "status=" + w.getStatus());
-                    });
+                    .untilAsserted(
+                            () -> {
+                                Workflow w = workflowClient.getWorkflow(wfId, false);
+                                assertTrue(
+                                        w.getStatus() == Workflow.WorkflowStatus.FAILED
+                                                || w.getStatus()
+                                                        == Workflow.WorkflowStatus.TIMED_OUT,
+                                        "ALERT_ONLY with totalTimeout must still terminate after budget exhausted; "
+                                                + "status="
+                                                + w.getStatus());
+                            });
 
             // Fewer tasks than retryCount — proves totalTimeout, not retry exhaustion, stopped it
             Workflow wfFinal = workflowClient.getWorkflow(wfId, true);
-            assertTrue(wfFinal.getTasks().size() < 100,
+            assertTrue(
+                    wfFinal.getTasks().size() < 100,
                     "Must have terminated before retryCount=100 is exhausted");
 
         } finally {
             if (workerConfigurer != null) {
-                try { workerConfigurer.shutdown(); } catch (Exception ignored) {}
+                try {
+                    workerConfigurer.shutdown();
+                } catch (Exception ignored) {
+                }
             }
         }
     }
@@ -1079,15 +1175,16 @@ public class RetryPolicyTests {
         ExecutorService pool = Executors.newFixedThreadPool(N);
         CountDownLatch done = new CountDownLatch(N);
         for (String id : wfIds) {
-            pool.submit(() -> {
-                try {
-                    failTask(id, pollTask(tt).getTaskId());
-                    awaitScheduledRetry(id, 2);
-                    completeTask(id, pollTask(tt).getTaskId());
-                } finally {
-                    done.countDown();
-                }
-            });
+            pool.submit(
+                    () -> {
+                        try {
+                            failTask(id, pollTask(tt).getTaskId());
+                            awaitScheduledRetry(id, 2);
+                            completeTask(id, pollTask(tt).getTaskId());
+                        } finally {
+                            done.countDown();
+                        }
+                    });
         }
         assertTrue(done.await(60, TimeUnit.SECONDS));
         pool.shutdown();
@@ -1095,7 +1192,9 @@ public class RetryPolicyTests {
         // All N workflows must complete — totalTimeout (30s) was not reached by any instance
         for (String id : wfIds) {
             Workflow w = workflowClient.getWorkflow(id, false);
-            assertEquals(Workflow.WorkflowStatus.COMPLETED, w.getStatus(),
+            assertEquals(
+                    Workflow.WorkflowStatus.COMPLETED,
+                    w.getStatus(),
                     "Every workflow instance must complete when total budget is not exhausted");
         }
     }

--- a/e2e/src/test/java/io/conductor/e2e/task/RetryPolicyTests.java
+++ b/e2e/src/test/java/io/conductor/e2e/task/RetryPolicyTests.java
@@ -594,7 +594,8 @@ public class RetryPolicyTests {
         List<String> wfIds = new ArrayList<>();
         for (int i = 0; i < N; i++) wfIds.add(startWorkflow(wf));
 
-        // Poll and fail all initial tasks concurrently so retries are scheduled at the same instant.
+        // Poll and fail all initial tasks concurrently so retries are scheduled at the same
+        // instant.
         // Use the task's own workflowInstanceId (not the lambda-captured id) so that the server
         // calls decide() on the correct workflow and schedules the retry.
         ExecutorService pool = Executors.newFixedThreadPool(N);
@@ -668,7 +669,8 @@ public class RetryPolicyTests {
         for (int i = 0; i < N; i++) wfIds.add(startWorkflow(wf));
 
         // Fail each initial task, then complete each retry — all under concurrent conditions.
-        // Poll the task first and derive the workflow ID from it so that failTask, awaitScheduledRetry,
+        // Poll the task first and derive the workflow ID from it so that failTask,
+        // awaitScheduledRetry,
         // and completeTask all operate on the same workflow (not the lambda-captured id which may
         // belong to a different workflow than the one whose task was polled).
         ExecutorService pool = Executors.newFixedThreadPool(N);
@@ -701,7 +703,7 @@ public class RetryPolicyTests {
         // Verify all N workflows completed successfully
         for (String id : wfIds) {
             Workflow w = workflowClient.getWorkflow(id, false);
-            if(!w.getStatus().isTerminal()) {
+            if (!w.getStatus().isTerminal()) {
                 workflowClient.runDecider(id);
             }
             w = workflowClient.getWorkflow(id, false);

--- a/e2e/src/test/java/io/conductor/e2e/task/RetryPolicyTests.java
+++ b/e2e/src/test/java/io/conductor/e2e/task/RetryPolicyTests.java
@@ -586,7 +586,7 @@ public class RetryPolicyTests {
         Map<String, Object> def = taskDefBase(tt);
         def.put("retryDelaySeconds", 1);
         def.put("retryLogic", "FIXED");
-        def.put("backoffJitterMs", 2000);
+        def.put("backoffJitterMs", 1000);
         registerTaskDef(def);
         registerWorkflow(wf, tt);
 
@@ -594,14 +594,17 @@ public class RetryPolicyTests {
         List<String> wfIds = new ArrayList<>();
         for (int i = 0; i < N; i++) wfIds.add(startWorkflow(wf));
 
-        // Poll and fail all initial tasks concurrently so retries are scheduled at the same instant
+        // Poll and fail all initial tasks concurrently so retries are scheduled at the same instant.
+        // Use the task's own workflowInstanceId (not the lambda-captured id) so that the server
+        // calls decide() on the correct workflow and schedules the retry.
         ExecutorService pool = Executors.newFixedThreadPool(N);
         CountDownLatch allFailed = new CountDownLatch(N);
-        for (String id : wfIds) {
+        for (int i = 0; i < N; i++) {
             pool.submit(
                     () -> {
                         try {
-                            failTask(id, pollTask(tt).getTaskId());
+                            Task t = pollTask(tt);
+                            failTask(t.getWorkflowInstanceId(), t.getTaskId());
                         } finally {
                             allFailed.countDown();
                         }
@@ -610,35 +613,37 @@ public class RetryPolicyTests {
         assertTrue(allFailed.await(30, TimeUnit.SECONDS), "All tasks failed within timeout");
         pool.shutdown();
 
-        // Collect timestamps of when each retry task first becomes poppable
+        // Collect timestamps of when each retry task first becomes poppable.
+        // Track tasksPolled (termination condition) separately from pollTimestampsSeconds (jitter
+        // spread check) — the set only grows when a new second-bucket is seen, so it cannot be
+        // used as a task counter.
+        int tasksPolled = 0;
         Set<Long> pollTimestampsSeconds = ConcurrentHashMap.newKeySet();
         long start = System.currentTimeMillis();
-        while (pollTimestampsSeconds.size() < N && System.currentTimeMillis() - start < 15_000) {
+        while (tasksPolled < N && System.currentTimeMillis() - start < 31_000) {
             List<Task> batch =
                     taskClient.batchPollTasksByTaskType(tt, "e2e-concurrency-worker", N, 500);
             long nowSec = System.currentTimeMillis() / 1000;
             for (Task t : batch) {
                 pollTimestampsSeconds.add(nowSec);
+                tasksPolled++;
                 completeTask(t.getWorkflowInstanceId(), t.getTaskId());
             }
             if (batch.isEmpty()) Thread.sleep(200);
         }
 
-        assertEquals(
-                N,
-                pollTimestampsSeconds.size() + /* could be in same second with low N */ 0,
-                "All " + N + " retry tasks must eventually be polled");
+        assertEquals(N, tasksPolled, "All " + N + " retry tasks must eventually be polled");
 
-        // With 2s jitter and N=5 tasks, it's statistically very unlikely that all tasks become
+        // With 1s jitter and N=5 tasks, it's statistically very unlikely that all tasks become
         // available in the exact same second bucket if jitter is truly random.
         // We assert that tasks spread across at least 2 distinct second-buckets.
-        // (P(all same bucket) ≈ (1/2)^4 = 6.25% with uniform jitter over 2s — acceptable flakiness
+        // (P(all same bucket) ≈ (1/2)^4 = 6.25% with uniform jitter over 1s — acceptable flakiness
         //  threshold given that test failures prompt investigation rather than automatic re-run.)
         assertTrue(
                 pollTimestampsSeconds.size() >= 2 || N == 1,
                 "With "
                         + N
-                        + " tasks and 2s jitter, retries must spread across ≥2 second-buckets. "
+                        + " tasks and 1s jitter, retries must spread across ≥2 second-buckets. "
                         + "All "
                         + N
                         + " tasks appeared in the same second — jitter may not be applied.");
@@ -662,23 +667,29 @@ public class RetryPolicyTests {
         List<String> wfIds = new ArrayList<>();
         for (int i = 0; i < N; i++) wfIds.add(startWorkflow(wf));
 
-        // Fail each initial task, then complete each retry — all under concurrent conditions
+        // Fail each initial task, then complete each retry — all under concurrent conditions.
+        // Poll the task first and derive the workflow ID from it so that failTask, awaitScheduledRetry,
+        // and completeTask all operate on the same workflow (not the lambda-captured id which may
+        // belong to a different workflow than the one whose task was polled).
         ExecutorService pool = Executors.newFixedThreadPool(N);
         CountDownLatch done = new CountDownLatch(N);
-        for (String id : wfIds) {
+        for (int i = 0; i < N; i++) {
             pool.submit(
                     () -> {
                         try {
-                            failTask(id, pollTask(tt).getTaskId());
+                            Task initial = pollTask(tt);
+                            String wfId = initial.getWorkflowInstanceId();
+                            failTask(wfId, initial.getTaskId());
                             // await and complete the retry
-                            Task retry = awaitScheduledRetry(id, 2);
-                            assertNotNull(retry, "retry task must be scheduled for wf " + id);
+                            Task retry = awaitScheduledRetry(wfId, 2);
+                            assertNotNull(retry, "retry task must be scheduled for wf " + wfId);
                             // cap applied: base=1s (retry0), raw retry1=2s (2^1 * 1) → capped to 2s
                             assertTrue(
                                     retry.getCallbackAfterSeconds() <= 2,
                                     "callbackAfterSeconds must be ≤ cap (2s); was "
                                             + retry.getCallbackAfterSeconds());
-                            completeTask(id, pollTask(tt).getTaskId());
+                            Task retryTask = pollTask(tt);
+                            completeTask(retryTask.getWorkflowInstanceId(), retryTask.getTaskId());
                         } finally {
                             done.countDown();
                         }
@@ -690,6 +701,10 @@ public class RetryPolicyTests {
         // Verify all N workflows completed successfully
         for (String id : wfIds) {
             Workflow w = workflowClient.getWorkflow(id, false);
+            if(!w.getStatus().isTerminal()) {
+                workflowClient.runDecider(id);
+            }
+            w = workflowClient.getWorkflow(id, false);
             assertEquals(
                     Workflow.WorkflowStatus.COMPLETED,
                     w.getStatus(),

--- a/e2e/src/test/java/io/conductor/e2e/task/RetryPolicyTests.java
+++ b/e2e/src/test/java/io/conductor/e2e/task/RetryPolicyTests.java
@@ -26,14 +26,17 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.netflix.conductor.client.automator.TaskRunnerConfigurer;
 import com.netflix.conductor.client.http.MetadataClient;
 import com.netflix.conductor.client.http.TaskClient;
 import com.netflix.conductor.client.http.WorkflowClient;
+import com.netflix.conductor.client.worker.Worker;
 import com.netflix.conductor.common.config.ObjectMapperProvider;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.TaskResult;
@@ -718,5 +721,209 @@ public class RetryPolicyTests {
         assertTrue(elapsed < 20_000,
                 "Task timed out " + elapsed + "ms after polling — poll gap fix must advance the"
                         + " sweep to responseTimeout (~3s), not pollTimeout (~30s)");
+    }
+
+    // =========================================================================
+    // totalTimeoutSeconds — hard wall-clock budget across all retry attempts
+    //
+    // Strategy: we cannot manipulate firstScheduledTime in e2e (no DB access),
+    // so we rely on real wall-clock time:
+    //   - "disabled" (=0) and "not exceeded" tests use manual poll/fail with
+    //     a generous total budget so real time never exceeds it.
+    //   - "exceeded" test uses a very short budget (4 s) and a background
+    //     worker that continuously fails the task; eventually the total budget
+    //     is exhausted and the workflow terminates.
+    // =========================================================================
+
+    /** Helper: starts a background worker that always fails every task of the given type. */
+    private TaskRunnerConfigurer startAlwaysFailingWorker(String taskType) {
+        Worker worker = new Worker() {
+            @Override public String getTaskDefName() { return taskType; }
+            @Override public TaskResult execute(Task task) {
+                TaskResult r = new TaskResult(task);
+                r.setStatus(TaskResult.Status.FAILED);
+                r.setReasonForIncompletion("e2e totalTimeout stress test");
+                return r;
+            }
+            @Override public int getPollingInterval() { return 100; }
+        };
+        TaskRunnerConfigurer configurer =
+                new TaskRunnerConfigurer.Builder(taskClient, List.of(worker))
+                        .withThreadCount(2)
+                        .withTaskPollTimeout(1)
+                        .build();
+        configurer.init();
+        return configurer;
+    }
+
+    @Test
+    @DisplayName("totalTimeoutSeconds=0: disabled — retries continue up to retryCount as normal")
+    void testTotalTimeoutSeconds_zero_disabled() {
+        String tt = "e2e-total-timeout-disabled-task", wf = "e2e-total-timeout-disabled-wf";
+
+        // totalTimeoutSeconds=0 means disabled; timeoutSeconds=0 to avoid constraint violation
+        Map<String, Object> def = new HashMap<>();
+        def.put("name", tt);
+        def.put("ownerEmail", "test@conductor.io");
+        def.put("retryCount", 5);
+        def.put("retryDelaySeconds", 0);
+        def.put("retryLogic", "FIXED");
+        def.put("totalTimeoutSeconds", 0);
+        def.put("timeoutSeconds", 0);
+        def.put("responseTimeoutSeconds", 1);
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        String wfId = startWorkflow(wf);
+
+        // Fail twice — total elapsed is well under any real-world constraint
+        failTask(wfId, pollTask(tt).getTaskId());
+        Task retry1 = awaitScheduledRetry(wfId, 2);
+        assertNotNull(retry1, "Retry must be scheduled when totalTimeoutSeconds=0 (disabled)");
+
+        failTask(wfId, pollTask(tt).getTaskId());
+        Task retry2 = awaitScheduledRetry(wfId, 3);
+        assertNotNull(retry2, "Second retry must be scheduled");
+
+        // Complete the third attempt — workflow should finish successfully
+        completeTask(wfId, pollTask(tt).getTaskId());
+        awaitCompleted(wfId);
+    }
+
+    @Test
+    @DisplayName("totalTimeoutSeconds not exceeded: retries complete and workflow succeeds")
+    void testTotalTimeoutSeconds_notExceeded_workflowCompletes() {
+        String tt = "e2e-total-timeout-ok-task", wf = "e2e-total-timeout-ok-wf";
+
+        // Generous 60 s budget; test finishes in << 1 s so budget is never hit
+        Map<String, Object> def = new HashMap<>();
+        def.put("name", tt);
+        def.put("ownerEmail", "test@conductor.io");
+        def.put("retryCount", 5);
+        def.put("retryDelaySeconds", 0);
+        def.put("retryLogic", "FIXED");
+        def.put("totalTimeoutSeconds", 60);
+        def.put("timeoutSeconds", 0);
+        def.put("responseTimeoutSeconds", 1);
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        String wfId = startWorkflow(wf);
+
+        failTask(wfId, pollTask(tt).getTaskId());
+        awaitScheduledRetry(wfId, 2);
+        failTask(wfId, pollTask(tt).getTaskId());
+        awaitScheduledRetry(wfId, 3);
+        completeTask(wfId, pollTask(tt).getTaskId());
+
+        awaitCompleted(wfId);
+        Workflow workflow = workflowClient.getWorkflow(wfId, false);
+        assertEquals(Workflow.WorkflowStatus.COMPLETED, workflow.getStatus(),
+                "Workflow must complete when total budget is not exhausted");
+    }
+
+    @Test
+    @DisplayName("totalTimeoutSeconds exceeded: workflow terminates before retryCount is exhausted")
+    void testTotalTimeoutSeconds_exceeded_workflowTerminates() {
+        String tt = "e2e-total-timeout-exceeded-task", wf = "e2e-total-timeout-exceeded-wf";
+
+        // 4-second budget, 100 retries allowed — total timeout should fire long before 100 retries
+        // timeoutSeconds must be ≤ totalTimeoutSeconds when both > 0, so we disable per-attempt
+        Map<String, Object> def = new HashMap<>();
+        def.put("name", tt);
+        def.put("ownerEmail", "test@conductor.io");
+        def.put("retryCount", 100);
+        def.put("retryDelaySeconds", 0);
+        def.put("retryLogic", "FIXED");
+        def.put("totalTimeoutSeconds", 4);
+        def.put("timeoutSeconds", 0);
+        def.put("responseTimeoutSeconds", 1);
+        def.put("timeoutPolicy", "TIME_OUT_WF");
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        // Auto-failing worker: keeps failing every attempt so totalTimeout is the only exit
+        TaskRunnerConfigurer workerConfigurer = startAlwaysFailingWorker(tt);
+        try {
+            String wfId = startWorkflow(wf);
+
+            // The workflow must terminate (FAILED or TIMED_OUT) within a generous window.
+            // With a 4-second total budget and rapid retries the termination should be fast.
+            AtomicReference<Workflow> finalWorkflow = new AtomicReference<>();
+            await().atMost(30, TimeUnit.SECONDS)
+                    .pollInterval(500, TimeUnit.MILLISECONDS)
+                    .untilAsserted(() -> {
+                        Workflow w = workflowClient.getWorkflow(wfId, false);
+                        assertTrue(
+                                w.getStatus() == Workflow.WorkflowStatus.FAILED
+                                        || w.getStatus() == Workflow.WorkflowStatus.TIMED_OUT,
+                                "Workflow must terminate once total timeout is exceeded; status="
+                                        + w.getStatus());
+                        finalWorkflow.set(w);
+                    });
+
+            // The key assertion: far fewer than 100 tasks were scheduled.
+            // If total timeout is enforced, the workflow terminates in a handful of retries.
+            // If it were NOT enforced, 100 retries at ~retryDelay=0 would still take time
+            // but the workflow would only fail at retry exhaustion, not after 4 s.
+            Workflow wf2 = workflowClient.getWorkflow(wfId, true);
+            int taskCount = wf2.getTasks().size();
+            log.info("Workflow terminated after {} task attempts (totalTimeoutSeconds=4, retryCount=100)",
+                    taskCount);
+            assertTrue(taskCount < 100,
+                    "Workflow must terminate before exhausting all 100 retries — "
+                            + "total timeout (4s) should fire first. taskCount=" + taskCount);
+
+        } finally {
+            try { workerConfigurer.shutdown(); } catch (Exception ignored) {}
+        }
+    }
+
+    @Test
+    @DisplayName("Concurrent workflows: totalTimeoutSeconds independent per workflow instance")
+    void testTotalTimeoutSeconds_concurrentWorkflows_eachInstanceIndependent()
+            throws InterruptedException {
+        final int N = 3;
+        String tt = "e2e-total-timeout-concurrent-task", wf = "e2e-total-timeout-concurrent-wf";
+
+        // Generous 30 s total budget — all N workflows complete well within it
+        Map<String, Object> def = new HashMap<>();
+        def.put("name", tt);
+        def.put("ownerEmail", "test@conductor.io");
+        def.put("retryCount", 5);
+        def.put("retryDelaySeconds", 0);
+        def.put("retryLogic", "FIXED");
+        def.put("totalTimeoutSeconds", 30);
+        def.put("timeoutSeconds", 0);
+        def.put("responseTimeoutSeconds", 1);
+        registerTaskDef(def);
+        registerWorkflow(wf, tt);
+
+        List<String> wfIds = new ArrayList<>();
+        for (int i = 0; i < N; i++) wfIds.add(startWorkflow(wf));
+
+        // For each workflow: fail once then complete
+        ExecutorService pool = Executors.newFixedThreadPool(N);
+        CountDownLatch done = new CountDownLatch(N);
+        for (String id : wfIds) {
+            pool.submit(() -> {
+                try {
+                    failTask(id, pollTask(tt).getTaskId());
+                    awaitScheduledRetry(id, 2);
+                    completeTask(id, pollTask(tt).getTaskId());
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+        assertTrue(done.await(60, TimeUnit.SECONDS));
+        pool.shutdown();
+
+        // All N workflows must complete — totalTimeout (30s) was not reached by any instance
+        for (String id : wfIds) {
+            Workflow w = workflowClient.getWorkflow(id, false);
+            assertEquals(Workflow.WorkflowStatus.COMPLETED, w.getStatus(),
+                    "Every workflow instance must complete when total budget is not exhausted");
+        }
     }
 }

--- a/e2e/src/test/java/io/conductor/e2e/util/ApiUtil.java
+++ b/e2e/src/test/java/io/conductor/e2e/util/ApiUtil.java
@@ -26,7 +26,7 @@ public class ApiUtil {
     private static final String SERVER_HOST =
             System.getProperty(
                     "SERVER_ROOT_URI",
-                    System.getenv().getOrDefault("SERVER_ROOT_URI", "http://localhost:8000"));
+                    System.getenv().getOrDefault("SERVER_ROOT_URI", "http://localhost:8000/api"));
 
     public static final String SERVER_ROOT_URI =
             SERVER_HOST.endsWith("/api") ? SERVER_HOST : SERVER_HOST + "/api";

--- a/e2e/src/test/java/io/conductor/e2e/workflow/WorkflowSearchTests.java
+++ b/e2e/src/test/java/io/conductor/e2e/workflow/WorkflowSearchTests.java
@@ -66,7 +66,8 @@ public class WorkflowSearchTests {
 
         workflowAdminClient.startWorkflow(startWorkflowRequest);
         workflowAdminClient.startWorkflow(startWorkflowRequest);
-        await().pollInterval(100, TimeUnit.MILLISECONDS)
+        await().atMost(30, TimeUnit.SECONDS)
+                .pollInterval(100, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () -> {
                             workflowSummarySearchResult.set(
@@ -88,7 +89,8 @@ public class WorkflowSearchTests {
         workflowAdminClient.startWorkflow(startWorkflowRequest);
         workflowAdminClient.startWorkflow(startWorkflowRequest);
         // In search result when only this workflow searched 2 results should come
-        await().pollInterval(100, TimeUnit.MILLISECONDS)
+        await().atMost(30, TimeUnit.SECONDS)
+                .pollInterval(100, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () -> {
                             workflowSummarySearchResult.set(
@@ -98,7 +100,8 @@ public class WorkflowSearchTests {
                         });
 
         // In search result when both workflow searched then 4 results should come
-        await().pollInterval(100, TimeUnit.MILLISECONDS)
+        await().atMost(30, TimeUnit.SECONDS)
+                .pollInterval(100, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () -> {
                             workflowSummarySearchResult.set(
@@ -139,7 +142,7 @@ public class WorkflowSearchTests {
         String workflowId = workflowClient.startWorkflow(startReq);
 
         // Search by workflowId with double quotes
-        await().atMost(10, TimeUnit.SECONDS)
+        await().atMost(30, TimeUnit.SECONDS)
                 .pollInterval(100, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () -> {
@@ -171,7 +174,7 @@ public class WorkflowSearchTests {
         String workflowId = workflowClient.startWorkflow(startReq);
 
         // Search by workflowId with single quotes — this was broken before the fix
-        await().atMost(10, TimeUnit.SECONDS)
+        await().atMost(30, TimeUnit.SECONDS)
                 .pollInterval(100, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () -> {
@@ -204,7 +207,7 @@ public class WorkflowSearchTests {
         workflowClient.startWorkflow(startReq);
 
         // Search by workflowType with single quotes
-        await().atMost(10, TimeUnit.SECONDS)
+        await().atMost(30, TimeUnit.SECONDS)
                 .pollInterval(100, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () -> {
@@ -248,7 +251,7 @@ public class WorkflowSearchTests {
         String otherWorkflowId = workflowClient.startWorkflow(otherReq);
 
         // Search with multiple single-quoted conditions — mimics getWorkflowsByCorrelationId
-        await().atMost(10, TimeUnit.SECONDS)
+        await().atMost(30, TimeUnit.SECONDS)
                 .pollInterval(100, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () -> {
@@ -289,7 +292,7 @@ public class WorkflowSearchTests {
         }
 
         // Wait for all 3 to be indexed
-        await().atMost(10, TimeUnit.SECONDS)
+        await().atMost(30, TimeUnit.SECONDS)
                 .pollInterval(100, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () -> {

--- a/e2e/src/test/java/io/conductor/e2e/workflow/WorkflowSearchTests.java
+++ b/e2e/src/test/java/io/conductor/e2e/workflow/WorkflowSearchTests.java
@@ -141,19 +141,27 @@ public class WorkflowSearchTests {
         startReq.setVersion(1);
         String workflowId = workflowClient.startWorkflow(startReq);
 
-        // Search by workflowId with double quotes
+        // First confirm the workflow is indexed at all (single-quote baseline)
         await().atMost(30, TimeUnit.SECONDS)
                 .pollInterval(100, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () -> {
-                            SearchResult<WorkflowSummary> result =
-                                    workflowClient.search("workflowId=\"" + workflowId + "\"");
+                            SearchResult<WorkflowSummary> baseline =
+                                    workflowClient.search("workflowId='" + workflowId + "'");
                             assertEquals(
                                     1,
-                                    result.getResults().size(),
-                                    "Search by workflowId with double quotes should return 1 result");
-                            assertEquals(workflowId, result.getResults().get(0).getWorkflowId());
+                                    baseline.getResults().size(),
+                                    "Baseline single-quote search must find workflow before testing double-quote");
                         });
+
+        // Now verify double quotes return the same result
+        SearchResult<WorkflowSummary> result =
+                workflowClient.search("workflowId=\"" + workflowId + "\"");
+        assertEquals(
+                1,
+                result.getResults().size(),
+                "Search by workflowId with double quotes should return 1 result");
+        assertEquals(workflowId, result.getResults().get(0).getWorkflowId());
 
         workflowClient.terminateWorkflow(workflowId, "test cleanup");
         metadataClient.unregisterWorkflowDef(workflowName, 1);
@@ -250,24 +258,32 @@ public class WorkflowSearchTests {
         otherReq.setVersion(1);
         String otherWorkflowId = workflowClient.startWorkflow(otherReq);
 
-        // Search with multiple single-quoted conditions — mimics getWorkflowsByCorrelationId
+        // Wait for both workflows to be indexed (single-field search as baseline)
         await().atMost(30, TimeUnit.SECONDS)
                 .pollInterval(100, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () -> {
-                            SearchResult<WorkflowSummary> result =
-                                    workflowClient.search(
-                                            "correlationId='"
-                                                    + correlationId
-                                                    + "' AND workflowType='"
-                                                    + workflowName
-                                                    + "'");
+                            SearchResult<WorkflowSummary> baseline =
+                                    workflowClient.search("workflowType='" + workflowName + "'");
                             assertEquals(
-                                    1,
-                                    result.getResults().size(),
-                                    "Multi-condition search with single quotes should return 1 result");
-                            assertEquals(workflowId, result.getResults().get(0).getWorkflowId());
+                                    2,
+                                    baseline.getResults().size(),
+                                    "Both workflows must be indexed before testing AND condition");
                         });
+
+        // Search with multiple single-quoted conditions — mimics getWorkflowsByCorrelationId
+        SearchResult<WorkflowSummary> result =
+                workflowClient.search(
+                        "correlationId='"
+                                + correlationId
+                                + "' AND workflowType='"
+                                + workflowName
+                                + "'");
+        assertEquals(
+                1,
+                result.getResults().size(),
+                "Multi-condition search with single quotes should return 1 result");
+        assertEquals(workflowId, result.getResults().get(0).getWorkflowId());
 
         workflowClient.terminateWorkflow(workflowId, "test cleanup");
         workflowClient.terminateWorkflow(otherWorkflowId, "test cleanup");

--- a/e2e/src/test/java/io/conductor/e2e/workflow/WorkflowSearchTests.java
+++ b/e2e/src/test/java/io/conductor/e2e/workflow/WorkflowSearchTests.java
@@ -141,27 +141,19 @@ public class WorkflowSearchTests {
         startReq.setVersion(1);
         String workflowId = workflowClient.startWorkflow(startReq);
 
-        // First confirm the workflow is indexed at all (single-quote baseline)
+        // Search by workflowId with double quotes
         await().atMost(30, TimeUnit.SECONDS)
                 .pollInterval(100, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () -> {
-                            SearchResult<WorkflowSummary> baseline =
-                                    workflowClient.search("workflowId='" + workflowId + "'");
+                            SearchResult<WorkflowSummary> result =
+                                    workflowClient.search("workflowId=\"" + workflowId + "\"");
                             assertEquals(
                                     1,
-                                    baseline.getResults().size(),
-                                    "Baseline single-quote search must find workflow before testing double-quote");
+                                    result.getResults().size(),
+                                    "Search by workflowId with double quotes should return 1 result");
+                            assertEquals(workflowId, result.getResults().get(0).getWorkflowId());
                         });
-
-        // Now verify double quotes return the same result
-        SearchResult<WorkflowSummary> result =
-                workflowClient.search("workflowId=\"" + workflowId + "\"");
-        assertEquals(
-                1,
-                result.getResults().size(),
-                "Search by workflowId with double quotes should return 1 result");
-        assertEquals(workflowId, result.getResults().get(0).getWorkflowId());
 
         workflowClient.terminateWorkflow(workflowId, "test cleanup");
         metadataClient.unregisterWorkflowDef(workflowName, 1);
@@ -258,32 +250,24 @@ public class WorkflowSearchTests {
         otherReq.setVersion(1);
         String otherWorkflowId = workflowClient.startWorkflow(otherReq);
 
-        // Wait for both workflows to be indexed (single-field search as baseline)
+        // Search with multiple single-quoted conditions — mimics getWorkflowsByCorrelationId
         await().atMost(30, TimeUnit.SECONDS)
                 .pollInterval(100, TimeUnit.MILLISECONDS)
                 .untilAsserted(
                         () -> {
-                            SearchResult<WorkflowSummary> baseline =
-                                    workflowClient.search("workflowType='" + workflowName + "'");
+                            SearchResult<WorkflowSummary> result =
+                                    workflowClient.search(
+                                            "correlationId='"
+                                                    + correlationId
+                                                    + "' AND workflowType='"
+                                                    + workflowName
+                                                    + "'");
                             assertEquals(
-                                    2,
-                                    baseline.getResults().size(),
-                                    "Both workflows must be indexed before testing AND condition");
+                                    1,
+                                    result.getResults().size(),
+                                    "Multi-condition search with single quotes should return 1 result");
+                            assertEquals(workflowId, result.getResults().get(0).getWorkflowId());
                         });
-
-        // Search with multiple single-quoted conditions — mimics getWorkflowsByCorrelationId
-        SearchResult<WorkflowSummary> result =
-                workflowClient.search(
-                        "correlationId='"
-                                + correlationId
-                                + "' AND workflowType='"
-                                + workflowName
-                                + "'");
-        assertEquals(
-                1,
-                result.getResults().size(),
-                "Multi-condition search with single quotes should return 1 result");
-        assertEquals(workflowId, result.getResults().get(0).getWorkflowId());
 
         workflowClient.terminateWorkflow(workflowId, "test cleanup");
         workflowClient.terminateWorkflow(otherWorkflowId, "test cleanup");

--- a/es8-persistence/src/main/java/org/conductoross/conductor/es8/dao/query/parser/NameValue.java
+++ b/es8-persistence/src/main/java/org/conductoross/conductor/es8/dao/query/parser/NameValue.java
@@ -215,7 +215,7 @@ public class NameValue extends AbstractNode implements FilterProvider {
         }
 
         try {
-            if (token.contains(".") || token.contains("e") || token.contains("E")) {
+            if (token.contains(".")) {
                 return FieldValue.of(Double.parseDouble(token));
             }
             return FieldValue.of(Long.parseLong(token));

--- a/es8-persistence/src/test/java/org/conductoross/conductor/es8/dao/index/Es8SearchSupportTest.java
+++ b/es8-persistence/src/test/java/org/conductoross/conductor/es8/dao/index/Es8SearchSupportTest.java
@@ -12,8 +12,11 @@
  */
 package org.conductoross.conductor.es8.dao.index;
 
+import java.util.List;
+
 import org.junit.Test;
 
+import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 import static org.junit.Assert.assertEquals;
@@ -37,6 +40,19 @@ public class Es8SearchSupportTest {
         Query query = support.boolQueryBuilder("", " ");
 
         assertTrue(query.isMatchAll());
+    }
+
+    @Test
+    public void unquotedValueWithENotParsedAsDouble() throws Exception {
+        // Regression: workflow names like "1E234" or "12E34" were incorrectly parsed as doubles,
+        // causing terms queries on keyword fields to return 0 results.
+        Query query = support.boolQueryBuilder("workflowType IN (1E234)", "*");
+
+        assertTrue(query.isTerms());
+        List<FieldValue> values = query.terms().terms().value();
+        assertEquals(1, values.size());
+        assertTrue(values.get(0).isString());
+        assertEquals("1E234", values.get(0).stringValue());
     }
 
     @Test

--- a/es8-persistence/src/test/java/org/conductoross/conductor/es8/dao/index/Es8SearchSupportTest.java
+++ b/es8-persistence/src/test/java/org/conductoross/conductor/es8/dao/index/Es8SearchSupportTest.java
@@ -40,6 +40,27 @@ public class Es8SearchSupportTest {
     }
 
     @Test
+    public void doubleQuotedStructuredQueryUsesTermQuery() throws Exception {
+        String uuid = "09d13af8-3a2a-48bf-a91d-ef0a9114f07a";
+        Query query = support.boolQueryBuilder("workflowId=\"" + uuid + "\"", "*");
+
+        assertTrue(query.isTerm());
+        assertEquals("workflowId", query.term().field());
+        assertEquals(uuid, query.term().value().stringValue());
+    }
+
+    @Test
+    public void andConditionStructuredQueryUsesBoolMustQuery() throws Exception {
+        Query query =
+                support.boolQueryBuilder(
+                        "correlationId='corr-abc' AND workflowType='MyWorkflow'", "*");
+
+        assertTrue(query.isBool());
+        assertEquals(2, query.bool().must().size());
+        assertTrue(query.bool().must().stream().anyMatch(Query::isTerm));
+    }
+
+    @Test
     public void explicitFreeTextAddsSimpleQueryStringClause() throws Exception {
         Query query = support.boolQueryBuilder("status='RUNNING'", "workflowId:abc");
 

--- a/es8-persistence/src/test/java/org/conductoross/conductor/es8/dao/query/parser/TestNameValueQueryBuilder.java
+++ b/es8-persistence/src/test/java/org/conductoross/conductor/es8/dao/query/parser/TestNameValueQueryBuilder.java
@@ -69,6 +69,19 @@ public class TestNameValueQueryBuilder extends AbstractParserTest {
     }
 
     @Test
+    public void equalsWithDoubleQuotesUsesTermQuery() throws Exception {
+        String uuid = "09d13af8-3a2a-48bf-a91d-ef0a9114f07a";
+        NameValue nameValue = new NameValue(getInputStream("workflowId=\"" + uuid + "\""));
+
+        Query query = nameValue.getFilterBuilder();
+
+        assertTrue(query.isTerm());
+        assertEquals("workflowId", query.term().field());
+        assertTrue(query.term().value().isString());
+        assertEquals(uuid, query.term().value().stringValue());
+    }
+
+    @Test
     public void equalsNullUsesMissingFieldQuery() throws Exception {
         NameValue nameValue = new NameValue(getInputStream("archived = null"));
 

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -981,6 +981,7 @@ public abstract class AbstractProtoMapper {
             to.setBackoffScaleFactor( from.getBackoffScaleFactor() );
         }
         to.setMaxRetryDelaySeconds( from.getMaxRetryDelaySeconds() );
+        to.setBackoffJitterMs( from.getBackoffJitterMs() );
         if (from.getBaseType() != null) {
             to.setBaseType( from.getBaseType() );
         }
@@ -1015,6 +1016,7 @@ public abstract class AbstractProtoMapper {
         to.setPollTimeoutSeconds( from.getPollTimeoutSeconds() );
         to.setBackoffScaleFactor( from.getBackoffScaleFactor() );
         to.setMaxRetryDelaySeconds( from.getMaxRetryDelaySeconds() );
+        to.setBackoffJitterMs( from.getBackoffJitterMs() );
         to.setBaseType( from.getBaseType() );
         to.setTotalTimeoutSeconds( from.getTotalTimeoutSeconds() );
         to.setTaskStatusListenerEnabled( from.getTaskStatusListenerEnabled() );

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -980,6 +980,7 @@ public abstract class AbstractProtoMapper {
         if (from.getBackoffScaleFactor() != null) {
             to.setBackoffScaleFactor( from.getBackoffScaleFactor() );
         }
+        to.setMaxRetryDelaySeconds( from.getMaxRetryDelaySeconds() );
         if (from.getBaseType() != null) {
             to.setBaseType( from.getBaseType() );
         }
@@ -1013,6 +1014,7 @@ public abstract class AbstractProtoMapper {
         to.setOwnerEmail( from.getOwnerEmail() );
         to.setPollTimeoutSeconds( from.getPollTimeoutSeconds() );
         to.setBackoffScaleFactor( from.getBackoffScaleFactor() );
+        to.setMaxRetryDelaySeconds( from.getMaxRetryDelaySeconds() );
         to.setBaseType( from.getBaseType() );
         to.setTotalTimeoutSeconds( from.getTotalTimeoutSeconds() );
         to.setTaskStatusListenerEnabled( from.getTaskStatusListenerEnabled() );
@@ -1544,6 +1546,9 @@ public abstract class AbstractProtoMapper {
         if (from.getCreateTime() != null) {
             to.setCreateTime( from.getCreateTime() );
         }
+        if (from.getUpdateTime() != null) {
+            to.setUpdateTime( from.getUpdateTime() );
+        }
         return to.build();
     }
 
@@ -1552,6 +1557,7 @@ public abstract class AbstractProtoMapper {
         to.setName( from.getName() );
         to.setVersion( from.getVersion() );
         to.setCreateTime( from.getCreateTime() );
+        to.setUpdateTime( from.getUpdateTime() );
         return to;
     }
 

--- a/grpc/src/main/proto/model/taskdef.proto
+++ b/grpc/src/main/proto/model/taskdef.proto
@@ -38,6 +38,7 @@ message TaskDef {
     int32 poll_timeout_seconds = 19;
     int32 backoff_scale_factor = 20;
     int32 max_retry_delay_seconds = 24;
+    int32 backoff_jitter_ms = 25;
     string base_type = 21;
     int64 total_timeout_seconds = 22;
     bool task_status_listener_enabled = 23;

--- a/grpc/src/main/proto/model/taskdef.proto
+++ b/grpc/src/main/proto/model/taskdef.proto
@@ -37,6 +37,7 @@ message TaskDef {
     string owner_email = 18;
     int32 poll_timeout_seconds = 19;
     int32 backoff_scale_factor = 20;
+    int32 max_retry_delay_seconds = 24;
     string base_type = 21;
     int64 total_timeout_seconds = 22;
     bool task_status_listener_enabled = 23;

--- a/grpc/src/main/proto/model/workflowdefsummary.proto
+++ b/grpc/src/main/proto/model/workflowdefsummary.proto
@@ -10,4 +10,5 @@ message WorkflowDefSummary {
     string name = 1;
     int32 version = 2;
     int64 create_time = 3;
+    int64 update_time = 4;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
     - Microservice Orchestration: devguide/cookbook/microservice-orchestration.md
     - Dynamic Parallelism: devguide/cookbook/dynamic-parallelism.md
     - Wait & Timer Patterns: devguide/cookbook/wait-and-timers.md
+    - Task Timeouts & Retries: devguide/cookbook/task-timeouts-and-retries.md
     - Event-Driven Recipes: devguide/cookbook/event-driven.md
     - AI & LLM Recipes: devguide/cookbook/ai-llm.md
     - Dynamic Workflows in Code: devguide/cookbook/dynamic-workflows.md

--- a/mysql-persistence/build.gradle
+++ b/mysql-persistence/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     testImplementation project(':conductor-server')
     testImplementation project(':conductor-grpc-client')
     testImplementation project(':conductor-es7-persistence')
-    implementation "org.conductoross:conductor-client:${revConductorClient}"
 
     testImplementation project(':conductor-test-util').sourceSets.test.output
     testImplementation project(':conductor-common-persistence').sourceSets.test.output

--- a/mysql-persistence/src/main/java/com/netflix/conductor/mysql/dao/MySQLQueueDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/mysql/dao/MySQLQueueDAO.java
@@ -153,6 +153,29 @@ public class MySQLQueueDAO extends MySQLBaseDAO implements QueueDAO {
     }
 
     @Override
+    public boolean setUnackTimeoutIfShorter(
+            String queueName, String messageId, long unackTimeout) {
+        long updatedOffsetTimeInSecond = unackTimeout / 1000;
+
+        // Only update when the proposed deliver_on is earlier than what is already set,
+        // mirroring the ZADD LT semantics used by the Redis implementation.
+        final String UPDATE_UNACK_TIMEOUT_IF_SHORTER =
+                "UPDATE queue_message SET offset_time_seconds = ?, deliver_on = TIMESTAMPADD(SECOND, ?, CURRENT_TIMESTAMP)"
+                        + " WHERE queue_name = ? AND message_id = ? AND deliver_on > TIMESTAMPADD(SECOND, ?, CURRENT_TIMESTAMP)";
+
+        return queryWithTransaction(
+                        UPDATE_UNACK_TIMEOUT_IF_SHORTER,
+                        q ->
+                                q.addParameter(updatedOffsetTimeInSecond)
+                                        .addParameter(updatedOffsetTimeInSecond)
+                                        .addParameter(queueName)
+                                        .addParameter(messageId)
+                                        .addParameter(updatedOffsetTimeInSecond)
+                                        .executeUpdate())
+                == 1;
+    }
+
+    @Override
     public void flush(String queueName) {
         final String FLUSH_QUEUE = "DELETE FROM queue_message WHERE queue_name = ?";
         executeWithTransaction(FLUSH_QUEUE, q -> q.addParameter(queueName).executeDelete());

--- a/mysql-persistence/src/main/java/com/netflix/conductor/mysql/dao/MySQLQueueDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/mysql/dao/MySQLQueueDAO.java
@@ -153,8 +153,7 @@ public class MySQLQueueDAO extends MySQLBaseDAO implements QueueDAO {
     }
 
     @Override
-    public boolean setUnackTimeoutIfShorter(
-            String queueName, String messageId, long unackTimeout) {
+    public boolean setUnackTimeoutIfShorter(String queueName, String messageId, long unackTimeout) {
         long updatedOffsetTimeInSecond = unackTimeout / 1000;
 
         // Only update when the proposed deliver_on is earlier than what is already set,

--- a/mysql-persistence/src/test/java/com/netflix/conductor/mysql/dao/MySQLQueueDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/mysql/dao/MySQLQueueDAOTest.java
@@ -333,6 +333,50 @@ public class MySQLQueueDAOTest {
     }
 
     @Test
+    public void setUnackTimeoutIfShorterShortensDueTime() {
+        String queueName = "setUnackIfShorter_shorten";
+        String messageId = "msg-shorten";
+
+        // Push with a 1-hour delay so it is not immediately poppable
+        queueDAO.push(queueName, messageId, 3600L);
+        assertEquals(0, queueDAO.pop(queueName, 1, 100).size());
+
+        // Shorten delivery to now (0 s) — should succeed and return true
+        boolean shortened = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 0L);
+        assertTrue("setUnackTimeoutIfShorter should return true when it actually shortens", shortened);
+
+        // Message must now be immediately poppable
+        List<String> popped = queueDAO.pop(queueName, 1, 100);
+        assertEquals(1, popped.size());
+        assertEquals(messageId, popped.get(0));
+    }
+
+    @Test
+    public void setUnackTimeoutIfShorterDoesNotExtend() {
+        String queueName = "setUnackIfShorter_noextend";
+        String messageId = "msg-noextend";
+
+        // Push with offset 0 so it is immediately available
+        queueDAO.push(queueName, messageId, 0L);
+
+        // Try to push deliver_on far into the future — must be rejected
+        boolean extended = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 3_600_000L);
+        assertFalse("setUnackTimeoutIfShorter must not extend an already-closer delivery time", extended);
+
+        // Message must still be immediately poppable
+        List<String> popped = queueDAO.pop(queueName, 1, 100);
+        assertEquals(1, popped.size());
+        assertEquals(messageId, popped.get(0));
+    }
+
+    @Test
+    public void setUnackTimeoutIfShorterReturnsFalseForNonExistent() {
+        String queueName = "setUnackIfShorter_nonexistent";
+        boolean updated = queueDAO.setUnackTimeoutIfShorter(queueName, "no-such-message", 0L);
+        assertFalse("setUnackTimeoutIfShorter must return false for a non-existent message", updated);
+    }
+
+    @Test
     public void processUnacksTest() {
         final String queueName = "process_unacks_test";
         // Count of messages in the queue(s)

--- a/mysql-persistence/src/test/java/com/netflix/conductor/mysql/dao/MySQLQueueDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/mysql/dao/MySQLQueueDAOTest.java
@@ -377,6 +377,37 @@ public class MySQLQueueDAOTest {
     }
 
     @Test
+    public void setUnackTimeoutIfShorterReturnsFalseWhenEqualTimeout() {
+        String queueName = "setUnackIfShorter_equal";
+        String messageId = "msg-equal";
+        queueDAO.push(queueName, messageId, 0L);
+
+        boolean result = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 0L);
+        assertFalse("Equal timeout must not update deliver_on — returns false", result);
+
+        List<String> popped = queueDAO.pop(queueName, 1, 100);
+        assertEquals(1, popped.size());
+        assertEquals(messageId, popped.get(0));
+    }
+
+    @Test
+    public void setUnackTimeoutIfShorterRejectsExtensionThenAcceptsShortening() {
+        String queueName = "setUnackIfShorter_reject_then_accept";
+        String messageId = "msg-reject-accept";
+        queueDAO.push(queueName, messageId, 3600L);
+
+        boolean extended = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 7_200_000L);
+        assertFalse("Extending must return false", extended);
+
+        boolean shortened = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 0L);
+        assertTrue("Shortening to now must return true", shortened);
+
+        List<String> popped = queueDAO.pop(queueName, 1, 100);
+        assertEquals(1, popped.size());
+        assertEquals(messageId, popped.get(0));
+    }
+
+    @Test
     public void processUnacksTest() {
         final String queueName = "process_unacks_test";
         // Count of messages in the queue(s)

--- a/mysql-persistence/src/test/java/com/netflix/conductor/mysql/dao/MySQLQueueDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/mysql/dao/MySQLQueueDAOTest.java
@@ -343,7 +343,8 @@ public class MySQLQueueDAOTest {
 
         // Shorten delivery to now (0 s) — should succeed and return true
         boolean shortened = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 0L);
-        assertTrue("setUnackTimeoutIfShorter should return true when it actually shortens", shortened);
+        assertTrue(
+                "setUnackTimeoutIfShorter should return true when it actually shortens", shortened);
 
         // Message must now be immediately poppable
         List<String> popped = queueDAO.pop(queueName, 1, 100);
@@ -361,7 +362,9 @@ public class MySQLQueueDAOTest {
 
         // Try to push deliver_on far into the future — must be rejected
         boolean extended = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 3_600_000L);
-        assertFalse("setUnackTimeoutIfShorter must not extend an already-closer delivery time", extended);
+        assertFalse(
+                "setUnackTimeoutIfShorter must not extend an already-closer delivery time",
+                extended);
 
         // Message must still be immediately poppable
         List<String> popped = queueDAO.pop(queueName, 1, 100);
@@ -373,7 +376,8 @@ public class MySQLQueueDAOTest {
     public void setUnackTimeoutIfShorterReturnsFalseForNonExistent() {
         String queueName = "setUnackIfShorter_nonexistent";
         boolean updated = queueDAO.setUnackTimeoutIfShorter(queueName, "no-such-message", 0L);
-        assertFalse("setUnackTimeoutIfShorter must return false for a non-existent message", updated);
+        assertFalse(
+                "setUnackTimeoutIfShorter must return false for a non-existent message", updated);
     }
 
     @Test

--- a/postgres-persistence/build.gradle
+++ b/postgres-persistence/build.gradle
@@ -24,7 +24,6 @@ dependencies {
     testImplementation project(':conductor-es7-persistence')
 
     testImplementation "org.testcontainers:postgresql:${revTestContainer}"
-    implementation "org.conductoross:conductor-client:${revConductorClient}"
     testImplementation "org.testcontainers:elasticsearch:${revTestContainer}"
 
     testImplementation project(':conductor-test-util').sourceSets.test.output

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresQueueDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresQueueDAO.java
@@ -216,6 +216,29 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
     }
 
     @Override
+    public boolean setUnackTimeoutIfShorter(
+            String queueName, String messageId, long unackTimeout) {
+        long updatedOffsetTimeInSecond = unackTimeout / 1000;
+
+        // Only update when the proposed deliver_on is earlier than what is already set,
+        // mirroring the ZADD LT semantics used by the Redis implementation.
+        final String UPDATE_UNACK_TIMEOUT_IF_SHORTER =
+                "UPDATE queue_message SET offset_time_seconds = ?, deliver_on = (current_timestamp + (? ||' seconds')::interval)"
+                        + " WHERE queue_name = ? AND message_id = ? AND deliver_on > (current_timestamp + (? ||' seconds')::interval)";
+
+        return queryWithTransaction(
+                        UPDATE_UNACK_TIMEOUT_IF_SHORTER,
+                        q ->
+                                q.addParameter(updatedOffsetTimeInSecond)
+                                        .addParameter(updatedOffsetTimeInSecond)
+                                        .addParameter(queueName)
+                                        .addParameter(messageId)
+                                        .addParameter(updatedOffsetTimeInSecond)
+                                        .executeUpdate())
+                == 1;
+    }
+
+    @Override
     public void flush(String queueName) {
         final String FLUSH_QUEUE = "DELETE FROM queue_message WHERE queue_name = ?";
         executeWithTransaction(FLUSH_QUEUE, q -> q.addParameter(queueName).executeDelete());

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresQueueDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresQueueDAO.java
@@ -216,8 +216,7 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
     }
 
     @Override
-    public boolean setUnackTimeoutIfShorter(
-            String queueName, String messageId, long unackTimeout) {
+    public boolean setUnackTimeoutIfShorter(String queueName, String messageId, long unackTimeout) {
         long updatedOffsetTimeInSecond = unackTimeout / 1000;
 
         // Only update when the proposed deliver_on is earlier than what is already set,

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresQueueDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresQueueDAOTest.java
@@ -477,6 +477,53 @@ public class PostgresQueueDAOTest {
         assertFalse("setUnackTimeoutIfShorter must return false for a non-existent message", updated);
     }
 
+    /**
+     * Boundary: when the new timeout would result in the same delivery time as the current one,
+     * the message is NOT shorter — method must return false and leave deliver_on unchanged.
+     */
+    @Test
+    public void setUnackTimeoutIfShorterReturnsFalseWhenEqualTimeout() {
+        String queueName = "setUnackIfShorter_equal";
+        String messageId = "msg-equal";
+
+        // Push with offset 0 so deliver_on ≈ now
+        queueDAO.push(queueName, messageId, 0L);
+
+        // Try to set unack timeout to 0 again — deliver_on = LEAST(≈now, ≈now+0) = no change
+        // The WHERE condition `deliver_on > now + 0` is false, so returns false
+        boolean result = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 0L);
+        assertFalse("Equal timeout must not update deliver_on — returns false", result);
+
+        // Message remains immediately poppable (deliver_on unchanged)
+        List<String> popped = queueDAO.pop(queueName, 1, 100);
+        assertEquals(1, popped.size());
+        assertEquals(messageId, popped.get(0));
+    }
+
+    /**
+     * Boundary: a very large timeout (1 hour) is correctly rejected when message is already
+     * overdue, and a subsequent shortened call (0 ms) is accepted.
+     */
+    @Test
+    public void setUnackTimeoutIfShorterRejectsExtensionThenAcceptsShortening() {
+        String queueName = "setUnackIfShorter_reject_then_accept";
+        String messageId = "msg-reject-accept";
+
+        queueDAO.push(queueName, messageId, 3600L); // 1 hour delay
+
+        // Try to extend to 2 hours — must be rejected
+        boolean extended = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 7_200_000L);
+        assertFalse("Extending an already-future deliver_on must return false", extended);
+
+        // Shorten to immediate — must be accepted
+        boolean shortened = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 0L);
+        assertTrue("Shortening to now must return true", shortened);
+
+        List<String> popped = queueDAO.pop(queueName, 1, 100);
+        assertEquals(1, popped.size());
+        assertEquals(messageId, popped.get(0));
+    }
+
     // @Test
     public void processUnacksTest() {
         processUnacks(

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresQueueDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresQueueDAOTest.java
@@ -444,7 +444,8 @@ public class PostgresQueueDAOTest {
 
         // Shorten delivery to now (0 s) — should succeed and return true
         boolean shortened = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 0L);
-        assertTrue("setUnackTimeoutIfShorter should return true when it actually shortens", shortened);
+        assertTrue(
+                "setUnackTimeoutIfShorter should return true when it actually shortens", shortened);
 
         // Message must now be immediately poppable
         List<String> popped = queueDAO.pop(queueName, 1, 100);
@@ -462,7 +463,9 @@ public class PostgresQueueDAOTest {
 
         // Try to push deliver_on far into the future — must be rejected
         boolean extended = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 3_600_000L);
-        assertFalse("setUnackTimeoutIfShorter must not extend an already-closer delivery time", extended);
+        assertFalse(
+                "setUnackTimeoutIfShorter must not extend an already-closer delivery time",
+                extended);
 
         // Message must still be immediately poppable
         List<String> popped = queueDAO.pop(queueName, 1, 100);
@@ -474,12 +477,13 @@ public class PostgresQueueDAOTest {
     public void setUnackTimeoutIfShorterReturnsFalseForNonExistent() {
         String queueName = "setUnackIfShorter_nonexistent";
         boolean updated = queueDAO.setUnackTimeoutIfShorter(queueName, "no-such-message", 0L);
-        assertFalse("setUnackTimeoutIfShorter must return false for a non-existent message", updated);
+        assertFalse(
+                "setUnackTimeoutIfShorter must return false for a non-existent message", updated);
     }
 
     /**
-     * Boundary: when the new timeout would result in the same delivery time as the current one,
-     * the message is NOT shorter — method must return false and leave deliver_on unchanged.
+     * Boundary: when the new timeout would result in the same delivery time as the current one, the
+     * message is NOT shorter — method must return false and leave deliver_on unchanged.
      */
     @Test
     public void setUnackTimeoutIfShorterReturnsFalseWhenEqualTimeout() {

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresQueueDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresQueueDAOTest.java
@@ -433,6 +433,50 @@ public class PostgresQueueDAOTest {
         }
     }
 
+    @Test
+    public void setUnackTimeoutIfShorterShortensDueTime() {
+        String queueName = "setUnackIfShorter_shorten";
+        String messageId = "msg-shorten";
+
+        // Push with a 1-hour delay so it is not immediately poppable
+        queueDAO.push(queueName, messageId, 3600L);
+        assertEquals(0, queueDAO.pop(queueName, 1, 100).size());
+
+        // Shorten delivery to now (0 s) — should succeed and return true
+        boolean shortened = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 0L);
+        assertTrue("setUnackTimeoutIfShorter should return true when it actually shortens", shortened);
+
+        // Message must now be immediately poppable
+        List<String> popped = queueDAO.pop(queueName, 1, 100);
+        assertEquals(1, popped.size());
+        assertEquals(messageId, popped.get(0));
+    }
+
+    @Test
+    public void setUnackTimeoutIfShorterDoesNotExtend() {
+        String queueName = "setUnackIfShorter_noextend";
+        String messageId = "msg-noextend";
+
+        // Push with offset 0 so it is immediately available
+        queueDAO.push(queueName, messageId, 0L);
+
+        // Try to push deliver_on far into the future — must be rejected
+        boolean extended = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 3_600_000L);
+        assertFalse("setUnackTimeoutIfShorter must not extend an already-closer delivery time", extended);
+
+        // Message must still be immediately poppable
+        List<String> popped = queueDAO.pop(queueName, 1, 100);
+        assertEquals(1, popped.size());
+        assertEquals(messageId, popped.get(0));
+    }
+
+    @Test
+    public void setUnackTimeoutIfShorterReturnsFalseForNonExistent() {
+        String queueName = "setUnackIfShorter_nonexistent";
+        boolean updated = queueDAO.setUnackTimeoutIfShorter(queueName, "no-such-message", 0L);
+        assertFalse("setUnackTimeoutIfShorter must return false for a non-existent message", updated);
+    }
+
     // @Test
     public void processUnacksTest() {
         processUnacks(

--- a/redis-persistence/src/main/java/io/orkes/conductor/mq/dao/BaseRedisQueueDAO.java
+++ b/redis-persistence/src/main/java/io/orkes/conductor/mq/dao/BaseRedisQueueDAO.java
@@ -35,6 +35,7 @@ import com.netflix.conductor.redis.config.RedisProperties;
 import com.netflix.conductor.redis.jedis.JedisCommands;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import redis.clients.jedis.params.ZAddParams;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.orkes.conductor.mq.ConductorQueue;
 import io.orkes.conductor.mq.QueueMessage;
@@ -219,6 +220,19 @@ public abstract class BaseRedisQueueDAO implements QueueDAO {
     @Override
     public final boolean setUnackTimeout(String queueName, String messageId, long unackTimeout) {
         return get(queueName).setUnacktimeout(messageId, unackTimeout);
+    }
+
+    @Override
+    public final boolean setUnackTimeoutIfShorter(
+            String queueName, String messageId, long unackTimeout) {
+        // ZADD XX LT: update score only if the new value is less (sooner delivery time).
+        // This is atomic in Redis and avoids pushing the evaluation further out than whatever
+        // shorter timeout another in-flight task already established.
+        double score = System.currentTimeMillis() + unackTimeout;
+        String queueKey = queueNamespace + ".QUEUE." + queueName + "." + queueShard;
+        ZAddParams params = ZAddParams.zAddParams().xx().lt().ch();
+        Long modified = jedisCommands.zadd(queueKey, score, messageId, params);
+        return modified != null && modified > 0;
     }
 
     @Override

--- a/redis-persistence/src/main/java/io/orkes/conductor/mq/dao/BaseRedisQueueDAO.java
+++ b/redis-persistence/src/main/java/io/orkes/conductor/mq/dao/BaseRedisQueueDAO.java
@@ -35,11 +35,11 @@ import com.netflix.conductor.redis.config.RedisProperties;
 import com.netflix.conductor.redis.jedis.JedisCommands;
 
 import com.github.benmanes.caffeine.cache.Cache;
-import redis.clients.jedis.params.ZAddParams;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.orkes.conductor.mq.ConductorQueue;
 import io.orkes.conductor.mq.QueueMessage;
 import lombok.extern.slf4j.Slf4j;
+import redis.clients.jedis.params.ZAddParams;
 
 @Slf4j
 public abstract class BaseRedisQueueDAO implements QueueDAO {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -47,13 +47,12 @@ dependencies {
 
     // Indexing backend selection (build-time) to avoid Lucene conflicts between ES and OS
     def indexingBackend = project.findProperty('indexingBackend') ?: 'elasticsearch'
-    if (indexingBackend == 'opensearch' || indexingBackend == 'os') {
+
+    if (indexingBackend == 'opensearch3' || indexingBackend == 'os3') {
+        implementation project(':conductor-os-persistence-v3')
+    } else if (indexingBackend == 'opensearch' || indexingBackend == 'os') {
         implementation project(':conductor-os-persistence')
         implementation project(':conductor-os-persistence-v2')
-        // os-persistence-v3 excluded: requires API migration to opensearch-java 3.x
-        // The DAO layer needs reimplementation for the new client API (breaking changes)
-        // See: os-persistence-v3/build.gradle comments for details
-        // implementation project(':conductor-os-persistence-v3')
     } else if (indexingBackend == 'elasticsearch8' || indexingBackend == 'es8') {
         implementation project(':conductor-es8-persistence')
     } else if (indexingBackend == 'elasticsearch7' || indexingBackend == 'es7' || indexingBackend == 'elasticsearch') {

--- a/sqlite-persistence/build.gradle
+++ b/sqlite-persistence/build.gradle
@@ -24,7 +24,6 @@ dependencies {
 
     testImplementation "org.apache.groovy:groovy-all:${revGroovy}"
     testImplementation project(':conductor-server')
-    implementation "org.conductoross:conductor-client:${revConductorClient}"
     testImplementation project(':conductor-grpc-client')
     testImplementation project(':conductor-es7-persistence')
 

--- a/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/dao/SqliteQueueDAO.java
+++ b/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/dao/SqliteQueueDAO.java
@@ -204,8 +204,7 @@ public class SqliteQueueDAO extends SqliteBaseDAO implements QueueDAO {
     }
 
     @Override
-    public boolean setUnackTimeoutIfShorter(
-            String queueName, String messageId, long unackTimeout) {
+    public boolean setUnackTimeoutIfShorter(String queueName, String messageId, long unackTimeout) {
         long updatedOffsetTimeInSecond = unackTimeout / 1000;
 
         // Only update when the proposed deliver_on is earlier than what is already set,

--- a/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/dao/SqliteQueueDAO.java
+++ b/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/dao/SqliteQueueDAO.java
@@ -204,6 +204,29 @@ public class SqliteQueueDAO extends SqliteBaseDAO implements QueueDAO {
     }
 
     @Override
+    public boolean setUnackTimeoutIfShorter(
+            String queueName, String messageId, long unackTimeout) {
+        long updatedOffsetTimeInSecond = unackTimeout / 1000;
+
+        // Only update when the proposed deliver_on is earlier than what is already set,
+        // mirroring the ZADD LT semantics used by the Redis implementation.
+        final String UPDATE_UNACK_TIMEOUT_IF_SHORTER =
+                "UPDATE queue_message SET offset_time_seconds = ?, deliver_on = strftime('%Y-%m-%d %H:%M:%f', 'now', '+' || ? || ' seconds')"
+                        + " WHERE queue_name = ? AND message_id = ? AND deliver_on > strftime('%Y-%m-%d %H:%M:%f', 'now', '+' || ? || ' seconds')";
+
+        return queryWithTransaction(
+                        UPDATE_UNACK_TIMEOUT_IF_SHORTER,
+                        q ->
+                                q.addParameter(updatedOffsetTimeInSecond)
+                                        .addParameter(updatedOffsetTimeInSecond)
+                                        .addParameter(queueName)
+                                        .addParameter(messageId)
+                                        .addParameter(updatedOffsetTimeInSecond)
+                                        .executeUpdate())
+                == 1;
+    }
+
+    @Override
     public void flush(String queueName) {
         final String FLUSH_QUEUE = "DELETE FROM queue_message WHERE queue_name = ?";
         executeWithTransaction(FLUSH_QUEUE, q -> q.addParameter(queueName).executeDelete());

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteQueueDAOTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteQueueDAOTest.java
@@ -343,6 +343,50 @@ public class SqliteQueueDAOTest {
         }
     }
 
+    @Test
+    public void setUnackTimeoutIfShorterShortensDueTime() {
+        String queueName = "setUnackIfShorter_shorten";
+        String messageId = "msg-shorten";
+
+        // Push with a 1-hour delay so it is not immediately poppable
+        queueDAO.push(queueName, messageId, 3600L);
+        assertEquals(0, queueDAO.pop(queueName, 1, 100).size());
+
+        // Shorten delivery to now (0 s) — should succeed and return true
+        boolean shortened = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 0L);
+        assertTrue("setUnackTimeoutIfShorter should return true when it actually shortens", shortened);
+
+        // Message must now be immediately poppable
+        List<String> popped = queueDAO.pop(queueName, 1, 100);
+        assertEquals(1, popped.size());
+        assertEquals(messageId, popped.get(0));
+    }
+
+    @Test
+    public void setUnackTimeoutIfShorterDoesNotExtend() {
+        String queueName = "setUnackIfShorter_noextend";
+        String messageId = "msg-noextend";
+
+        // Push with offset 0 so it is immediately available
+        queueDAO.push(queueName, messageId, 0L);
+
+        // Try to push deliver_on far into the future — must be rejected
+        boolean extended = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 3_600_000L);
+        assertFalse("setUnackTimeoutIfShorter must not extend an already-closer delivery time", extended);
+
+        // Message must still be immediately poppable
+        List<String> popped = queueDAO.pop(queueName, 1, 100);
+        assertEquals(1, popped.size());
+        assertEquals(messageId, popped.get(0));
+    }
+
+    @Test
+    public void setUnackTimeoutIfShorterReturnsFalseForNonExistent() {
+        String queueName = "setUnackIfShorter_nonexistent";
+        boolean updated = queueDAO.setUnackTimeoutIfShorter(queueName, "no-such-message", 0L);
+        assertFalse("setUnackTimeoutIfShorter must return false for a non-existent message", updated);
+    }
+
     // @Test
     public void processUnacksTest() {
         processUnacks(

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteQueueDAOTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteQueueDAOTest.java
@@ -354,7 +354,8 @@ public class SqliteQueueDAOTest {
 
         // Shorten delivery to now (0 s) — should succeed and return true
         boolean shortened = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 0L);
-        assertTrue("setUnackTimeoutIfShorter should return true when it actually shortens", shortened);
+        assertTrue(
+                "setUnackTimeoutIfShorter should return true when it actually shortens", shortened);
 
         // Message must now be immediately poppable
         List<String> popped = queueDAO.pop(queueName, 1, 100);
@@ -372,7 +373,9 @@ public class SqliteQueueDAOTest {
 
         // Try to push deliver_on far into the future — must be rejected
         boolean extended = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 3_600_000L);
-        assertFalse("setUnackTimeoutIfShorter must not extend an already-closer delivery time", extended);
+        assertFalse(
+                "setUnackTimeoutIfShorter must not extend an already-closer delivery time",
+                extended);
 
         // Message must still be immediately poppable
         List<String> popped = queueDAO.pop(queueName, 1, 100);
@@ -384,7 +387,8 @@ public class SqliteQueueDAOTest {
     public void setUnackTimeoutIfShorterReturnsFalseForNonExistent() {
         String queueName = "setUnackIfShorter_nonexistent";
         boolean updated = queueDAO.setUnackTimeoutIfShorter(queueName, "no-such-message", 0L);
-        assertFalse("setUnackTimeoutIfShorter must return false for a non-existent message", updated);
+        assertFalse(
+                "setUnackTimeoutIfShorter must return false for a non-existent message", updated);
     }
 
     @Test

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteQueueDAOTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteQueueDAOTest.java
@@ -387,6 +387,37 @@ public class SqliteQueueDAOTest {
         assertFalse("setUnackTimeoutIfShorter must return false for a non-existent message", updated);
     }
 
+    @Test
+    public void setUnackTimeoutIfShorterReturnsFalseWhenEqualTimeout() {
+        String queueName = "setUnackIfShorter_equal";
+        String messageId = "msg-equal";
+        queueDAO.push(queueName, messageId, 0L);
+
+        boolean result = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 0L);
+        assertFalse("Equal timeout must not update deliver_on — returns false", result);
+
+        List<String> popped = queueDAO.pop(queueName, 1, 100);
+        assertEquals(1, popped.size());
+        assertEquals(messageId, popped.get(0));
+    }
+
+    @Test
+    public void setUnackTimeoutIfShorterRejectsExtensionThenAcceptsShortening() {
+        String queueName = "setUnackIfShorter_reject_then_accept";
+        String messageId = "msg-reject-accept";
+        queueDAO.push(queueName, messageId, 3600L);
+
+        boolean extended = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 7_200_000L);
+        assertFalse("Extending must return false", extended);
+
+        boolean shortened = queueDAO.setUnackTimeoutIfShorter(queueName, messageId, 0L);
+        assertTrue("Shortening to now must return true", shortened);
+
+        List<String> popped = queueDAO.pop(queueName, 1, 100);
+        assertEquals(1, popped.size());
+        assertEquals(messageId, popped.get(0));
+    }
+
     // @Test
     public void processUnacksTest() {
         processUnacks(

--- a/test-harness/build.gradle
+++ b/test-harness/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testImplementation project(':conductor-json-jq-task')
     testImplementation project(':conductor-http-task')
 
-    implementation "org.conductoross:conductor-client:${revConductorClient}"
+    testImplementation "org.conductoross:conductor-client:${revConductorClient}"
 
     testImplementation "org.springframework.retry:spring-retry"
 

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/LambdaAndTerminateTaskSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/LambdaAndTerminateTaskSpec.groovy
@@ -18,6 +18,7 @@ import com.netflix.conductor.common.metadata.tasks.Task
 import com.netflix.conductor.common.metadata.tasks.TaskResult
 import com.netflix.conductor.common.run.Workflow
 import com.netflix.conductor.core.execution.tasks.SubWorkflow
+import com.netflix.conductor.model.WorkflowModel
 import com.netflix.conductor.test.base.AbstractSpecification
 
 import spock.lang.Shared
@@ -103,8 +104,8 @@ class LambdaAndTerminateTaskSpec extends AbstractSpecification {
             tasks[1].seq == 2
             output
             def failedWorkflowId = output['conductor.failure_workflow'] as String
-            with(workflowExecutionService.getExecutionStatus(failedWorkflowId, true)) {
-                status == Workflow.WorkflowStatus.COMPLETED
+            with(workflowExecutionService.getWorkflowModel(failedWorkflowId, true)) {
+                status == WorkflowModel.Status.COMPLETED
                 input['workflowId'] == workflowInstanceId
                 tasks.size() == 1
                 tasks[0].taskType == 'LAMBDA'

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/RetryPolicySpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/RetryPolicySpec.groovy
@@ -22,6 +22,7 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowDef
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask
 import com.netflix.conductor.common.run.Workflow
 import com.netflix.conductor.core.dal.ExecutionDAOFacade
+import com.netflix.conductor.core.exception.TerminateWorkflowException
 import com.netflix.conductor.test.base.AbstractSpecification
 
 /**
@@ -251,6 +252,104 @@ class RetryPolicySpec extends AbstractSpecification {
             def taskModel = executionDAOFacade.getTaskModel(rescheduled.taskId)
             assert taskModel.callbackAfterMs >= 3_000
             assert taskModel.callbackAfterMs <= 5_000
+        }
+    }
+
+    // =========================================================================
+    // totalTimeoutSeconds
+    // =========================================================================
+
+    def "totalTimeoutSeconds=0 is disabled — retries continue as normal"() {
+        given:
+        def taskDef = new TaskDef()
+        taskDef.name = TASK_NAME
+        taskDef.retryCount = 5
+        taskDef.retryDelaySeconds = 0
+        taskDef.retryLogic = TaskDef.RetryLogic.FIXED
+        taskDef.totalTimeoutSeconds = 0 // disabled
+        taskDef.timeoutSeconds = 3600
+        taskDef.responseTimeoutSeconds = 3600
+        metadataService.registerTaskDef([taskDef])
+
+        when:
+        def wfId = startWorkflow(WORKFLOW_NAME, 1, 'total-timeout-disabled', [:], null)
+        workflowExecutionService.updateTask(failedResult(pollUntilAvailable()))
+
+        then: "retry is scheduled (total timeout disabled)"
+        conditions.eventually {
+            def wf = workflowExecutionService.getExecutionStatus(wfId, true)
+            assert wf.tasks.size() >= 2
+            assert wf.tasks.last().status == Task.Status.SCHEDULED
+        }
+    }
+
+    def "totalTimeoutSeconds exceeded on retry — workflow fails with no further retries"() {
+        given: "A task with retries allowed but total budget of 5 s"
+        def taskDef = new TaskDef()
+        taskDef.name = TASK_NAME
+        taskDef.retryCount = 10
+        taskDef.retryDelaySeconds = 0
+        taskDef.retryLogic = TaskDef.RetryLogic.FIXED
+        taskDef.totalTimeoutSeconds = 5
+        taskDef.timeoutSeconds = 0      // disabled so constraint (timeoutSeconds ≤ totalTimeout) passes
+        taskDef.responseTimeoutSeconds = 1
+        taskDef.timeoutPolicy = TaskDef.TimeoutPolicy.TIME_OUT_WF
+        metadataService.registerTaskDef([taskDef])
+
+        when: "Start the workflow, burn some time, then fail the task"
+        def wfId = startWorkflow(WORKFLOW_NAME, 1, 'total-timeout-exceeded', [:], null)
+
+        // Retrieve the internal task model and backdate firstScheduledTime to exceed the budget
+        conditions.eventually {
+            assert workflowExecutionService.getExecutionStatus(wfId, true)
+                    .tasks.find { it.status == Task.Status.SCHEDULED } != null
+        }
+        def scheduled = workflowExecutionService.getExecutionStatus(wfId, true).tasks.first()
+        def taskModel = executionDAOFacade.getTaskModel(scheduled.taskId)
+        taskModel.firstScheduledTime = System.currentTimeMillis() - 60_000 // 60s ago > 5s budget
+        executionDAOFacade.updateTask(taskModel)
+
+        // Now fail the task — retry() should detect total timeout exceeded and terminate workflow
+        workflowExecutionService.updateTask(failedResult(pollUntilAvailable()))
+
+        then: "Workflow fails (total timeout exceeded, no more retries)"
+        conditions.eventually {
+            def wf = workflowExecutionService.getExecutionStatus(wfId, false)
+            assert wf.status == Workflow.WorkflowStatus.TIMED_OUT || wf.status == Workflow.WorkflowStatus.FAILED
+        }
+    }
+
+    def "totalTimeoutSeconds exceeded in checkTotalTimeout — IN_PROGRESS task is timed out"() {
+        given: "A task with RETRY timeout policy and a 5 s total budget"
+        def taskDef = new TaskDef()
+        taskDef.name = TASK_NAME
+        taskDef.retryCount = 10
+        taskDef.retryDelaySeconds = 0
+        taskDef.retryLogic = TaskDef.RetryLogic.FIXED
+        taskDef.totalTimeoutSeconds = 5
+        taskDef.timeoutSeconds = 0      // disabled so constraint passes
+        taskDef.responseTimeoutSeconds = 1
+        taskDef.timeoutPolicy = TaskDef.TimeoutPolicy.RETRY
+        metadataService.registerTaskDef([taskDef])
+
+        when: "Start the workflow, poll the task (IN_PROGRESS), then backdate firstScheduledTime"
+        def wfId = startWorkflow(WORKFLOW_NAME, 1, 'total-timeout-inprogress', [:], null)
+        def polled = pollUntilAvailable()
+
+        // Backdate firstScheduledTime on the IN_PROGRESS task to exceed total budget
+        def taskModel = executionDAOFacade.getTaskModel(polled.taskId)
+        taskModel.firstScheduledTime = System.currentTimeMillis() - 60_000
+        executionDAOFacade.updateTask(taskModel)
+
+        // Trigger a decide cycle (sweep) to fire checkTotalTimeout
+        sweep(wfId)
+
+        then: "Task is TIMED_OUT by checkTotalTimeout (RETRY policy sets status, doesn't terminate wf yet)"
+        conditions.eventually {
+            def wf = workflowExecutionService.getExecutionStatus(wfId, true)
+            def timedOutTask = wf.tasks.find { it.taskId == polled.taskId }
+            assert timedOutTask != null
+            assert timedOutTask.status == Task.Status.TIMED_OUT
         }
     }
 }

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/RetryPolicySpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/RetryPolicySpec.groovy
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.test.integration
+
+import org.springframework.beans.factory.annotation.Autowired
+
+import com.netflix.conductor.common.metadata.tasks.Task
+import com.netflix.conductor.common.metadata.tasks.TaskDef
+import com.netflix.conductor.common.metadata.tasks.TaskResult
+import com.netflix.conductor.common.metadata.tasks.TaskType
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask
+import com.netflix.conductor.common.run.Workflow
+import com.netflix.conductor.core.dal.ExecutionDAOFacade
+import com.netflix.conductor.test.base.AbstractSpecification
+
+/**
+ * End-to-end integration tests for retry policy features:
+ * - maxRetryDelaySeconds: caps the computed backoff delay so it never exceeds a configured ceiling
+ * - backoffJitterMs: adds a random millisecond offset in [0, maxJitterMs] to each retry delay,
+ *   spreading retries to prevent thundering-herd storms
+ */
+class RetryPolicySpec extends AbstractSpecification {
+
+    @Autowired
+    ExecutionDAOFacade executionDAOFacade
+
+    private static final String TASK_NAME = 'retry_policy_task'
+    private static final String WORKFLOW_NAME = 'retry_policy_wf'
+
+    def setup() {
+        def wfTask = new WorkflowTask()
+        wfTask.name = TASK_NAME
+        wfTask.taskReferenceName = 'retry_task_ref'
+        wfTask.type = TaskType.SIMPLE
+
+        def wfDef = new WorkflowDef()
+        wfDef.name = WORKFLOW_NAME
+        wfDef.version = 1
+        wfDef.tasks = [wfTask]
+        wfDef.ownerEmail = 'test@example.com'
+        wfDef.timeoutSeconds = 3600
+        wfDef.timeoutPolicy = WorkflowDef.TimeoutPolicy.ALERT_ONLY
+        metadataService.registerWorkflowDef(wfDef)
+    }
+
+    def cleanup() {
+        try { metadataService.unregisterWorkflowDef(WORKFLOW_NAME, 1) } catch (ignored) {}
+        try { metadataService.unregisterTaskDef(TASK_NAME) } catch (ignored) {}
+    }
+
+    /** Poll until the next SCHEDULED task is available to be polled (handles callbackAfter delays). */
+    private Task pollUntilAvailable() {
+        Task polled = null
+        conditions.eventually {
+            polled = workflowExecutionService.poll(TASK_NAME, 'test-worker')
+            assert polled != null
+        }
+        return polled
+    }
+
+    private static TaskResult failedResult(Task task) {
+        def r = new TaskResult(task)
+        r.status = TaskResult.Status.FAILED
+        return r
+    }
+
+    // -------------------------------------------------------------------------
+    // maxRetryDelaySeconds
+    // -------------------------------------------------------------------------
+
+    def "Exponential backoff delay is capped by maxRetryDelaySeconds"() {
+        given: "A task def with exponential backoff, base delay 2 s, cap 3 s"
+        // retry 0: 2 * 2^0 = 2 s (below cap); retry 1: 2 * 2^1 = 4 s → capped to 3 s
+        def taskDef = new TaskDef()
+        taskDef.name = TASK_NAME
+        taskDef.retryCount = 5
+        taskDef.retryDelaySeconds = 2
+        taskDef.retryLogic = TaskDef.RetryLogic.EXPONENTIAL_BACKOFF
+        taskDef.maxRetryDelaySeconds = 3
+        taskDef.timeoutSeconds = 3600
+        taskDef.responseTimeoutSeconds = 3600
+        metadataService.registerTaskDef([taskDef])
+
+        when: "Start the workflow and fail the task (retry 0 — raw = 2 s, below cap)"
+        def wfId = startWorkflow(WORKFLOW_NAME, 1, 'retry-cap-exp', [:], null)
+        workflowExecutionService.updateTask(failedResult(pollUntilAvailable()))
+
+        then: "Rescheduled task (retry 0) has callbackAfterSeconds = 2 (below the 3 s cap)"
+        conditions.eventually {
+            def rescheduled = workflowExecutionService.getExecutionStatus(wfId, true)
+                    .tasks.find { it.status == Task.Status.SCHEDULED }
+            assert rescheduled != null
+            assert rescheduled.callbackAfterSeconds == 2
+        }
+
+        when: "Fail the task again (retry 1 — raw = 4 s, above cap)"
+        workflowExecutionService.updateTask(failedResult(pollUntilAvailable()))
+
+        then: "Rescheduled task (retry 1) has callbackAfterSeconds = 3 (capped from 4 s)"
+        conditions.eventually {
+            def rescheduled = workflowExecutionService.getExecutionStatus(wfId, true)
+                    .tasks.findAll { it.status == Task.Status.SCHEDULED }.last()
+            assert rescheduled != null
+            assert rescheduled.callbackAfterSeconds == 3
+        }
+    }
+
+    def "Linear backoff delay is capped by maxRetryDelaySeconds"() {
+        given: "A task def with linear backoff (scale=2), base delay 2 s, cap 5 s"
+        // retry 0: 2 * 2 * 1 = 4 s (below cap 5 s); retry 1: 2 * 2 * 2 = 8 s → capped to 5 s
+        def taskDef = new TaskDef()
+        taskDef.name = TASK_NAME
+        taskDef.retryCount = 5
+        taskDef.retryDelaySeconds = 2
+        taskDef.retryLogic = TaskDef.RetryLogic.LINEAR_BACKOFF
+        taskDef.backoffScaleFactor = 2
+        taskDef.maxRetryDelaySeconds = 5
+        taskDef.timeoutSeconds = 3600
+        taskDef.responseTimeoutSeconds = 3600
+        metadataService.registerTaskDef([taskDef])
+
+        when: "Start the workflow and fail the task (retry 0 — raw = 4 s, below cap)"
+        def wfId = startWorkflow(WORKFLOW_NAME, 1, 'retry-cap-lin', [:], null)
+        workflowExecutionService.updateTask(failedResult(pollUntilAvailable()))
+
+        then: "Rescheduled task has callbackAfterSeconds = 4 (below cap)"
+        conditions.eventually {
+            def rescheduled = workflowExecutionService.getExecutionStatus(wfId, true)
+                    .tasks.find { it.status == Task.Status.SCHEDULED }
+            assert rescheduled?.callbackAfterSeconds == 4
+        }
+
+        when: "Fail the task again (retry 1 — raw = 8 s, above cap)"
+        workflowExecutionService.updateTask(failedResult(pollUntilAvailable()))
+
+        then: "Rescheduled task has callbackAfterSeconds = 5 (capped from 8 s)"
+        conditions.eventually {
+            def rescheduled = workflowExecutionService.getExecutionStatus(wfId, true)
+                    .tasks.findAll { it.status == Task.Status.SCHEDULED }.last()
+            assert rescheduled?.callbackAfterSeconds == 5
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // backoffJitterMs
+    // -------------------------------------------------------------------------
+
+    def "backoffJitterMs adds a random offset in [0, maxJitterMs] to the retry delay"() {
+        given: "A task def with fixed retry (60 s) and 5000 ms of jitter"
+        def taskDef = new TaskDef()
+        taskDef.name = TASK_NAME
+        taskDef.retryCount = 3
+        taskDef.retryDelaySeconds = 60
+        taskDef.retryLogic = TaskDef.RetryLogic.FIXED
+        taskDef.backoffJitterMs = 5000
+        taskDef.timeoutSeconds = 3600
+        taskDef.responseTimeoutSeconds = 3600
+        metadataService.registerTaskDef([taskDef])
+
+        when: "Start the workflow and fail the task once"
+        def wfId = startWorkflow(WORKFLOW_NAME, 1, 'jitter-test', [:], null)
+        workflowExecutionService.updateTask(failedResult(pollUntilAvailable()))
+
+        then: "callbackAfterSeconds stays at the base delay (60)"
+        and: "callbackAfterMs on the TaskModel is in [60_000, 65_000] — base + up to maxJitterMs"
+        conditions.eventually {
+            def rescheduled = workflowExecutionService.getExecutionStatus(wfId, true)
+                    .tasks.find { it.status == Task.Status.SCHEDULED }
+            assert rescheduled != null
+            assert rescheduled.callbackAfterSeconds == 60
+            def taskModel = executionDAOFacade.getTaskModel(rescheduled.taskId)
+            assert taskModel.callbackAfterMs >= 60_000
+            assert taskModel.callbackAfterMs <= 65_000
+        }
+    }
+
+    def "backoffJitterMs of zero produces no jitter — callbackAfterMs equals base delay exactly"() {
+        given: "A task def with zero jitter"
+        def taskDef = new TaskDef()
+        taskDef.name = TASK_NAME
+        taskDef.retryCount = 3
+        taskDef.retryDelaySeconds = 30
+        taskDef.retryLogic = TaskDef.RetryLogic.FIXED
+        taskDef.backoffJitterMs = 0
+        taskDef.timeoutSeconds = 3600
+        taskDef.responseTimeoutSeconds = 3600
+        metadataService.registerTaskDef([taskDef])
+
+        when:
+        def wfId = startWorkflow(WORKFLOW_NAME, 1, 'no-jitter-test', [:], null)
+        workflowExecutionService.updateTask(failedResult(pollUntilAvailable()))
+
+        then: "callbackAfterMs is exactly 30_000 (no jitter added)"
+        conditions.eventually {
+            def rescheduled = workflowExecutionService.getExecutionStatus(wfId, true)
+                    .tasks.find { it.status == Task.Status.SCHEDULED }
+            assert rescheduled != null
+            def taskModel = executionDAOFacade.getTaskModel(rescheduled.taskId)
+            assert taskModel.callbackAfterMs == 30_000
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // cap + jitter combined
+    // -------------------------------------------------------------------------
+
+    def "Cap is applied before jitter — callbackAfterMs is in [cap_ms, cap_ms + maxJitterMs]"() {
+        given: "Exponential backoff: base=2s, cap=3s, jitter up to 2000ms"
+        // retry 0: raw=2s, below cap; retry 1: raw=4s → capped to 3s; callbackAfterMs in [3000, 5000]
+        def taskDef = new TaskDef()
+        taskDef.name = TASK_NAME
+        taskDef.retryCount = 5
+        taskDef.retryDelaySeconds = 2
+        taskDef.retryLogic = TaskDef.RetryLogic.EXPONENTIAL_BACKOFF
+        taskDef.maxRetryDelaySeconds = 3
+        taskDef.backoffJitterMs = 2000
+        taskDef.timeoutSeconds = 3600
+        taskDef.responseTimeoutSeconds = 3600
+        metadataService.registerTaskDef([taskDef])
+
+        when: "Start workflow and fail the task (retry 0 — raw=2s, below cap)"
+        def wfId = startWorkflow(WORKFLOW_NAME, 1, 'cap-jitter-test', [:], null)
+        workflowExecutionService.updateTask(failedResult(pollUntilAvailable()))
+
+        // wait for retry 0 to be rescheduled before polling again
+        conditions.eventually {
+            assert workflowExecutionService.getExecutionStatus(wfId, true)
+                    .tasks.find { it.status == Task.Status.SCHEDULED } != null
+        }
+
+        and: "Fail again (retry 1 — raw=4s → capped to 3s)"
+        workflowExecutionService.updateTask(failedResult(pollUntilAvailable()))
+
+        then: "callbackAfterSeconds = 3 (the cap) and callbackAfterMs is in [3_000, 5_000]"
+        conditions.eventually {
+            def rescheduled = workflowExecutionService.getExecutionStatus(wfId, true)
+                    .tasks.findAll { it.status == Task.Status.SCHEDULED }.last()
+            assert rescheduled != null
+            assert rescheduled.callbackAfterSeconds == 3
+            def taskModel = executionDAOFacade.getTaskModel(rescheduled.taskId)
+            assert taskModel.callbackAfterMs >= 3_000
+            assert taskModel.callbackAfterMs <= 5_000
+        }
+    }
+}


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----


  - computePostpone (workflow sweeper): SCHEDULED tasks did not subtract elapsed time since scheduling when computing the next sweep delay — the full pollTimeoutSeconds was used instead of the remaining window. Similarly, when taskDef.responseTimeoutSeconds=0 the task model's responseTimeoutSeconds was silently ignored.

 - maxRetryDelaySeconds — cap on per-retry delay
  Adds a configurable ceiling on the computed backoff delay. Exponential/linear backoff grows unboundedly today; with maxRetryDelaySeconds=300 it caps at 5 minutes regardless of retry count or backoff factor.

 - backoffJitterMs — random spread to prevent thundering herd
  Adds a random [0, maxJitterMs] millisecond offset to every retry delay regardless of retry logic type. When many tasks fail simultaneously (e.g. downstream outage), without jitter all
  workers retry at the same instants and re-hammer the service together. Uses the Duration overload of queueDAO.push for sub-second precision through to the Redis sorted-set score.

 - totalTimeoutSeconds — hard wall-clock budget across all attempts

-  Poll gap fix (setUnackTimeoutIfShorter)
  When a task transitions SCHEDULED → IN_PROGRESS, the decider queue entry kept the old poll-timeout-based postpone. If responseTimeoutSeconds < pollTimeoutSeconds, the sweeper would fire
  too late and miss the response deadline. ExecutionService.poll() now calls setUnackTimeoutIfShorter with responseTimeoutSeconds to advance the sweep without risk of pushing it out further
  (other tasks with shorter remaining timeouts are preserved).


_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
