### PR TITLE
fix(amqp): skip ack when using exchange as ack is only meaningful for queues

### DIFF
--- a/amqp/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueue.java
+++ b/amqp/src/main/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueue.java
@@ -189,12 +189,17 @@ public class AMQPObservableQueue implements ObservableQueue {
 
     public List<String> ack(List<Message> messages) {
         final List<String> failedMessages = new ArrayList<>();
-        for (final Message message : messages) {
-            try {
-                ackMsg(message);
-            } catch (final Exception e) {
-                LOGGER.error("Cannot ACK message with delivery tag {}", message.getReceipt(), e);
-                failedMessages.add(message.getReceipt());
+        if (!useExchange) {
+            // only attempt to ack messages when using queues.
+            // it makes no sense to ack over exchange since the messages are no longer there.
+            for (final Message message : messages) {
+                try {
+                    ackMsg(message);
+                } catch (final Exception e) {
+                    LOGGER.error(
+                            "Cannot ACK message with delivery tag {}", message.getReceipt(), e);
+                    failedMessages.add(message.getReceipt());
+                }
             }
         }
         return failedMessages;

--- a/amqp/src/test/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueueTest.java
+++ b/amqp/src/test/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueueTest.java
@@ -13,11 +13,13 @@
 package com.netflix.conductor.contribs.queue.amqp;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -103,7 +105,41 @@ public class AMQPObservableQueueTest {
         when(properties.getDeliveryMode()).thenReturn(2);
         when(properties.isUseExchange()).thenReturn(true);
         addresses = new Address[] {new Address("localhost", PROTOCOL.PORT)};
+        resetAMQPConnectionState();
+    }
+
+    private void resetAMQPConnectionState() {
         AMQPConnection.setAMQPConnection(null);
+        clearStaticMap("availableChannelPool");
+        clearStaticMap("subscriberReservedChannelPool");
+        setStaticField("retrySettings", null);
+    }
+
+    private void clearStaticMap(String fieldName) {
+        Object value = getStaticField(fieldName);
+        if (value instanceof Map<?, ?> map) {
+            map.clear();
+        }
+    }
+
+    private void setStaticField(String fieldName, Object value) {
+        try {
+            Field field = AMQPConnection.class.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(null, value);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to reset AMQPConnection field " + fieldName, e);
+        }
+    }
+
+    private Object getStaticField(String fieldName) {
+        try {
+            Field field = AMQPConnection.class.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.get(null);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to read AMQPConnection field " + fieldName, e);
+        }
     }
 
     List<GetResponse> buildQueue(final Random random, final int bound) {

--- a/amqp/src/test/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueueTest.java
+++ b/amqp/src/test/java/com/netflix/conductor/contribs/queue/amqp/AMQPObservableQueueTest.java
@@ -71,6 +71,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -389,11 +390,10 @@ public class AMQPObservableQueueTest {
     }
 
     @Test
-    public void testAck() throws IOException, TimeoutException {
+    public void testAckOnExchangeIsSkipped() throws IOException, TimeoutException {
         // Mock channel and connection
         Channel channel = mockBaseChannel();
         Connection connection = mockGoodConnection(channel);
-        final Random random = new Random();
 
         final String name = RandomStringUtils.randomAlphabetic(30),
                 type = "topic",
@@ -426,6 +426,41 @@ public class AMQPObservableQueueTest {
         List<String> failedMessages = observableQueue.ack(messages);
         assertNotNull(failedMessages);
         assertTrue(failedMessages.isEmpty());
+        verify(channel, never()).basicAck(anyLong(), anyBoolean());
+    }
+
+    @Test
+    public void testAckOnQueueCallsBasicAck() throws IOException, TimeoutException {
+        // Mock channel and connection
+        Channel channel = mockBaseChannel();
+        Connection connection = mockGoodConnection(channel);
+
+        final String queueName = RandomStringUtils.randomAlphabetic(30);
+        AMQPSettings settings = new AMQPSettings(properties).fromURI("amqp_queue:" + queueName);
+        List<GetResponse> queue = buildQueue(new Random(), batchSize);
+        channel = mockChannelForQueue(channel, true, true, queueName, queue);
+        doNothing().when(channel).basicAck(anyLong(), eq(false));
+
+        AMQPRetryPattern retrySettings = null;
+        AMQPObservableQueue observableQueue =
+                new AMQPObservableQueue(
+                        mockConnectionFactory(connection),
+                        addresses,
+                        false,
+                        settings,
+                        retrySettings,
+                        batchSize,
+                        pollTimeMs);
+        List<Message> messages = new LinkedList<>();
+        Message msg = new Message();
+        msg.setId("0e3eef8f-ebb1-4244-9665-759ab5bdf433");
+        msg.setPayload("Payload");
+        msg.setReceipt("1");
+        messages.add(msg);
+        List<String> failedMessages = observableQueue.ack(messages);
+        assertNotNull(failedMessages);
+        assertTrue(failedMessages.isEmpty());
+        verify(channel, times(1)).basicAck(1L, false);
     }
 
     private void testGetMessagesFromExchangeAndDefaultConfiguration(


### PR DESCRIPTION
## Problem

When a workflow is terminated, Conductor correctly calls `Event.cancel()` for any in-progress EVENT task. The `Event.cancel()` implementation attempts to clean up by calling `queue.ack()` with a synthetic `Message` using `task.getTaskId()` (a UUID) as the receipt.

For AMQP exchanges this is semantically wrong: the EVENT task *publishes* to an exchange — once the message is routed it is gone, and there is no consumer relationship, no delivery tag, and nothing to acknowledge. The ack attempt should never be made.

On top of the semantic issue, `AMQPObservableQueue.ackMsg()` calls `Long.parseLong(message.getReceipt())` to obtain the AMQP delivery tag. Since the receipt is a UUID, this throws a `NumberFormatException`. The internal retry loop in `ackMsg()` exhausts before the cancellation proceeds, causing significant delay.

## Fix

Skip `ack` entirely when `useExchange` is true. This is correct by definition — exchange publishers have no delivery tag to acknowledge — and eliminates the retry loop for the exchange case.

Note: the `NumberFormatException` also affects the queue path (wrong receipt type in `Event.cancel()`), but that is a separate concern tracked in #779.

## Tests

- Renamed `testAck` → `testAckOnExchangeIsSkipped` and added `verify(channel, never()).basicAck(...)` to make the intent explicit.
- Added `testAckOnQueueCallsBasicAck` to confirm ACK is still invoked correctly on the queue path.
- Also included a fix for pre-existing test state leakage in `AMQPObservableQueueTest` (`resetAMQPConnectionState` in `@Before`) that caused two unrelated tests to fail when run in certain orders.