### PR TITLE
fix:Remove AI_TASKS from OSS supportedTasks to avoid duplicates with enterprise plugin

### DIFF
--- a/ui-next/src/components/features/flow/components/RichAddTaskMenu/supportedTasks.ts
+++ b/ui-next/src/components/features/flow/components/RichAddTaskMenu/supportedTasks.ts
@@ -200,54 +200,6 @@ const getPluginTaskMenuItems = (): BaseTaskMenuItem[] => {
   }));
 };
 
-/**
- * AI/LLM Tasks for Agentic Orchestration
- * These are AI-powered tasks for building intelligent workflows.
- */
-export const AI_TASKS: BaseTaskMenuItem[] = [
-  {
-    name: "LLM Chat Complete",
-    description: "Generate text using a large language model chat interface.",
-    type: TaskType.LLM_CHAT_COMPLETE,
-    category: RichAddMenuTabs.AI_AGENTS_TAB,
-  },
-  {
-    name: "LLM Text Complete",
-    description: "Generate text using a large language model completion API.",
-    type: TaskType.LLM_TEXT_COMPLETE,
-    category: RichAddMenuTabs.AI_AGENTS_TAB,
-  },
-  {
-    name: "LLM Generate Embeddings",
-    description: "Generate vector embeddings from text.",
-    type: TaskType.LLM_GENERATE_EMBEDDINGS,
-    category: RichAddMenuTabs.AI_AGENTS_TAB,
-  },
-  {
-    name: "LLM Get Embeddings",
-    description: "Retrieve stored embeddings by ID or query.",
-    type: TaskType.LLM_GET_EMBEDDINGS,
-    category: RichAddMenuTabs.AI_AGENTS_TAB,
-  },
-  {
-    name: "LLM Index Document",
-    description: "Index a document into a vector database for semantic search.",
-    type: TaskType.LLM_INDEX_DOCUMENT,
-    category: RichAddMenuTabs.AI_AGENTS_TAB,
-  },
-  {
-    name: "LLM Search Index",
-    description: "Search indexed documents using semantic similarity.",
-    type: TaskType.LLM_SEARCH_INDEX,
-    category: RichAddMenuTabs.AI_AGENTS_TAB,
-  },
-];
-
-/**
- * @deprecated Use AI_TASKS instead
- */
-export const LLM_TASKS: BaseTaskMenuItem[] = AI_TASKS;
-
 const [simpleTask, ...remainingWorkerTasks] = WORKER_TASKS;
 
 /**
@@ -258,7 +210,6 @@ export const getALL_TASKS = (): BaseTaskMenuItem[] => [
   simpleTask,
   ...SYSTEM_TASKS,
   ...OPERATOR_TASKS,
-  ...AI_TASKS,
   ...getPluginTaskMenuItems(),
   ...remainingWorkerTasks,
 ];


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

- [x] The OSS AI_TASKS list duplicated the AI/Agent task entries supplied by the enterprise plugin, causing each LLM task to appear twice in the "Add Task" menu under the AI Agents tab. 
Removed AI_TASKS, the deprecated LLM_TASKS alias, and the corresponding spread from getALL_TASKS() in `ui-next/src/components/features/flow/components/RichAddTaskMenu/supportedTasks.ts`. The AI/LLM tasks now come exclusively from the enterprise plugin via getPluginTaskMenuItems().
