### PR TITLE
fix: respect Spring property hierarchy for external config

### DIFF
--- a/server-lite/src/main/java/org/conductoross/conductor/Conductor.java
+++ b/server-lite/src/main/java/org/conductoross/conductor/Conductor.java
@@ -12,9 +12,6 @@
  */
 package org.conductoross.conductor;
 
-import java.io.IOException;
-import java.util.Properties;
-
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,7 +20,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.core.io.FileSystemResource;
 
 // Prevents from the datasource beans to be loaded, AS they are needed only for specific databases.
 // In case that SQL database is selected this class will be imported back in the appropriate
@@ -34,38 +30,29 @@ public class Conductor {
 
     private static final Logger log = LoggerFactory.getLogger(Conductor.class);
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) {
         loadExternalConfig();
 
         SpringApplication.run(Conductor.class, args);
     }
 
     /**
-     * Reads properties from the location specified in <code>CONDUCTOR_LITE_CONFIG_FILE</code> and
-     * sets them as system properties so they override the default properties.
+     * If <code>CONDUCTOR_LITE_CONFIG_FILE</code> is set, registers the file as an additional Spring
+     * Boot config location. Spring then loads the file as part of its standard property resolution,
+     * placing it above default properties but below environment variables, JVM system properties,
+     * and command-line args.
      *
      * <p>Spring Boot property hierarchy is documented here,
-     * https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config
-     *
-     * @throws IOException if file can't be read.
+     * https://docs.spring.io/spring-boot/reference/features/external-config.html#features.external-config
      */
-    private static void loadExternalConfig() throws IOException {
+    private static void loadExternalConfig() {
         String configFile = System.getProperty("CONDUCTOR_LITE_CONFIG_FILE");
         if (StringUtils.isBlank(configFile)) {
             configFile = System.getenv("CONDUCTOR_LITE_CONFIG_FILE");
         }
         if (StringUtils.isNotBlank(configFile)) {
-            log.info("Loading {}", configFile);
-            FileSystemResource resource = new FileSystemResource(configFile);
-            if (resource.exists()) {
-                Properties properties = new Properties();
-                properties.load(resource.getInputStream());
-                properties.forEach(
-                        (key, value) -> System.setProperty((String) key, (String) value));
-                log.info("Loaded {} properties from {}", properties.size(), configFile);
-            } else {
-                log.warn("Ignoring {} since it does not exist", configFile);
-            }
+            log.info("Loading external config from {}", configFile);
+            System.setProperty("spring.config.additional-location", "optional:file:" + configFile);
         }
     }
 }

--- a/server/src/main/java/com/netflix/conductor/Conductor.java
+++ b/server/src/main/java/com/netflix/conductor/Conductor.java
@@ -12,9 +12,7 @@
  */
 package com.netflix.conductor;
 
-import java.io.IOException;
 import java.net.InetAddress;
-import java.util.Properties;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -27,7 +25,6 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.core.env.Environment;
-import org.springframework.core.io.FileSystemResource;
 
 // Prevents from the datasource beans to be loaded, AS they are needed only for specific databases.
 // In case that SQL database is selected this class will be imported back in the appropriate
@@ -49,7 +46,7 @@ public class Conductor implements ApplicationRunner {
         this.environment = environment;
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) {
         loadExternalConfig();
 
         SpringApplication.run(Conductor.class, args);
@@ -96,31 +93,22 @@ public class Conductor implements ApplicationRunner {
     }
 
     /**
-     * Reads properties from the location specified in <code>CONDUCTOR_CONFIG_FILE</code> and sets
-     * them as system properties so they override the default properties.
+     * If <code>CONDUCTOR_CONFIG_FILE</code> is set, registers the file as an additional Spring Boot
+     * config location. Spring then loads the file as part of its standard property resolution,
+     * placing it above default properties but below environment variables, JVM system properties,
+     * and command-line args.
      *
      * <p>Spring Boot property hierarchy is documented here,
-     * https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config
-     *
-     * @throws IOException if file can't be read.
+     * https://docs.spring.io/spring-boot/reference/features/external-config.html#features.external-config
      */
-    private static void loadExternalConfig() throws IOException {
+    private static void loadExternalConfig() {
         String configFile = System.getProperty("CONDUCTOR_CONFIG_FILE");
         if (StringUtils.isBlank(configFile)) {
             configFile = System.getenv("CONDUCTOR_CONFIG_FILE");
         }
         if (StringUtils.isNotBlank(configFile)) {
-            log.info("Loading {}", configFile);
-            FileSystemResource resource = new FileSystemResource(configFile);
-            if (resource.exists()) {
-                Properties properties = new Properties();
-                properties.load(resource.getInputStream());
-                properties.forEach(
-                        (key, value) -> System.setProperty((String) key, (String) value));
-                log.info("Loaded {} properties from {}", properties.size(), configFile);
-            } else {
-                log.warn("Ignoring {} since it does not exist", configFile);
-            }
+            log.info("Loading external config from {}", configFile);
+            System.setProperty("spring.config.additional-location", "optional:file:" + configFile);
         }
     }
 }


### PR DESCRIPTION
## Summary

Register `CONDUCTOR_CONFIG_FILE` as a Spring [config-data location][spring-docs]
instead of pushing every entry into JVM system properties. This restores the
documented Spring Boot property hierarchy: env vars and JVM args now correctly
override values from the config file, while the file still overrides Spring's
built-in defaults.

The previous behavior blocked the standard PaaS deployment pattern (Railway,
Heroku, K8s, ECS) where credentials and connection strings are injected via
env vars. Operators currently work around it by passing `-D...` JVM flags
via `JAVA_OPTS`.

The same fix is applied to `server-lite` (`CONDUCTOR_LITE_CONFIG_FILE`),
which had identical code.

Resolves #547.

## Fix

```java
System.setProperty("spring.config.additional-location", "optional:file:" + configFile);
```

Spring then loads the file as part of its standard property resolution. The
resulting precedence (low → high):

1. Default properties
2. `@PropertySource` annotations
3. Config data (`application.properties`, etc.) ← `CONDUCTOR_CONFIG_FILE` lands here
4. OS environment variables
5. Java System properties
6. Command-line arguments

The `optional:` prefix preserves existing behavior of tolerating a missing
file rather than failing startup.

## Verification

A test config file defines `spring.datasource.url=jdbc:postgresql://from-file:5432/postgres`.
An optional env var sets `SPRING_DATASOURCE_URL=jdbc:postgresql://from-env:5432/postgres`.
Conductor's startup connection attempt fails with
`java.net.UnknownHostException: <host>` — the `<host>` proves which
`spring.datasource.url` value Spring resolved.

| # | Branch  | Env var    | File value  | Resolved host | Outcome                                    |
|---|---------|------------|-------------|---------------|--------------------------------------------|
| 1 | `main`  | `from-env` | `from-file` | `from-file`   | Reproduces #547 — env var ignored          |
| 2 | this PR | `from-env` | `from-file` | `from-env`    | Env var overrides file ✅                   |
| 3 | this PR | (unset)    | `from-file` | `from-file`   | File still overrides classpath defaults ✅ |

## Backward compatibility

**Env-var precedence change.** Users currently relying on `CONDUCTOR_CONFIG_FILE`
to override env-var-set values will see those env vars take effect after this change. 
Migration: set the value via env var (which now works as expected)
or via `-D` JVM args (which still take precedence over both file and env).
The previous behavior contradicted the documented Spring Boot property
hierarchy; this change brings Conductor in line with it.

**Workflow placeholder resolution.** Workflow `${VAR}` placeholders are
resolved by `EnvUtils`, which reads `System.getProperty` and `System.getenv`.
Before this change, every key in `CONDUCTOR_CONFIG_FILE` was reachable that
way — including sensitive keys like `spring.datasource.password`. 
After this change, file-defined values are no longer reachable; 
placeholders for them will be left unsubstituted in task inputs.

[spring-docs]: https://docs.spring.io/spring-boot/reference/features/external-config.html