### PR TITLE
Change Redis cluster port mapping to work on mac

### DIFF
--- a/redis-configuration/src/test/java/com/netflix/conductor/redis/jedis/JedisClusterCommandsBatchTest.java
+++ b/redis-configuration/src/test/java/com/netflix/conductor/redis/jedis/JedisClusterCommandsBatchTest.java
@@ -29,6 +29,7 @@ import org.testcontainers.utility.DockerImageName;
 import com.netflix.conductor.redis.testutil.FixedPortContainer;
 
 import com.google.common.util.concurrent.Uninterruptibles;
+import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 
@@ -40,18 +41,18 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class JedisClusterCommandsBatchTest {
 
-    static int[] ports = new int[] {7000, 7001, 7002, 7003, 7004, 7005};
+    static int[] ports = new int[] {17000, 17001, 17002, 17003, 17004, 17005};
 
     private static FixedPortContainer redis =
             new FixedPortContainer(DockerImageName.parse("orkesio/redis-cluster"));
 
     static {
-        redis.exposePort(7000, 7000);
-        redis.exposePort(7001, 7001);
-        redis.exposePort(7002, 7002);
-        redis.exposePort(7003, 7003);
-        redis.exposePort(7004, 7004);
-        redis.exposePort(7005, 7005);
+        redis.exposePort(17000, 7000);
+        redis.exposePort(17001, 7001);
+        redis.exposePort(17002, 7002);
+        redis.exposePort(17003, 7003);
+        redis.exposePort(17004, 7004);
+        redis.exposePort(17005, 7005);
     }
 
     private static JedisClusterCommands commands;
@@ -67,7 +68,18 @@ public class JedisClusterCommandsBatchTest {
             hostAndPorts.add(new HostAndPort("localhost", port));
         }
 
-        jedisCluster = new JedisCluster(hostAndPorts);
+        // Redis cluster nodes announce themselves on internal ports 7000-7005, but the container
+        // exposes them on 17000-17005 to avoid host port conflicts. This mapper translates.
+        DefaultJedisClientConfig clientConfig =
+                DefaultJedisClientConfig.builder()
+                        .hostAndPortMapper(
+                                hp ->
+                                        hp.getPort() >= 7000 && hp.getPort() <= 7005
+                                                ? new HostAndPort("127.0.0.1", hp.getPort() + 10000)
+                                                : hp)
+                        .build();
+
+        jedisCluster = new JedisCluster(hostAndPorts, clientConfig);
         commands = new JedisClusterCommands(jedisCluster);
     }
 


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

`JedisClusterCommandsBatchTest` was failing with `JedisClusterOperationException: Cluster retry deadline exceeded` / `SocketTimeoutException: Read timed out` because of a Redis Cluster port-mapping mismatch.

The test maps container ports 7000–7005 to host ports 17000–17005 to avoid a conflict with macOS Control Center, which permanently occupies port 7000 on macOS (it registers as `afs3-fileserver`). However, Redis Cluster nodes advertise their own address to clients via the cluster topology (MOVED redirects), and the container's nodes announce themselves on their internal ports (7000–7005). When Jedis followed a redirect to `127.0.0.1:7000`, that port was not open on the host, causing every connection attempt to time out.

Fix: pass a `HostAndPortMapper` in `DefaultJedisClientConfig` when constructing `JedisCluster`. The mapper intercepts every address returned by the cluster topology and shifts ports 7000–7005 → 17000–17005, so Jedis always connects through the exposed host ports.

Issue #

Alternatives considered
----

**Map container ports 7000→7000 (original setup):** Fails on macOS because Control Center permanently occupies port 7000 (`afs3-fileserver`). This is a macOS system process that cannot be stopped, so the original mapping is not viable on developer machines running macOS.

**Use Testcontainers' dynamic port assignment:** Would avoid fixed-port conflicts entirely, but requires the Redis cluster image to support runtime `cluster-announce-port` configuration (injected as env vars at startup). The current `orkesio/redis-cluster` image does not expose that knob, so this would need an image change.
