### PR TITLE
fix(docker): don't pass -DCONDUCTOR_CONFIG_FILE when CONFIG_PROP is unset (#1041)

### DIFF
--- a/docker/server/bin/startup.sh
+++ b/docker/server/bin/startup.sh
@@ -24,17 +24,21 @@ nginx
 cd /app/libs
 echo "Property file: $CONFIG_PROP"
 echo $CONFIG_PROP
-export config_file=
 
-if [ -z "$CONFIG_PROP" ];
-  then
-    echo "Using default configuration file";
-    export config_file=/app/config/config.properties
-  else
-    echo "Using '$CONFIG_PROP'";
-    export config_file=/app/config/$CONFIG_PROP
-fi
-
+# Only pass -DCONDUCTOR_CONFIG_FILE when the operator explicitly set
+# $CONFIG_PROP. The bundled /app/config/config.properties ships with
+# everything commented out, so passing it suppresses the JAR's built-in
+# defaults (SQLite persistence + in-memory queues) and the server fails
+# to initialize on `docker run conductoross/conductor:latest` with no
+# overrides. Letting the flag fall off matches the CLI path
+# (`conductor server start`) which relies on the JAR defaults too.
+# See https://github.com/conductor-oss/conductor/issues/1041.
 echo "Using java options config: $JAVA_OPTS"
 
-java ${JAVA_OPTS} -jar -DCONDUCTOR_CONFIG_FILE=$config_file conductor-server.jar 2>&1 | tee -a /app/logs/server.log
+if [ -z "$CONFIG_PROP" ]; then
+  echo "No CONFIG_PROP supplied — using JAR built-in defaults"
+  java ${JAVA_OPTS} -jar conductor-server.jar 2>&1 | tee -a /app/logs/server.log
+else
+  echo "Using '$CONFIG_PROP'"
+  java ${JAVA_OPTS} -jar -DCONDUCTOR_CONFIG_FILE=/app/config/$CONFIG_PROP conductor-server.jar 2>&1 | tee -a /app/logs/server.log
+fi


### PR DESCRIPTION
## Summary

\`docker/server/bin/startup.sh\` fell through to \`/app/config/config.properties\` whenever \`CONFIG_PROP\` was empty, and then passed that file to the JVM as \`-DCONDUCTOR_CONFIG_FILE\`. The bundled \`config.properties\` ships with everything commented out, so the empty file overrode the JAR's built-in defaults and the server failed to initialize on a plain:

\`\`\`
docker run -p 8080:8080 conductoross/conductor:latest
\`\`\`

The CLI path (\`conductor server start\`) doesn't pass \`-DCONDUCTOR_CONFIG_FILE\` at all, so the JAR's SQLite persistence + in-memory queues defaults apply and the server comes up cleanly.

## Fix

Swap the branches so the default path drops \`-DCONDUCTOR_CONFIG_FILE\` entirely — matching the CLI behaviour. Any user-provided \`CONFIG_PROP\` still maps to \`/app/config/\$CONFIG_PROP\` exactly as before, and \`JAVA_OPTS\` continues to forward.

Fixes #1041

## Test plan

- [x] \`sh -n docker/server/bin/startup.sh\` — clean
- [x] Traced both branches by hand: \`CONFIG_PROP=\`→ JAR defaults apply; \`CONFIG_PROP=foo.properties\`→ path resolves to \`/app/config/foo.properties\` as before.