### PR TITLE
fix: prevent DO_WHILE horizontal overlap inside FORK_JOIN

### DIFF
--- a/ui-next/src/components/features/flow/nodes/mapper/doWhile.ts
+++ b/ui-next/src/components/features/flow/nodes/mapper/doWhile.ts
@@ -7,6 +7,13 @@ import { taskToNode } from "./common";
 import { DoWhileTaskDef, Crumb, CommonTaskDef } from "types";
 import { NodeData, EdgeData } from "reaflow";
 
+// When DO_WHILE has children ELK treats it as a compound node and computes its
+// width from children + horizontal nodePadding. Without this, ELK allocates
+// ~450px (50+350+50) while the visual card enforces minWidth:570px, causing
+// 120px of horizontal overflow and overlap with adjacent fork branches.
+const DO_WHILE_ELK_HORIZONTAL_PADDING = 110; // (570_min_width - 350_default_child) / 2
+const DO_WHILE_ELK_DEFAULT_VERTICAL_PADDING = 50; // keep reaflow default
+
 type DoWhileTaskDefWithMaybeExecutionData = DoWhileTaskDef & {
   executionData?: any;
 };
@@ -50,11 +57,19 @@ export const processDoWhile = async (
   const nodeMapper: (nodes: NodeData[]) => NodeData[] =
     executionData == null ? maybeAddPortsToWhileNodes : _identity;
 
+  const doWhileNode: NodeData = {
+    ...(taskToNode(doWhileTask as CommonTaskDef, crumbs) as NodeData),
+    nodePadding: [
+      DO_WHILE_ELK_DEFAULT_VERTICAL_PADDING,
+      DO_WHILE_ELK_HORIZONTAL_PADDING,
+      DO_WHILE_ELK_DEFAULT_VERTICAL_PADDING,
+      DO_WHILE_ELK_HORIZONTAL_PADDING,
+    ] as [number, number, number, number],
+  };
+
   return {
     // TODO Fix when importing the sdk
-    nodes: [
-      taskToNode(doWhileTask as CommonTaskDef, crumbs) as NodeData,
-    ].concat(
+    nodes: [doWhileNode].concat(
       nodeMapper(loopOverNodesEdges!.nodes!).map((t) =>
         _isNil(t.parent)
           ? {

--- a/ui-next/src/components/features/flow/theme.ts
+++ b/ui-next/src/components/features/flow/theme.ts
@@ -4,6 +4,7 @@ import { colors } from "theme/tokens/variables";
 const DEFAULT_NODE_WIDTH = 350;
 const DEFAULT_NODE_HEIGHT = 100;
 const DO_WHILE_PADDING = 30;
+export const DO_WHILE_MIN_WIDTH = 570;
 
 export const getFlowTheme = (mode = "light") => ({
   nodeTypes: {
@@ -13,7 +14,7 @@ export const getFlowTheme = (mode = "light") => ({
     },
     [TaskType.DO_WHILE]: {
       padding: DO_WHILE_PADDING,
-      width: DEFAULT_NODE_WIDTH + DO_WHILE_PADDING * 2,
+      width: DO_WHILE_MIN_WIDTH,
       height: 450,
       itemHeight: 150,
     },


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
### fix: prevent DO_WHILE horizontal overlap inside FORK_JOIN
- [x] Increased `DO_WHILE` min width from 410px to 570px in `theme.ts` to prevent overlap when the container has no children

- [x] Set explicit ELK `nodePadding` (110px horizontal, 50px vertical) on DO_WHILE compound nodes in `doWhile.ts` to prevent overlap when children are present

## Screenshots
| Before | After |
|--------|--------|
| <img width="702" height="649" alt="Screenshot 2026-04-20 at 12 49 38 PM" src="https://github.com/user-attachments/assets/f11a56ad-b5db-4b85-9ee6-5a06e55bc95a" /> | <img width="857" height="644" alt="Screenshot 2026-04-20 at 12 49 14 PM" src="https://github.com/user-attachments/assets/b8d5bc2e-6f8f-45b1-bbe0-60f31dc52d57" /> |
| <img width="691" height="553" alt="Screenshot 2026-04-20 at 12 49 52 PM" src="https://github.com/user-attachments/assets/2f65766d-f32d-4cfc-a7a7-4406548dcb5f" /> | <img width="767" height="587" alt="Screenshot 2026-04-20 at 12 50 46 PM" src="https://github.com/user-attachments/assets/73a7e82d-c92e-4f54-8a81-672caa628c67" /> | 