### PR TITLE
Remove Spring AI provider SDKs and add native tools

### DIFF
--- a/ai/README.md
+++ b/ai/README.md
@@ -80,6 +80,13 @@ Multi-turn conversational AI with support for tool calling.
 | `topP` | Number | ❌ | Nucleus sampling parameter |
 | `stopSequences` | Array | ❌ | Sequences that stop generation |
 | `tools` | Array | ❌ | Tool definitions for function calling |
+| `webSearch` | Boolean | ❌ | Enable provider-native web search (OpenAI, Anthropic, Gemini) |
+| `codeInterpreter` | Boolean | ❌ | Enable sandboxed code execution (OpenAI, Anthropic, Gemini) |
+| `fileSearchVectorStoreIds` | Array | ❌ | Vector store IDs for OpenAI file search |
+| `thinkingTokenLimit` | Integer | ❌ | Token budget for extended thinking (Anthropic, Gemini) |
+| `reasoningEffort` | String | ❌ | Reasoning effort: `low`, `medium`, `high` (OpenAI) |
+| `googleSearchRetrieval` | Boolean | ❌ | Enable Google Search grounding (Gemini only) |
+| `previousResponseId` | String | ❌ | Chain multi-turn conversations without resending history (OpenAI/Azure) |
 
 **Outputs:**
 

--- a/ai/build.gradle
+++ b/ai/build.gradle
@@ -16,19 +16,12 @@ dependencies {
     api "org.springframework.ai:spring-ai-commons:${revSpringAI}"
     api "org.springframework.ai:spring-ai-model:${revSpringAI}"
     api "org.springframework.ai:spring-ai-client-chat:${revSpringAI}"
-    api "org.springframework.ai:spring-ai-openai:${revSpringAI}"
-    api "org.springframework.ai:spring-ai-openai-sdk:${revSpringAI}"
-    api "org.springframework.ai:spring-ai-anthropic:${revSpringAI}"
     api "org.springframework.ai:spring-ai-mistral-ai:${revSpringAI}"
     api "org.springframework.ai:spring-ai-huggingface:${revSpringAI}"
-    api "org.springframework.ai:spring-ai-coherence-store:${revSpringAI}"
-    api "org.springframework.ai:spring-ai-vertex-ai-gemini:${revSpringAI}"
-    api "org.springframework.ai:spring-ai-google-genai:${revSpringAI}"
     api "org.springframework.ai:spring-ai-bedrock-converse:${revSpringAI}"
-    api "org.springframework.ai:spring-ai-vertex-ai-embedding:${revSpringAI}"
-    api "org.springframework.ai:spring-ai-azure-openai:${revSpringAI}"
     api "org.springframework.ai:spring-ai-ollama:${revSpringAI}"
-    api "com.google.genai:google-genai:1.18.0"
+
+    api "com.google.genai:google-genai:1.28.0"
     api "com.networknt:json-schema-validator:${revJSonSchemaValidator}"
 
     api("io.modelcontextprotocol.sdk:mcp-core:${revMCP}")

--- a/ai/examples/17-web-search.json
+++ b/ai/examples/17-web-search.json
@@ -1,0 +1,34 @@
+{
+  "name": "web_search_workflow",
+  "description": "Chat completion with built-in web search — the LLM can search the web for real-time information",
+  "version": 1,
+  "schemaVersion": 2,
+  "inputParameters": ["question"],
+  "tasks": [
+    {
+      "name": "web_search_chat",
+      "taskReferenceName": "chat",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "openai",
+        "model": "gpt-4o-mini",
+        "messages": [
+          {
+            "role": "system",
+            "message": "You are a helpful research assistant. Use web search to find current information."
+          },
+          {
+            "role": "user",
+            "message": "${workflow.input.question}"
+          }
+        ],
+        "webSearch": true,
+        "temperature": 0.3,
+        "maxTokens": 1000
+      }
+    }
+  ],
+  "outputParameters": {
+    "answer": "${chat.output.result}"
+  }
+}

--- a/ai/examples/18-code-execution.json
+++ b/ai/examples/18-code-execution.json
@@ -1,0 +1,34 @@
+{
+  "name": "code_execution_workflow",
+  "description": "Chat completion with built-in code execution — the LLM can write and run code in a sandbox",
+  "version": 1,
+  "schemaVersion": 2,
+  "inputParameters": ["task"],
+  "tasks": [
+    {
+      "name": "code_execution_chat",
+      "taskReferenceName": "chat",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "google_gemini",
+        "model": "gemini-2.5-flash",
+        "messages": [
+          {
+            "role": "system",
+            "message": "You are a data analyst. Use code execution to compute results, generate charts, and analyze data."
+          },
+          {
+            "role": "user",
+            "message": "${workflow.input.task}"
+          }
+        ],
+        "codeInterpreter": true,
+        "temperature": 0.2,
+        "maxTokens": 2000
+      }
+    }
+  ],
+  "outputParameters": {
+    "result": "${chat.output.result}"
+  }
+}

--- a/ai/examples/19-coding-agent.json
+++ b/ai/examples/19-coding-agent.json
@@ -1,0 +1,78 @@
+{
+  "name": "coding_agent",
+  "description": "A coding agent that uses OpenAI code_interpreter to write, run, and iterate on code",
+  "version": 1,
+  "schemaVersion": 2,
+  "inputParameters": ["task"],
+  "tasks": [
+    {
+      "name": "plan_implementation",
+      "taskReferenceName": "plan",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "openai",
+        "model": "gpt-4o",
+        "messages": [
+          {
+            "role": "system",
+            "message": "You are a senior software engineer. Break down the coding task into clear steps. Output a numbered plan."
+          },
+          {
+            "role": "user",
+            "message": "${workflow.input.task}"
+          }
+        ],
+        "temperature": 0.2,
+        "maxTokens": 1000
+      }
+    },
+    {
+      "name": "write_and_run_code",
+      "taskReferenceName": "code",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "openai",
+        "model": "gpt-4o",
+        "messages": [
+          {
+            "role": "system",
+            "message": "You are a coding assistant with access to a code execution sandbox. Write the code, run it, verify the output, and fix any errors. Return the final working code and its output."
+          },
+          {
+            "role": "user",
+            "message": "Implementation plan:\n${plan.output.result}\n\nOriginal task: ${workflow.input.task}\n\nWrite the code, execute it, and return the working result."
+          }
+        ],
+        "codeInterpreter": true,
+        "temperature": 0.1,
+        "maxTokens": 4000
+      }
+    },
+    {
+      "name": "review_code",
+      "taskReferenceName": "review",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "openai",
+        "model": "gpt-4o-mini",
+        "messages": [
+          {
+            "role": "system",
+            "message": "You are a code reviewer. Review the implementation for correctness, edge cases, and code quality. Provide a brief summary of what was built and any suggestions."
+          },
+          {
+            "role": "user",
+            "message": "Task: ${workflow.input.task}\n\nImplementation:\n${code.output.result}"
+          }
+        ],
+        "temperature": 0.3,
+        "maxTokens": 1000
+      }
+    }
+  ],
+  "outputParameters": {
+    "plan": "${plan.output.result}",
+    "code": "${code.output.result}",
+    "review": "${review.output.result}"
+  }
+}

--- a/ai/examples/20-extended-thinking.json
+++ b/ai/examples/20-extended-thinking.json
@@ -1,0 +1,29 @@
+{
+  "name": "extended_thinking_workflow",
+  "description": "Chat completion with extended thinking — gives the LLM a token budget for step-by-step reasoning",
+  "version": 1,
+  "schemaVersion": 2,
+  "inputParameters": ["problem"],
+  "tasks": [
+    {
+      "name": "think_deeply",
+      "taskReferenceName": "think",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "anthropic",
+        "model": "claude-sonnet-4-20250514",
+        "messages": [
+          {
+            "role": "user",
+            "message": "${workflow.input.problem}"
+          }
+        ],
+        "thinkingTokenLimit": 10000,
+        "maxTokens": 16000
+      }
+    }
+  ],
+  "outputParameters": {
+    "answer": "${think.output.result}"
+  }
+}

--- a/ai/examples/21-web-search-research-agent.json
+++ b/ai/examples/21-web-search-research-agent.json
@@ -1,0 +1,70 @@
+{
+  "name": "web_research_agent",
+  "description": "An autonomous research agent that uses web search to gather information and synthesize a report",
+  "version": 1,
+  "schemaVersion": 2,
+  "inputParameters": ["topic"],
+  "tasks": [
+    {
+      "name": "gather_information",
+      "taskReferenceName": "research",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "openai",
+        "model": "gpt-4o",
+        "messages": [
+          {
+            "role": "system",
+            "message": "You are a research analyst. Use web search to find comprehensive, current information about the topic. Search for multiple perspectives and recent developments."
+          },
+          {
+            "role": "user",
+            "message": "Research this topic thoroughly: ${workflow.input.topic}"
+          }
+        ],
+        "webSearch": true,
+        "temperature": 0.3,
+        "maxTokens": 3000
+      }
+    },
+    {
+      "name": "synthesize_report",
+      "taskReferenceName": "report",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "anthropic",
+        "model": "claude-sonnet-4-20250514",
+        "messages": [
+          {
+            "role": "system",
+            "message": "You are a technical writer. Synthesize the research into a well-structured markdown report with sections, key findings, and citations."
+          },
+          {
+            "role": "user",
+            "message": "Topic: ${workflow.input.topic}\n\nResearch findings:\n${research.output.result}\n\nWrite a comprehensive report in markdown format."
+          }
+        ],
+        "thinkingTokenLimit": 5000,
+        "maxTokens": 8000
+      }
+    },
+    {
+      "name": "convert_to_pdf",
+      "taskReferenceName": "pdf",
+      "type": "GENERATE_PDF",
+      "inputParameters": {
+        "markdown": "${report.output.result}",
+        "pageSize": "A4",
+        "theme": "default",
+        "pdfMetadata": {
+          "title": "${workflow.input.topic}",
+          "author": "Conductor Research Agent"
+        }
+      }
+    }
+  ],
+  "outputParameters": {
+    "report": "${report.output.result}",
+    "pdf": "${pdf.output.result.location}"
+  }
+}

--- a/ai/examples/22-multi-turn-chain.json
+++ b/ai/examples/22-multi-turn-chain.json
@@ -1,0 +1,52 @@
+{
+  "name": "multi_turn_chain",
+  "description": "Two-step conversation using previousResponseId to avoid resending history",
+  "version": 1,
+  "schemaVersion": 2,
+  "inputParameters": ["topic"],
+  "tasks": [
+    {
+      "name": "first_turn",
+      "taskReferenceName": "turn1",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "openai",
+        "model": "gpt-4o",
+        "messages": [
+          {
+            "role": "system",
+            "message": "You are a technical architect. Be concise."
+          },
+          {
+            "role": "user",
+            "message": "Design a high-level architecture for: ${workflow.input.topic}"
+          }
+        ],
+        "temperature": 0.3,
+        "maxTokens": 2000
+      }
+    },
+    {
+      "name": "follow_up",
+      "taskReferenceName": "turn2",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "openai",
+        "model": "gpt-4o",
+        "messages": [
+          {
+            "role": "user",
+            "message": "Now list the key risks and mitigations for this architecture."
+          }
+        ],
+        "previousResponseId": "${turn1.output.responseId}",
+        "temperature": 0.3,
+        "maxTokens": 2000
+      }
+    }
+  ],
+  "outputParameters": {
+    "architecture": "${turn1.output.result}",
+    "risks": "${turn2.output.result}"
+  }
+}

--- a/ai/examples/README.md
+++ b/ai/examples/README.md
@@ -15,22 +15,24 @@ Ensure Conductor is running with AI integrations enabled:
 
 ### 2. Configure AI Providers
 
-Add the following to your conductor server configuration file:
+Set environment variables before starting the server:
 
-```properties
-# Enable AI integrations
-conductor.integrations.ai.enabled=true
-
+```bash
 # OpenAI (required for most examples)
-conductor.ai.openai.apiKey=sk-your-openai-api-key
+export OPENAI_API_KEY=sk-your-openai-api-key
 
 # Anthropic (optional, for RAG examples)
-conductor.ai.anthropic.apiKey=sk-ant-your-anthropic-key
+export ANTHROPIC_API_KEY=sk-ant-your-anthropic-key
 
-# Google Vertex AI (optional, for Gemini/Veo video examples)
-conductor.ai.gemini.project-id=your-gcp-project
-conductor.ai.gemini.location=us-central1
+# Google Gemini (optional, for Gemini/Veo examples)
+# Option 1: API key (simplest)
+export GEMINI_API_KEY=your-gemini-api-key
+# Option 2: Vertex AI — set project and location in application.properties
+```
 
+For vector database examples, add to `application.properties`:
+
+```properties
 # PostgreSQL Vector DB (for RAG/embedding examples)
 conductor.vectordb.instances[0].name=postgres-prod
 conductor.vectordb.instances[0].type=postgres
@@ -40,16 +42,16 @@ conductor.vectordb.instances[0].postgres.password=secret
 conductor.vectordb.instances[0].postgres.dimensions=1536
 ```
 
-### 3. MCP Weather Server (for MCP examples)
+### 3. MCP Test Server (for MCP examples)
 
-Install and start the MCP weather server:
+Install and start the MCP test server:
 
 ```bash
-# Install the MCP weather server
-pip install mcp-server-fetch
+# Install mcp-testkit — a test MCP server with 65 deterministic tools
+pip install mcp-testkit
 
-# Start the server in streamable HTTP mode
-python3 -m mcp_server_fetch --mode streamable-http --host localhost --port 3001 --stateless
+# Start the server in HTTP mode
+mcp-testkit --transport http
 ```
 
 The server will be available at `http://localhost:3001/mcp`.
@@ -76,6 +78,12 @@ The server will be available at `http://localhost:3001/mcp`.
 | `14-stabilityai-image.json` | Image generation with Stability AI (SD3.5) | Stability AI |
 | `15-pdf-generation.json` | Generate PDF from markdown content | None (built-in) |
 | `16-llm-to-pdf-pipeline.json` | LLM generates report → convert to PDF | OpenAI |
+| `17-web-search.json` | Chat with built-in web search for real-time info | OpenAI |
+| `18-code-execution.json` | Chat with built-in code execution sandbox | Google Gemini |
+| `19-coding-agent.json` | Coding agent: plan → write & run code → review | OpenAI |
+| `20-extended-thinking.json` | Extended thinking with token budget for reasoning | Anthropic |
+| `21-web-search-research-agent.json` | Research agent: web search → synthesize → PDF | OpenAI, Anthropic |
+| `22-multi-turn-chain.json` | Multi-turn conversation chaining with previousResponseId | OpenAI |
 
 ---
 
@@ -346,6 +354,90 @@ curl -X POST 'http://localhost:8080/api/workflow/llm_to_pdf_pipeline' \
   -d '{"topic": "Cloud Migration Best Practices", "audience": "CTO and engineering leadership"}'
 ```
 
+### 17. Web Search
+
+```bash
+# Register
+curl -X POST 'http://localhost:8080/api/metadata/workflow' \
+  -H 'Content-Type: application/json' \
+  -d @17-web-search.json
+
+# Execute with a question about current events
+curl -X POST 'http://localhost:8080/api/workflow/web_search_workflow' \
+  -H 'Content-Type: application/json' \
+  -d '{"question": "What are the latest developments in AI regulation?"}'
+```
+
+### 18. Code Execution
+
+```bash
+# Register
+curl -X POST 'http://localhost:8080/api/metadata/workflow' \
+  -H 'Content-Type: application/json' \
+  -d @18-code-execution.json
+
+# Execute with a data analysis task
+curl -X POST 'http://localhost:8080/api/workflow/code_execution_workflow' \
+  -H 'Content-Type: application/json' \
+  -d '{"task": "Generate the first 50 Fibonacci numbers and calculate the golden ratio convergence"}'
+```
+
+### 19. Coding Agent
+
+```bash
+# Register
+curl -X POST 'http://localhost:8080/api/metadata/workflow' \
+  -H 'Content-Type: application/json' \
+  -d @19-coding-agent.json
+
+# Execute — the agent plans, writes code, executes, and reviews
+curl -X POST 'http://localhost:8080/api/workflow/coding_agent' \
+  -H 'Content-Type: application/json' \
+  -d '{"task": "Write a Python function that converts Roman numerals to integers, with unit tests"}'
+```
+
+### 20. Extended Thinking
+
+```bash
+# Register
+curl -X POST 'http://localhost:8080/api/metadata/workflow' \
+  -H 'Content-Type: application/json' \
+  -d @20-extended-thinking.json
+
+# Execute with a complex reasoning problem
+curl -X POST 'http://localhost:8080/api/workflow/extended_thinking_workflow' \
+  -H 'Content-Type: application/json' \
+  -d '{"problem": "Design a distributed consensus algorithm for a system with up to 3 Byzantine nodes out of 10 total. Explain the correctness proof."}'
+```
+
+### 21. Web Research Agent
+
+```bash
+# Register
+curl -X POST 'http://localhost:8080/api/metadata/workflow' \
+  -H 'Content-Type: application/json' \
+  -d @21-web-search-research-agent.json
+
+# Execute — researches the topic, writes a report, converts to PDF
+curl -X POST 'http://localhost:8080/api/workflow/web_research_agent' \
+  -H 'Content-Type: application/json' \
+  -d '{"topic": "The state of WebAssembly in 2026"}'
+```
+
+### 22. Multi-Turn Conversation Chain
+
+```bash
+# Register
+curl -X POST 'http://localhost:8080/api/metadata/workflow' \
+  -H 'Content-Type: application/json' \
+  -d @22-multi-turn-chain.json
+
+# Execute — second turn uses previousResponseId to continue the conversation without resending history
+curl -X POST 'http://localhost:8080/api/workflow/multi_turn_chain' \
+  -H 'Content-Type: application/json' \
+  -d '{"topic": "Real-time collaborative document editor"}'
+```
+
 ---
 
 ## Register All Workflows at Once
@@ -380,10 +472,10 @@ conductor.vectordb.instances[0].postgres.dimensions=1536
 
 ### "No configuration found for: openai"
 
-Ensure you have set the OpenAI API key:
+Ensure you have set the OpenAI API key environment variable:
 
-```properties
-conductor.ai.openai.apiKey=sk-your-openai-api-key
+```bash
+export OPENAI_API_KEY=sk-your-openai-api-key
 ```
 
 ### MCP Server Connection Refused

--- a/ai/src/main/java/org/conductoross/conductor/ai/LLMHelper.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/LLMHelper.java
@@ -430,11 +430,20 @@ public class LLMHelper {
             result = responses.getFirst();
         }
         finishReason = finishReasonMap.getOrDefault(finishReason, finishReason).toUpperCase();
+
+        // Extract response_id if present (set by OpenAI Responses API for chaining)
+        String responseId = null;
+        Object respIdObj = chatResponse.getMetadata().get("response_id");
+        if (respIdObj instanceof String rid) {
+            responseId = rid;
+        }
+
         return LLMResponse.builder()
                 .result(result)
                 .media(media)
                 .toolCalls(tools)
                 .finishReason(finishReason)
+                .responseId(responseId)
                 .completionTokens(chatResponse.getMetadata().getUsage().getCompletionTokens())
                 .promptTokens(chatResponse.getMetadata().getUsage().getPromptTokens())
                 .tokenUsed(chatResponse.getMetadata().getUsage().getTotalTokens())

--- a/ai/src/main/java/org/conductoross/conductor/ai/models/ChatCompletion.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/models/ChatCompletion.java
@@ -72,14 +72,38 @@ public class ChatCompletion extends LLMWorkerInput {
     private String outputMimeType;
 
     // Used for thinking models
-    @Documented(usage = "applicable for Anthropic models, token allowance for thinking")
+    @Documented(
+            usage =
+                    "Token budget for extended thinking/reasoning before the model generates its final response. Supported by Anthropic and Google Gemini.")
     private int thinkingTokenLimit;
 
-    @Documented(usage = "applicable for OpenAI models, reasoning effort - low, medium or high")
+    @Documented(
+            usage =
+                    "Reasoning effort level: low, medium, or high. Supported by OpenAI models.")
     private String reasoningEffort;
 
     @Documented(usage = "Location where the results should be stored.  Useful for media generation")
     private String outputLocation;
+
+    @Documented(
+            usage =
+                    "ID of a previous response to chain multi-turn conversations without resending full message history. Supported by OpenAI and Azure OpenAI (Responses API).")
+    private String previousResponseId;
+
+    @Documented(
+            usage =
+                    "Enable built-in web search. The LLM can search the web for real-time information. Supported by OpenAI, Anthropic, and Google Gemini.")
+    private boolean webSearch;
+
+    @Documented(
+            usage =
+                    "Enable built-in code execution. The LLM can write and run code in a sandboxed environment. Supported by OpenAI (code_interpreter), Anthropic (code_execution), and Google Gemini (codeExecution).")
+    private boolean codeInterpreter;
+
+    @Documented(
+            usage =
+                    "Vector store IDs for file search. The LLM can search through uploaded files. Supported by OpenAI only.")
+    private List<String> fileSearchVectorStoreIds;
 
     // Audio output
     private String voice;

--- a/ai/src/main/java/org/conductoross/conductor/ai/models/ChatCompletion.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/models/ChatCompletion.java
@@ -77,9 +77,7 @@ public class ChatCompletion extends LLMWorkerInput {
                     "Token budget for extended thinking/reasoning before the model generates its final response. Supported by Anthropic and Google Gemini.")
     private int thinkingTokenLimit;
 
-    @Documented(
-            usage =
-                    "Reasoning effort level: low, medium, or high. Supported by OpenAI models.")
+    @Documented(usage = "Reasoning effort level: low, medium, or high. Supported by OpenAI models.")
     private String reasoningEffort;
 
     @Documented(usage = "Location where the results should be stored.  Useful for media generation")

--- a/ai/src/main/java/org/conductoross/conductor/ai/models/LLMResponse.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/models/LLMResponse.java
@@ -35,6 +35,7 @@ public class LLMResponse {
     private List<ToolCall> toolCalls;
     private WorkflowDef workflow;
     private String jobId;
+    private String responseId;
 
     public boolean hasToolCalls() {
         return toolCalls != null && !toolCalls.isEmpty();

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/Anthropic.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/Anthropic.java
@@ -12,31 +12,40 @@
  */
 package org.conductoross.conductor.ai.providers.anthropic;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
 import org.conductoross.conductor.ai.AIModel;
 import org.conductoross.conductor.ai.models.ChatCompletion;
 import org.conductoross.conductor.ai.models.EmbeddingGenRequest;
-import org.springframework.ai.anthropic.AnthropicChatModel;
-import org.springframework.ai.anthropic.AnthropicChatOptions;
-import org.springframework.ai.anthropic.api.AnthropicApi;
+import org.conductoross.conductor.ai.models.ToolSpec;
+import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi;
+import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.Tool;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.image.ImageModel;
-import org.springframework.ai.tool.ToolCallback;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
-import org.springframework.web.client.RestClient;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class Anthropic implements AIModel {
 
     public static final String NAME = "anthropic";
     private final AnthropicConfiguration config;
 
+    private final AnthropicMessagesApi messagesApi;
+    private final AnthropicChatModel chatModel;
+
+    @SuppressWarnings("unchecked")
     public Anthropic(AnthropicConfiguration config) {
         this.config = config;
+        long timeoutSecs = config.getTimeout() != null ? config.getTimeout().getSeconds() : 600;
+
+        this.messagesApi =
+                new AnthropicMessagesApi(
+                        config.getApiKey(), config.getBaseURL(), config.getVersion(), timeoutSecs);
+        this.chatModel = new AnthropicChatModel(messagesApi);
     }
 
     @Override
@@ -51,59 +60,62 @@ public class Anthropic implements AIModel {
 
     @Override
     public ChatModel getChatModel() {
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setReadTimeout(config.getTimeout());
-
-        var builder =
-                AnthropicApi.builder()
-                        .baseUrl(config.getBaseURL())
-                        .apiKey(config.getApiKey())
-                        .restClientBuilder(RestClient.builder().requestFactory(factory));
-
-        if (StringUtils.isNotBlank(config.getVersion())) {
-            builder.anthropicVersion(config.getVersion());
-        }
-        if (StringUtils.isNotBlank(config.getBetaVersion())) {
-            builder.anthropicBetaFeatures(config.getBetaVersion());
-        }
-        if (StringUtils.isNotBlank(config.getCompletionsPath())) {
-            builder.completionsPath(config.getCompletionsPath());
-        }
-        AnthropicApi anthropicApi = builder.build();
-        return AnthropicChatModel.builder().anthropicApi(anthropicApi).build();
+        return this.chatModel;
     }
 
     @Override
     public ChatOptions getChatOptions(ChatCompletion input) {
-        List<ToolCallback> toolCallbacks = getToolCallback(input);
-        Set<String> toolNames =
-                toolCallbacks.stream()
-                        .map(tc -> tc.getToolDefinition().name())
-                        .collect(Collectors.toSet());
+        List<Tool> tools = convertTools(input);
         Double temperature = input.getTemperature();
-        AnthropicApi.ChatCompletionRequest.ThinkingConfig thinkingConfig = null;
-        if (input.getThinkingTokenLimit() > 0) {
-            thinkingConfig =
-                    new AnthropicApi.ChatCompletionRequest.ThinkingConfig(
-                            AnthropicApi.ThinkingType.ENABLED, input.getThinkingTokenLimit());
-            temperature = 1.0;
-        }
-        AnthropicChatOptions.Builder builder =
-                AnthropicChatOptions.builder()
-                        .model(input.getModel())
-                        .thinking(thinkingConfig)
-                        .topP(input.getTopP())
-                        .toolCallbacks(toolCallbacks)
-                        .toolNames(toolNames)
-                        .internalToolExecutionEnabled(false)
-                        .temperature(temperature)
-                        .maxTokens(input.getMaxTokens());
+        Integer thinkingBudget = null;
 
-        return builder.build();
+        if (input.getThinkingTokenLimit() > 0) {
+            thinkingBudget = input.getThinkingTokenLimit();
+            temperature = 1.0; // Thinking mode requires temperature=1
+        }
+
+        return AnthropicChatOptions.builder()
+                .model(input.getModel())
+                .maxTokens(input.getMaxTokens())
+                .temperature(temperature)
+                .topP(input.getTopP())
+                .topK(input.getTopK())
+                .stopSequences(input.getStopWords())
+                .thinkingBudgetTokens(thinkingBudget)
+                .tools(tools.isEmpty() ? null : tools)
+                .build();
     }
 
     @Override
     public ImageModel getImageModel() {
         throw new UnsupportedOperationException("Image generation not supported by the model yet");
+    }
+
+    // -- Helpers --
+
+    @SuppressWarnings("unchecked")
+    private List<Tool> convertTools(ChatCompletion input) {
+        List<Tool> tools = new ArrayList<>();
+
+        // Built-in tools
+        if (input.isWebSearch()) {
+            tools.add(Tool.webSearch());
+        }
+        if (input.isCodeInterpreter()) {
+            tools.add(Tool.codeExecution());
+        }
+
+        // Convert Conductor ToolSpecs to Anthropic function tools
+        if (input.getTools() != null) {
+            for (ToolSpec toolSpec : input.getTools()) {
+                Map<String, Object> schema =
+                        toolSpec.getInputSchema() != null
+                                ? toolSpec.getInputSchema()
+                                : Map.of("type", "object");
+                tools.add(Tool.function(toolSpec.getName(), toolSpec.getDescription(), schema));
+            }
+        }
+
+        return tools;
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicChatModel.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicChatModel.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.anthropic;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi;
+import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.ContentBlock;
+import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.Message;
+import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.MessagesRequest;
+import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.MessagesResponse;
+import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.ResponseContentBlock;
+import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.ResponseUsage;
+import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.Thinking;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Spring AI {@link ChatModel} implementation backed by the Anthropic Messages API via OkHttp.
+ *
+ * <p>Converts Spring AI {@link Prompt} messages to Anthropic Messages API format, calls the API,
+ * and converts the response back to Spring AI's {@link ChatResponse}.
+ */
+@Slf4j
+public class AnthropicChatModel implements ChatModel {
+
+    private final AnthropicMessagesApi messagesApi;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public AnthropicChatModel(AnthropicMessagesApi messagesApi) {
+        this.messagesApi = messagesApi;
+    }
+
+    @Override
+    public ChatResponse call(Prompt prompt) {
+        try {
+            MessagesRequest request = buildRequest(prompt);
+            MessagesResponse result = messagesApi.createMessage(request);
+            return toSpringChatResponse(result);
+        } catch (IOException e) {
+            throw new RuntimeException("Anthropic Messages API call failed: " + e.getMessage(), e);
+        }
+    }
+
+    private MessagesRequest buildRequest(Prompt prompt) {
+        List<org.springframework.ai.chat.messages.Message> springMessages =
+                prompt.getInstructions();
+        ChatOptions options = prompt.getOptions();
+
+        // Extract system messages
+        String system = null;
+        List<org.springframework.ai.chat.messages.Message> nonSystemMessages = new ArrayList<>();
+        for (org.springframework.ai.chat.messages.Message msg : springMessages) {
+            if (msg.getMessageType() == MessageType.SYSTEM) {
+                String sysText = ((SystemMessage) msg).getText();
+                system = system == null ? sysText : system + "\n" + sysText;
+            } else {
+                nonSystemMessages.add(msg);
+            }
+        }
+
+        // Convert messages to Anthropic format
+        List<Message> messages = new ArrayList<>();
+        for (org.springframework.ai.chat.messages.Message msg : nonSystemMessages) {
+            messages.addAll(convertMessage(msg));
+        }
+
+        // Extract options
+        AnthropicChatOptions opts = options instanceof AnthropicChatOptions aco ? aco : null;
+
+        MessagesRequest.Builder builder =
+                MessagesRequest.builder().messages(messages).system(system);
+
+        if (opts != null) {
+            builder.model(opts.getModel())
+                    .maxTokens(opts.getMaxTokens())
+                    .temperature(opts.getTemperature())
+                    .topP(opts.getTopP())
+                    .topK(opts.getTopK())
+                    .stopSequences(opts.getStopSequences())
+                    .tools(opts.getTools());
+
+            // Thinking mode
+            if (opts.getThinkingBudgetTokens() != null && opts.getThinkingBudgetTokens() > 0) {
+                builder.thinking(Thinking.enabled(opts.getThinkingBudgetTokens()));
+            }
+
+            // Check if code_execution tool is present — requires beta header
+            if (opts.getTools() != null) {
+                boolean hasCodeExec =
+                        opts.getTools().stream()
+                                .anyMatch(t -> "code_execution_20250825".equals(t.type()));
+                if (hasCodeExec) {
+                    builder.betaFeatures(List.of("code-execution-2025-08-25"));
+                }
+            }
+        } else if (options != null) {
+            builder.model(options.getModel())
+                    .maxTokens(options.getMaxTokens())
+                    .temperature(options.getTemperature())
+                    .topP(options.getTopP())
+                    .topK(options.getTopK())
+                    .stopSequences(options.getStopSequences());
+        }
+
+        return builder.build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Message> convertMessage(org.springframework.ai.chat.messages.Message msg) {
+        List<Message> messages = new ArrayList<>();
+
+        switch (msg.getMessageType()) {
+            case USER -> {
+                UserMessage userMsg = (UserMessage) msg;
+                messages.add(Message.user(userMsg.getText()));
+            }
+
+            case ASSISTANT -> {
+                AssistantMessage assistantMsg = (AssistantMessage) msg;
+                if (assistantMsg.hasToolCalls()) {
+                    // Convert tool calls to content blocks
+                    List<ContentBlock> blocks = new ArrayList<>();
+                    if (assistantMsg.getText() != null && !assistantMsg.getText().isBlank()) {
+                        blocks.add(ContentBlock.text(assistantMsg.getText()));
+                    }
+                    for (AssistantMessage.ToolCall tc : assistantMsg.getToolCalls()) {
+                        Object input;
+                        try {
+                            input = objectMapper.readValue(tc.arguments(), Map.class);
+                        } catch (Exception e) {
+                            input = Map.of();
+                        }
+                        blocks.add(ContentBlock.toolUse(tc.id(), tc.name(), input));
+                    }
+                    messages.add(Message.assistant(blocks));
+                } else {
+                    String text = assistantMsg.getText();
+                    if (text != null && !text.isBlank()) {
+                        messages.add(Message.assistant(text));
+                    }
+                }
+            }
+
+            case TOOL -> {
+                ToolResponseMessage toolMsg = (ToolResponseMessage) msg;
+                List<ContentBlock> blocks = new ArrayList<>();
+                for (ToolResponseMessage.ToolResponse tr : toolMsg.getResponses()) {
+                    blocks.add(ContentBlock.toolResult(tr.id(), tr.responseData()));
+                }
+                messages.add(new Message("user", blocks));
+            }
+
+            default -> log.warn("Unsupported message type: {}", msg.getMessageType());
+        }
+
+        return messages;
+    }
+
+    private ChatResponse toSpringChatResponse(MessagesResponse result) {
+        List<Generation> generations = new ArrayList<>();
+        List<AssistantMessage.ToolCall> toolCalls = new ArrayList<>();
+        StringBuilder textBuilder = new StringBuilder();
+        String finishReason = mapStopReason(result.stopReason());
+
+        if (result.content() != null) {
+            for (ResponseContentBlock block : result.content()) {
+                switch (block.type()) {
+                    case "text" -> {
+                        if (block.text() != null) {
+                            if (!textBuilder.isEmpty()) {
+                                textBuilder.append("\n");
+                            }
+                            textBuilder.append(block.text());
+                        }
+                    }
+                    case "tool_use" -> {
+                        String argsJson;
+                        try {
+                            argsJson = objectMapper.writeValueAsString(block.input());
+                        } catch (Exception e) {
+                            argsJson = "{}";
+                        }
+                        toolCalls.add(
+                                new AssistantMessage.ToolCall(
+                                        block.id(), "function", block.name(), argsJson));
+                        finishReason = "TOOL_CALLS";
+                    }
+                    case "thinking" -> {
+                        // Thinking blocks are internal reasoning — skip in main output
+                    }
+                    default -> {
+                        // web_search_tool_result, code_execution_tool_result, etc.
+                        // Server-side tool results — the text output is already in text blocks
+                        log.debug("Ignoring content block type: {}", block.type());
+                    }
+                }
+            }
+        }
+
+        // Build a single Generation with text + any tool calls
+        AssistantMessage assistantMessage;
+        if (!toolCalls.isEmpty()) {
+            assistantMessage =
+                    AssistantMessage.builder()
+                            .content(textBuilder.toString())
+                            .toolCalls(toolCalls)
+                            .build();
+        } else {
+            assistantMessage = new AssistantMessage(textBuilder.toString());
+        }
+
+        ChatGenerationMetadata genMeta =
+                ChatGenerationMetadata.builder().finishReason(finishReason).build();
+        generations.add(new Generation(assistantMessage, genMeta));
+
+        // Build usage metadata
+        ResponseUsage usage = result.usage();
+        int inputTok = usage != null && usage.inputTokens() != null ? usage.inputTokens() : 0;
+        int outputTok = usage != null && usage.outputTokens() != null ? usage.outputTokens() : 0;
+        DefaultUsage springUsage = new DefaultUsage(inputTok, outputTok, inputTok + outputTok);
+
+        ChatResponseMetadata.Builder metaBuilder =
+                ChatResponseMetadata.builder()
+                        .id(result.id())
+                        .model(result.model())
+                        .usage(springUsage);
+
+        return new ChatResponse(generations, metaBuilder.build());
+    }
+
+    private String mapStopReason(String stopReason) {
+        if (stopReason == null) return "STOP";
+        return switch (stopReason) {
+            case "end_turn" -> "STOP";
+            case "tool_use" -> "TOOL_CALLS";
+            case "max_tokens" -> "MAX_TOKENS";
+            case "stop_sequence" -> "STOP_SEQUENCE";
+            default -> stopReason.toUpperCase();
+        };
+    }
+
+    @Override
+    public ChatOptions getDefaultOptions() {
+        return ToolCallingChatOptions.builder().build();
+    }
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicChatOptions.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicChatOptions.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.anthropic;
+
+import java.util.List;
+
+import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi;
+import org.springframework.ai.chat.prompt.ChatOptions;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Chat options for the Anthropic Messages API. Carries both standard ChatOptions fields and
+ * Anthropic-specific fields (thinking, built-in tools, etc.).
+ */
+@Data
+@Builder
+public class AnthropicChatOptions implements ChatOptions {
+
+    private String model;
+    private Double temperature;
+    private Double topP;
+    private Integer topK;
+    private Integer maxTokens;
+    private List<String> stopSequences;
+
+    // Anthropic-specific
+    private Integer thinkingBudgetTokens;
+    private List<AnthropicMessagesApi.Tool> tools;
+
+    @Override
+    public Double getFrequencyPenalty() {
+        return null; // Not supported by Anthropic
+    }
+
+    @Override
+    public Double getPresencePenalty() {
+        return null; // Not supported by Anthropic
+    }
+
+    @Override
+    public ChatOptions copy() {
+        return AnthropicChatOptions.builder()
+                .model(model)
+                .temperature(temperature)
+                .topP(topP)
+                .topK(topK)
+                .maxTokens(maxTokens)
+                .stopSequences(stopSequences)
+                .thinkingBudgetTokens(thinkingBudgetTokens)
+                .tools(tools)
+                .build();
+    }
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/api/AnthropicMessagesApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/api/AnthropicMessagesApi.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.anthropic.api;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import com.netflix.conductor.common.config.ObjectMapperProvider;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+/**
+ * OkHttp REST client for the Anthropic Messages API.
+ *
+ * <p>Endpoint: POST /v1/messages
+ *
+ * @see <a href="https://docs.anthropic.com/en/api/messages">Anthropic Messages API</a>
+ */
+@Slf4j
+public class AnthropicMessagesApi {
+
+    private static final MediaType JSON = MediaType.parse("application/json");
+    private static final String DEFAULT_VERSION = "2023-06-01";
+
+    private final String baseUrl;
+    private final String apiKey;
+    private final String anthropicVersion;
+    private final OkHttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    public AnthropicMessagesApi(String apiKey, String baseUrl, long timeoutSeconds) {
+        this(apiKey, baseUrl, null, timeoutSeconds);
+    }
+
+    public AnthropicMessagesApi(
+            String apiKey, String baseUrl, String anthropicVersion, long timeoutSeconds) {
+        this.baseUrl = baseUrl != null ? baseUrl : "https://api.anthropic.com";
+        this.apiKey = apiKey;
+        this.anthropicVersion = anthropicVersion != null ? anthropicVersion : DEFAULT_VERSION;
+        this.httpClient =
+                new OkHttpClient.Builder()
+                        .connectTimeout(60, TimeUnit.SECONDS)
+                        .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
+                        .writeTimeout(60, TimeUnit.SECONDS)
+                        .build();
+        this.objectMapper = new ObjectMapperProvider().getObjectMapper();
+    }
+
+    /**
+     * Create a message via POST /v1/messages.
+     *
+     * @param request The message creation request
+     * @return The API response
+     */
+    public MessagesResponse createMessage(MessagesRequest request) throws IOException {
+        String jsonBody = objectMapper.writeValueAsString(request);
+        log.debug("Anthropic Messages API request: {}", jsonBody);
+
+        Request.Builder httpBuilder =
+                new Request.Builder()
+                        .url(baseUrl + "/v1/messages")
+                        .header("x-api-key", apiKey)
+                        .header("anthropic-version", anthropicVersion)
+                        .header("Content-Type", "application/json")
+                        .post(RequestBody.create(jsonBody, JSON));
+
+        // Add beta header if request has beta features
+        if (request.betaFeatures() != null && !request.betaFeatures().isEmpty()) {
+            httpBuilder.header("anthropic-beta", String.join(",", request.betaFeatures()));
+        }
+
+        try (Response response = httpClient.newCall(httpBuilder.build()).execute()) {
+            String responseBody = readBody(response);
+            if (!response.isSuccessful()) {
+                throw new IOException(
+                        "Anthropic Messages API failed with status %d: %s"
+                                .formatted(response.code(), responseBody));
+            }
+            log.debug("Anthropic Messages API response: {}", responseBody);
+            return objectMapper.readValue(responseBody, MessagesResponse.class);
+        }
+    }
+
+    private String readBody(Response response) throws IOException {
+        ResponseBody body = response.body();
+        return body != null ? body.string() : "";
+    }
+
+    // -- Request DTOs --
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record MessagesRequest(
+            String model,
+            @JsonProperty("max_tokens") Integer maxTokens,
+            List<Message> messages,
+            String system,
+            Double temperature,
+            @JsonProperty("top_p") Double topP,
+            @JsonProperty("top_k") Integer topK,
+            @JsonProperty("stop_sequences") List<String> stopSequences,
+            List<Tool> tools,
+            Thinking thinking,
+            // Not serialized — used to set the anthropic-beta HTTP header
+            @JsonIgnoreProperties @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+                    List<String> betaFeatures) {
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static class Builder {
+            private String model;
+            private Integer maxTokens;
+            private List<Message> messages;
+            private String system;
+            private Double temperature;
+            private Double topP;
+            private Integer topK;
+            private List<String> stopSequences;
+            private List<Tool> tools;
+            private Thinking thinking;
+            private List<String> betaFeatures;
+
+            public Builder model(String model) {
+                this.model = model;
+                return this;
+            }
+
+            public Builder maxTokens(Integer maxTokens) {
+                this.maxTokens = maxTokens;
+                return this;
+            }
+
+            public Builder messages(List<Message> messages) {
+                this.messages = messages;
+                return this;
+            }
+
+            public Builder system(String system) {
+                this.system = system;
+                return this;
+            }
+
+            public Builder temperature(Double temperature) {
+                this.temperature = temperature;
+                return this;
+            }
+
+            public Builder topP(Double topP) {
+                this.topP = topP;
+                return this;
+            }
+
+            public Builder topK(Integer topK) {
+                this.topK = topK;
+                return this;
+            }
+
+            public Builder stopSequences(List<String> stopSequences) {
+                this.stopSequences = stopSequences;
+                return this;
+            }
+
+            public Builder tools(List<Tool> tools) {
+                this.tools = tools;
+                return this;
+            }
+
+            public Builder thinking(Thinking thinking) {
+                this.thinking = thinking;
+                return this;
+            }
+
+            public Builder betaFeatures(List<String> betaFeatures) {
+                this.betaFeatures = betaFeatures;
+                return this;
+            }
+
+            public MessagesRequest build() {
+                return new MessagesRequest(
+                        model,
+                        maxTokens,
+                        messages,
+                        system,
+                        temperature,
+                        topP,
+                        topK,
+                        stopSequences,
+                        tools,
+                        thinking,
+                        betaFeatures);
+            }
+        }
+    }
+
+    /** A message in the conversation. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Message(
+            String role, // "user" or "assistant"
+            Object content // String or List<ContentBlock>
+            ) {
+
+        public static Message user(String text) {
+            return new Message("user", text);
+        }
+
+        public static Message user(List<ContentBlock> blocks) {
+            return new Message("user", blocks);
+        }
+
+        public static Message assistant(String text) {
+            return new Message("assistant", text);
+        }
+
+        public static Message assistant(List<ContentBlock> blocks) {
+            return new Message("assistant", blocks);
+        }
+    }
+
+    /** Content block within a message (request side). */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record ContentBlock(
+            String type, // "text", "image", "tool_use", "tool_result"
+            String text,
+            // tool_use fields
+            String id,
+            String name,
+            Object input,
+            // tool_result fields
+            @JsonProperty("tool_use_id") String toolUseId,
+            Object content, // String or nested blocks for tool_result
+            @JsonProperty("is_error") Boolean isError,
+            // image fields
+            Source source) {
+
+        public static ContentBlock text(String text) {
+            return new ContentBlock("text", text, null, null, null, null, null, null, null);
+        }
+
+        public static ContentBlock toolUse(String id, String name, Object input) {
+            return new ContentBlock("tool_use", null, id, name, input, null, null, null, null);
+        }
+
+        public static ContentBlock toolResult(String toolUseId, String content) {
+            return new ContentBlock(
+                    "tool_result", null, null, null, null, toolUseId, content, null, null);
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public record Source(
+                String type, // "base64"
+                @JsonProperty("media_type") String mediaType,
+                String data) {}
+    }
+
+    /** Tool definition. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Tool(
+            String type, // "custom", "web_search_20250305", "code_execution_20250825"
+            String name,
+            String description,
+            @JsonProperty("input_schema") Map<String, Object> inputSchema) {
+
+        /** Create a custom function tool. */
+        public static Tool function(
+                String name, String description, Map<String, Object> inputSchema) {
+            return new Tool("custom", name, description, inputSchema);
+        }
+
+        /** Create a web search built-in tool. */
+        public static Tool webSearch() {
+            return new Tool("web_search_20250305", "web_search", null, null);
+        }
+
+        /** Create a code execution built-in tool. */
+        public static Tool codeExecution() {
+            return new Tool("code_execution_20250825", "code_execution", null, null);
+        }
+    }
+
+    /** Thinking configuration for extended thinking mode. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Thinking(
+            String type, // "enabled" or "disabled"
+            @JsonProperty("budget_tokens") Integer budgetTokens) {
+
+        public static Thinking enabled(int budgetTokens) {
+            return new Thinking("enabled", budgetTokens);
+        }
+    }
+
+    // -- Response DTOs --
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record MessagesResponse(
+            String id,
+            String type, // "message"
+            String role, // "assistant"
+            List<ResponseContentBlock> content,
+            String model,
+            @JsonProperty("stop_reason") String stopReason,
+            @JsonProperty("stop_sequence") String stopSequence,
+            ResponseUsage usage) {}
+
+    /** Content block in the response. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ResponseContentBlock(
+            String type, // "text", "tool_use", "thinking", "web_search_tool_result",
+            // "code_execution_tool_result", etc.
+            String text,
+            // tool_use fields
+            String id,
+            String name,
+            Object input,
+            // thinking fields
+            String thinking,
+            String signature,
+            // server tool result fields (web_search, code_execution)
+            Object content) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ResponseUsage(
+            @JsonProperty("input_tokens") Integer inputTokens,
+            @JsonProperty("output_tokens") Integer outputTokens,
+            @JsonProperty("cache_creation_input_tokens") Integer cacheCreationInputTokens,
+            @JsonProperty("cache_read_input_tokens") Integer cacheReadInputTokens) {}
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAI.java
@@ -12,85 +12,107 @@
  */
 package org.conductoross.conductor.ai.providers.azureopenai;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.conductoross.conductor.ai.AIModel;
 import org.conductoross.conductor.ai.models.ChatCompletion;
 import org.conductoross.conductor.ai.models.EmbeddingGenRequest;
-import org.springframework.ai.azure.openai.AzureOpenAiChatModel;
-import org.springframework.ai.azure.openai.AzureOpenAiChatOptions;
-import org.springframework.ai.azure.openai.AzureOpenAiEmbeddingModel;
-import org.springframework.ai.azure.openai.AzureOpenAiEmbeddingOptions;
-import org.springframework.ai.azure.openai.AzureOpenAiImageModel;
-import org.springframework.ai.azure.openai.AzureOpenAiImageOptions;
-import org.springframework.ai.azure.openai.AzureOpenAiResponseFormat;
+import org.conductoross.conductor.ai.models.ToolSpec;
+import org.conductoross.conductor.ai.providers.openai.OpenAIHttpImageModel;
+import org.conductoross.conductor.ai.providers.openai.OpenAIResponsesChatModel;
+import org.conductoross.conductor.ai.providers.openai.OpenAIResponsesChatOptions;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIEmbeddingsApi;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIImageGenApi;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIResponsesApi;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIResponsesApi.Tool;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
-import org.springframework.ai.embedding.EmbeddingRequest;
 import org.springframework.ai.image.ImageModel;
 
-import com.azure.ai.openai.OpenAIClient;
-import com.azure.ai.openai.OpenAIClientBuilder;
-import com.azure.core.credential.AzureKeyCredential;
-import com.azure.core.util.HttpClientOptions;
-import com.google.common.primitives.Floats;
+import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Azure OpenAI provider backed by OkHttp calls to the Azure OpenAI Responses API.
+ *
+ * <p>Uses the same API classes as the OpenAI provider but with Azure-specific authentication
+ * (api-key header) and base URL format.
+ */
+@Slf4j
 public class AzureOpenAI implements AIModel {
 
     public static final String NAME = "azure_openai";
     private final AzureOpenAIConfiguration config;
 
+    private final OpenAIResponsesApi responsesApi;
+    private final OpenAIEmbeddingsApi embeddingsApi;
+    private final OpenAIImageGenApi imageGenApi;
+    private final OpenAIResponsesChatModel chatModel;
+    private final OpenAIHttpImageModel imageModel;
+
     public AzureOpenAI(AzureOpenAIConfiguration config) {
         this.config = config;
+        long timeoutSecs = config.getTimeout() != null ? config.getTimeout().getSeconds() : 600;
+
+        // Azure base URL format: https://RESOURCE.openai.azure.com/openai/v1
+        String baseUrl = toAzureV1Url(config.getBaseURL());
+
+        this.responsesApi = new OpenAIResponsesApi(config.getApiKey(), baseUrl, true, timeoutSecs);
+        this.embeddingsApi =
+                new OpenAIEmbeddingsApi(config.getApiKey(), baseUrl, true, timeoutSecs);
+        this.imageGenApi = new OpenAIImageGenApi(config.getApiKey(), baseUrl, true, timeoutSecs);
+        this.chatModel = new OpenAIResponsesChatModel(responsesApi);
+        this.imageModel = new OpenAIHttpImageModel(imageGenApi);
     }
 
+    @Override
     public String getModelProvider() {
         return NAME;
     }
 
     @Override
     public List<Float> generateEmbeddings(EmbeddingGenRequest embeddingGenRequest) {
-        AzureOpenAiEmbeddingOptions options =
-                AzureOpenAiEmbeddingOptions.builder()
-                        .deploymentName(embeddingGenRequest.getModel())
-                        .dimensions(embeddingGenRequest.getDimensions())
-                        .build();
-
-        OpenAIClient client = getOpenAIClientBuilder().buildClient();
-        AzureOpenAiEmbeddingModel model = new AzureOpenAiEmbeddingModel(client);
-
-        EmbeddingRequest embeddingRequest =
-                new EmbeddingRequest(List.of(embeddingGenRequest.getText()), options);
-
-        float[] embeddingsResponse = model.call(embeddingRequest).getResult().getOutput();
-        return Floats.asList(embeddingsResponse);
+        try {
+            var request =
+                    new OpenAIEmbeddingsApi.EmbeddingRequest(
+                            embeddingGenRequest.getModel(),
+                            embeddingGenRequest.getText(),
+                            embeddingGenRequest.getDimensions());
+            var result = embeddingsApi.createEmbeddings(request);
+            if (result.data() != null && !result.data().isEmpty()) {
+                return result.data().getFirst().embedding();
+            }
+            return List.of();
+        } catch (IOException e) {
+            throw new RuntimeException("Embeddings API call failed: " + e.getMessage(), e);
+        }
     }
 
     @Override
     public ChatOptions getChatOptions(ChatCompletion input) {
-        AzureOpenAiChatOptions.Builder builder =
-                AzureOpenAiChatOptions.builder()
-                        .deploymentName(input.getModel())
+        List<Tool> tools = convertTools(input);
+
+        // Azure uses deployment name as the model
+        String model = input.getModel();
+
+        OpenAIResponsesChatOptions.OpenAIResponsesChatOptionsBuilder builder =
+                OpenAIResponsesChatOptions.builder()
+                        .model(model)
                         .topP(input.getTopP())
-                        .stop(input.getStopWords())
                         .frequencyPenalty(input.getFrequencyPenalty())
+                        .presencePenalty(input.getPresencePenalty())
                         .maxTokens(input.getMaxTokens())
-                        .toolCallbacks(getToolCallback(input))
-                        .internalToolExecutionEnabled(false)
-                        .presencePenalty(input.getPresencePenalty());
+                        .stopSequences(input.getStopWords())
+                        .previousResponseId(input.getPreviousResponseId())
+                        .reasoningEffort(input.getReasoningEffort())
+                        .jsonOutput(input.isJsonOutput())
+                        .responsesApiTools(tools.isEmpty() ? null : tools);
 
-        if (input.isJsonOutput()) {
-            builder.responseFormat(
-                    AzureOpenAiResponseFormat.builder()
-                            .type(AzureOpenAiResponseFormat.Type.JSON_OBJECT)
-                            .build());
-        }
-
-        // remove temperature, stop and topP for reasoning models
-        if (isReasoningModel(input.getModel())) {
+        if (isReasoningModel(model)) {
             builder.temperature(null);
             builder.topP(null);
-            builder.stop(null);
+            builder.stopSequences(null);
         }
 
         return builder.build();
@@ -98,19 +120,28 @@ public class AzureOpenAI implements AIModel {
 
     @Override
     public ChatModel getChatModel() {
-        return AzureOpenAiChatModel.builder().openAIClientBuilder(getOpenAIClientBuilder()).build();
+        return this.chatModel;
     }
 
-    private OpenAIClientBuilder getOpenAIClientBuilder() {
-        HttpClientOptions clientOptions =
-                new HttpClientOptions()
-                        .setReadTimeout(config.getTimeout())
-                        .setResponseTimeout(config.getTimeout());
+    @Override
+    public ImageModel getImageModel() {
+        return this.imageModel;
+    }
 
-        return new OpenAIClientBuilder()
-                .endpoint(config.getBaseURL())
-                .credential(new AzureKeyCredential(config.getApiKey()))
-                .clientOptions(clientOptions);
+    // -- Helpers --
+
+    private List<Tool> convertTools(ChatCompletion input) {
+        List<Tool> tools = new ArrayList<>();
+        if (input.getTools() != null) {
+            for (ToolSpec toolSpec : input.getTools()) {
+                tools.add(
+                        Tool.function(
+                                toolSpec.getName(),
+                                toolSpec.getDescription(),
+                                toolSpec.getInputSchema()));
+            }
+        }
+        return tools;
     }
 
     private boolean isReasoningModel(String modelName) {
@@ -118,17 +149,22 @@ public class AzureOpenAI implements AIModel {
             return false;
         }
         String model = modelName.toLowerCase();
-        return model.startsWith("o1") || model.startsWith("o3") || model.startsWith("gpt-5");
+        return model.startsWith("o1")
+                || model.startsWith("o3")
+                || model.startsWith("o4")
+                || model.startsWith("gpt-5");
     }
 
-    @Override
-    public ImageModel getImageModel() {
-        OpenAIClient client = getOpenAIClientBuilder().buildClient();
-        AzureOpenAiImageOptions options =
-                AzureOpenAiImageOptions.builder()
-                        .deploymentName(config.getDeploymentName())
-                        .user(config.getUser())
-                        .build();
-        return new AzureOpenAiImageModel(client, options);
+    /**
+     * Converts an Azure OpenAI endpoint to the v1 URL format expected by the Responses API. Input:
+     * "https://resource.openai.azure.com" → Output: "https://resource.openai.azure.com/openai/v1"
+     */
+    private static String toAzureV1Url(String baseUrl) {
+        if (baseUrl == null) return null;
+        // If already has /openai/v1, return as-is
+        if (baseUrl.endsWith("/openai/v1")) return baseUrl;
+        // Strip trailing slash
+        String url = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        return url + "/openai/v1";
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiChatModel.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiChatModel.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.gemini;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.conductoross.conductor.ai.models.ToolSpec;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.genai.Client;
+import com.google.genai.types.Content;
+import com.google.genai.types.FunctionCall;
+import com.google.genai.types.FunctionDeclaration;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.GenerateContentResponseUsageMetadata;
+import com.google.genai.types.GoogleSearch;
+import com.google.genai.types.Part;
+import com.google.genai.types.ThinkingConfig;
+import com.google.genai.types.Tool;
+import com.google.genai.types.ToolCodeExecution;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Spring AI {@link ChatModel} implementation backed by the Google GenAI SDK.
+ *
+ * <p>Converts Spring AI {@link Prompt} messages to GenAI {@link Content} objects, calls {@code
+ * Client.models.generateContent()}, and converts the response back to Spring AI's {@link
+ * ChatResponse}.
+ */
+@Slf4j
+public class GeminiChatModel implements ChatModel {
+
+    private final Client client;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public GeminiChatModel(Client client) {
+        this.client = client;
+    }
+
+    @Override
+    public ChatResponse call(Prompt prompt) {
+        List<org.springframework.ai.chat.messages.Message> springMessages =
+                prompt.getInstructions();
+        ChatOptions options = prompt.getOptions();
+
+        // Extract system messages
+        StringBuilder systemBuilder = new StringBuilder();
+        List<org.springframework.ai.chat.messages.Message> nonSystemMessages = new ArrayList<>();
+        for (org.springframework.ai.chat.messages.Message msg : springMessages) {
+            if (msg.getMessageType() == MessageType.SYSTEM) {
+                String sysText = ((SystemMessage) msg).getText();
+                if (!systemBuilder.isEmpty()) {
+                    systemBuilder.append("\n");
+                }
+                systemBuilder.append(sysText);
+            } else {
+                nonSystemMessages.add(msg);
+            }
+        }
+
+        // Convert messages to GenAI Content
+        List<Content> contents = new ArrayList<>();
+        for (org.springframework.ai.chat.messages.Message msg : nonSystemMessages) {
+            contents.addAll(convertMessage(msg));
+        }
+
+        // Build config
+        GenerateContentConfig.Builder configBuilder = GenerateContentConfig.builder();
+
+        if (!systemBuilder.isEmpty()) {
+            configBuilder.systemInstruction(
+                    Content.builder()
+                            .parts(List.of(Part.fromText(systemBuilder.toString())))
+                            .build());
+        }
+
+        GeminiChatOptions opts = options instanceof GeminiChatOptions gco ? gco : null;
+
+        if (opts != null) {
+            if (opts.getMaxTokens() != null) configBuilder.maxOutputTokens(opts.getMaxTokens());
+            if (opts.getTemperature() != null)
+                configBuilder.temperature(opts.getTemperature().floatValue());
+            if (opts.getTopP() != null) configBuilder.topP(opts.getTopP().floatValue());
+            if (opts.getTopK() != null) configBuilder.topK(opts.getTopK().floatValue());
+            if (opts.getStopSequences() != null)
+                configBuilder.stopSequences(opts.getStopSequences());
+            if (opts.getFrequencyPenalty() != null)
+                configBuilder.frequencyPenalty(opts.getFrequencyPenalty().floatValue());
+            if (opts.getPresencePenalty() != null)
+                configBuilder.presencePenalty(opts.getPresencePenalty().floatValue());
+
+            // Tools
+            List<Tool> tools = buildTools(opts);
+            if (!tools.isEmpty()) {
+                configBuilder.tools(tools);
+            }
+
+            // Thinking
+            if (opts.getThinkingBudgetTokens() != null && opts.getThinkingBudgetTokens() > 0) {
+                configBuilder.thinkingConfig(
+                        ThinkingConfig.builder()
+                                .thinkingBudget(opts.getThinkingBudgetTokens())
+                                .build());
+            }
+        } else if (options != null) {
+            if (options.getMaxTokens() != null)
+                configBuilder.maxOutputTokens(options.getMaxTokens());
+            if (options.getTemperature() != null)
+                configBuilder.temperature(options.getTemperature().floatValue());
+            if (options.getTopP() != null) configBuilder.topP(options.getTopP().floatValue());
+            if (options.getTopK() != null) configBuilder.topK(options.getTopK().floatValue());
+            if (options.getStopSequences() != null)
+                configBuilder.stopSequences(options.getStopSequences());
+            if (options.getFrequencyPenalty() != null)
+                configBuilder.frequencyPenalty(options.getFrequencyPenalty().floatValue());
+            if (options.getPresencePenalty() != null)
+                configBuilder.presencePenalty(options.getPresencePenalty().floatValue());
+        }
+
+        String model =
+                opts != null ? opts.getModel() : (options != null ? options.getModel() : null);
+        if (model == null) {
+            model = "gemini-2.5-flash";
+        }
+
+        GenerateContentResponse result =
+                client.models.generateContent(model, contents, configBuilder.build());
+
+        return toSpringChatResponse(result, model);
+    }
+
+    private List<Tool> buildTools(GeminiChatOptions opts) {
+        List<Tool> tools = new ArrayList<>();
+
+        // Google Search
+        if (opts.isGoogleSearchRetrieval()) {
+            tools.add(Tool.builder().googleSearch(GoogleSearch.builder().build()).build());
+        }
+
+        // Code execution
+        if (opts.isCodeExecution()) {
+            tools.add(Tool.builder().codeExecution(ToolCodeExecution.builder().build()).build());
+        }
+
+        // Function tools
+        if (opts.getTools() != null && !opts.getTools().isEmpty()) {
+            List<FunctionDeclaration> declarations = new ArrayList<>();
+            for (ToolSpec toolSpec : opts.getTools()) {
+                FunctionDeclaration.Builder declBuilder =
+                        FunctionDeclaration.builder()
+                                .name(toolSpec.getName())
+                                .description(
+                                        toolSpec.getDescription() != null
+                                                ? toolSpec.getDescription()
+                                                : "");
+                if (toolSpec.getInputSchema() != null && !toolSpec.getInputSchema().isEmpty()) {
+                    declBuilder.parametersJsonSchema(toolSpec.getInputSchema());
+                }
+                declarations.add(declBuilder.build());
+            }
+            tools.add(Tool.builder().functionDeclarations(declarations).build());
+        }
+
+        return tools;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Content> convertMessage(org.springframework.ai.chat.messages.Message msg) {
+        List<Content> contents = new ArrayList<>();
+
+        switch (msg.getMessageType()) {
+            case USER -> {
+                UserMessage userMsg = (UserMessage) msg;
+                contents.add(
+                        Content.builder()
+                                .role("user")
+                                .parts(List.of(Part.fromText(userMsg.getText())))
+                                .build());
+            }
+
+            case ASSISTANT -> {
+                AssistantMessage assistantMsg = (AssistantMessage) msg;
+                List<Part> parts = new ArrayList<>();
+                if (assistantMsg.getText() != null && !assistantMsg.getText().isBlank()) {
+                    parts.add(Part.fromText(assistantMsg.getText()));
+                }
+                if (assistantMsg.hasToolCalls()) {
+                    for (AssistantMessage.ToolCall tc : assistantMsg.getToolCalls()) {
+                        Map<String, Object> args;
+                        try {
+                            args = objectMapper.readValue(tc.arguments(), Map.class);
+                        } catch (Exception e) {
+                            args = Map.of();
+                        }
+                        parts.add(Part.fromFunctionCall(tc.name(), args));
+                    }
+                }
+                if (!parts.isEmpty()) {
+                    contents.add(Content.builder().role("model").parts(parts).build());
+                }
+            }
+
+            case TOOL -> {
+                ToolResponseMessage toolMsg = (ToolResponseMessage) msg;
+                List<Part> parts = new ArrayList<>();
+                for (ToolResponseMessage.ToolResponse tr : toolMsg.getResponses()) {
+                    Map<String, Object> responseMap;
+                    try {
+                        responseMap = objectMapper.readValue(tr.responseData(), Map.class);
+                    } catch (Exception e) {
+                        responseMap = Map.of("result", tr.responseData());
+                    }
+                    parts.add(Part.fromFunctionResponse(tr.name(), responseMap));
+                }
+                contents.add(Content.builder().role("user").parts(parts).build());
+            }
+
+            default -> log.warn("Unsupported message type: {}", msg.getMessageType());
+        }
+
+        return contents;
+    }
+
+    private ChatResponse toSpringChatResponse(GenerateContentResponse result, String model) {
+        List<Generation> generations = new ArrayList<>();
+        List<AssistantMessage.ToolCall> toolCalls = new ArrayList<>();
+        StringBuilder textBuilder = new StringBuilder();
+
+        // Extract finish reason
+        String finishReason = "STOP";
+        var geminiFinishReason = result.finishReason();
+        if (geminiFinishReason != null) {
+            finishReason = geminiFinishReason.toString();
+        }
+
+        // Extract text from response
+        try {
+            String text = result.text();
+            if (text != null && !text.isEmpty()) {
+                textBuilder.append(text);
+            }
+        } catch (Exception e) {
+            // text() throws if no text content
+        }
+
+        // Extract function calls
+        var functionCalls = result.functionCalls();
+        if (functionCalls != null && !functionCalls.isEmpty()) {
+            for (FunctionCall fc : functionCalls) {
+                String name = fc.name().orElse("");
+                String id = fc.id().orElse(name);
+                String argsJson;
+                try {
+                    argsJson = objectMapper.writeValueAsString(fc.args().orElse(Map.of()));
+                } catch (Exception e) {
+                    argsJson = "{}";
+                }
+                toolCalls.add(new AssistantMessage.ToolCall(id, "function", name, argsJson));
+            }
+            finishReason = "TOOL_CALLS";
+        }
+
+        // Build AssistantMessage
+        AssistantMessage assistantMessage;
+        if (!toolCalls.isEmpty()) {
+            assistantMessage =
+                    AssistantMessage.builder()
+                            .content(textBuilder.toString())
+                            .toolCalls(toolCalls)
+                            .build();
+        } else {
+            assistantMessage = new AssistantMessage(textBuilder.toString());
+        }
+
+        ChatGenerationMetadata genMeta =
+                ChatGenerationMetadata.builder().finishReason(finishReason).build();
+        generations.add(new Generation(assistantMessage, genMeta));
+
+        // Usage metadata
+        int inputTok = 0;
+        int outputTok = 0;
+        var usageMeta = result.usageMetadata();
+        if (usageMeta.isPresent()) {
+            GenerateContentResponseUsageMetadata usage = usageMeta.get();
+            inputTok = usage.promptTokenCount().orElse(0);
+            outputTok = usage.candidatesTokenCount().orElse(0);
+        }
+        DefaultUsage springUsage = new DefaultUsage(inputTok, outputTok, inputTok + outputTok);
+
+        String responseId = result.responseId().orElse(null);
+        ChatResponseMetadata.Builder metaBuilder =
+                ChatResponseMetadata.builder().model(model).usage(springUsage);
+        if (responseId != null) {
+            metaBuilder.id(responseId);
+        }
+
+        return new ChatResponse(generations, metaBuilder.build());
+    }
+
+    @Override
+    public ChatOptions getDefaultOptions() {
+        return ToolCallingChatOptions.builder().build();
+    }
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiChatOptions.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiChatOptions.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.gemini;
+
+import java.util.List;
+
+import org.conductoross.conductor.ai.models.ToolSpec;
+import org.springframework.ai.chat.prompt.ChatOptions;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Chat options for the Gemini API. Carries standard ChatOptions fields plus Gemini-specific fields
+ * (tools, google search, code execution, thinking).
+ */
+@Data
+@Builder
+public class GeminiChatOptions implements ChatOptions {
+
+    private String model;
+    private Double temperature;
+    private Double topP;
+    private Integer topK;
+    private Integer maxTokens;
+    private List<String> stopSequences;
+    private Double frequencyPenalty;
+    private Double presencePenalty;
+
+    // Gemini-specific
+    private List<ToolSpec> tools;
+    private boolean googleSearchRetrieval;
+    private boolean codeExecution;
+    private Integer thinkingBudgetTokens;
+
+    @Override
+    public ChatOptions copy() {
+        return GeminiChatOptions.builder()
+                .model(model)
+                .temperature(temperature)
+                .topP(topP)
+                .topK(topK)
+                .maxTokens(maxTokens)
+                .stopSequences(stopSequences)
+                .frequencyPenalty(frequencyPenalty)
+                .presencePenalty(presencePenalty)
+                .tools(tools)
+                .googleSearchRetrieval(googleSearchRetrieval)
+                .codeExecution(codeExecution)
+                .thinkingBudgetTokens(thinkingBudgetTokens)
+                .build();
+    }
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertex.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertex.java
@@ -15,8 +15,6 @@ package org.conductoross.conductor.ai.providers.gemini;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.conductoross.conductor.ai.AIModel;
 import org.conductoross.conductor.ai.models.AudioGenRequest;
@@ -33,34 +31,20 @@ import org.conductoross.conductor.ai.video.VideoPrompt;
 import org.conductoross.conductor.ai.video.VideoResponse;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
-import org.springframework.ai.google.genai.GoogleGenAiChatModel;
-import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
 import org.springframework.ai.image.ImageModel;
-import org.springframework.ai.model.tool.DefaultToolCallingManager;
-import org.springframework.ai.tool.ToolCallback;
-import org.springframework.ai.tool.definition.ToolDefinition;
-import org.springframework.ai.vertexai.embedding.VertexAiEmbeddingConnectionDetails;
-import org.springframework.ai.vertexai.embedding.text.VertexAiTextEmbeddingModel;
-import org.springframework.ai.vertexai.embedding.text.VertexAiTextEmbeddingOptions;
-import org.springframework.ai.vertexai.gemini.VertexAiGeminiChatModel;
-import org.springframework.ai.vertexai.gemini.VertexAiGeminiChatOptions;
-import org.springframework.retry.support.RetryTemplate;
 
-import com.google.api.gax.core.FixedCredentialsProvider;
-import com.google.cloud.aiplatform.v1.PredictionServiceSettings;
-import com.google.cloud.vertexai.VertexAI;
-import com.google.common.primitives.Floats;
 import com.google.genai.Client;
 import com.google.genai.types.Blob;
 import com.google.genai.types.Candidate;
 import com.google.genai.types.Content;
+import com.google.genai.types.ContentEmbedding;
+import com.google.genai.types.EmbedContentConfig;
+import com.google.genai.types.EmbedContentResponse;
 import com.google.genai.types.GenerateContentConfig;
 import com.google.genai.types.GenerateContentResponse;
 import com.google.genai.types.PrebuiltVoiceConfig;
 import com.google.genai.types.SpeechConfig;
 import com.google.genai.types.VoiceConfig;
-import io.micrometer.observation.ObservationRegistry;
-import lombok.SneakyThrows;
 
 public class GeminiVertex implements AIModel {
 
@@ -86,189 +70,51 @@ public class GeminiVertex implements AIModel {
 
     @Override
     public List<Float> generateEmbeddings(EmbeddingGenRequest embeddingGenRequest) {
-
-        VertexAiTextEmbeddingOptions options =
-                VertexAiTextEmbeddingOptions.builder()
-                        .model(embeddingGenRequest.getModel())
-                        .dimensions(embeddingGenRequest.getDimensions())
-                        .build();
-
-        VertexAiEmbeddingConnectionDetails connectionDetails =
-                getVertexAiEmbeddingConnectionDetails();
-        VertexAiTextEmbeddingModel model =
-                new VertexAiTextEmbeddingModel(connectionDetails, options);
-
-        float[] embeddingsResponse =
-                model.embedForResponse(List.of(embeddingGenRequest.getText()))
-                        .getResult()
-                        .getOutput();
-        return Floats.asList(embeddingsResponse);
+        Client client = createGenAIClient();
+        EmbedContentConfig.Builder configBuilder = EmbedContentConfig.builder();
+        if (embeddingGenRequest.getDimensions() != null) {
+            configBuilder.outputDimensionality(embeddingGenRequest.getDimensions());
+        }
+        EmbedContentResponse response =
+                client.models.embedContent(
+                        embeddingGenRequest.getModel(),
+                        embeddingGenRequest.getText(),
+                        configBuilder.build());
+        return response.embeddings()
+                .flatMap(
+                        embeddings ->
+                                embeddings.isEmpty()
+                                        ? java.util.Optional.empty()
+                                        : java.util.Optional.of(embeddings.getFirst()))
+                .flatMap(ContentEmbedding::values)
+                .orElseThrow(() -> new RuntimeException("No embeddings returned from Gemini API"));
     }
 
     @Override
     public ChatModel getChatModel() {
-        // API key path: use GoogleGenAiChatModel (REST, works with AI Studio keys)
-        if (config.getApiKey() != null
-                && !config.getApiKey().isBlank()
-                && config.getGoogleCredentials() == null) {
-            Client genAiClient = createGenAIClient();
-            return new GoogleGenAiChatModel(
-                    genAiClient,
-                    GoogleGenAiChatOptions.builder()
-                            .model("gemini-2.5-flash") // default, overridden per-call by
-                            // getChatOptions()
-                            .build(),
-                    DefaultToolCallingManager.builder().build(),
-                    RetryTemplate.defaultInstance(),
-                    ObservationRegistry.NOOP);
-        }
-        // Vertex AI path: use gRPC with GCP IAM credentials
-        VertexAI vertexAI = getVertexAI();
-        return VertexAiGeminiChatModel.builder().vertexAI(vertexAI).build();
-    }
-
-    @SneakyThrows
-    private VertexAI getVertexAI() {
-        VertexAI.Builder builder = new VertexAI.Builder();
-        if (config.getGoogleCredentials() != null) {
-            var scopedCredentials =
-                    config.getGoogleCredentials()
-                            .createScoped("https://www.googleapis.com/auth/cloud-platform");
-            builder = builder.setCredentials(scopedCredentials);
-        }
-
-        return builder.setProjectId(config.getProjectId())
-                .setLocation(config.getLocation())
-                .build();
-    }
-
-    @SneakyThrows
-    private VertexAiEmbeddingConnectionDetails getVertexAiEmbeddingConnectionDetails() {
-        var builder =
-                VertexAiEmbeddingConnectionDetails.builder()
-                        .projectId(config.getProjectId())
-                        .location(config.getLocation())
-                        .apiEndpoint(config.getBaseURL());
-
-        // Only configure custom credentials if available
-        if (config.getGoogleCredentials() != null) {
-            // Scope credentials for Vertex AI
-            var scopedCredentials =
-                    config.getGoogleCredentials()
-                            .createScoped("https://www.googleapis.com/auth/cloud-platform");
-            builder.predictionServiceSettings(
-                    PredictionServiceSettings.newBuilder()
-                            .setEndpoint(config.getBaseURL())
-                            .setCredentialsProvider(
-                                    FixedCredentialsProvider.create(scopedCredentials))
-                            .build());
-        }
-
-        return builder.build();
+        return new GeminiChatModel(createGenAIClient());
     }
 
     @Override
     public ChatOptions getChatOptions(ChatCompletion input) {
-        List<ToolCallback> toolCallbacks = getToolCallback(input);
-        Set<String> toolNames =
-                toolCallbacks.stream()
-                        .map(tc -> tc.getToolDefinition().name())
-                        .collect(Collectors.toSet());
-
-        // For API key path: use GoogleGenAiChatOptions
-        // Build tool callbacks with proper schemas from ChatCompletion.getTools()
-        if (config.getApiKey() != null
-                && !config.getApiKey().isBlank()
-                && config.getGoogleCredentials() == null) {
-
-            List<ToolCallback> genaiCallbacks = buildGenAiToolCallbacks(input);
-            Set<String> genaiToolNames =
-                    genaiCallbacks.stream()
-                            .map(tc -> tc.getToolDefinition().name())
-                            .collect(Collectors.toSet());
-
-            return GoogleGenAiChatOptions.builder()
-                    .model(input.getModel())
-                    .temperature(input.getTemperature())
-                    .maxOutputTokens(input.getMaxTokens())
-                    .frequencyPenalty(input.getFrequencyPenalty())
-                    .internalToolExecutionEnabled(false)
-                    .presencePenalty(input.getPresencePenalty())
-                    .stopSequences(input.getStopWords())
-                    .toolCallbacks(genaiCallbacks)
-                    .toolNames(genaiToolNames)
-                    .topK(input.getTopK())
-                    .topP(input.getTopP())
-                    .googleSearchRetrieval(input.isGoogleSearchRetrieval())
-                    .build();
-        }
-
-        // Vertex AI path: use VertexAiGeminiChatOptions
-        return VertexAiGeminiChatOptions.builder()
+        return GeminiChatOptions.builder()
                 .model(input.getModel())
                 .temperature(input.getTemperature())
-                .maxOutputTokens(input.getMaxTokens())
+                .maxTokens(input.getMaxTokens())
                 .frequencyPenalty(input.getFrequencyPenalty())
-                .internalToolExecutionEnabled(false)
                 .presencePenalty(input.getPresencePenalty())
                 .stopSequences(input.getStopWords())
-                .toolCallbacks(toolCallbacks)
-                .toolNames(toolNames)
                 .topK(input.getTopK())
                 .topP(input.getTopP())
-                .googleSearchRetrieval(input.isGoogleSearchRetrieval())
+                .googleSearchRetrieval(input.isGoogleSearchRetrieval() || input.isWebSearch())
+                .codeExecution(input.isCodeInterpreter())
+                .tools(
+                        input.getTools() != null && !input.getTools().isEmpty()
+                                ? input.getTools()
+                                : null)
+                .thinkingBudgetTokens(
+                        input.getThinkingTokenLimit() > 0 ? input.getThinkingTokenLimit() : null)
                 .build();
-    }
-
-    /**
-     * Build ToolCallbacks with proper inputSchema from ChatCompletion.getTools(). Conductor's
-     * default getToolCallback() creates callbacks with null inputSchema, which causes
-     * GoogleGenAiToolCallingManager to crash.
-     */
-    private List<ToolCallback> buildGenAiToolCallbacks(ChatCompletion input) {
-        if (input.getTools() == null || input.getTools().isEmpty()) {
-            return List.of();
-        }
-
-        List<ToolCallback> callbacks = new ArrayList<>();
-        var mapper = new com.fasterxml.jackson.databind.ObjectMapper();
-
-        for (var toolSpec : input.getTools()) {
-            String schemaJson = "{}";
-            if (toolSpec.getInputSchema() != null && !toolSpec.getInputSchema().isEmpty()) {
-                try {
-                    schemaJson = mapper.writeValueAsString(toolSpec.getInputSchema());
-                } catch (Exception e) {
-                    // fallback
-                }
-            }
-
-            var toolDef =
-                    ToolDefinition.builder()
-                            .name(toolSpec.getName())
-                            .description(
-                                    toolSpec.getDescription() != null
-                                            ? toolSpec.getDescription()
-                                            : "")
-                            .inputSchema(schemaJson)
-                            .build();
-
-            // Create a no-op callback — Conductor manages tool execution externally
-            callbacks.add(
-                    new ToolCallback() {
-                        @Override
-                        public ToolDefinition getToolDefinition() {
-                            return toolDef;
-                        }
-
-                        @Override
-                        public String call(String toolInput) {
-                            return "{}";
-                        }
-                    });
-        }
-
-        return callbacks;
     }
 
     @Override
@@ -306,21 +152,17 @@ public class GeminiVertex implements AIModel {
             List<Media> mediaList = new ArrayList<>();
             for (VideoGeneration gen : response.getResults()) {
                 Video video = gen.getOutput();
-                // Use the mime type from the Video if set, default to video/mp4
                 String mimeType = video.getMimeType() != null ? video.getMimeType() : "video/mp4";
 
-                // Prefer direct byte data to avoid redundant operations
                 if (video.getData() != null) {
                     mediaList.add(Media.builder().data(video.getData()).mimeType(mimeType).build());
                 } else if (video.getB64Json() != null) {
-                    // Fallback to base64 decoding if data field not populated
                     mediaList.add(
                             Media.builder()
                                     .data(Base64.getDecoder().decode(video.getB64Json()))
                                     .mimeType(mimeType)
                                     .build());
                 } else if (video.getUrl() != null) {
-                    // Last resort: Download from URL (e.g., GCS URI) to get bytes
                     byte[] bytes = downloadFromUrl(video.getUrl());
                     mediaList.add(Media.builder().data(bytes).mimeType(mimeType).build());
                 }
@@ -336,12 +178,15 @@ public class GeminiVertex implements AIModel {
         if (config.getApiKey() != null && !config.getApiKey().isBlank()) {
             return Client.builder().apiKey(config.getApiKey()).build();
         }
-        return Client.builder()
-                .vertexAI(true)
-                .credentials(config.getGoogleCredentials())
-                .location(config.getLocation())
-                .project(config.getProjectId())
-                .build();
+        Client.Builder builder =
+                Client.builder()
+                        .vertexAI(true)
+                        .location(config.getLocation())
+                        .project(config.getProjectId());
+        if (config.getGoogleCredentials() != null) {
+            builder.credentials(config.getGoogleCredentials());
+        }
+        return builder.build();
     }
 
     private byte[] downloadFromUrl(String url) {

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexConfiguration.java
@@ -17,7 +17,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.vertexai.api.PredictionServiceClient;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -35,7 +34,6 @@ public class GeminiVertexConfiguration implements ModelConfiguration<GeminiVerte
     private String publisher;
     private String apiKey;
     GoogleCredentials googleCredentials;
-    PredictionServiceClient predictionServiceClient;
 
     public String getBaseURL() {
         return baseURL == null

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/grok/Grok.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/grok/Grok.java
@@ -19,23 +19,30 @@ import java.util.stream.Collectors;
 import org.conductoross.conductor.ai.AIModel;
 import org.conductoross.conductor.ai.models.ChatCompletion;
 import org.conductoross.conductor.ai.models.EmbeddingGenRequest;
+import org.conductoross.conductor.ai.providers.openai.OpenAICompatChatModel;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIChatCompletionsApi;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.image.ImageModel;
-import org.springframework.ai.openai.OpenAiChatModel;
-import org.springframework.ai.openai.OpenAiChatOptions;
-import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.tool.ToolCallback;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
-import org.springframework.web.client.RestClient;
 
 public class Grok implements AIModel {
 
     public static final String NAME = "Grok";
     private final GrokAIConfiguration config;
+    private final OpenAICompatChatModel chatModel;
 
     public Grok(GrokAIConfiguration config) {
         this.config = config;
+        long timeoutSecs = config.getTimeout() != null ? config.getTimeout().getSeconds() : 600;
+        OpenAIChatCompletionsApi api =
+                new OpenAIChatCompletionsApi(
+                        config.getApiKey(),
+                        config.getBaseURL(),
+                        "/v1/chat/completions",
+                        timeoutSecs);
+        this.chatModel = new OpenAICompatChatModel(api);
     }
 
     @Override
@@ -56,35 +63,23 @@ public class Grok implements AIModel {
                         .map(tc -> tc.getToolDefinition().name())
                         .collect(Collectors.toSet());
 
-        OpenAiChatOptions.Builder builder =
-                OpenAiChatOptions.builder()
-                        .model(input.getModel())
-                        .temperature(input.getTemperature())
-                        .topP(input.getTopP())
-                        .maxTokens(input.getMaxTokens())
-                        .stop(input.getStopWords())
-                        .frequencyPenalty(input.getFrequencyPenalty())
-                        .presencePenalty(input.getPresencePenalty())
-                        .toolCallbacks(toolCallbacks)
-                        .toolNames(toolNames)
-                        .internalToolExecutionEnabled(false);
-
-        return builder.build();
+        return ToolCallingChatOptions.builder()
+                .model(input.getModel())
+                .temperature(input.getTemperature())
+                .topP(input.getTopP())
+                .maxTokens(input.getMaxTokens())
+                .stopSequences(input.getStopWords())
+                .frequencyPenalty(input.getFrequencyPenalty())
+                .presencePenalty(input.getPresencePenalty())
+                .toolCallbacks(toolCallbacks)
+                .toolNames(toolNames)
+                .internalToolExecutionEnabled(false)
+                .build();
     }
 
     @Override
     public ChatModel getChatModel() {
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setReadTimeout(config.getTimeout());
-
-        OpenAiApi grokApi =
-                OpenAiApi.builder()
-                        .baseUrl(config.getBaseURL())
-                        .apiKey(config.getApiKey())
-                        .completionsPath("/v1/chat/completions")
-                        .restClientBuilder(RestClient.builder().requestFactory(factory))
-                        .build();
-        return OpenAiChatModel.builder().openAiApi(grokApi).build();
+        return this.chatModel;
     }
 
     @Override

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAI.java
@@ -12,47 +12,33 @@
  */
 package org.conductoross.conductor.ai.providers.openai;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.conductoross.conductor.ai.AIModel;
 import org.conductoross.conductor.ai.models.AudioGenRequest;
 import org.conductoross.conductor.ai.models.ChatCompletion;
 import org.conductoross.conductor.ai.models.EmbeddingGenRequest;
 import org.conductoross.conductor.ai.models.LLMResponse;
 import org.conductoross.conductor.ai.models.Media;
+import org.conductoross.conductor.ai.models.ToolSpec;
 import org.conductoross.conductor.ai.models.VideoGenRequest;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIEmbeddingsApi;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIImageGenApi;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIResponsesApi;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIResponsesApi.Tool;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAISpeechApi;
 import org.conductoross.conductor.ai.providers.openai.api.OpenAIVideoApi;
-import org.conductoross.conductor.ai.video.Video;
-import org.conductoross.conductor.ai.video.VideoGeneration;
 import org.conductoross.conductor.ai.video.VideoModel;
 import org.conductoross.conductor.ai.video.VideoOptions;
 import org.conductoross.conductor.ai.video.VideoPrompt;
 import org.conductoross.conductor.ai.video.VideoResponse;
-import org.springframework.ai.audio.tts.Speech;
-import org.springframework.ai.audio.tts.TextToSpeechPrompt;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
-import org.springframework.ai.embedding.EmbeddingRequest;
-import org.springframework.ai.embedding.EmbeddingResponse;
 import org.springframework.ai.image.ImageModel;
-import org.springframework.ai.openai.OpenAiAudioSpeechModel;
-import org.springframework.ai.openai.OpenAiAudioSpeechOptions;
-import org.springframework.ai.openai.api.OpenAiAudioApi;
-import org.springframework.ai.openaisdk.OpenAiSdkChatModel;
-import org.springframework.ai.openaisdk.OpenAiSdkChatOptions;
-import org.springframework.ai.openaisdk.OpenAiSdkEmbeddingModel;
-import org.springframework.ai.openaisdk.OpenAiSdkEmbeddingOptions;
-import org.springframework.ai.openaisdk.OpenAiSdkImageModel;
-import org.springframework.ai.openaisdk.OpenAiSdkImageOptions;
-import org.springframework.ai.tool.ToolCallback;
-import org.springframework.util.LinkedMultiValueMap;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -61,22 +47,38 @@ public class OpenAI implements AIModel {
     public static final String NAME = "openai";
     private final OpenAIConfiguration config;
 
-    // Cached instances
-    private final OpenAiSdkChatModel chatModel;
-    private final OpenAiSdkEmbeddingModel embeddingModel;
-    private final OpenAiSdkImageModel imageModel;
-    private final OpenAiAudioApi audioApi;
-    private final OpenAiAudioSpeechModel speechModel;
+    // OkHttp-based API clients
+    private final OpenAIResponsesApi responsesApi;
+    private final OpenAIEmbeddingsApi embeddingsApi;
+    private final OpenAIImageGenApi imageGenApi;
+    private final OpenAISpeechApi speechApi;
+    private final OpenAIVideoApi videoApi;
+
+    // Spring AI adapter
+    private final OpenAIResponsesChatModel chatModel;
+    private final OpenAIHttpImageModel imageModel;
     private final OpenAIVideoModel videoModel;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public OpenAI(OpenAIConfiguration config) {
         this.config = config;
-        this.chatModel = createChatModel();
-        this.embeddingModel = createEmbeddingModel();
-        this.imageModel = createImageModel();
-        this.audioApi = createAudioApi();
-        this.speechModel = new OpenAiAudioSpeechModel(this.audioApi);
-        this.videoModel = createVideoModel();
+        long timeoutSecs = config.getTimeout() != null ? config.getTimeout().getSeconds() : 600;
+        String baseUrl = config.getBaseURL();
+
+        this.responsesApi = new OpenAIResponsesApi(config.getApiKey(), baseUrl, false, timeoutSecs);
+        this.embeddingsApi =
+                new OpenAIEmbeddingsApi(config.getApiKey(), baseUrl, false, timeoutSecs);
+        this.imageGenApi = new OpenAIImageGenApi(config.getApiKey(), baseUrl, false, timeoutSecs);
+
+        // Audio and Video APIs need base URL without /v1 suffix
+        String baseUrlNoV1 = stripV1(baseUrl);
+        this.speechApi = new OpenAISpeechApi(config.getApiKey(), baseUrl, false, timeoutSecs);
+        this.videoApi = new OpenAIVideoApi(config.getApiKey(), baseUrlNoV1);
+
+        this.chatModel = new OpenAIResponsesChatModel(responsesApi);
+        this.imageModel = new OpenAIHttpImageModel(imageGenApi);
+        this.videoModel = new OpenAIVideoModel(videoApi);
     }
 
     @Override
@@ -86,79 +88,46 @@ public class OpenAI implements AIModel {
 
     @Override
     public List<Float> generateEmbeddings(EmbeddingGenRequest embeddingGenRequest) {
-        OpenAiSdkEmbeddingOptions options =
-                OpenAiSdkEmbeddingOptions.builder()
-                        .model(embeddingGenRequest.getModel())
-                        .dimensions(embeddingGenRequest.getDimensions())
-                        .build();
-        EmbeddingRequest request =
-                new EmbeddingRequest(List.of(embeddingGenRequest.getText()), options);
-        EmbeddingResponse response = embeddingModel.call(request);
-        return List.of(ArrayUtils.toObject(response.getResult().getOutput()));
+        try {
+            var request =
+                    new OpenAIEmbeddingsApi.EmbeddingRequest(
+                            embeddingGenRequest.getModel(),
+                            embeddingGenRequest.getText(),
+                            embeddingGenRequest.getDimensions());
+            var result = embeddingsApi.createEmbeddings(request);
+            if (result.data() != null && !result.data().isEmpty()) {
+                return result.data().getFirst().embedding();
+            }
+            return List.of();
+        } catch (IOException e) {
+            throw new RuntimeException("Embeddings API call failed: " + e.getMessage(), e);
+        }
     }
 
     @Override
     public ChatOptions getChatOptions(ChatCompletion input) {
-        List<ToolCallback> toolCallbacks = getToolCallback(input);
-        Set<String> toolNames =
-                toolCallbacks.stream()
-                        .map(tc -> tc.getToolDefinition().name())
-                        .collect(Collectors.toSet());
+        List<Tool> tools = convertTools(input);
 
-        List<String> outputModalities = null;
-        OpenAiSdkChatOptions.AudioParameters audioParameters = null;
-        if (input.getOutputMimeType() != null && input.getOutputMimeType().startsWith("audio/")) {
-            outputModalities = new ArrayList<>();
-            outputModalities.add("text");
-            outputModalities.add("audio");
-            OpenAiSdkChatOptions.AudioParameters.AudioResponseFormat responseFormat =
-                    OpenAiSdkChatOptions.AudioParameters.AudioResponseFormat.MP3;
-            OpenAiSdkChatOptions.AudioParameters.Voice voice =
-                    OpenAiSdkChatOptions.AudioParameters.Voice.ALLOY;
-            try {
-                responseFormat =
-                        OpenAiSdkChatOptions.AudioParameters.AudioResponseFormat.valueOf(
-                                input.getOutputMimeType().replace("audio/", ""));
-            } catch (Exception ignored) {
-            }
-
-            try {
-                voice = OpenAiSdkChatOptions.AudioParameters.Voice.valueOf(input.getVoice());
-            } catch (Exception ignored) {
-            }
-
-            audioParameters = new OpenAiSdkChatOptions.AudioParameters(voice, responseFormat);
-        }
-
-        OpenAiSdkChatOptions.Builder builder =
-                OpenAiSdkChatOptions.builder()
+        OpenAIResponsesChatOptions.OpenAIResponsesChatOptionsBuilder builder =
+                OpenAIResponsesChatOptions.builder()
                         .model(input.getModel())
                         .topP(input.getTopP())
-                        .stop(input.getStopWords())
-                        .outputModalities(outputModalities)
-                        .outputAudio(audioParameters)
                         .frequencyPenalty(input.getFrequencyPenalty())
-                        .maxCompletionTokens(input.getMaxTokens())
-                        .toolCallbacks(toolCallbacks)
-                        .toolNames(toolNames)
-                        .model(input.getModel())
-                        .internalToolExecutionEnabled(false)
+                        .presencePenalty(input.getPresencePenalty())
+                        .maxTokens(input.getMaxTokens())
+                        .stopSequences(input.getStopWords())
+                        .previousResponseId(input.getPreviousResponseId())
                         .reasoningEffort(input.getReasoningEffort())
-                        .presencePenalty(input.getPresencePenalty());
+                        .jsonOutput(input.isJsonOutput())
+                        .responsesApiTools(tools.isEmpty() ? null : tools);
 
-        if (input.isJsonOutput()) {
-            builder.responseFormat(
-                    OpenAiSdkChatModel.ResponseFormat.builder()
-                            .type(OpenAiSdkChatModel.ResponseFormat.Type.JSON_OBJECT)
-                            .build());
-        }
-
-        // remove temperature, stop and topP for reasoning models
+        // Reasoning models don't support temperature/topP/stop
         if (isReasoningModel(input.getModel())) {
             builder.temperature(null);
             builder.topP(null);
-            builder.stop(null);
+            builder.stopSequences(null);
         }
+
         return builder.build();
     }
 
@@ -174,35 +143,27 @@ public class OpenAI implements AIModel {
 
     @Override
     public LLMResponse generateAudio(AudioGenRequest request) {
-        var options = getSpeechOptions(request);
-
-        var prompt = new TextToSpeechPrompt(request.getText(), options);
-        var response = speechModel.call(prompt);
-        List<Media> media = new ArrayList<>();
-        for (Speech result : response.getResults()) {
-            byte[] data = result.getOutput();
-            media.add(Media.builder().data(data).mimeType("audio/*").build());
-        }
-        return LLMResponse.builder().media(media).build();
-    }
-
-    public OpenAiAudioSpeechOptions getSpeechOptions(AudioGenRequest request) {
-        OpenAiAudioApi.SpeechRequest.AudioResponseFormat responseFormat =
-                OpenAiAudioApi.SpeechRequest.AudioResponseFormat.MP3;
         try {
-            if (request.getResponseFormat() != null) {
-                responseFormat =
-                        OpenAiAudioApi.SpeechRequest.AudioResponseFormat.valueOf(
-                                request.getResponseFormat().toUpperCase());
-            }
-        } catch (IllegalArgumentException ignored) {
+            String responseFormat =
+                    request.getResponseFormat() != null
+                            ? request.getResponseFormat().toLowerCase()
+                            : "mp3";
+
+            var speechRequest =
+                    new OpenAISpeechApi.SpeechRequest(
+                            request.getModel(),
+                            request.getText(),
+                            request.getVoice(),
+                            responseFormat,
+                            request.getSpeed());
+            byte[] audioData = speechApi.createSpeech(speechRequest);
+
+            List<Media> media = new ArrayList<>();
+            media.add(Media.builder().data(audioData).mimeType("audio/*").build());
+            return LLMResponse.builder().media(media).build();
+        } catch (IOException e) {
+            throw new RuntimeException("Speech API call failed: " + e.getMessage(), e);
         }
-        return OpenAiAudioSpeechOptions.builder()
-                .responseFormat(responseFormat)
-                .speed(request.getSpeed())
-                .model(request.getModel())
-                .voice(request.getVoice())
-                .build();
     }
 
     @Override
@@ -231,16 +192,13 @@ public class OpenAI implements AIModel {
 
         if ("COMPLETED".equals(status)) {
             List<Media> mediaList = new ArrayList<>();
-            for (VideoGeneration gen : response.getResults()) {
-                Video video = gen.getOutput();
-                // Use the mime type from the Video if set, default to video/mp4
+            for (var gen : response.getResults()) {
+                var video = gen.getOutput();
                 String mimeType = video.getMimeType() != null ? video.getMimeType() : "video/mp4";
 
-                // Prefer direct byte data to avoid redundant base64 decode
                 if (video.getData() != null) {
                     mediaList.add(Media.builder().data(video.getData()).mimeType(mimeType).build());
                 } else if (video.getB64Json() != null) {
-                    // Fallback to base64 decoding if data field not populated
                     mediaList.add(
                             Media.builder()
                                     .data(java.util.Base64.getDecoder().decode(video.getB64Json()))
@@ -254,78 +212,53 @@ public class OpenAI implements AIModel {
         return builder.build();
     }
 
-    // Initialization helpers
+    // -- Helpers --
 
-    private OpenAiSdkEmbeddingModel createEmbeddingModel() {
-        return new OpenAiSdkEmbeddingModel(
-                OpenAiSdkEmbeddingOptions.builder()
-                        .apiKey(config.getApiKey())
-                        .baseUrl(config.getBaseURL())
-                        .organizationId(config.getOrganizationId())
-                        .timeout(config.getTimeout())
-                        .build());
-    }
+    private List<Tool> convertTools(ChatCompletion input) {
+        List<Tool> tools = new ArrayList<>();
 
-    private OpenAiSdkChatModel createChatModel() {
-        OpenAiSdkChatOptions opts =
-                OpenAiSdkChatOptions.builder()
-                        .temperature(null)
-                        .topP(null)
-                        .stop(null)
-                        .organizationId(config.getOrganizationId())
-                        .apiKey(config.getApiKey())
-                        .baseUrl(config.getBaseURL())
-                        .timeout(config.getTimeout())
-                        .customHeaders(Map.of())
-                        .build();
-        return new OpenAiSdkChatModel(opts);
-    }
-
-    private OpenAiSdkImageModel createImageModel() {
-        return new OpenAiSdkImageModel(
-                OpenAiSdkImageOptions.builder()
-                        .organizationId(config.getOrganizationId())
-                        .apiKey(config.getApiKey())
-                        .baseUrl(config.getBaseURL())
-                        .build());
-    }
-
-    private OpenAiAudioApi createAudioApi() {
-        LinkedMultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
-        if (StringUtils.isNotBlank(config.getOrganizationId())) {
-            headers.put("OpenAI-Organization", List.of(config.getOrganizationId()));
+        // OpenAI Responses API built-in tools
+        if (input.isWebSearch()) {
+            tools.add(Tool.webSearch());
+        }
+        if (input.isCodeInterpreter()) {
+            tools.add(Tool.codeInterpreter());
+        }
+        if (input.getFileSearchVectorStoreIds() != null
+                && !input.getFileSearchVectorStoreIds().isEmpty()) {
+            tools.add(Tool.fileSearch(input.getFileSearchVectorStoreIds()));
         }
 
-        // OpenAiAudioApi appends /v1 automatically, so we must remove it if present to
-        // avoid 404
-        String baseURL = config.getBaseURL();
-        if (baseURL != null && baseURL.endsWith("/v1")) {
-            baseURL = baseURL.substring(0, baseURL.length() - 3);
+        // Convert Conductor ToolSpecs to Responses API function tools
+        if (input.getTools() != null) {
+            for (ToolSpec toolSpec : input.getTools()) {
+                try {
+                    Object params = toolSpec.getInputSchema();
+                    tools.add(Tool.function(toolSpec.getName(), toolSpec.getDescription(), params));
+                } catch (Exception e) {
+                    log.warn("Failed to convert tool spec: {}", toolSpec.getName(), e);
+                }
+            }
         }
 
-        return OpenAiAudioApi.builder()
-                .apiKey(config.getApiKey())
-                .baseUrl(baseURL)
-                .headers(headers)
-                .build();
+        return tools;
     }
 
-    private OpenAIVideoModel createVideoModel() {
-        // OpenAIVideoApi manages its own /v1/ path, so strip /v1 from base URL
-        String baseUrl = config.getBaseURL();
-        if (baseUrl != null && baseUrl.endsWith("/v1")) {
-            baseUrl = baseUrl.substring(0, baseUrl.length() - 3);
-        }
-        OpenAIVideoApi videoApi = new OpenAIVideoApi(config.getApiKey(), baseUrl);
-        return new OpenAIVideoModel(videoApi);
-    }
-
-    // Private methods
     private boolean isReasoningModel(String modelName) {
         if (modelName == null) {
             return false;
         }
         String model = modelName.toLowerCase();
-        return model.startsWith("o1") || model.startsWith("o3") || model.startsWith("gpt-5");
+        return model.startsWith("o1")
+                || model.startsWith("o3")
+                || model.startsWith("o4")
+                || model.startsWith("gpt-5");
+    }
+
+    private static String stripV1(String baseUrl) {
+        if (baseUrl != null && baseUrl.endsWith("/v1")) {
+            return baseUrl.substring(0, baseUrl.length() - 3);
+        }
+        return baseUrl;
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAICompatChatModel.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAICompatChatModel.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.openai;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIChatCompletionsApi;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIChatCompletionsApi.*;
+import org.springframework.ai.chat.messages.*;
+import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Spring AI {@link ChatModel} backed by the OpenAI-compatible Chat Completions API via OkHttp.
+ *
+ * <p>Works with any provider that implements the standard Chat Completions format (Perplexity,
+ * Grok, Together AI, etc.).
+ */
+@Slf4j
+public class OpenAICompatChatModel implements ChatModel {
+
+    private final OpenAIChatCompletionsApi api;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public OpenAICompatChatModel(OpenAIChatCompletionsApi api) {
+        this.api = api;
+    }
+
+    @Override
+    public ChatResponse call(Prompt prompt) {
+        try {
+            ChatCompletionRequest request = buildRequest(prompt);
+            ChatCompletionResult result = api.createChatCompletion(request);
+            return toSpringChatResponse(result);
+        } catch (IOException e) {
+            throw new RuntimeException("Chat Completions API call failed: " + e.getMessage(), e);
+        }
+    }
+
+    private ChatCompletionRequest buildRequest(Prompt prompt) {
+        List<Message> messages = prompt.getInstructions();
+        ChatOptions options = prompt.getOptions();
+
+        List<MessageItem> items = new ArrayList<>();
+        for (Message msg : messages) {
+            items.addAll(convertMessage(msg));
+        }
+
+        String model = options != null ? options.getModel() : null;
+        Double temperature = options != null ? options.getTemperature() : null;
+        Double topP = options != null ? options.getTopP() : null;
+        Integer maxTokens = options != null ? options.getMaxTokens() : null;
+        List<String> stop = options != null ? options.getStopSequences() : null;
+        Double frequencyPenalty = options != null ? options.getFrequencyPenalty() : null;
+        Double presencePenalty = options != null ? options.getPresencePenalty() : null;
+        Integer topK = options != null ? options.getTopK() : null;
+
+        List<ToolDef> tools = null;
+        if (options instanceof ToolCallingChatOptions tcOpts
+                && tcOpts.getToolCallbacks() != null
+                && !tcOpts.getToolCallbacks().isEmpty()) {
+            tools = new ArrayList<>();
+            for (var cb : tcOpts.getToolCallbacks()) {
+                var def = cb.getToolDefinition();
+                // inputSchema() returns a JSON string — parse it to an object so Jackson
+                // serializes it as a nested JSON object, not a quoted string
+                Object parameters = parseSchemaToObject(def.inputSchema());
+                tools.add(ToolDef.function(def.name(), def.description(), parameters));
+            }
+        }
+
+        return ChatCompletionRequest.builder()
+                .model(model)
+                .messages(items)
+                .temperature(temperature)
+                .topP(topP)
+                .maxTokens(maxTokens)
+                .stop(stop != null && !stop.isEmpty() ? stop : null)
+                .frequencyPenalty(frequencyPenalty)
+                .presencePenalty(presencePenalty)
+                .topK(topK)
+                .tools(tools != null && !tools.isEmpty() ? tools : null)
+                .build();
+    }
+
+    private List<MessageItem> convertMessage(Message msg) {
+        List<MessageItem> items = new ArrayList<>();
+        switch (msg.getMessageType()) {
+            case SYSTEM -> items.add(MessageItem.system(((SystemMessage) msg).getText()));
+            case USER -> items.add(MessageItem.user(((UserMessage) msg).getText()));
+            case ASSISTANT -> {
+                AssistantMessage assistantMsg = (AssistantMessage) msg;
+                if (assistantMsg.hasToolCalls()) {
+                    List<ToolCallItem> toolCalls = new ArrayList<>();
+                    for (AssistantMessage.ToolCall tc : assistantMsg.getToolCalls()) {
+                        toolCalls.add(
+                                new ToolCallItem(
+                                        tc.id(),
+                                        "function",
+                                        new FunctionCall(tc.name(), tc.arguments())));
+                    }
+                    items.add(MessageItem.assistant(assistantMsg.getText(), toolCalls));
+                } else {
+                    items.add(MessageItem.assistant(assistantMsg.getText()));
+                }
+            }
+            case TOOL -> {
+                ToolResponseMessage toolMsg = (ToolResponseMessage) msg;
+                for (ToolResponseMessage.ToolResponse tr : toolMsg.getResponses()) {
+                    items.add(MessageItem.tool(tr.id(), tr.responseData()));
+                }
+            }
+            default -> log.warn("Unsupported message type: {}", msg.getMessageType());
+        }
+        return items;
+    }
+
+    private ChatResponse toSpringChatResponse(ChatCompletionResult result) {
+        List<Generation> generations = new ArrayList<>();
+
+        if (result.choices() != null) {
+            for (Choice choice : result.choices()) {
+                MessageItem msg = choice.message();
+                String text = msg != null && msg.content() instanceof String s ? s : "";
+                String finishReason = choice.finishReason();
+
+                AssistantMessage assistantMessage;
+                if (msg != null && msg.toolCalls() != null && !msg.toolCalls().isEmpty()) {
+                    List<AssistantMessage.ToolCall> toolCalls = new ArrayList<>();
+                    for (ToolCallItem tc : msg.toolCalls()) {
+                        toolCalls.add(
+                                new AssistantMessage.ToolCall(
+                                        tc.id(),
+                                        "function",
+                                        tc.function().name(),
+                                        tc.function().arguments()));
+                    }
+                    assistantMessage =
+                            AssistantMessage.builder().content(text).toolCalls(toolCalls).build();
+                    finishReason = "TOOL_CALLS";
+                } else {
+                    assistantMessage = new AssistantMessage(text);
+                }
+
+                String mappedReason = mapFinishReason(finishReason);
+                ChatGenerationMetadata genMeta =
+                        ChatGenerationMetadata.builder().finishReason(mappedReason).build();
+                generations.add(new Generation(assistantMessage, genMeta));
+            }
+        }
+
+        Usage usage = result.usage();
+        int inputTok = usage != null && usage.promptTokens() != null ? usage.promptTokens() : 0;
+        int outputTok =
+                usage != null && usage.completionTokens() != null ? usage.completionTokens() : 0;
+        int totalTok = usage != null && usage.totalTokens() != null ? usage.totalTokens() : 0;
+        DefaultUsage springUsage = new DefaultUsage(inputTok, outputTok, totalTok);
+
+        ChatResponseMetadata metadata =
+                ChatResponseMetadata.builder()
+                        .id(result.id())
+                        .model(result.model())
+                        .usage(springUsage)
+                        .build();
+
+        return new ChatResponse(generations, metadata);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object parseSchemaToObject(String schemaJson) {
+        if (schemaJson == null || schemaJson.isBlank()) {
+            return Map.of("type", "object");
+        }
+        try {
+            return objectMapper.readValue(schemaJson, Map.class);
+        } catch (Exception e) {
+            return Map.of("type", "object");
+        }
+    }
+
+    private String mapFinishReason(String reason) {
+        if (reason == null) return "STOP";
+        return switch (reason) {
+            case "stop" -> "STOP";
+            case "length" -> "MAX_TOKENS";
+            case "tool_calls" -> "TOOL_CALLS";
+            case "content_filter" -> "CONTENT_FILTER";
+            default -> reason.toUpperCase();
+        };
+    }
+
+    @Override
+    public ChatOptions getDefaultOptions() {
+        return ToolCallingChatOptions.builder().build();
+    }
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAIHttpImageModel.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAIHttpImageModel.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.openai;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIImageGenApi;
+import org.springframework.ai.image.Image;
+import org.springframework.ai.image.ImageGeneration;
+import org.springframework.ai.image.ImageModel;
+import org.springframework.ai.image.ImageOptions;
+import org.springframework.ai.image.ImagePrompt;
+import org.springframework.ai.image.ImageResponse;
+
+/**
+ * Spring AI {@link ImageModel} implementation backed by OkHttp calls to OpenAI's image generation
+ * API.
+ */
+public class OpenAIHttpImageModel implements ImageModel {
+
+    private final OpenAIImageGenApi imageGenApi;
+
+    public OpenAIHttpImageModel(OpenAIImageGenApi imageGenApi) {
+        this.imageGenApi = imageGenApi;
+    }
+
+    @Override
+    public ImageResponse call(ImagePrompt prompt) {
+        try {
+            ImageOptions options = prompt.getOptions();
+            String promptText =
+                    prompt.getInstructions().stream()
+                            .map(msg -> msg.getText())
+                            .reduce((a, b) -> a + " " + b)
+                            .orElse("");
+
+            String size = null;
+            if (options != null && options.getWidth() != null && options.getHeight() != null) {
+                size = options.getWidth() + "x" + options.getHeight();
+            }
+
+            var request =
+                    OpenAIImageGenApi.ImageRequest.builder()
+                            .model(options != null ? options.getModel() : null)
+                            .prompt(promptText)
+                            .n(options != null && options.getN() != null ? options.getN() : 1)
+                            .size(size)
+                            .style(options != null ? options.getStyle() : null)
+                            .responseFormat(
+                                    options != null && options.getResponseFormat() != null
+                                            ? options.getResponseFormat()
+                                            : "b64_json")
+                            .build();
+
+            var result = imageGenApi.createImage(request);
+
+            List<ImageGeneration> generations = new ArrayList<>();
+            if (result.data() != null) {
+                for (var imageData : result.data()) {
+                    Image image = new Image(imageData.url(), imageData.b64Json());
+                    generations.add(new ImageGeneration(image));
+                }
+            }
+
+            return new ImageResponse(generations);
+        } catch (IOException e) {
+            throw new RuntimeException("Image generation API call failed: " + e.getMessage(), e);
+        }
+    }
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAIResponsesChatModel.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAIResponsesChatModel.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.openai;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIResponsesApi;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIResponsesApi.ContentPart;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIResponsesApi.InputItem;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIResponsesApi.OutputContent;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIResponsesApi.OutputItem;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIResponsesApi.ResponseRequest;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIResponsesApi.ResponseResult;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIResponsesApi.TextFormat;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIResponsesApi.Tool;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIResponsesApi.Usage;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.content.Media;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Spring AI {@link ChatModel} implementation backed by the OpenAI Responses API via OkHttp.
+ *
+ * <p>Converts Spring AI {@link Prompt} messages to Responses API input format, calls the API, and
+ * converts the response back to Spring AI's {@link ChatResponse}.
+ */
+@Slf4j
+public class OpenAIResponsesChatModel implements ChatModel {
+
+    private final OpenAIResponsesApi responsesApi;
+
+    public OpenAIResponsesChatModel(OpenAIResponsesApi responsesApi) {
+        this.responsesApi = responsesApi;
+    }
+
+    @Override
+    public ChatResponse call(Prompt prompt) {
+        try {
+            ResponseRequest request = buildRequest(prompt);
+            ResponseResult result = responsesApi.createResponse(request);
+            return toSpringChatResponse(result);
+        } catch (IOException e) {
+            throw new RuntimeException("OpenAI Responses API call failed: " + e.getMessage(), e);
+        }
+    }
+
+    private ResponseRequest buildRequest(Prompt prompt) throws JsonProcessingException {
+        List<Message> messages = prompt.getInstructions();
+        ChatOptions options = prompt.getOptions();
+
+        // Extract system messages → instructions field
+        String instructions = null;
+        List<Message> nonSystemMessages = new ArrayList<>();
+        for (Message msg : messages) {
+            if (msg.getMessageType() == MessageType.SYSTEM) {
+                // Concatenate multiple system messages
+                String sysText = ((SystemMessage) msg).getText();
+                instructions = instructions == null ? sysText : instructions + "\n" + sysText;
+            } else {
+                nonSystemMessages.add(msg);
+            }
+        }
+
+        // Convert messages → Responses API input items
+        List<InputItem> inputItems = new ArrayList<>();
+        for (Message msg : nonSystemMessages) {
+            inputItems.addAll(convertMessage(msg));
+        }
+
+        // Extract options
+        String model = options != null ? options.getModel() : null;
+        Double temperature = options != null ? options.getTemperature() : null;
+        Double topP = options != null ? options.getTopP() : null;
+        Integer maxTokens = options != null ? options.getMaxTokens() : null;
+
+        // Extract extended options from OpenAIResponsesChatOptions
+        String previousResponseId = null;
+        String reasoningEffort = null;
+        Boolean jsonOutput = null;
+        List<Tool> tools = null;
+
+        if (options instanceof OpenAIResponsesChatOptions extOpts) {
+            previousResponseId = extOpts.getPreviousResponseId();
+            reasoningEffort = extOpts.getReasoningEffort();
+            jsonOutput = extOpts.getJsonOutput();
+            tools = extOpts.getResponsesApiTools();
+        }
+
+        // Build text format for JSON output
+        TextFormat textFormat = null;
+        if (Boolean.TRUE.equals(jsonOutput)) {
+            textFormat = TextFormat.jsonObject();
+        }
+
+        ResponseRequest.Builder builder =
+                ResponseRequest.builder()
+                        .model(model)
+                        .input(inputItems)
+                        .instructions(instructions)
+                        .tools(tools != null && !tools.isEmpty() ? tools : null)
+                        .previousResponseId(previousResponseId)
+                        .temperature(temperature)
+                        .topP(topP)
+                        .maxOutputTokens(maxTokens)
+                        .reasoningEffort(reasoningEffort)
+                        .text(textFormat);
+
+        return builder.build();
+    }
+
+    private List<InputItem> convertMessage(Message msg) throws JsonProcessingException {
+        List<InputItem> items = new ArrayList<>();
+
+        switch (msg.getMessageType()) {
+            case USER -> {
+                UserMessage userMsg = (UserMessage) msg;
+                List<Media> media = userMsg.getMedia();
+                if (media != null && !media.isEmpty()) {
+                    // Multi-modal: text + images
+                    List<ContentPart> parts = new ArrayList<>();
+                    if (userMsg.getText() != null && !userMsg.getText().isBlank()) {
+                        parts.add(ContentPart.inputText(userMsg.getText()));
+                    }
+                    for (Media m : media) {
+                        // Media can be URL or base64 data
+                        String dataStr =
+                                m.getData() instanceof byte[] bytes
+                                        ? "data:"
+                                                + m.getMimeType()
+                                                + ";base64,"
+                                                + java.util.Base64.getEncoder()
+                                                        .encodeToString(bytes)
+                                        : m.getData().toString();
+                        parts.add(ContentPart.inputImage(dataStr));
+                    }
+                    items.add(InputItem.userMessage(parts));
+                } else {
+                    items.add(InputItem.userMessage(userMsg.getText()));
+                }
+            }
+
+            case ASSISTANT -> {
+                AssistantMessage assistantMsg = (AssistantMessage) msg;
+                if (assistantMsg.hasToolCalls()) {
+                    // Tool call messages: emit function_call items
+                    for (AssistantMessage.ToolCall tc : assistantMsg.getToolCalls()) {
+                        items.add(InputItem.functionCall(tc.id(), tc.name(), tc.arguments()));
+                    }
+                } else {
+                    String text = assistantMsg.getText();
+                    if (text != null && !text.isBlank()) {
+                        items.add(InputItem.assistantMessage(text));
+                    }
+                }
+            }
+
+            case TOOL -> {
+                ToolResponseMessage toolMsg = (ToolResponseMessage) msg;
+                for (ToolResponseMessage.ToolResponse tr : toolMsg.getResponses()) {
+                    items.add(InputItem.functionCallOutput(tr.id(), tr.responseData()));
+                }
+            }
+
+            default -> log.warn("Unsupported message type: {}", msg.getMessageType());
+        }
+
+        return items;
+    }
+
+    private ChatResponse toSpringChatResponse(ResponseResult result) {
+        List<Generation> generations = new ArrayList<>();
+        Usage usage = result.usage();
+
+        if (result.output() != null) {
+            // Collect text from message outputs and tool calls separately
+            StringBuilder textBuilder = new StringBuilder();
+            List<AssistantMessage.ToolCall> toolCalls = new ArrayList<>();
+            String finishReason = result.status(); // "completed" typically
+
+            for (OutputItem item : result.output()) {
+                if ("message".equals(item.type())) {
+                    if (item.content() != null) {
+                        for (OutputContent content : item.content()) {
+                            if ("output_text".equals(content.type()) && content.text() != null) {
+                                if (!textBuilder.isEmpty()) {
+                                    textBuilder.append("\n");
+                                }
+                                textBuilder.append(content.text());
+                            }
+                        }
+                    }
+                } else if ("function_call".equals(item.type())) {
+                    toolCalls.add(
+                            new AssistantMessage.ToolCall(
+                                    item.callId(), "function", item.name(), item.arguments()));
+                    finishReason = "TOOL_CALLS";
+                }
+            }
+
+            // Build a single Generation with text + any tool calls
+            AssistantMessage assistantMessage;
+            if (!toolCalls.isEmpty()) {
+                assistantMessage =
+                        AssistantMessage.builder()
+                                .content(textBuilder.toString())
+                                .toolCalls(toolCalls)
+                                .build();
+            } else {
+                assistantMessage = new AssistantMessage(textBuilder.toString());
+            }
+
+            // Map status to finish reason
+            String mappedReason = mapFinishReason(finishReason);
+            ChatGenerationMetadata genMeta =
+                    ChatGenerationMetadata.builder().finishReason(mappedReason).build();
+            generations.add(new Generation(assistantMessage, genMeta));
+        }
+
+        // Build usage metadata
+        int inputTok = usage != null && usage.inputTokens() != null ? usage.inputTokens() : 0;
+        int outputTok = usage != null && usage.outputTokens() != null ? usage.outputTokens() : 0;
+        int totalTok = usage != null && usage.totalTokens() != null ? usage.totalTokens() : 0;
+        org.springframework.ai.chat.metadata.DefaultUsage springUsage =
+                new org.springframework.ai.chat.metadata.DefaultUsage(
+                        inputTok, outputTok, totalTok);
+
+        ChatResponseMetadata.Builder metaBuilder =
+                ChatResponseMetadata.builder()
+                        .id(result.id())
+                        .model(result.model())
+                        .usage(springUsage);
+
+        // Store the response ID in metadata for previous_response_id chaining
+        if (result.id() != null) {
+            metaBuilder.keyValue("response_id", result.id());
+        }
+
+        return new ChatResponse(generations, metaBuilder.build());
+    }
+
+    private String mapFinishReason(String status) {
+        if (status == null) return "STOP";
+        return switch (status) {
+            case "completed" -> "STOP";
+            case "TOOL_CALLS" -> "TOOL_CALLS";
+            case "incomplete" -> "MAX_TOKENS";
+            case "failed" -> "ERROR";
+            default -> status.toUpperCase();
+        };
+    }
+
+    @Override
+    public ChatOptions getDefaultOptions() {
+        return ToolCallingChatOptions.builder().build();
+    }
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAIResponsesChatOptions.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAIResponsesChatOptions.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.openai;
+
+import java.util.List;
+
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIResponsesApi;
+import org.springframework.ai.chat.prompt.ChatOptions;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Chat options for the OpenAI Responses API. Carries both standard ChatOptions fields and
+ * Responses-API-specific fields (previousResponseId, reasoningEffort, built-in tools, etc.) through
+ * Spring AI's ChatOptions interface.
+ */
+@Data
+@Builder
+public class OpenAIResponsesChatOptions implements ChatOptions {
+
+    private String model;
+    private Double temperature;
+    private Double topP;
+    private Integer maxTokens;
+    private Double frequencyPenalty;
+    private Double presencePenalty;
+    private List<String> stopSequences;
+
+    // Responses API specific
+    private String previousResponseId;
+    private String reasoningEffort;
+    private Boolean jsonOutput;
+    private List<OpenAIResponsesApi.Tool> responsesApiTools;
+
+    @Override
+    public Integer getTopK() {
+        return null; // Not supported by OpenAI
+    }
+
+    @Override
+    public ChatOptions copy() {
+        return OpenAIResponsesChatOptions.builder()
+                .model(model)
+                .temperature(temperature)
+                .topP(topP)
+                .maxTokens(maxTokens)
+                .frequencyPenalty(frequencyPenalty)
+                .presencePenalty(presencePenalty)
+                .stopSequences(stopSequences)
+                .previousResponseId(previousResponseId)
+                .reasoningEffort(reasoningEffort)
+                .jsonOutput(jsonOutput)
+                .responsesApiTools(responsesApiTools)
+                .build();
+    }
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIChatCompletionsApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIChatCompletionsApi.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.openai.api;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.netflix.conductor.common.config.ObjectMapperProvider;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+/**
+ * OkHttp REST client for OpenAI-compatible Chat Completions API (POST /chat/completions).
+ *
+ * <p>Works with any provider that implements the OpenAI Chat Completions format: Perplexity, Grok
+ * (xAI), Together AI, etc.
+ */
+@Slf4j
+public class OpenAIChatCompletionsApi {
+
+    private static final MediaType JSON = MediaType.parse("application/json");
+
+    private final String baseUrl;
+    private final String apiKey;
+    private final String completionsPath;
+    private final OkHttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    public OpenAIChatCompletionsApi(
+            String apiKey, String baseUrl, String completionsPath, long timeoutSeconds) {
+        this.baseUrl =
+                baseUrl != null && baseUrl.endsWith("/")
+                        ? baseUrl.substring(0, baseUrl.length() - 1)
+                        : baseUrl;
+        this.apiKey = apiKey;
+        this.completionsPath = completionsPath != null ? completionsPath : "/chat/completions";
+        this.httpClient =
+                new OkHttpClient.Builder()
+                        .connectTimeout(60, TimeUnit.SECONDS)
+                        .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
+                        .writeTimeout(60, TimeUnit.SECONDS)
+                        .build();
+        this.objectMapper = new ObjectMapperProvider().getObjectMapper();
+    }
+
+    public OpenAIChatCompletionsApi(String apiKey, String baseUrl, long timeoutSeconds) {
+        this(apiKey, baseUrl, null, timeoutSeconds);
+    }
+
+    public ChatCompletionResult createChatCompletion(ChatCompletionRequest request)
+            throws IOException {
+        String jsonBody = objectMapper.writeValueAsString(request);
+        log.debug("Chat Completions API request: {}", jsonBody);
+
+        Request httpRequest =
+                new Request.Builder()
+                        .url(baseUrl + completionsPath)
+                        .header("Authorization", "Bearer " + apiKey)
+                        .header("Content-Type", "application/json")
+                        .post(RequestBody.create(jsonBody, JSON))
+                        .build();
+
+        try (Response response = httpClient.newCall(httpRequest).execute()) {
+            ResponseBody body = response.body();
+            String responseBody = body != null ? body.string() : "";
+            if (!response.isSuccessful()) {
+                throw new IOException(
+                        "Chat Completions API failed with status %d: %s"
+                                .formatted(response.code(), responseBody));
+            }
+            log.debug("Chat Completions API response: {}", responseBody);
+            return objectMapper.readValue(responseBody, ChatCompletionResult.class);
+        }
+    }
+
+    // -- Request DTOs --
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record ChatCompletionRequest(
+            String model,
+            List<MessageItem> messages,
+            Double temperature,
+            @JsonProperty("top_p") Double topP,
+            @JsonProperty("max_tokens") Integer maxTokens,
+            List<String> stop,
+            @JsonProperty("frequency_penalty") Double frequencyPenalty,
+            @JsonProperty("presence_penalty") Double presencePenalty,
+            @JsonProperty("top_k") Integer topK,
+            @JsonProperty("response_format") ResponseFormat responseFormat,
+            List<ToolDef> tools,
+            @JsonProperty("tool_choice") Object toolChoice) {
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static class Builder {
+            private String model;
+            private List<MessageItem> messages;
+            private Double temperature;
+            private Double topP;
+            private Integer maxTokens;
+            private List<String> stop;
+            private Double frequencyPenalty;
+            private Double presencePenalty;
+            private Integer topK;
+            private ResponseFormat responseFormat;
+            private List<ToolDef> tools;
+            private Object toolChoice;
+
+            public Builder model(String model) {
+                this.model = model;
+                return this;
+            }
+
+            public Builder messages(List<MessageItem> messages) {
+                this.messages = messages;
+                return this;
+            }
+
+            public Builder temperature(Double temperature) {
+                this.temperature = temperature;
+                return this;
+            }
+
+            public Builder topP(Double topP) {
+                this.topP = topP;
+                return this;
+            }
+
+            public Builder maxTokens(Integer maxTokens) {
+                this.maxTokens = maxTokens;
+                return this;
+            }
+
+            public Builder stop(List<String> stop) {
+                this.stop = stop;
+                return this;
+            }
+
+            public Builder frequencyPenalty(Double frequencyPenalty) {
+                this.frequencyPenalty = frequencyPenalty;
+                return this;
+            }
+
+            public Builder presencePenalty(Double presencePenalty) {
+                this.presencePenalty = presencePenalty;
+                return this;
+            }
+
+            public Builder topK(Integer topK) {
+                this.topK = topK;
+                return this;
+            }
+
+            public Builder responseFormat(ResponseFormat responseFormat) {
+                this.responseFormat = responseFormat;
+                return this;
+            }
+
+            public Builder tools(List<ToolDef> tools) {
+                this.tools = tools;
+                return this;
+            }
+
+            public Builder toolChoice(Object toolChoice) {
+                this.toolChoice = toolChoice;
+                return this;
+            }
+
+            public ChatCompletionRequest build() {
+                return new ChatCompletionRequest(
+                        model,
+                        messages,
+                        temperature,
+                        topP,
+                        maxTokens,
+                        stop,
+                        frequencyPenalty,
+                        presencePenalty,
+                        topK,
+                        responseFormat,
+                        tools,
+                        toolChoice);
+            }
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record MessageItem(
+            String role,
+            Object content, // String or List<ContentPart>
+            String name,
+            @JsonProperty("tool_calls") List<ToolCallItem> toolCalls,
+            @JsonProperty("tool_call_id") String toolCallId) {
+
+        public static MessageItem system(String content) {
+            return new MessageItem("system", content, null, null, null);
+        }
+
+        public static MessageItem user(String content) {
+            return new MessageItem("user", content, null, null, null);
+        }
+
+        public static MessageItem assistant(String content) {
+            return new MessageItem("assistant", content, null, null, null);
+        }
+
+        public static MessageItem assistant(String content, List<ToolCallItem> toolCalls) {
+            return new MessageItem("assistant", content, null, toolCalls, null);
+        }
+
+        public static MessageItem tool(String toolCallId, String content) {
+            return new MessageItem("tool", content, null, null, toolCallId);
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record ToolCallItem(String id, String type, FunctionCall function) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record FunctionCall(String name, String arguments) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record ResponseFormat(String type) {
+
+        public static ResponseFormat jsonObject() {
+            return new ResponseFormat("json_object");
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record ToolDef(String type, FunctionDef function) {
+
+        public static ToolDef function(String name, String description, Object parameters) {
+            return new ToolDef("function", new FunctionDef(name, description, parameters));
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record FunctionDef(String name, String description, Object parameters) {}
+
+    // -- Response DTOs --
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ChatCompletionResult(
+            String id, String object, String model, List<Choice> choices, Usage usage) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Choice(
+            Integer index,
+            MessageItem message,
+            @JsonProperty("finish_reason") String finishReason) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Usage(
+            @JsonProperty("prompt_tokens") Integer promptTokens,
+            @JsonProperty("completion_tokens") Integer completionTokens,
+            @JsonProperty("total_tokens") Integer totalTokens) {}
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIEmbeddingsApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIEmbeddingsApi.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.openai.api;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.netflix.conductor.common.config.ObjectMapperProvider;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+/**
+ * OkHttp REST client for the OpenAI Embeddings API (POST /v1/embeddings).
+ *
+ * <p>Supports both OpenAI and Azure OpenAI endpoints.
+ */
+@Slf4j
+public class OpenAIEmbeddingsApi {
+
+    private static final MediaType JSON = MediaType.parse("application/json");
+
+    private final String baseUrl;
+    private final String authHeaderName;
+    private final String authHeaderValue;
+    private final OkHttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    public OpenAIEmbeddingsApi(
+            String apiKey, String baseUrl, boolean azureAuth, long timeoutSeconds) {
+        this.baseUrl = baseUrl != null ? baseUrl : "https://api.openai.com/v1";
+        this.authHeaderName = azureAuth ? "api-key" : "Authorization";
+        this.authHeaderValue = azureAuth ? apiKey : "Bearer " + apiKey;
+        this.httpClient =
+                new OkHttpClient.Builder()
+                        .connectTimeout(60, TimeUnit.SECONDS)
+                        .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
+                        .writeTimeout(60, TimeUnit.SECONDS)
+                        .build();
+        this.objectMapper = new ObjectMapperProvider().getObjectMapper();
+    }
+
+    public OpenAIEmbeddingsApi(String apiKey, String baseUrl, boolean azureAuth) {
+        this(apiKey, baseUrl, azureAuth, 120);
+    }
+
+    public EmbeddingResult createEmbeddings(EmbeddingRequest request) throws IOException {
+        String jsonBody = objectMapper.writeValueAsString(request);
+
+        Request httpRequest =
+                new Request.Builder()
+                        .url(baseUrl + "/embeddings")
+                        .header(authHeaderName, authHeaderValue)
+                        .header("Content-Type", "application/json")
+                        .post(RequestBody.create(jsonBody, JSON))
+                        .build();
+
+        try (Response response = httpClient.newCall(httpRequest).execute()) {
+            ResponseBody body = response.body();
+            String responseBody = body != null ? body.string() : "";
+            if (!response.isSuccessful()) {
+                throw new IOException(
+                        "Embeddings API failed with status %d: %s"
+                                .formatted(response.code(), responseBody));
+            }
+            return objectMapper.readValue(responseBody, EmbeddingResult.class);
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record EmbeddingRequest(String model, String input, Integer dimensions) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record EmbeddingResult(String object, List<EmbeddingData> data, String model) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record EmbeddingData(String object, Integer index, List<Float> embedding) {}
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIImageGenApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIImageGenApi.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.openai.api;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.netflix.conductor.common.config.ObjectMapperProvider;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+/**
+ * OkHttp REST client for the OpenAI Image Generation API (POST /v1/images/generations).
+ *
+ * <p>Supports both OpenAI and Azure OpenAI endpoints.
+ */
+@Slf4j
+public class OpenAIImageGenApi {
+
+    private static final MediaType JSON = MediaType.parse("application/json");
+
+    private final String baseUrl;
+    private final String authHeaderName;
+    private final String authHeaderValue;
+    private final OkHttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    public OpenAIImageGenApi(
+            String apiKey, String baseUrl, boolean azureAuth, long timeoutSeconds) {
+        this.baseUrl = baseUrl != null ? baseUrl : "https://api.openai.com/v1";
+        this.authHeaderName = azureAuth ? "api-key" : "Authorization";
+        this.authHeaderValue = azureAuth ? apiKey : "Bearer " + apiKey;
+        this.httpClient =
+                new OkHttpClient.Builder()
+                        .connectTimeout(60, TimeUnit.SECONDS)
+                        .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
+                        .writeTimeout(60, TimeUnit.SECONDS)
+                        .build();
+        this.objectMapper = new ObjectMapperProvider().getObjectMapper();
+    }
+
+    public OpenAIImageGenApi(String apiKey, String baseUrl, boolean azureAuth) {
+        this(apiKey, baseUrl, azureAuth, 120);
+    }
+
+    public ImageResult createImage(ImageRequest request) throws IOException {
+        String jsonBody = objectMapper.writeValueAsString(request);
+
+        Request httpRequest =
+                new Request.Builder()
+                        .url(baseUrl + "/images/generations")
+                        .header(authHeaderName, authHeaderValue)
+                        .header("Content-Type", "application/json")
+                        .post(RequestBody.create(jsonBody, JSON))
+                        .build();
+
+        try (Response response = httpClient.newCall(httpRequest).execute()) {
+            ResponseBody body = response.body();
+            String responseBody = body != null ? body.string() : "";
+            if (!response.isSuccessful()) {
+                throw new IOException(
+                        "Image Generation API failed with status %d: %s"
+                                .formatted(response.code(), responseBody));
+            }
+            return objectMapper.readValue(responseBody, ImageResult.class);
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record ImageRequest(
+            String model,
+            String prompt,
+            Integer n,
+            String size,
+            String style,
+            String quality,
+            @JsonProperty("response_format") String responseFormat // "url" or "b64_json"
+            ) {
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static class Builder {
+            private String model;
+            private String prompt;
+            private Integer n;
+            private String size;
+            private String style;
+            private String quality;
+            private String responseFormat = "b64_json";
+
+            public Builder model(String model) {
+                this.model = model;
+                return this;
+            }
+
+            public Builder prompt(String prompt) {
+                this.prompt = prompt;
+                return this;
+            }
+
+            public Builder n(Integer n) {
+                this.n = n;
+                return this;
+            }
+
+            public Builder size(String size) {
+                this.size = size;
+                return this;
+            }
+
+            public Builder style(String style) {
+                this.style = style;
+                return this;
+            }
+
+            public Builder quality(String quality) {
+                this.quality = quality;
+                return this;
+            }
+
+            public Builder responseFormat(String responseFormat) {
+                this.responseFormat = responseFormat;
+                return this;
+            }
+
+            public ImageRequest build() {
+                return new ImageRequest(model, prompt, n, size, style, quality, responseFormat);
+            }
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ImageResult(Long created, List<ImageData> data) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ImageData(
+            String url,
+            @JsonProperty("b64_json") String b64Json,
+            @JsonProperty("revised_prompt") String revisedPrompt) {}
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIResponsesApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIResponsesApi.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.openai.api;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import com.netflix.conductor.common.config.ObjectMapperProvider;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+/**
+ * OkHttp REST client for the OpenAI Responses API.
+ *
+ * <p>Supports both OpenAI and Azure OpenAI endpoints via configurable auth.
+ *
+ * <p>Endpoint: POST /v1/responses (OpenAI) or POST /openai/v1/responses (Azure)
+ *
+ * @see <a href="https://developers.openai.com/api/reference/resources/responses">OpenAI Responses
+ *     API</a>
+ */
+@Slf4j
+public class OpenAIResponsesApi {
+
+    private static final MediaType JSON = MediaType.parse("application/json");
+
+    private final String baseUrl;
+    private final String authHeaderName;
+    private final String authHeaderValue;
+    private final OkHttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * @param apiKey API key
+     * @param baseUrl Base URL (e.g. "https://api.openai.com/v1" or
+     *     "https://resource.openai.azure.com/openai/v1")
+     * @param azureAuth true for Azure (api-key header), false for OpenAI (Bearer token)
+     * @param timeoutSeconds HTTP timeout in seconds
+     */
+    public OpenAIResponsesApi(
+            String apiKey, String baseUrl, boolean azureAuth, long timeoutSeconds) {
+        this.baseUrl = baseUrl != null ? baseUrl : "https://api.openai.com/v1";
+        this.authHeaderName = azureAuth ? "api-key" : "Authorization";
+        this.authHeaderValue = azureAuth ? apiKey : "Bearer " + apiKey;
+        this.httpClient =
+                new OkHttpClient.Builder()
+                        .connectTimeout(60, TimeUnit.SECONDS)
+                        .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
+                        .writeTimeout(60, TimeUnit.SECONDS)
+                        .build();
+        this.objectMapper = new ObjectMapperProvider().getObjectMapper();
+    }
+
+    public OpenAIResponsesApi(String apiKey, String baseUrl, boolean azureAuth) {
+        this(apiKey, baseUrl, azureAuth, 600);
+    }
+
+    /**
+     * Create a model response via POST /v1/responses.
+     *
+     * @param request The response creation request
+     * @return The API response
+     */
+    public ResponseResult createResponse(ResponseRequest request) throws IOException {
+        String jsonBody = objectMapper.writeValueAsString(request);
+        log.debug("Responses API request: {}", jsonBody);
+
+        Request httpRequest =
+                new Request.Builder()
+                        .url(baseUrl + "/responses")
+                        .header(authHeaderName, authHeaderValue)
+                        .header("Content-Type", "application/json")
+                        .post(RequestBody.create(jsonBody, JSON))
+                        .build();
+
+        try (Response response = httpClient.newCall(httpRequest).execute()) {
+            String responseBody = readBody(response);
+            if (!response.isSuccessful()) {
+                throw new IOException(
+                        "Responses API failed with status %d: %s"
+                                .formatted(response.code(), responseBody));
+            }
+            log.debug("Responses API response: {}", responseBody);
+            return objectMapper.readValue(responseBody, ResponseResult.class);
+        }
+    }
+
+    private String readBody(Response response) throws IOException {
+        ResponseBody body = response.body();
+        return body != null ? body.string() : "";
+    }
+
+    // -- Request DTOs --
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record ResponseRequest(
+            String model,
+            Object input, // String or List<InputItem>
+            String instructions,
+            List<Tool> tools,
+            @JsonProperty("previous_response_id") String previousResponseId,
+            Double temperature,
+            @JsonProperty("top_p") Double topP,
+            @JsonProperty("max_output_tokens") Integer maxOutputTokens,
+            @JsonProperty("reasoning_effort") String reasoningEffort,
+            TextFormat text,
+            @JsonProperty("tool_choice") Object toolChoice,
+            Boolean store) {
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static class Builder {
+            private String model;
+            private Object input;
+            private String instructions;
+            private List<Tool> tools;
+            private String previousResponseId;
+            private Double temperature;
+            private Double topP;
+            private Integer maxOutputTokens;
+            private String reasoningEffort;
+            private TextFormat text;
+            private Object toolChoice;
+            private Boolean store;
+
+            public Builder model(String model) {
+                this.model = model;
+                return this;
+            }
+
+            public Builder input(Object input) {
+                this.input = input;
+                return this;
+            }
+
+            public Builder instructions(String instructions) {
+                this.instructions = instructions;
+                return this;
+            }
+
+            public Builder tools(List<Tool> tools) {
+                this.tools = tools;
+                return this;
+            }
+
+            public Builder previousResponseId(String previousResponseId) {
+                this.previousResponseId = previousResponseId;
+                return this;
+            }
+
+            public Builder temperature(Double temperature) {
+                this.temperature = temperature;
+                return this;
+            }
+
+            public Builder topP(Double topP) {
+                this.topP = topP;
+                return this;
+            }
+
+            public Builder maxOutputTokens(Integer maxOutputTokens) {
+                this.maxOutputTokens = maxOutputTokens;
+                return this;
+            }
+
+            public Builder reasoningEffort(String reasoningEffort) {
+                this.reasoningEffort = reasoningEffort;
+                return this;
+            }
+
+            public Builder text(TextFormat text) {
+                this.text = text;
+                return this;
+            }
+
+            public Builder toolChoice(Object toolChoice) {
+                this.toolChoice = toolChoice;
+                return this;
+            }
+
+            public Builder store(Boolean store) {
+                this.store = store;
+                return this;
+            }
+
+            public ResponseRequest build() {
+                return new ResponseRequest(
+                        model,
+                        input,
+                        instructions,
+                        tools,
+                        previousResponseId,
+                        temperature,
+                        topP,
+                        maxOutputTokens,
+                        reasoningEffort,
+                        text,
+                        toolChoice,
+                        store);
+            }
+        }
+    }
+
+    /** Input item for the Responses API input array. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record InputItem(
+            String type, // "message", "function_call", "function_call_output"
+            String role, // "user", "assistant", "system"
+            Object content, // String or List<ContentPart>
+            String id,
+            @JsonProperty("call_id") String callId,
+            String name,
+            String arguments,
+            String output,
+            String status) {
+
+        public static InputItem userMessage(String text) {
+            return new InputItem("message", "user", text, null, null, null, null, null, null);
+        }
+
+        public static InputItem userMessage(List<ContentPart> parts) {
+            return new InputItem("message", "user", parts, null, null, null, null, null, null);
+        }
+
+        public static InputItem assistantMessage(String text) {
+            List<ContentPart> content = List.of(ContentPart.outputText(text));
+            return new InputItem(
+                    "message", "assistant", content, null, null, null, null, null, null);
+        }
+
+        public static InputItem functionCall(String callId, String name, String arguments) {
+            return new InputItem(
+                    "function_call", null, null, null, callId, name, arguments, null, null);
+        }
+
+        public static InputItem functionCallOutput(String callId, String outputJson) {
+            return new InputItem(
+                    "function_call_output", null, null, null, callId, null, null, outputJson, null);
+        }
+    }
+
+    /** Content part within a message. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record ContentPart(
+            String type, // "input_text", "input_image", "output_text"
+            String text,
+            @JsonProperty("image_url") String imageUrl,
+            List<Object> annotations) {
+
+        public static ContentPart inputText(String text) {
+            return new ContentPart("input_text", text, null, null);
+        }
+
+        public static ContentPart outputText(String text) {
+            return new ContentPart("output_text", text, null, List.of());
+        }
+
+        public static ContentPart inputImage(String url) {
+            return new ContentPart("input_image", null, url, null);
+        }
+    }
+
+    /** Tool definition for the Responses API. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Tool(
+            String type, // "function", "web_search", "code_interpreter", "file_search"
+            String name,
+            String description,
+            Object parameters, // JSON Schema object for function tools
+            Object container, // for code_interpreter
+            @JsonProperty("vector_store_ids") List<String> vectorStoreIds // for file_search
+            ) {
+
+        public static Tool function(String name, String description, Object parameters) {
+            return new Tool("function", name, description, parameters, null, null);
+        }
+
+        public static Tool webSearch() {
+            return new Tool("web_search", null, null, null, null, null);
+        }
+
+        public static Tool codeInterpreter() {
+            return new Tool("code_interpreter", null, null, null, Map.of("type", "auto"), null);
+        }
+
+        public static Tool fileSearch(List<String> vectorStoreIds) {
+            return new Tool("file_search", null, null, null, null, vectorStoreIds);
+        }
+    }
+
+    /** Text format configuration (for JSON mode). */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record TextFormat(Format format) {
+
+        public static TextFormat jsonObject() {
+            return new TextFormat(new Format("json_object", null));
+        }
+
+        public static TextFormat jsonSchema(Object schema) {
+            return new TextFormat(new Format("json_schema", schema));
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public record Format(String type, Object schema) {}
+    }
+
+    // -- Response DTOs --
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ResponseResult(
+            String id,
+            String object,
+            String model,
+            String status,
+            List<OutputItem> output,
+            @JsonProperty("output_text") String outputText,
+            Usage usage,
+            @JsonProperty("previous_response_id") String previousResponseId,
+            @JsonProperty("reasoning_effort") String reasoningEffort,
+            @JsonProperty("incomplete_details") Object incompleteDetails,
+            Object error) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OutputItem(
+            String type, // "message", "function_call"
+            String id,
+            String role,
+            List<OutputContent> content,
+            String status,
+            // function_call fields
+            @JsonProperty("call_id") String callId,
+            String name,
+            String arguments) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OutputContent(
+            String type, // "output_text"
+            String text,
+            List<Object> annotations) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Usage(
+            @JsonProperty("input_tokens") Integer inputTokens,
+            @JsonProperty("output_tokens") Integer outputTokens,
+            @JsonProperty("total_tokens") Integer totalTokens,
+            @JsonProperty("output_tokens_details") OutputTokensDetails outputTokensDetails) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OutputTokensDetails(@JsonProperty("reasoning_tokens") Integer reasoningTokens) {}
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAISpeechApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAISpeechApi.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.openai.api;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import com.netflix.conductor.common.config.ObjectMapperProvider;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+/**
+ * OkHttp REST client for the OpenAI Text-to-Speech API (POST /v1/audio/speech).
+ *
+ * <p>Supports both OpenAI and Azure OpenAI endpoints.
+ */
+@Slf4j
+public class OpenAISpeechApi {
+
+    private static final MediaType JSON = MediaType.parse("application/json");
+
+    private final String baseUrl;
+    private final String authHeaderName;
+    private final String authHeaderValue;
+    private final OkHttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    public OpenAISpeechApi(String apiKey, String baseUrl, boolean azureAuth, long timeoutSeconds) {
+        this.baseUrl = baseUrl != null ? baseUrl : "https://api.openai.com/v1";
+        this.authHeaderName = azureAuth ? "api-key" : "Authorization";
+        this.authHeaderValue = azureAuth ? apiKey : "Bearer " + apiKey;
+        this.httpClient =
+                new OkHttpClient.Builder()
+                        .connectTimeout(60, TimeUnit.SECONDS)
+                        .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
+                        .writeTimeout(60, TimeUnit.SECONDS)
+                        .build();
+        this.objectMapper = new ObjectMapperProvider().getObjectMapper();
+    }
+
+    public OpenAISpeechApi(String apiKey, String baseUrl, boolean azureAuth) {
+        this(apiKey, baseUrl, azureAuth, 120);
+    }
+
+    /**
+     * Generate speech audio from text.
+     *
+     * @param request Speech request parameters
+     * @return Raw audio bytes in the requested format
+     */
+    public byte[] createSpeech(SpeechRequest request) throws IOException {
+        String jsonBody = objectMapper.writeValueAsString(request);
+
+        Request httpRequest =
+                new Request.Builder()
+                        .url(baseUrl + "/audio/speech")
+                        .header(authHeaderName, authHeaderValue)
+                        .header("Content-Type", "application/json")
+                        .post(RequestBody.create(jsonBody, JSON))
+                        .build();
+
+        try (Response response = httpClient.newCall(httpRequest).execute()) {
+            if (!response.isSuccessful()) {
+                ResponseBody body = response.body();
+                String errorBody = body != null ? body.string() : "";
+                throw new IOException(
+                        "Speech API failed with status %d: %s"
+                                .formatted(response.code(), errorBody));
+            }
+            ResponseBody body = response.body();
+            if (body == null) {
+                throw new IOException("Speech API returned empty body");
+            }
+            return body.bytes();
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record SpeechRequest(
+            String model,
+            String input,
+            String voice,
+            @JsonProperty("response_format") String responseFormat,
+            Double speed) {}
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIVideoApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIVideoApi.java
@@ -265,10 +265,10 @@ public class OpenAIVideoApi {
     public record VideoStatusResponse(
             String id,
             String object,
-            @JsonProperty("created_at") long createdAt,
+            @JsonProperty("created_at") Long createdAt,
             String status,
             String model,
-            int progress,
+            Integer progress,
             String seconds,
             String size) {}
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/perplexity/PerplexityAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/perplexity/PerplexityAI.java
@@ -17,23 +17,26 @@ import java.util.List;
 import org.conductoross.conductor.ai.AIModel;
 import org.conductoross.conductor.ai.models.ChatCompletion;
 import org.conductoross.conductor.ai.models.EmbeddingGenRequest;
+import org.conductoross.conductor.ai.providers.openai.OpenAICompatChatModel;
+import org.conductoross.conductor.ai.providers.openai.api.OpenAIChatCompletionsApi;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.image.ImageModel;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
-import org.springframework.ai.openai.OpenAiChatModel;
-import org.springframework.ai.openai.api.OpenAiApi;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
-import org.springframework.web.client.RestClient;
 
 public class PerplexityAI implements AIModel {
 
     public static final String NAME = "perplexity";
-    private static final String chatPath = "/chat/completions";
     private final PerplexityAIConfiguration config;
+    private final OpenAICompatChatModel chatModel;
 
     public PerplexityAI(PerplexityAIConfiguration config) {
         this.config = config;
+        long timeoutSecs = config.getTimeout() != null ? config.getTimeout().getSeconds() : 600;
+        OpenAIChatCompletionsApi api =
+                new OpenAIChatCompletionsApi(
+                        config.getApiKey(), config.getBaseURL(), "/chat/completions", timeoutSecs);
+        this.chatModel = new OpenAICompatChatModel(api);
     }
 
     @Override
@@ -57,25 +60,13 @@ public class PerplexityAI implements AIModel {
                 .internalToolExecutionEnabled(false)
                 .frequencyPenalty(input.getFrequencyPenalty())
                 .topK(input.getTopK())
-                .internalToolExecutionEnabled(false)
                 .presencePenalty(input.getPresencePenalty())
                 .build();
     }
 
     @Override
     public ChatModel getChatModel() {
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setReadTimeout(config.getTimeout());
-
-        OpenAiApi perplexityAI =
-                OpenAiApi.builder()
-                        .baseUrl(config.getBaseURL())
-                        .apiKey(config.getApiKey())
-                        .completionsPath(chatPath)
-                        .restClientBuilder(RestClient.builder().requestFactory(factory))
-                        .build();
-
-        return OpenAiChatModel.builder().openAiApi(perplexityAI).build();
+        return this.chatModel;
     }
 
     @Override

--- a/ai/src/test/java/org/conductoross/conductor/ai/examples/ExampleWorkflowValidationTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/examples/ExampleWorkflowValidationTest.java
@@ -35,11 +35,9 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class ExampleWorkflowValidationTest {
 
-    private static final ObjectMapper objectMapper =
-            new ObjectMapperProvider().getObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapperProvider().getObjectMapper();
 
-    private static final Path EXAMPLES_DIR =
-            Paths.get(System.getProperty("user.dir"), "examples");
+    private static final Path EXAMPLES_DIR = Paths.get(System.getProperty("user.dir"), "examples");
 
     @Test
     void allExampleJsonFilesDeserializeToWorkflowDef() throws IOException {
@@ -73,8 +71,7 @@ class ExampleWorkflowValidationTest {
                 String taskCtx = fileName + " task[" + i + "]";
                 assertNotNull(task.getName(), taskCtx + " must have a name");
                 assertNotNull(
-                        task.getTaskReferenceName(),
-                        taskCtx + " must have a taskReferenceName");
+                        task.getTaskReferenceName(), taskCtx + " must have a taskReferenceName");
                 assertNotNull(task.getType(), taskCtx + " must have a type");
             }
         }

--- a/ai/src/test/java/org/conductoross/conductor/ai/examples/ExampleWorkflowValidationTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/examples/ExampleWorkflowValidationTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.examples;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.netflix.conductor.common.config.ObjectMapperProvider;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Validates that all JSON files in ai/examples/ are valid WorkflowDef definitions that can be
+ * deserialized and have required fields populated.
+ */
+class ExampleWorkflowValidationTest {
+
+    private static final ObjectMapper objectMapper =
+            new ObjectMapperProvider().getObjectMapper();
+
+    private static final Path EXAMPLES_DIR =
+            Paths.get(System.getProperty("user.dir"), "examples");
+
+    @Test
+    void allExampleJsonFilesDeserializeToWorkflowDef() throws IOException {
+        assertTrue(Files.isDirectory(EXAMPLES_DIR), "examples/ directory must exist");
+
+        List<Path> jsonFiles = new ArrayList<>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(EXAMPLES_DIR, "*.json")) {
+            stream.forEach(jsonFiles::add);
+        }
+
+        assertFalse(jsonFiles.isEmpty(), "examples/ directory must contain JSON files");
+
+        for (Path jsonFile : jsonFiles) {
+            String fileName = jsonFile.getFileName().toString();
+            String json = Files.readString(jsonFile);
+
+            WorkflowDef def =
+                    assertDoesNotThrow(
+                            () -> objectMapper.readValue(json, WorkflowDef.class),
+                            fileName + " failed to deserialize to WorkflowDef");
+
+            assertNotNull(def.getName(), fileName + " must have a name");
+            assertFalse(def.getName().isBlank(), fileName + " name must not be blank");
+            assertTrue(def.getVersion() > 0, fileName + " version must be > 0");
+            assertNotNull(def.getTasks(), fileName + " must have tasks");
+            assertFalse(def.getTasks().isEmpty(), fileName + " must have at least one task");
+
+            // Verify every task has a name, taskReferenceName, and type
+            for (int i = 0; i < def.getTasks().size(); i++) {
+                var task = def.getTasks().get(i);
+                String taskCtx = fileName + " task[" + i + "]";
+                assertNotNull(task.getName(), taskCtx + " must have a name");
+                assertNotNull(
+                        task.getTaskReferenceName(),
+                        taskCtx + " must have a taskReferenceName");
+                assertNotNull(task.getType(), taskCtx + " must have a type");
+            }
+        }
+    }
+}

--- a/ai/src/test/java/org/conductoross/conductor/ai/integration/AIModelIntegrationTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/integration/AIModelIntegrationTest.java
@@ -13,12 +13,14 @@
 package org.conductoross.conductor.ai.integration;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.conductoross.conductor.ai.models.AudioGenRequest;
 import org.conductoross.conductor.ai.models.ChatCompletion;
 import org.conductoross.conductor.ai.models.EmbeddingGenRequest;
 import org.conductoross.conductor.ai.models.LLMResponse;
+import org.conductoross.conductor.ai.models.ToolSpec;
 import org.conductoross.conductor.ai.providers.anthropic.Anthropic;
 import org.conductoross.conductor.ai.providers.anthropic.AnthropicConfiguration;
 import org.conductoross.conductor.ai.providers.azureopenai.AzureOpenAI;
@@ -49,9 +51,9 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.image.ImageModel;
+import org.springframework.ai.image.ImageOptionsBuilder;
 import org.springframework.ai.image.ImagePrompt;
 import org.springframework.ai.image.ImageResponse;
-import org.springframework.ai.openai.OpenAiImageOptions;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -88,6 +90,12 @@ public class AIModelIntegrationTest {
     }
 
     static boolean isGeminiConfigured() {
+        // API key path (Google AI Studio)
+        String apiKey = System.getenv("GEMINI_API_KEY");
+        if (StringUtils.isNotBlank(apiKey) && !apiKey.equals("your-gemini-api-key")) {
+            return true;
+        }
+        // Vertex AI path (GCP project + credentials)
         String projectId = System.getenv("GOOGLE_PROJECT_ID");
         String creds = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
         String vertexCreds = System.getenv("VERTEX_AI_CREDENTIALS");
@@ -187,17 +195,16 @@ public class AIModelIntegrationTest {
             ImageModel imageModel = openAI.getImageModel();
             assertNotNull(imageModel);
 
-            // Use OpenAiImageOptions to set model and parameters
-            OpenAiImageOptions imageOptions =
-                    OpenAiImageOptions.builder()
+            // Use generic ImageOptions to set model and parameters
+            var imageOptions =
+                    ImageOptionsBuilder.builder()
                             .model("dall-e-3")
-                            .quality("standard")
                             .height(1024)
                             .width(1024)
                             .build();
 
             ImagePrompt prompt =
-                    new ImagePrompt("A simple red circle on white background", imageOptions);
+                    new ImagePrompt("A simple blue circle on white background", imageOptions);
             ImageResponse response = imageModel.call(prompt);
 
             assertNotNull(response);
@@ -245,6 +252,192 @@ public class AIModelIntegrationTest {
             assertNotNull(embeddings);
             assertFalse(embeddings.isEmpty());
             assertEquals(1536, embeddings.size(), "Expected 1536 dimensions");
+        }
+
+        @Test
+        @DisplayName("Chat completion with Codex model")
+        void testChatCompletion_codex() {
+            ChatModel chatModel = openAI.getChatModel();
+            assertNotNull(chatModel);
+
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("gpt-5.3-codex");
+            input.setMaxTokens(200);
+
+            var chatOptions = openAI.getChatOptions(input);
+            Prompt prompt =
+                    new Prompt(
+                            "Write a Python function that returns the factorial of n", chatOptions);
+
+            ChatResponse response = chatModel.call(prompt);
+
+            assertNotNull(response);
+            assertNotNull(response.getResult());
+            String text = response.getResult().getOutput().getText();
+            assertNotNull(text);
+            assertFalse(text.isEmpty(), "Expected code output from Codex model");
+            assertTrue(
+                    text.contains("def") || text.contains("factorial"),
+                    "Expected Python code with 'def' or 'factorial', got: " + text);
+        }
+
+        @Test
+        @DisplayName("Chat completion with web_search tool")
+        void testChatCompletion_webSearch() {
+            ChatModel chatModel = openAI.getChatModel();
+            assertNotNull(chatModel);
+
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("gpt-4o-mini");
+            input.setMaxTokens(200);
+            input.setTemperature(0.0);
+            input.setWebSearch(true);
+
+            var chatOptions = openAI.getChatOptions(input);
+            Prompt prompt =
+                    new Prompt("What is the current weather in San Francisco?", chatOptions);
+
+            ChatResponse response = chatModel.call(prompt);
+
+            assertNotNull(response);
+            assertNotNull(response.getResult());
+            String text = response.getResult().getOutput().getText();
+            assertNotNull(text);
+            System.out.println(text);
+            assertFalse(text.isEmpty(), "Expected a response with web search results");
+        }
+
+        @Test
+        @DisplayName("Function tool calling - model returns tool_use, not result")
+        void testFunctionToolCalling() {
+            ChatModel chatModel = openAI.getChatModel();
+
+            ToolSpec weatherTool = new ToolSpec();
+            weatherTool.setName("get_weather");
+            weatherTool.setDescription("Get the current weather for a location");
+            weatherTool.setInputSchema(
+                    Map.of(
+                            "type", "object",
+                            "properties",
+                                    Map.of(
+                                            "location",
+                                            Map.of("type", "string", "description", "City name")),
+                            "required", List.of("location")));
+
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("gpt-4o-mini");
+            input.setMaxTokens(200);
+            input.setTemperature(0.0);
+            input.setTools(List.of(weatherTool));
+
+            var chatOptions = openAI.getChatOptions(input);
+            Prompt prompt = new Prompt("What is the weather in Tokyo?", chatOptions);
+
+            ChatResponse response = chatModel.call(prompt);
+
+            assertNotNull(response);
+            assertNotNull(response.getResult());
+
+            var output = response.getResult().getOutput();
+            // Model should return a tool call, not execute it
+            assertNotNull(output.getToolCalls(), "Expected tool calls in response");
+            assertFalse(output.getToolCalls().isEmpty(), "Expected at least one tool call");
+
+            var toolCall = output.getToolCalls().getFirst();
+            assertEquals("get_weather", toolCall.name(), "Expected get_weather tool call");
+            assertNotNull(toolCall.arguments(), "Expected arguments in tool call");
+            assertTrue(
+                    toolCall.arguments().toLowerCase().contains("tokyo"),
+                    "Expected 'tokyo' in arguments: " + toolCall.arguments());
+
+            // Finish reason should indicate tool calls
+            String finishReason = response.getResult().getMetadata().getFinishReason();
+            assertEquals(
+                    "TOOL_CALLS",
+                    finishReason,
+                    "Expected TOOL_CALLS finish reason, got: " + finishReason);
+        }
+
+        @Test
+        @DisplayName("Built-in code_interpreter - server-side execution, returns text")
+        void testCodeInterpreter() {
+            ChatModel chatModel = openAI.getChatModel();
+
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("gpt-4o-mini");
+            input.setMaxTokens(500);
+            input.setTemperature(0.0);
+            input.setCodeInterpreter(true);
+
+            var chatOptions = openAI.getChatOptions(input);
+            Prompt prompt =
+                    new Prompt(
+                            "Calculate the first 10 prime numbers using code. Return ONLY the list.",
+                            chatOptions);
+
+            ChatResponse response = chatModel.call(prompt);
+
+            assertNotNull(response);
+            assertNotNull(response.getResult());
+            String text = response.getResult().getOutput().getText();
+            assertNotNull(text);
+            assertFalse(text.isEmpty(), "Expected text result from code_interpreter");
+            System.out.println(text);
+            // Server-side tool: should return computed text, NOT a tool_call
+            assertTrue(
+                    text.contains("2") && text.contains("29"),
+                    "Expected prime numbers including 2 and 29, got: " + text);
+        }
+
+        @Test
+        @DisplayName("Multi-turn conversation with previousResponseId")
+        void testPreviousResponseId() {
+            ChatModel chatModel = openAI.getChatModel();
+
+            // Turn 1: establish context
+            ChatCompletion turn1Input = new ChatCompletion();
+            turn1Input.setModel("gpt-4o-mini");
+            turn1Input.setMaxTokens(200);
+            turn1Input.setTemperature(0.0);
+
+            var turn1Options = openAI.getChatOptions(turn1Input);
+            Prompt turn1Prompt =
+                    new Prompt("My name is Conductor. Remember that.", turn1Options);
+
+            ChatResponse turn1Response = chatModel.call(turn1Prompt);
+            assertNotNull(turn1Response);
+            assertNotNull(turn1Response.getResult());
+
+            // Extract response_id from metadata
+            String responseId =
+                    (String) turn1Response.getMetadata().get("response_id");
+            assertNotNull(responseId, "Expected response_id in metadata for chaining");
+            assertFalse(responseId.isBlank(), "response_id must not be blank");
+
+            // Turn 2: reference previous response — only send follow-up, no history
+            ChatCompletion turn2Input = new ChatCompletion();
+            turn2Input.setModel("gpt-4o-mini");
+            turn2Input.setMaxTokens(200);
+            turn2Input.setTemperature(0.0);
+            turn2Input.setPreviousResponseId(responseId);
+
+            var turn2Options = openAI.getChatOptions(turn2Input);
+            Prompt turn2Prompt = new Prompt("What is my name?", turn2Options);
+
+            ChatResponse turn2Response = chatModel.call(turn2Prompt);
+            assertNotNull(turn2Response);
+            assertNotNull(turn2Response.getResult());
+
+            String text = turn2Response.getResult().getOutput().getText();
+            assertNotNull(text);
+            assertTrue(
+                    text.toLowerCase().contains("conductor"),
+                    "Expected model to recall 'Conductor' from previous turn, got: " + text);
+
+            // Second response should also have its own response_id
+            String turn2ResponseId =
+                    (String) turn2Response.getMetadata().get("response_id");
+            assertNotNull(turn2ResponseId, "Expected response_id in turn 2 metadata");
         }
 
         @Test
@@ -346,6 +539,56 @@ public class AIModelIntegrationTest {
         }
 
         @Test
+        @DisplayName("Function tool calling - model returns tool_use, not result")
+        void testFunctionToolCalling() {
+            ChatModel chatModel = anthropic.getChatModel();
+
+            ToolSpec weatherTool = new ToolSpec();
+            weatherTool.setName("get_weather");
+            weatherTool.setDescription("Get the current weather for a location");
+            weatherTool.setInputSchema(
+                    Map.of(
+                            "type", "object",
+                            "properties",
+                                    Map.of(
+                                            "location",
+                                            Map.of("type", "string", "description", "City name")),
+                            "required", List.of("location")));
+
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("claude-haiku-4-5");
+            input.setMaxTokens(200);
+            input.setTemperature(0.0);
+            input.setTools(List.of(weatherTool));
+
+            var chatOptions = anthropic.getChatOptions(input);
+            Prompt prompt = new Prompt("What is the weather in Tokyo?", chatOptions);
+
+            ChatResponse response = chatModel.call(prompt);
+
+            assertNotNull(response);
+            assertNotNull(response.getResult());
+
+            var output = response.getResult().getOutput();
+            assertNotNull(output.getToolCalls(), "Expected tool calls in response");
+            assertFalse(output.getToolCalls().isEmpty(), "Expected at least one tool call");
+
+            var toolCall = output.getToolCalls().getFirst();
+            assertEquals("get_weather", toolCall.name(), "Expected get_weather tool call");
+            assertNotNull(toolCall.arguments(), "Expected arguments in tool call");
+            assertTrue(
+                    toolCall.arguments().toLowerCase().contains("tokyo"),
+                    "Expected 'tokyo' in arguments: " + toolCall.arguments());
+
+            // Finish reason should indicate tool calls
+            String finishReason = response.getResult().getMetadata().getFinishReason();
+            assertEquals(
+                    "TOOL_CALLS",
+                    finishReason,
+                    "Expected TOOL_CALLS finish reason, got: " + finishReason);
+        }
+
+        @Test
         @DisplayName("Model provider name")
         void testModelProviderName() {
             assertEquals("anthropic", anthropic.getModelProvider());
@@ -368,18 +611,26 @@ public class AIModelIntegrationTest {
         @BeforeAll
         void setup() throws Exception {
             GeminiVertexConfiguration config = new GeminiVertexConfiguration();
-            config.setProjectId(System.getenv("GOOGLE_PROJECT_ID"));
-            config.setLocation(System.getenv("GOOGLE_LOCATION"));
 
-            // Try to load credentials from VERTEX_AI_CREDENTIALS env var (JSON string)
-            String vertexCreds = System.getenv("VERTEX_AI_CREDENTIALS");
-            if (StringUtils.isNotBlank(vertexCreds)) {
-                var credentials =
-                        com.google.auth.oauth2.GoogleCredentials.fromStream(
-                                new java.io.ByteArrayInputStream(
-                                        vertexCreds.getBytes(
-                                                java.nio.charset.StandardCharsets.UTF_8)));
-                config.setGoogleCredentials(credentials);
+            // Prefer API key path (Google AI Studio) if available
+            String apiKey = System.getenv("GEMINI_API_KEY");
+            if (StringUtils.isNotBlank(apiKey)) {
+                config.setApiKey(apiKey);
+            } else {
+                // Vertex AI path (GCP project + credentials)
+                config.setProjectId(System.getenv("GOOGLE_PROJECT_ID"));
+                config.setLocation(System.getenv("GOOGLE_CLOUD_LOCATION"));
+
+                // Try to load credentials from VERTEX_AI_CREDENTIALS env var (JSON string)
+                String vertexCreds = System.getenv("VERTEX_AI_CREDENTIALS");
+                if (StringUtils.isNotBlank(vertexCreds)) {
+                    var credentials =
+                            com.google.auth.oauth2.GoogleCredentials.fromStream(
+                                    new java.io.ByteArrayInputStream(
+                                            vertexCreds.getBytes(
+                                                    java.nio.charset.StandardCharsets.UTF_8)));
+                    config.setGoogleCredentials(credentials);
+                }
             }
 
             gemini = new GeminiVertex(config);
@@ -392,8 +643,8 @@ public class AIModelIntegrationTest {
             assertNotNull(chatModel);
 
             ChatCompletion input = new ChatCompletion();
-            input.setModel("gemini-2.0-flash-001");
-            input.setMaxTokens(50);
+            input.setModel("gemini-2.5-flash");
+            input.setMaxTokens(500);
             input.setTemperature(0.0);
 
             var chatOptions = gemini.getChatOptions(input);
@@ -413,13 +664,82 @@ public class AIModelIntegrationTest {
         void testEmbeddings() {
             EmbeddingGenRequest request = new EmbeddingGenRequest();
             request.setText(EMBEDDING_TEXT);
-            request.setModel("text-embedding-005");
+            request.setModel("gemini-embedding-001");
 
             List<Float> embeddings = gemini.generateEmbeddings(request);
 
             assertNotNull(embeddings);
             assertFalse(embeddings.isEmpty());
-            assertEquals(768, embeddings.size(), "Expected 768 dimensions");
+            assertEquals(3072, embeddings.size(), "Expected 3072 dimensions");
+        }
+
+        @Test
+        @DisplayName("Function tool calling - model returns tool_use, not result")
+        void testFunctionToolCalling() {
+            ChatModel chatModel = gemini.getChatModel();
+
+            ToolSpec weatherTool = new ToolSpec();
+            weatherTool.setName("get_weather");
+            weatherTool.setDescription("Get the current weather for a location");
+            weatherTool.setInputSchema(
+                    Map.of(
+                            "type",
+                            "object",
+                            "properties",
+                            Map.of(
+                                    "location",
+                                    Map.of("type", "string", "description", "City name")),
+                            "required",
+                            List.of("location")));
+
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("gemini-2.5-flash");
+            input.setMaxTokens(200);
+            input.setTemperature(0.0);
+            input.setTools(List.of(weatherTool));
+
+            var chatOptions = gemini.getChatOptions(input);
+            Prompt prompt = new Prompt("What is the weather in Tokyo?", chatOptions);
+
+            ChatResponse response = chatModel.call(prompt);
+
+            assertNotNull(response);
+            assertNotNull(response.getResult());
+
+            var output = response.getResult().getOutput();
+            assertNotNull(output.getToolCalls(), "Expected tool calls in response");
+            assertFalse(output.getToolCalls().isEmpty(), "Expected at least one tool call");
+
+            var toolCall = output.getToolCalls().getFirst();
+            assertEquals("get_weather", toolCall.name(), "Expected get_weather tool call");
+            assertNotNull(toolCall.arguments(), "Expected arguments in tool call");
+            assertTrue(
+                    toolCall.arguments().toLowerCase().contains("tokyo"),
+                    "Expected 'tokyo' in arguments: " + toolCall.arguments());
+        }
+
+        @Test
+        @DisplayName("Web search via Google Search Retrieval")
+        void testWebSearch() {
+            ChatModel chatModel = gemini.getChatModel();
+
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("gemini-2.5-flash");
+            input.setMaxTokens(200);
+            input.setTemperature(0.0);
+            input.setWebSearch(true);
+
+            var chatOptions = gemini.getChatOptions(input);
+            Prompt prompt =
+                    new Prompt("What is the current weather in San Francisco?", chatOptions);
+
+            ChatResponse response = chatModel.call(prompt);
+
+            assertNotNull(response);
+            assertNotNull(response.getResult());
+            String text = response.getResult().getOutput().getText();
+            assertNotNull(text);
+            assertFalse(text.isEmpty(), "Expected a response with web search results");
         }
 
         @Test
@@ -536,6 +856,51 @@ public class AIModelIntegrationTest {
             assertNotNull(embeddings);
             assertFalse(embeddings.isEmpty());
             assertEquals(1024, embeddings.size(), "Expected 1024 dimensions");
+        }
+
+        @Test
+        @DisplayName("Function tool calling - model returns tool_use, not result")
+        void testFunctionToolCalling() {
+            ChatModel chatModel = mistral.getChatModel();
+
+            ToolSpec weatherTool = new ToolSpec();
+            weatherTool.setName("get_weather");
+            weatherTool.setDescription("Get the current weather for a location");
+            weatherTool.setInputSchema(
+                    Map.of(
+                            "type",
+                            "object",
+                            "properties",
+                            Map.of(
+                                    "location",
+                                    Map.of("type", "string", "description", "City name")),
+                            "required",
+                            List.of("location")));
+
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("mistral-small-latest");
+            input.setMaxTokens(200);
+            input.setTemperature(0.0);
+            input.setTools(List.of(weatherTool));
+
+            var chatOptions = mistral.getChatOptions(input);
+            Prompt prompt = new Prompt("What is the weather in Tokyo?", chatOptions);
+
+            ChatResponse response = chatModel.call(prompt);
+
+            assertNotNull(response);
+            assertNotNull(response.getResult());
+
+            var output = response.getResult().getOutput();
+            assertNotNull(output.getToolCalls(), "Expected tool calls in response");
+            assertFalse(output.getToolCalls().isEmpty(), "Expected at least one tool call");
+
+            var toolCall = output.getToolCalls().getFirst();
+            assertEquals("get_weather", toolCall.name(), "Expected get_weather tool call");
+            assertNotNull(toolCall.arguments(), "Expected arguments in tool call");
+            assertTrue(
+                    toolCall.arguments().toLowerCase().contains("tokyo"),
+                    "Expected 'tokyo' in arguments: " + toolCall.arguments());
         }
 
         @Test
@@ -698,6 +1063,51 @@ public class AIModelIntegrationTest {
             String text = response.getResult().getOutput().getText();
             assertNotNull(text);
             assertTrue(text.contains("4"), "Expected response to contain '4', got: " + text);
+        }
+
+        @Test
+        @DisplayName("Function tool calling - model returns tool_use, not result")
+        void testFunctionToolCalling() {
+            ChatModel chatModel = grok.getChatModel();
+
+            ToolSpec weatherTool = new ToolSpec();
+            weatherTool.setName("get_weather");
+            weatherTool.setDescription("Get the current weather for a location");
+            weatherTool.setInputSchema(
+                    Map.of(
+                            "type",
+                            "object",
+                            "properties",
+                            Map.of(
+                                    "location",
+                                    Map.of("type", "string", "description", "City name")),
+                            "required",
+                            List.of("location")));
+
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("grok-3-mini");
+            input.setMaxTokens(200);
+            input.setTemperature(0.0);
+            input.setTools(List.of(weatherTool));
+
+            var chatOptions = grok.getChatOptions(input);
+            Prompt prompt = new Prompt("What is the weather in Tokyo?", chatOptions);
+
+            ChatResponse response = chatModel.call(prompt);
+
+            assertNotNull(response);
+            assertNotNull(response.getResult());
+
+            var output = response.getResult().getOutput();
+            assertNotNull(output.getToolCalls(), "Expected tool calls in response");
+            assertFalse(output.getToolCalls().isEmpty(), "Expected at least one tool call");
+
+            var toolCall = output.getToolCalls().getFirst();
+            assertEquals("get_weather", toolCall.name(), "Expected get_weather tool call");
+            assertNotNull(toolCall.arguments(), "Expected arguments in tool call");
+            assertTrue(
+                    toolCall.arguments().toLowerCase().contains("tokyo"),
+                    "Expected 'tokyo' in arguments: " + toolCall.arguments());
         }
 
         @Test
@@ -890,7 +1300,7 @@ public class AIModelIntegrationTest {
 
             ChatCompletion input = new ChatCompletion();
             // Use US cross-region inference profile (required for API key auth)
-            input.setModel("us.anthropic.claude-haiku-4-5-20251001-v1:0");
+            input.setModel("us.anthropic.claude-sonnet-4-6");
             input.setMaxTokens(50);
             input.setTemperature(0.0);
 

--- a/ai/src/test/java/org/conductoross/conductor/ai/integration/AIModelIntegrationTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/integration/AIModelIntegrationTest.java
@@ -401,16 +401,14 @@ public class AIModelIntegrationTest {
             turn1Input.setTemperature(0.0);
 
             var turn1Options = openAI.getChatOptions(turn1Input);
-            Prompt turn1Prompt =
-                    new Prompt("My name is Conductor. Remember that.", turn1Options);
+            Prompt turn1Prompt = new Prompt("My name is Conductor. Remember that.", turn1Options);
 
             ChatResponse turn1Response = chatModel.call(turn1Prompt);
             assertNotNull(turn1Response);
             assertNotNull(turn1Response.getResult());
 
             // Extract response_id from metadata
-            String responseId =
-                    (String) turn1Response.getMetadata().get("response_id");
+            String responseId = (String) turn1Response.getMetadata().get("response_id");
             assertNotNull(responseId, "Expected response_id in metadata for chaining");
             assertFalse(responseId.isBlank(), "response_id must not be blank");
 
@@ -435,8 +433,7 @@ public class AIModelIntegrationTest {
                     "Expected model to recall 'Conductor' from previous turn, got: " + text);
 
             // Second response should also have its own response_id
-            String turn2ResponseId =
-                    (String) turn2Response.getMetadata().get("response_id");
+            String turn2ResponseId = (String) turn2Response.getMetadata().get("response_id");
             assertNotNull(turn2ResponseId, "Expected response_id in turn 2 metadata");
         }
 

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicTest.java
@@ -13,6 +13,7 @@
 package org.conductoross.conductor.ai.providers.anthropic;
 
 import java.util.List;
+import java.util.Map;
 
 import org.conductoross.conductor.ai.models.ChatCompletion;
 import org.conductoross.conductor.ai.models.ToolSpec;
@@ -60,7 +61,7 @@ class AnthropicTest {
         @Test
         void testGetChatOptions_basicOptions() {
             ChatCompletion input = new ChatCompletion();
-            input.setModel("claude-3-haiku-20240307");
+            input.setModel("claude-sonnet-4-6");
             input.setMaxTokens(1000);
             input.setTemperature(0.7);
             input.setTopP(0.9);
@@ -68,6 +69,12 @@ class AnthropicTest {
             var options = anthropic.getChatOptions(input);
 
             assertNotNull(options);
+            assertInstanceOf(AnthropicChatOptions.class, options);
+            AnthropicChatOptions opts = (AnthropicChatOptions) options;
+            assertEquals("claude-sonnet-4-6", opts.getModel());
+            assertEquals(1000, opts.getMaxTokens());
+            assertEquals(0.7, opts.getTemperature());
+            assertEquals(0.9, opts.getTopP());
         }
 
         @Test
@@ -81,30 +88,109 @@ class AnthropicTest {
             var options = anthropic.getChatOptions(input);
 
             assertNotNull(options);
+            assertInstanceOf(AnthropicChatOptions.class, options);
+            AnthropicChatOptions opts = (AnthropicChatOptions) options;
+            assertEquals(10000, opts.getThinkingBudgetTokens());
+            assertEquals(1.0, opts.getTemperature()); // Forced to 1.0 for thinking
         }
 
         @Test
         void testGetChatOptions_withTools() {
             ChatCompletion input = new ChatCompletion();
-            input.setModel("claude-3-haiku-20240307");
+            input.setModel("claude-sonnet-4-6");
             input.setMaxTokens(1000);
 
             ToolSpec tool = new ToolSpec();
             tool.setName("test_tool");
             tool.setDescription("A test tool");
-            tool.setInputSchema(
-                    java.util.Map.of("type", "object", "properties", java.util.Map.of()));
+            tool.setInputSchema(Map.of("type", "object", "properties", Map.of()));
             input.setTools(List.of(tool));
 
             var options = anthropic.getChatOptions(input);
 
             assertNotNull(options);
+            assertInstanceOf(AnthropicChatOptions.class, options);
+            AnthropicChatOptions opts = (AnthropicChatOptions) options;
+            assertNotNull(opts.getTools());
+            assertEquals(1, opts.getTools().size());
+            assertEquals("test_tool", opts.getTools().getFirst().name());
+            assertEquals("custom", opts.getTools().getFirst().type());
         }
 
         @Test
         void testGetChatModel_createsModel() {
             var chatModel = anthropic.getChatModel();
             assertNotNull(chatModel);
+            assertInstanceOf(AnthropicChatModel.class, chatModel);
+        }
+
+        @Test
+        void testGetChatOptions_withWebSearch() {
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("claude-sonnet-4-6");
+            input.setMaxTokens(500);
+            input.setWebSearch(true);
+
+            var options = anthropic.getChatOptions(input);
+
+            assertInstanceOf(AnthropicChatOptions.class, options);
+            AnthropicChatOptions opts = (AnthropicChatOptions) options;
+            assertNotNull(opts.getTools());
+            assertTrue(
+                    opts.getTools().stream()
+                            .anyMatch(
+                                    t ->
+                                            "web_search_20250305".equals(t.type())
+                                                    && "web_search".equals(t.name())));
+        }
+
+        @Test
+        void testGetChatOptions_withCodeExecution() {
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("claude-sonnet-4-6");
+            input.setMaxTokens(500);
+            input.setCodeInterpreter(true);
+
+            var options = anthropic.getChatOptions(input);
+
+            assertInstanceOf(AnthropicChatOptions.class, options);
+            AnthropicChatOptions opts = (AnthropicChatOptions) options;
+            assertNotNull(opts.getTools());
+            assertTrue(
+                    opts.getTools().stream()
+                            .anyMatch(
+                                    t ->
+                                            "code_execution_20250825".equals(t.type())
+                                                    && "code_execution".equals(t.name())));
+        }
+
+        @Test
+        void testGetChatOptions_withBothBuiltInTools() {
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("claude-sonnet-4-6");
+            input.setMaxTokens(500);
+            input.setWebSearch(true);
+            input.setCodeInterpreter(true);
+
+            var options = anthropic.getChatOptions(input);
+
+            assertInstanceOf(AnthropicChatOptions.class, options);
+            AnthropicChatOptions opts = (AnthropicChatOptions) options;
+            assertNotNull(opts.getTools());
+            assertEquals(2, opts.getTools().size());
+        }
+
+        @Test
+        void testGetChatOptions_noTools() {
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("claude-sonnet-4-6");
+            input.setMaxTokens(500);
+
+            var options = anthropic.getChatOptions(input);
+
+            assertInstanceOf(AnthropicChatOptions.class, options);
+            AnthropicChatOptions opts = (AnthropicChatOptions) options;
+            assertNull(opts.getTools());
         }
     }
 
@@ -124,7 +210,7 @@ class AnthropicTest {
         @Test
         void testChatCompletion() {
             ChatCompletion input = new ChatCompletion();
-            input.setModel("claude-3-haiku-20240307");
+            input.setModel("claude-haiku-4-5");
             input.setMaxTokens(100);
             input.setTemperature(0.7);
 
@@ -143,7 +229,7 @@ class AnthropicTest {
         @Test
         void testChatCompletion_withThinking() {
             ChatCompletion input = new ChatCompletion();
-            input.setModel("claude-sonnet-4-20250514");
+            input.setModel("claude-sonnet-4-5");
             input.setMaxTokens(16000);
             input.setThinkingTokenLimit(10000);
 

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAITest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAITest.java
@@ -17,6 +17,9 @@ import java.util.List;
 import org.conductoross.conductor.ai.models.ChatCompletion;
 import org.conductoross.conductor.ai.models.EmbeddingGenRequest;
 import org.conductoross.conductor.ai.models.ImageGenRequest;
+import org.conductoross.conductor.ai.providers.openai.OpenAIHttpImageModel;
+import org.conductoross.conductor.ai.providers.openai.OpenAIResponsesChatModel;
+import org.conductoross.conductor.ai.providers.openai.OpenAIResponsesChatOptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -60,6 +63,8 @@ class AzureOpenAITest {
             var options = azureOpenAI.getChatOptions(input);
 
             assertNotNull(options);
+            assertInstanceOf(OpenAIResponsesChatOptions.class, options);
+            assertEquals("gpt-4", options.getModel());
         }
 
         @Test
@@ -73,6 +78,20 @@ class AzureOpenAITest {
             var options = azureOpenAI.getImageOptions(input);
 
             assertNotNull(options);
+        }
+
+        @Test
+        void testGetChatModel_createsResponsesModel() {
+            var chatModel = azureOpenAI.getChatModel();
+            assertNotNull(chatModel);
+            assertInstanceOf(OpenAIResponsesChatModel.class, chatModel);
+        }
+
+        @Test
+        void testGetImageModel_createsHttpModel() {
+            var imageModel = azureOpenAI.getImageModel();
+            assertNotNull(imageModel);
+            assertInstanceOf(OpenAIHttpImageModel.class, imageModel);
         }
     }
 

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexConfigurationTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexConfigurationTest.java
@@ -51,7 +51,6 @@ class GeminiVertexConfigurationTest {
         assertNull(config.getLocation());
         assertNull(config.getPublisher());
         assertNull(config.getGoogleCredentials());
-        assertNull(config.getPredictionServiceClient());
     }
 
     @Test

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexTest.java
@@ -134,9 +134,19 @@ class GeminiVertexTest {
 
         @Test
         void testGetChatModel_createsModel() {
-            var chatModel = geminiVertex.getChatModel();
-            assertNotNull(chatModel);
-            assertInstanceOf(GeminiChatModel.class, chatModel);
+            // getChatModel() creates a real GenAI Client which requires either an API key
+            // or GCP Application Default Credentials. Skip gracefully when neither is available.
+            try {
+                var chatModel = geminiVertex.getChatModel();
+                assertNotNull(chatModel);
+                assertInstanceOf(GeminiChatModel.class, chatModel);
+            } catch (Exception e) {
+                if (e.getMessage() != null && e.getMessage().contains("credentials")) {
+                    org.junit.jupiter.api.Assumptions.assumeTrue(
+                            false, "Skipping: no GCP credentials available");
+                }
+                throw e;
+            }
         }
     }
 

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexTest.java
@@ -60,6 +60,13 @@ class GeminiVertexTest {
             var options = geminiVertex.getChatOptions(input);
 
             assertNotNull(options);
+            assertInstanceOf(GeminiChatOptions.class, options);
+            GeminiChatOptions opts = (GeminiChatOptions) options;
+            assertEquals("gemini-1.5-flash", opts.getModel());
+            assertEquals(1000, opts.getMaxTokens());
+            assertEquals(0.7, opts.getTemperature());
+            assertEquals(0.9, opts.getTopP());
+            assertEquals(40, opts.getTopK());
         }
 
         @Test
@@ -72,12 +79,64 @@ class GeminiVertexTest {
             var options = geminiVertex.getChatOptions(input);
 
             assertNotNull(options);
+            assertInstanceOf(GeminiChatOptions.class, options);
+            GeminiChatOptions opts = (GeminiChatOptions) options;
+            assertTrue(opts.isGoogleSearchRetrieval());
+        }
+
+        @Test
+        void testGetChatOptions_withWebSearchFlag() {
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("gemini-2.5-flash");
+            input.setMaxTokens(500);
+            input.setWebSearch(true);
+
+            var options = geminiVertex.getChatOptions(input);
+
+            assertNotNull(options);
+            assertInstanceOf(GeminiChatOptions.class, options);
+            GeminiChatOptions opts = (GeminiChatOptions) options;
+            assertTrue(opts.isGoogleSearchRetrieval());
+        }
+
+        @Test
+        void testGetChatOptions_withWebSearchFlag_apiKeyPath() {
+            GeminiVertexConfiguration apiKeyConfig = new GeminiVertexConfiguration();
+            apiKeyConfig.setApiKey("test-api-key");
+            GeminiVertex apiKeyGemini = new GeminiVertex(apiKeyConfig);
+
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("gemini-2.5-flash");
+            input.setMaxTokens(500);
+            input.setWebSearch(true);
+
+            var options = apiKeyGemini.getChatOptions(input);
+
+            assertNotNull(options);
+            assertInstanceOf(GeminiChatOptions.class, options);
+            GeminiChatOptions opts = (GeminiChatOptions) options;
+            assertTrue(opts.isGoogleSearchRetrieval());
+        }
+
+        @Test
+        void testGetChatOptions_withCodeExecution() {
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("gemini-2.5-flash");
+            input.setMaxTokens(500);
+            input.setCodeInterpreter(true);
+
+            var options = geminiVertex.getChatOptions(input);
+
+            assertInstanceOf(GeminiChatOptions.class, options);
+            GeminiChatOptions opts = (GeminiChatOptions) options;
+            assertTrue(opts.isCodeExecution());
         }
 
         @Test
         void testGetChatModel_createsModel() {
             var chatModel = geminiVertex.getChatModel();
             assertNotNull(chatModel);
+            assertInstanceOf(GeminiChatModel.class, chatModel);
         }
     }
 

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/openai/OpenAITest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/openai/OpenAITest.java
@@ -58,6 +58,8 @@ class OpenAITest {
             var options = openAI.getChatOptions(input);
 
             assertNotNull(options);
+            assertInstanceOf(OpenAIResponsesChatOptions.class, options);
+            assertEquals("gpt-4o-mini", options.getModel());
         }
 
         @Test
@@ -70,6 +72,83 @@ class OpenAITest {
             var options = openAI.getChatOptions(input);
 
             assertNotNull(options);
+            assertInstanceOf(OpenAIResponsesChatOptions.class, options);
+        }
+
+        @Test
+        void testGetChatOptions_withPreviousResponseId() {
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("gpt-4o");
+            input.setPreviousResponseId("resp_abc123");
+
+            var options = openAI.getChatOptions(input);
+
+            assertInstanceOf(OpenAIResponsesChatOptions.class, options);
+            OpenAIResponsesChatOptions responsesOpts = (OpenAIResponsesChatOptions) options;
+            assertEquals("resp_abc123", responsesOpts.getPreviousResponseId());
+        }
+
+        @Test
+        void testGetChatOptions_reasoningModelDisablesTemperature() {
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("o3");
+            input.setTemperature(0.7);
+            input.setTopP(0.9);
+            input.setReasoningEffort("medium");
+
+            var options = openAI.getChatOptions(input);
+            assertInstanceOf(OpenAIResponsesChatOptions.class, options);
+            OpenAIResponsesChatOptions responsesOpts = (OpenAIResponsesChatOptions) options;
+            assertNull(responsesOpts.getTemperature());
+            assertNull(responsesOpts.getTopP());
+            assertEquals("medium", responsesOpts.getReasoningEffort());
+        }
+
+        @Test
+        void testGetChatOptions_withWebSearch() {
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("gpt-4o");
+            input.setMaxTokens(500);
+            input.setWebSearch(true);
+
+            var options = openAI.getChatOptions(input);
+
+            assertInstanceOf(OpenAIResponsesChatOptions.class, options);
+            OpenAIResponsesChatOptions responsesOpts = (OpenAIResponsesChatOptions) options;
+            assertNotNull(responsesOpts.getResponsesApiTools());
+            assertFalse(responsesOpts.getResponsesApiTools().isEmpty());
+            assertEquals("web_search", responsesOpts.getResponsesApiTools().getFirst().type());
+        }
+
+        @Test
+        void testGetChatOptions_withCodeInterpreter() {
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("gpt-4o");
+            input.setMaxTokens(500);
+            input.setCodeInterpreter(true);
+
+            var options = openAI.getChatOptions(input);
+
+            assertInstanceOf(OpenAIResponsesChatOptions.class, options);
+            OpenAIResponsesChatOptions responsesOpts = (OpenAIResponsesChatOptions) options;
+            assertNotNull(responsesOpts.getResponsesApiTools());
+            assertEquals(
+                    "code_interpreter", responsesOpts.getResponsesApiTools().getFirst().type());
+        }
+
+        @Test
+        void testGetChatOptions_withFileSearch() {
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("gpt-4o");
+            input.setMaxTokens(500);
+            input.setFileSearchVectorStoreIds(List.of("vs_abc123"));
+
+            var options = openAI.getChatOptions(input);
+
+            assertInstanceOf(OpenAIResponsesChatOptions.class, options);
+            OpenAIResponsesChatOptions responsesOpts = (OpenAIResponsesChatOptions) options;
+            assertNotNull(responsesOpts.getResponsesApiTools());
+            assertEquals("file_search", responsesOpts.getResponsesApiTools().getFirst().type());
         }
 
         @Test
@@ -90,12 +169,14 @@ class OpenAITest {
         void testGetChatModel_createsModel() {
             var chatModel = openAI.getChatModel();
             assertNotNull(chatModel);
+            assertInstanceOf(OpenAIResponsesChatModel.class, chatModel);
         }
 
         @Test
         void testGetImageModel_createsModel() {
             var imageModel = openAI.getImageModel();
             assertNotNull(imageModel);
+            assertInstanceOf(OpenAIHttpImageModel.class, imageModel);
         }
     }
 
@@ -128,6 +209,55 @@ class OpenAITest {
             assertNotNull(response);
             assertNotNull(response.getResult());
             assertNotNull(response.getResult().getOutput());
+            assertFalse(response.getResult().getOutput().getText().isEmpty());
+        }
+
+        @Test
+        @EnabledIfEnvironmentVariable(named = "OPENAI_CODEX_MODEL", matches = ".+")
+        void testChatCompletion_withCodexModel() {
+            String codexModel =
+                    System.getenv("OPENAI_CODEX_MODEL") != null
+                            ? System.getenv("OPENAI_CODEX_MODEL")
+                            : "codex-mini-latest";
+            ChatCompletion input = new ChatCompletion();
+            input.setModel(codexModel);
+            input.setMaxTokens(200);
+
+            var chatModel = openAI.getChatModel();
+            var options = openAI.getChatOptions(input);
+
+            Prompt prompt =
+                    new Prompt(
+                            List.of(new UserMessage("Write a hello world function in Python")),
+                            options);
+            var response = chatModel.call(prompt);
+
+            assertNotNull(response);
+            assertNotNull(response.getResult());
+            assertFalse(response.getResult().getOutput().getText().isEmpty());
+        }
+
+        @Test
+        void testChatCompletion_withWebSearch() {
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("gpt-4o-mini");
+            input.setMaxTokens(200);
+            input.setTemperature(0.0);
+            input.setWebSearch(true);
+
+            var chatModel = openAI.getChatModel();
+            var options = openAI.getChatOptions(input);
+
+            Prompt prompt =
+                    new Prompt(
+                            List.of(
+                                    new UserMessage(
+                                            "What is the current weather in San Francisco?")),
+                            options);
+            var response = chatModel.call(prompt);
+
+            assertNotNull(response);
+            assertNotNull(response.getResult());
             assertFalse(response.getResult().getOutput().getText().isEmpty());
         }
 

--- a/ai/src/test/resources/ai-test-env.sh
+++ b/ai/src/test/resources/ai-test-env.sh
@@ -23,8 +23,11 @@ export ANTHROPIC_API_KEY="your-anthropic-api-key"
 # export ANTHROPIC_BASE_URL="https://api.anthropic.com"
 
 # ============================================================================
-# Google Cloud / Gemini (Vertex AI)
+# Google Cloud / Gemini
 # ============================================================================
+# Option 1: API key (Google AI Studio) - simplest setup
+export GEMINI_API_KEY="your-gemini-api-key"
+# Option 2: Vertex AI (GCP project + credentials)
 export GOOGLE_PROJECT_ID="your-gcp-project-id"
 export GOOGLE_LOCATION="us-central1"
 # Set path to your service account JSON key file
@@ -89,6 +92,7 @@ echo "AI integration test environment variables loaded."
 echo "Providers configured:"
 [ -n "$OPENAI_API_KEY" ] && [ "$OPENAI_API_KEY" != "your-openai-api-key" ] && echo "  ✓ OpenAI"
 [ -n "$ANTHROPIC_API_KEY" ] && [ "$ANTHROPIC_API_KEY" != "your-anthropic-api-key" ] && echo "  ✓ Anthropic"
+[ -n "$GEMINI_API_KEY" ] && [ "$GEMINI_API_KEY" != "your-gemini-api-key" ] && echo "  ✓ Gemini (API key)"
 [ -n "$GOOGLE_PROJECT_ID" ] && [ "$GOOGLE_PROJECT_ID" != "your-gcp-project-id" ] && echo "  ✓ Gemini/Vertex AI"
 [ -n "$MISTRAL_API_KEY" ] && [ "$MISTRAL_API_KEY" != "your-mistral-api-key" ] && echo "  ✓ Mistral"
 [ -n "$OLLAMA_BASE_URL" ] && echo "  ✓ Ollama (at $OLLAMA_BASE_URL)"

--- a/docs/devguide/ai/first-ai-agent.md
+++ b/docs/devguide/ai/first-ai-agent.md
@@ -21,7 +21,7 @@ pip install mcp-testkit
 mcp-testkit --transport http
 ```
 
-This starts an MCP server at `http://localhost:3001/mcp` with 65 deterministic tools for testing. You'll use this URL in the workflow definition.
+This starts an MCP server at `http://localhost:3001/mcp` with deterministic tools for testing. You'll use this URL in the workflow definition.
 
 !!! tip "Any MCP server works"
     Conductor connects to any MCP-compatible server. Use community MCP servers for GitHub, Slack, databases, or any API — or build your own. See the [MCP integration guide](mcp-guide.md) for details.
@@ -29,17 +29,15 @@ This starts an MCP server at `http://localhost:3001/mcp` with 65 deterministic t
 
 ## Step 2: Configure your LLM provider
 
-Add your API key to Conductor's configuration. If you started with the CLI, edit `~/.conductor/config.properties`:
+Set your API key as an environment variable before starting the server:
 
-```properties
-conductor.integrations.ai.enabled=true
-
+```bash
 # Choose one (or both):
-conductor.ai.openai.apiKey=sk-your-openai-key
-conductor.ai.anthropic.apiKey=sk-ant-your-anthropic-key
+export OPENAI_API_KEY=sk-your-openai-key
+export ANTHROPIC_API_KEY=sk-ant-your-anthropic-key
 ```
 
-Restart the server after updating the configuration.
+Then start (or restart) the server. Conductor auto-enables providers when their API key is set.
 
 
 ## Step 3: Create the agent workflow
@@ -293,4 +291,4 @@ All of this with zero custom code. The entire agent is a JSON workflow definitio
 - **[Human-in-the-Loop](human-in-the-loop.md)** — Advanced approval patterns: conditional review, LLM-as-judge.
 - **[Dynamic Workflows](dynamic-workflows.md)** — Agents that generate their own execution plans as JSON.
 - **[Token Efficiency](token-efficiency.md)** — How durable execution saves tokens and reduces LLM costs.
-- **[LLM Orchestration](llm-orchestration.md)** — 14+ native LLM providers, vector databases, content generation.
+- **[LLM Orchestration](llm-orchestration.md)** — 12 native LLM providers, vector databases, content generation.

--- a/docs/devguide/ai/index.md
+++ b/docs/devguide/ai/index.md
@@ -44,7 +44,7 @@ Your agent code starts a workflow. Conductor schedules each step as a task, pers
 
 | Agent pattern | Conductor primitive | What happens mechanically |
 |---|---|---|
-| **LLM call** | `LLM_CHAT_COMPLETE` / `LLM_TEXT_COMPLETE` system task | Native LLM task. Configure provider and model as parameters. Retried on failure. Prompt, response, and token usage persisted. |
+| **LLM call** | `LLM_CHAT_COMPLETE` / `LLM_TEXT_COMPLETE` system task | Native LLM task. Configure provider and model as parameters. Retried on failure. Prompt, response, and token usage persisted. Supports built-in tools: web search, code execution, file search, extended thinking. |
 | **Embeddings** | `LLM_GENERATE_EMBEDDINGS` system task | Generate vector embeddings using any configured provider. Output stored and passed to downstream tasks. |
 | **Tool call / function calling** | `CALL_MCP_TOOL` system task, or `SIMPLE` / `HTTP` task | Call tools on any MCP server, or implement custom tool workers. Each call is tracked, retried on failure, and fully auditable. |
 | **Tool discovery** | `LIST_MCP_TOOLS` system task | Discover available tools from an MCP server at runtime. Feed the tool list to an LLM for dynamic tool selection. |
@@ -79,12 +79,13 @@ Conductor provides all of this as infrastructure. Your agent code focuses on the
 ## Next steps
 
 - **[Build Your First AI Agent](first-ai-agent.md)** &mdash; Step-by-step: discover MCP tools, call an LLM, execute, add human approval, make it autonomous. 5 minutes.
+- **[AI & LLM Recipes](../cookbook/ai-llm.md)** &mdash; Ready-to-use recipes: chat completion, RAG, MCP agents, web search, code execution, coding agents, extended thinking, and more.
+- **[LLM Orchestration](llm-orchestration.md)** &mdash; Native LLM providers, built-in tools, vector databases, and content generation.
+- **[MCP Integration](mcp-guide.md)** &mdash; Connect to any MCP server, expose workflows as MCP tools, multi-server agents.
 - **[Production Agent Architecture](production-agent-architecture.md)** &mdash; The canonical reference architecture for a durable production agent. End-to-end pattern with every primitive mapped.
 - **[Failure Semantics for AI Agents](failure-semantics.md)** &mdash; The exact failure contract: what happens under crashes, retries, duplicates, long waits, and partial side effects.
 - **[Why Conductor for Agents](why-conductor.md)** &mdash; What Conductor gives you out of the box for agentic workflows.
-- **[MCP Integration](mcp-guide.md)** &mdash; Connect to any MCP server, expose workflows as MCP tools, multi-server agents.
 - **[Durable Agents](durable-agents.md)** &mdash; What persists, what gets retried, and why JSON is AI-native.
 - **[Human-in-the-Loop](human-in-the-loop.md)** &mdash; Pre-execution review, conditional approval, and LLM-as-judge patterns.
 - **[Dynamic Workflows](dynamic-workflows.md)** &mdash; Agent loops, dynamic workflow generation, and tool use examples.
-- **[LLM Orchestration](llm-orchestration.md)** &mdash; Native LLM providers, vector databases, and content generation.
 - **[Token Efficiency](token-efficiency.md)** &mdash; How durable execution saves tokens and reduces LLM costs.

--- a/docs/devguide/ai/llm-orchestration.md
+++ b/docs/devguide/ai/llm-orchestration.md
@@ -26,6 +26,76 @@ Conductor provides native system tasks for LLM orchestration and integration. No
 No other open source workflow engine provides native LLM orchestration at this breadth. Each provider is a configuration — switch models by changing a parameter, not your code.
 
 
+## Built-in tools & advanced capabilities
+
+Conductor supports provider-native tools that run on the provider's infrastructure — no MCP server or custom worker needed. Enable them with a single parameter in the `LLM_CHAT_COMPLETE` task.
+
+| Capability | Parameter | OpenAI | Anthropic | Google Gemini |
+|---|---|---|---|---|
+| Web Search | `webSearch: true` | ✓ | ✓ | ✓ |
+| Code Execution | `codeInterpreter: true` | ✓ (code_interpreter) | ✓ (code_execution) | ✓ (code_execution) |
+| File Search | `fileSearchVectorStoreIds: [...]` | ✓ | — | — |
+| Extended Thinking | `thinkingTokenLimit: N` | — | ✓ | ✓ |
+| Reasoning Effort | `reasoningEffort: "high"` | ✓ | — | — |
+| Google Search | `googleSearchRetrieval: true` | — | — | ✓ |
+| Custom Functions | `tools: [...]` | ✓ | ✓ | ✓ |
+
+### Web search
+
+The LLM can search the web for real-time information during chat completion. Enable it with `"webSearch": true`:
+
+```json
+{
+  "type": "LLM_CHAT_COMPLETE",
+  "inputParameters": {
+    "llmProvider": "openai",
+    "model": "gpt-4o-mini",
+    "messages": [{"role": "user", "message": "What happened in tech news today?"}],
+    "webSearch": true
+  }
+}
+```
+
+Works with OpenAI, Anthropic, and Google Gemini. Each provider uses its own native web search implementation.
+
+### Code execution
+
+The LLM can write and execute code in a sandboxed environment. Enable it with `"codeInterpreter": true`:
+
+```json
+{
+  "type": "LLM_CHAT_COMPLETE",
+  "inputParameters": {
+    "llmProvider": "google_gemini",
+    "model": "gemini-2.5-flash",
+    "messages": [{"role": "user", "message": "Calculate the first 100 prime numbers and plot them"}],
+    "codeInterpreter": true
+  }
+}
+```
+
+Use this for data analysis, chart generation, mathematical computation, or any task that benefits from running code.
+
+### Extended thinking
+
+Give the LLM a token budget for step-by-step reasoning before it responds. Useful for complex problems that benefit from chain-of-thought reasoning:
+
+```json
+{
+  "type": "LLM_CHAT_COMPLETE",
+  "inputParameters": {
+    "llmProvider": "anthropic",
+    "model": "claude-sonnet-4-20250514",
+    "messages": [{"role": "user", "message": "Prove that there are infinitely many primes"}],
+    "thinkingTokenLimit": 10000,
+    "maxTokens": 16000
+  }
+}
+```
+
+Supported by Anthropic and Google Gemini.
+
+
 ## Vector database workflows
 
 Built-in vector database integration enables RAG (retrieval-augmented generation) pipelines as standard vector database workflows.
@@ -144,6 +214,12 @@ Ready-to-use workflow definitions for every AI task type. Each example is a comp
 | [StabilityAI Image](https://github.com/conductor-oss/conductor/blob/main/ai/examples/14-stabilityai-image.json) | `GENERATE_IMAGE` |
 | [PDF Generation](https://github.com/conductor-oss/conductor/blob/main/ai/examples/15-pdf-generation.json) | `GENERATE_PDF` |
 | [LLM-to-PDF Pipeline](https://github.com/conductor-oss/conductor/blob/main/ai/examples/16-llm-to-pdf-pipeline.json) | `LLM_CHAT_COMPLETE`, `GENERATE_PDF` |
+| [Web Search](https://github.com/conductor-oss/conductor/blob/main/ai/examples/17-web-search.json) | `LLM_CHAT_COMPLETE` (web search) |
+| [Code Execution](https://github.com/conductor-oss/conductor/blob/main/ai/examples/18-code-execution.json) | `LLM_CHAT_COMPLETE` (code execution) |
+| [Coding Agent](https://github.com/conductor-oss/conductor/blob/main/ai/examples/19-coding-agent.json) | `LLM_CHAT_COMPLETE` (code_interpreter) |
+| [Extended Thinking](https://github.com/conductor-oss/conductor/blob/main/ai/examples/20-extended-thinking.json) | `LLM_CHAT_COMPLETE` (thinking) |
+| [Web Research Agent](https://github.com/conductor-oss/conductor/blob/main/ai/examples/21-web-search-research-agent.json) | `LLM_CHAT_COMPLETE` (web search + thinking), `GENERATE_PDF` |
+| [Multi-Turn Chain](https://github.com/conductor-oss/conductor/blob/main/ai/examples/22-multi-turn-chain.json) | `LLM_CHAT_COMPLETE` (previousResponseId) |
 
 Browse all examples: [`ai/examples/`](https://github.com/conductor-oss/conductor/tree/main/ai/examples)
 

--- a/docs/devguide/ai/mcp-guide.md
+++ b/docs/devguide/ai/mcp-guide.md
@@ -242,4 +242,4 @@ Every task type here — `LIST_MCP_TOOLS`, `LLM_CHAT_COMPLETE`, `CALL_MCP_TOOL`,
 - **[Build Your First AI Agent](first-ai-agent.md)** — Step-by-step tutorial using MCP.
 - **[Dynamic Workflows](dynamic-workflows.md)** — Agents that generate their own execution plans.
 - **[Human-in-the-Loop](human-in-the-loop.md)** — Approval patterns for MCP tool calls.
-- **[LLM Orchestration](llm-orchestration.md)** — 14+ native LLM providers, vector databases, content generation.
+- **[LLM Orchestration](llm-orchestration.md)** — 12 native LLM providers, vector databases, content generation.

--- a/docs/devguide/cookbook/ai-llm.md
+++ b/docs/devguide/cookbook/ai-llm.md
@@ -1,5 +1,5 @@
 ---
-description: "LLM orchestration cookbook — AI agent orchestration recipes for chat completion, RAG pipelines with vector databases, MCP agents with function calling and tool use, image generation, LLM-to-PDF, and provider configuration."
+description: "LLM orchestration cookbook — AI agent orchestration recipes for chat completion, RAG pipelines, MCP agents with function calling, web search, code execution, coding agents, extended thinking, image generation, LLM-to-PDF, and provider configuration."
 ---
 
 # AI & LLM orchestration recipes
@@ -306,24 +306,398 @@ curl -X POST 'http://localhost:8080/api/workflow/llm_to_pdf_pipeline' \
 
 ---
 
+### Web search — real-time information retrieval
+
+Enable the LLM's built-in web search to answer questions about current events or find up-to-date information. No MCP server or external tool needed — the provider handles the search natively.
+
+```json
+{
+  "name": "web_search_workflow",
+  "version": 1,
+  "schemaVersion": 2,
+  "inputParameters": ["question"],
+  "tasks": [
+    {
+      "name": "web_search_chat",
+      "taskReferenceName": "chat",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "openai",
+        "model": "gpt-4o-mini",
+        "messages": [
+          {"role": "system", "message": "Use web search to find current information."},
+          {"role": "user", "message": "${workflow.input.question}"}
+        ],
+        "webSearch": true,
+        "maxTokens": 1000
+      }
+    }
+  ],
+  "outputParameters": {
+    "answer": "${chat.output.result}"
+  }
+}
+```
+
+**Register and run:**
+
+```shell
+curl -X POST 'http://localhost:8080/api/metadata/workflow' \
+  -H 'Content-Type: application/json' \
+  -d @web_search_workflow.json
+
+curl -X POST 'http://localhost:8080/api/workflow/web_search_workflow' \
+  -H 'Content-Type: application/json' \
+  -d '{"question": "What are the latest developments in AI regulation?"}'
+```
+
+!!! note "Provider support"
+    Web search is supported by OpenAI, Anthropic, and Google Gemini. Set `"webSearch": true` — the same parameter works across all providers.
+
+---
+
+### Code execution — sandboxed code interpreter
+
+Let the LLM write and run code in a sandboxed environment. Useful for data analysis, calculations, chart generation, and tasks that benefit from executable code.
+
+```json
+{
+  "name": "code_execution_workflow",
+  "version": 1,
+  "schemaVersion": 2,
+  "inputParameters": ["task"],
+  "tasks": [
+    {
+      "name": "code_chat",
+      "taskReferenceName": "chat",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "google_gemini",
+        "model": "gemini-2.5-flash",
+        "messages": [
+          {"role": "system", "message": "Use code execution to compute results and analyze data."},
+          {"role": "user", "message": "${workflow.input.task}"}
+        ],
+        "codeInterpreter": true,
+        "maxTokens": 2000
+      }
+    }
+  ],
+  "outputParameters": {
+    "result": "${chat.output.result}"
+  }
+}
+```
+
+**Register and run:**
+
+```shell
+curl -X POST 'http://localhost:8080/api/metadata/workflow' \
+  -H 'Content-Type: application/json' \
+  -d @code_execution_workflow.json
+
+curl -X POST 'http://localhost:8080/api/workflow/code_execution_workflow' \
+  -H 'Content-Type: application/json' \
+  -d '{"task": "Calculate the first 100 prime numbers and find the average gap between consecutive primes"}'
+```
+
+!!! note "Provider support"
+    Code execution is supported by OpenAI (`code_interpreter`), Anthropic (`code_execution`), and Google Gemini (`codeExecution`). Set `"codeInterpreter": true` — the same parameter works across all providers.
+
+---
+
+### Coding agent — plan, code, and review
+
+A three-step agent that plans an implementation, writes and executes the code using the code interpreter, and reviews the result. This pattern is useful for automated code generation tasks.
+
+```json
+{
+  "name": "coding_agent",
+  "version": 1,
+  "schemaVersion": 2,
+  "inputParameters": ["task"],
+  "tasks": [
+    {
+      "name": "plan",
+      "taskReferenceName": "plan",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "openai",
+        "model": "gpt-4o",
+        "messages": [
+          {"role": "system", "message": "Break down the coding task into clear numbered steps."},
+          {"role": "user", "message": "${workflow.input.task}"}
+        ],
+        "temperature": 0.2,
+        "maxTokens": 1000
+      }
+    },
+    {
+      "name": "write_and_run",
+      "taskReferenceName": "code",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "openai",
+        "model": "gpt-4o",
+        "messages": [
+          {"role": "system", "message": "Write the code, run it, verify the output, and fix any errors."},
+          {"role": "user", "message": "Plan:\n${plan.output.result}\n\nTask: ${workflow.input.task}"}
+        ],
+        "codeInterpreter": true,
+        "temperature": 0.1,
+        "maxTokens": 4000
+      }
+    },
+    {
+      "name": "review",
+      "taskReferenceName": "review",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "openai",
+        "model": "gpt-4o-mini",
+        "messages": [
+          {"role": "system", "message": "Review the implementation for correctness and code quality."},
+          {"role": "user", "message": "Task: ${workflow.input.task}\n\nCode:\n${code.output.result}"}
+        ],
+        "maxTokens": 1000
+      }
+    }
+  ],
+  "outputParameters": {
+    "code": "${code.output.result}",
+    "review": "${review.output.result}"
+  }
+}
+```
+
+**Register and run:**
+
+```shell
+curl -X POST 'http://localhost:8080/api/metadata/workflow' \
+  -H 'Content-Type: application/json' \
+  -d @coding_agent.json
+
+curl -X POST 'http://localhost:8080/api/workflow/coding_agent' \
+  -H 'Content-Type: application/json' \
+  -d '{"task": "Write a Python function that converts Roman numerals to integers, with unit tests"}'
+```
+
+---
+
+### Extended thinking — complex reasoning
+
+Give the LLM a token budget for step-by-step reasoning before generating its final response. Useful for math, logic, code review, and complex analysis.
+
+```json
+{
+  "name": "extended_thinking_workflow",
+  "version": 1,
+  "schemaVersion": 2,
+  "inputParameters": ["problem"],
+  "tasks": [
+    {
+      "name": "think_deeply",
+      "taskReferenceName": "think",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "anthropic",
+        "model": "claude-sonnet-4-20250514",
+        "messages": [
+          {"role": "user", "message": "${workflow.input.problem}"}
+        ],
+        "thinkingTokenLimit": 10000,
+        "maxTokens": 16000
+      }
+    }
+  ],
+  "outputParameters": {
+    "answer": "${think.output.result}"
+  }
+}
+```
+
+**Register and run:**
+
+```shell
+curl -X POST 'http://localhost:8080/api/metadata/workflow' \
+  -H 'Content-Type: application/json' \
+  -d @extended_thinking_workflow.json
+
+curl -X POST 'http://localhost:8080/api/workflow/extended_thinking_workflow' \
+  -H 'Content-Type: application/json' \
+  -d '{"problem": "Prove that the square root of 2 is irrational."}'
+```
+
+!!! note "Provider support"
+    Extended thinking is supported by Anthropic (`thinkingTokenLimit`) and Google Gemini (`thinkingBudgetTokens`). OpenAI uses `"reasoningEffort": "high"` for a similar effect.
+
+---
+
+### Multi-turn conversation chaining with previousResponseId
+
+Chain multiple LLM calls as a conversation without resending the full message history. The first call returns a `responseId`; pass it as `previousResponseId` to the next call. OpenAI's Responses API stores the conversation server-side, saving tokens and latency.
+
+```json
+{
+  "name": "multi_turn_chain",
+  "description": "Two-step conversation using previousResponseId to avoid resending history",
+  "version": 1,
+  "schemaVersion": 2,
+  "inputParameters": ["topic"],
+  "tasks": [
+    {
+      "name": "first_turn",
+      "taskReferenceName": "turn1",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "openai",
+        "model": "gpt-4o",
+        "messages": [
+          {"role": "system", "message": "You are a technical architect. Be concise."},
+          {"role": "user", "message": "Design a high-level architecture for: ${workflow.input.topic}"}
+        ],
+        "temperature": 0.3,
+        "maxTokens": 2000
+      }
+    },
+    {
+      "name": "follow_up",
+      "taskReferenceName": "turn2",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "openai",
+        "model": "gpt-4o",
+        "messages": [
+          {"role": "user", "message": "Now list the key risks and mitigations for this architecture."}
+        ],
+        "previousResponseId": "${turn1.output.responseId}",
+        "temperature": 0.3,
+        "maxTokens": 2000
+      }
+    }
+  ],
+  "outputParameters": {
+    "architecture": "${turn1.output.result}",
+    "risks": "${turn2.output.result}"
+  }
+}
+```
+
+**Register and run:**
+
+```shell
+curl -X POST 'http://localhost:8080/api/metadata/workflow' \
+  -H 'Content-Type: application/json' \
+  -d @multi_turn_chain.json
+
+curl -X POST 'http://localhost:8080/api/workflow/multi_turn_chain' \
+  -H 'Content-Type: application/json' \
+  -d '{"topic": "Real-time collaborative document editor"}'
+```
+
+The second call sends only the new user message — OpenAI already has the full conversation context from `previousResponseId`. This is especially useful for long agent loops where resending the full history each iteration would be expensive.
+
+!!! note "Provider support"
+    `previousResponseId` is supported by OpenAI and Azure OpenAI (Responses API). Other providers require sending the full message history in each call.
+
+---
+
+### Web research agent — search, synthesize, PDF
+
+A multi-step agent that uses web search to gather information, an LLM with extended thinking to synthesize a report, and converts it to PDF. Combines three built-in capabilities in a single workflow.
+
+```json
+{
+  "name": "web_research_agent",
+  "version": 1,
+  "schemaVersion": 2,
+  "inputParameters": ["topic"],
+  "tasks": [
+    {
+      "name": "gather_information",
+      "taskReferenceName": "research",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "openai",
+        "model": "gpt-4o",
+        "messages": [
+          {"role": "system", "message": "Use web search to find comprehensive, current information. Search for multiple perspectives and recent developments."},
+          {"role": "user", "message": "Research this topic thoroughly: ${workflow.input.topic}"}
+        ],
+        "webSearch": true,
+        "temperature": 0.3,
+        "maxTokens": 3000
+      }
+    },
+    {
+      "name": "synthesize_report",
+      "taskReferenceName": "report",
+      "type": "LLM_CHAT_COMPLETE",
+      "inputParameters": {
+        "llmProvider": "anthropic",
+        "model": "claude-sonnet-4-20250514",
+        "messages": [
+          {"role": "system", "message": "Synthesize the research into a well-structured markdown report with sections, key findings, and citations."},
+          {"role": "user", "message": "Topic: ${workflow.input.topic}\n\nResearch:\n${research.output.result}\n\nWrite a comprehensive report."}
+        ],
+        "thinkingTokenLimit": 5000,
+        "maxTokens": 8000
+      }
+    },
+    {
+      "name": "convert_to_pdf",
+      "taskReferenceName": "pdf",
+      "type": "GENERATE_PDF",
+      "inputParameters": {
+        "markdown": "${report.output.result}",
+        "pageSize": "A4",
+        "pdfMetadata": {
+          "title": "${workflow.input.topic}",
+          "author": "Conductor Research Agent"
+        }
+      }
+    }
+  ],
+  "outputParameters": {
+    "report": "${report.output.result}",
+    "pdf": "${pdf.output.result.location}"
+  }
+}
+```
+
+**Register and run:**
+
+```shell
+curl -X POST 'http://localhost:8080/api/metadata/workflow' \
+  -H 'Content-Type: application/json' \
+  -d @web_research_agent.json
+
+curl -X POST 'http://localhost:8080/api/workflow/web_research_agent' \
+  -H 'Content-Type: application/json' \
+  -d '{"topic": "The state of WebAssembly adoption in 2026"}'
+```
+
+---
+
 ### AI provider configuration
 
-Configure LLM providers and vector databases in `application.properties` to use the AI recipes above.
+Set environment variables before starting the server. Conductor auto-enables providers when their API key is present.
+
+```bash
+# OpenAI (required for most examples)
+export OPENAI_API_KEY=sk-your-openai-api-key
+
+# Anthropic (for RAG, extended thinking examples)
+export ANTHROPIC_API_KEY=sk-ant-your-anthropic-key
+
+# Google Gemini — API key (simplest)
+export GEMINI_API_KEY=your-gemini-api-key
+# Or Vertex AI (for enterprise/GCP) — set project and location in application.properties
+```
+
+For vector database and other advanced configuration, add to `application.properties`:
 
 ```properties
-# Enable AI integrations
-conductor.integrations.ai.enabled=true
-
-# OpenAI
-conductor.ai.openai.apiKey=sk-your-openai-api-key
-
-# Anthropic
-conductor.ai.anthropic.apiKey=sk-ant-your-anthropic-key
-
-# Google Vertex AI (Gemini)
-conductor.ai.gemini.project-id=your-gcp-project
-conductor.ai.gemini.location=us-central1
-
 # PostgreSQL Vector DB (for RAG examples)
 conductor.vectordb.instances[0].name=postgres-prod
 conductor.vectordb.instances[0].type=postgres

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,14 +48,15 @@ nav:
   - AI Cookbook:
     - devguide/ai/index.md
     - Build Your First AI Agent: devguide/ai/first-ai-agent.md
+    - AI & LLM Recipes: devguide/cookbook/ai-llm.md
+    - LLM Orchestration: devguide/ai/llm-orchestration.md
+    - MCP Integration: devguide/ai/mcp-guide.md
     - Production Agent Architecture: devguide/ai/production-agent-architecture.md
     - Failure Semantics: devguide/ai/failure-semantics.md
     - Why Conductor for Agents: devguide/ai/why-conductor.md
-    - MCP Integration: devguide/ai/mcp-guide.md
     - Durable Agents: devguide/ai/durable-agents.md
     - Human-in-the-Loop: devguide/ai/human-in-the-loop.md
     - Dynamic Workflows: devguide/ai/dynamic-workflows.md
-    - LLM Orchestration: devguide/ai/llm-orchestration.md
     - Token Efficiency: devguide/ai/token-efficiency.md
   - SDKs:
     - documentation/clientsdks/index.md

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -260,6 +260,7 @@ conductor.ai.azureopenai.deployment-name=${AZURE_OPENAI_DEPLOYMENT:}
 conductor.ai.bedrock.access-key=${AWS_ACCESS_KEY_ID:}
 conductor.ai.bedrock.secret-key=${AWS_SECRET_ACCESS_KEY:}
 conductor.ai.bedrock.region=${AWS_REGION:us-east-1}
+conductor.ai.bedrock.bearerToken=${AWS_BEARER_TOKEN_BEDROCK:}
 
 # Google Gemini / Vertex AI (Gemini, Veo) - use API key OR GOOGLE_APPLICATION_CREDENTIALS for auth
 conductor.ai.gemini.api-key=${GEMINI_API_KEY:}


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Replace spring-ai-openai-sdk, spring-ai-anthropic, spring-ai-vertex-ai-gemini, and spring-ai-azure-openai with direct OkHttp REST clients for OpenAI, Anthropic, and Gemini. This removes heavyweight transitive dependencies while preserving the Spring AI ChatModel/ImageModel abstractions.

New capabilities:
- Built-in provider-native tools: webSearch, codeInterpreter, fileSearch, extendedThinking, reasoningEffort, googleSearchRetrieval
- Multi-turn conversation chaining via previousResponseId (OpenAI/Azure)
- New example workflows (17-22): web search, code execution, coding agent, extended thinking, web research agent, multi-turn chain

Docs and tests:
- Update AI cookbook with recipes for all new capabilities
- Fix @Documented annotations in ChatCompletion for correct provider support
- Add ExampleWorkflowValidationTest for all 22 example JSON files
- Add previousResponseId integration test in AIModelIntegrationTest
- Fix docs: env var config, provider count (12 not 14+), mkdocs nav


_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
