### PR TITLE
Fix flaky tests on test-harness

### DIFF
--- a/e2e/src/test/java/io/conductor/e2e/workflow/WorkflowRerunTests.java
+++ b/e2e/src/test/java/io/conductor/e2e/workflow/WorkflowRerunTests.java
@@ -239,7 +239,7 @@ public class WorkflowRerunTests {
         assertEquals(Workflow.WorkflowStatus.COMPLETED, subWorkflow.getStatus());
 
         await().pollInterval(Duration.ofSeconds(1))
-                .atMost(Duration.ofSeconds(5))
+                .atMost(Duration.ofSeconds(30))
                 .untilAsserted(
                         () -> {
                             Workflow workflow1 = workflowClient.getWorkflow(workflowId, true);

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/HierarchicalForkJoinSubworkflowRestartSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/HierarchicalForkJoinSubworkflowRestartSpec.groovy
@@ -382,11 +382,19 @@ class HierarchicalForkJoinSubworkflowRestartSpec extends AbstractSpecification {
             tasks[1].status == Task.Status.COMPLETED
         }
 
-        when: "the mid level and root workflows are 'decided'"
+        when: "the mid level and root workflows are sweeped"
         sweep(midLevelWorkflowId)
         sweep(rootWorkflowId)
 
-        and: "JOIN tasks are executed"
+        then: "wait for mid-level SUB_WORKFLOW task to reflect the completed leaf before executing JOINs"
+        // Leaf completion propagates to the parent SUB_WORKFLOW task asynchronously;
+        // the explicit sweeps above are not sufficient on their own.
+        await().atMost(10, TimeUnit.SECONDS).until {
+            workflowExecutionService.getExecutionStatus(midLevelWorkflowId, true)
+                    .getTaskByRefName('st1').status == Task.Status.COMPLETED
+        }
+
+        when: "JOIN tasks are executed"
         asyncSystemTaskExecutor.execute(joinTask, midJoinId)
         asyncSystemTaskExecutor.execute(joinTask, rootJoinId)
 

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/SimpleWorkflowSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/SimpleWorkflowSpec.groovy
@@ -12,6 +12,8 @@
  */
 package com.netflix.conductor.test.integration
 
+import java.util.concurrent.TimeUnit
+
 import org.apache.commons.lang3.StringUtils
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -30,6 +32,8 @@ import com.netflix.conductor.test.base.AbstractSpecification
 import spock.lang.Shared
 
 import static com.netflix.conductor.test.util.WorkflowTestUtil.verifyPolledAndAcknowledgedTask
+
+import static org.awaitility.Awaitility.await
 
 class SimpleWorkflowSpec extends AbstractSpecification {
 
@@ -268,7 +272,8 @@ class SimpleWorkflowSpec extends AbstractSpecification {
         workflowExecutor.decide(workflowInstanceId)
 
         then: "Expect a new task to be added to the queue in place of the timed out task"
-        queueDAO.getSize('task_rt') == 1
+        // Background sweeper/timer threads may briefly produce an extra queue entry; wait to settle.
+        await().atMost(5, TimeUnit.SECONDS).until { queueDAO.getSize('task_rt') == 1 }
         with(workflowExecutionService.getExecutionStatus(workflowInstanceId, true)) {
             status == Workflow.WorkflowStatus.RUNNING
             tasks.size() == 2

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/util/WorkflowTestUtil.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/util/WorkflowTestUtil.groovy
@@ -185,9 +185,14 @@ class WorkflowTestUtil {
             int version = Integer.parseInt(StringUtils.substringAfter(workflowWithVersion, ":"))
             List<String> running = workflowExecutionService.getRunningWorkflows(workflowName, version)
             for (String workflowId : running) {
-                WorkflowModel workflow = workflowExecutor.getWorkflow(workflowId, false)
-                if (!workflow.getStatus().isTerminal()) {
-                    workflowExecutor.terminateWorkflow(workflowId, "cleanup")
+                try {
+                    WorkflowModel workflow = workflowExecutor.getWorkflow(workflowId, false)
+                    if (!workflow.getStatus().isTerminal()) {
+                        workflowExecutor.terminateWorkflow(workflowId, "cleanup")
+                    }
+                } catch (Exception e) {
+                    // payload may be missing from external storage; force-terminate to unblock cleanup
+                    try { workflowExecutor.terminateWorkflow(workflowId, "cleanup") } catch (Exception ignored) {}
                 }
             }
         }


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [x] Other (please describe): Fix existing flaky tests

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

Four independent flaky test fixes, each in its own commit.

**`WorkflowAndTaskConfigurationSpec` — NPE in cleanup** (`eb23d1f8`): `WorkflowTestUtil.clearWorkflows` would throw a `NullPointerException` when `ExternalPayloadStorageUtils.downloadPayload` received a `null` stream from `MockExternalPayloadStorage` for a missing payload path. This caused `cleanup()` to abort mid-loop, leaving stale tasks in the queue that poisoned subsequent tests. Fixed by making `downloadPayload` throw a clear `NonTransientException` on null streams, and wrapping each workflow termination in `clearWorkflows` with a try-catch so one bad workflow doesn't block the rest.

**`HierarchicalForkJoinSubworkflowRestartSpec > mid-level restart`** (`0caafe1`): After a mid-level workflow restart and leaf completion, the parent's `SUB_WORKFLOW` task transitions to `COMPLETED` asynchronously. The test asserted `COMPLETED` immediately after `sweep()`, which is not a synchronous barrier for sub-workflow propagation. Fixed by adding `await().atMost(10s)` before executing the JOIN tasks — the same pattern already in place in the sibling "leaf restart" test.

**`SimpleWorkflowSpec > response timeout`** (`fab6013`): Background system task worker threads can briefly produce a second `task_rt` queue entry during response-timeout processing, making `queueDAO.getSize('task_rt') == 1` transiently fail with `2`. Fixed by wrapping the assertion in `await().atMost(5s)`.

**`WorkflowRerunTests > Check workflow with sub_workflow task and rerun functionality`** (`cde5dd68`): After completing the sub-workflow, the parent workflow's `SUB_WORKFLOW` task update and decide happen asynchronously. The 5-second `await` timeout was too tight for CI environments under load. Bumped to 30 seconds.

Issue #1039 

Alternatives considered
----

**Case 1 (NPE)**: Adding a null-check only in `ExternalPayloadStorageUtils` without fixing `MockExternalPayloadStorage` would mask the contract violation rather than surface it clearly. Alternatively, fixing `MockExternalPayloadStorage.download()` to throw on missing file (aligning with S3/Azure/GCS impls) was considered — either approach works; the chosen fix addresses both the crash site and the loop isolation.

**Case 2 (mid-level restart)**: Retrying `assertWorkflowIsCompleted` via `await()` directly on the final assertion was considered, but it's less precise — it would mask other causes of failure. Waiting specifically for `st1.status == COMPLETED` before executing JOINs is the minimal, targeted condition.

**Case 3 (queue size)**: Adding a `Thread.sleep` before the assertion was rejected as fragile. `await()` polls actively and terminates as soon as the condition is met, making the test both correct and fast on non-flaky runs.

**Case 4 (rerun timeout)**: A longer `Thread.sleep` before the assertion was considered but rejected. Increasing the `atMost` ceiling while keeping the 1-second poll interval is the right tradeoff — fast on a healthy server, resilient on a loaded CI runner.

