### PR TITLE
Fix WorkflowSweeper self-deadlock with non-reentrant locks (#1058)

### DIFF
--- a/core/src/main/java/org/conductoross/conductor/core/execution/WorkflowSweeper.java
+++ b/core/src/main/java/org/conductoross/conductor/core/execution/WorkflowSweeper.java
@@ -40,7 +40,6 @@ import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.metrics.Monitors;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
-import com.netflix.conductor.service.ExecutionLockService;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -65,7 +64,6 @@ public class WorkflowSweeper extends LifecycleAwareComponent {
     private final ConductorProperties properties;
     private final ObjectMapper objectMapper;
     private SystemTaskRegistry systemTaskRegistry;
-    private final ExecutionLockService executionLockService;
     private final Clock clock = Clock.systemDefaultZone();
     private AtomicBoolean stop = new AtomicBoolean(false);
 
@@ -77,8 +75,7 @@ public class WorkflowSweeper extends LifecycleAwareComponent {
             ConductorProperties properties,
             SweeperProperties sweeperProperties,
             SystemTaskRegistry systemTaskRegistry,
-            ObjectMapper objectMapper,
-            ExecutionLockService executionLockService) {
+            ObjectMapper objectMapper) {
         this.queueDAO = queueDAO;
         this.executionDAO = executionDAO;
         this.sweeperProperties = sweeperProperties;
@@ -88,7 +85,6 @@ public class WorkflowSweeper extends LifecycleAwareComponent {
         this.properties = properties;
         this.systemTaskRegistry = systemTaskRegistry;
         this.objectMapper = objectMapper;
-        this.executionLockService = executionLockService;
         log.info("Initializing sweeper with {} threads", properties.getSweeperThreadCount());
         for (int i = 0; i < properties.getSweeperThreadCount(); i++) {
             sweeperExecutor.execute(this::pollAndSweep);
@@ -159,10 +155,6 @@ public class WorkflowSweeper extends LifecycleAwareComponent {
     }
 
     public void sweep(String workflowId) {
-        if (!executionLockService.acquireLock(workflowId)) {
-            log.error("Couldn't acquire lock to sweep workflow {}", workflowId);
-            return;
-        }
         log.info("Running sweeper for workflow {}", workflowId);
 
         try {
@@ -295,8 +287,6 @@ public class WorkflowSweeper extends LifecycleAwareComponent {
             queueDAO.remove(DECIDER_QUEUE, workflowId);
         } catch (Throwable e) {
             log.error("Error running sweep for {}, error = {}", workflowId, e.getMessage(), e);
-        } finally {
-            executionLockService.releaseLock(workflowId);
         }
     }
 

--- a/core/src/test/java/org/conductoross/conductor/core/execution/WorkflowSweeperTest.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/WorkflowSweeperTest.java
@@ -180,14 +180,13 @@ public class WorkflowSweeperTest {
      *
      * <p>Previously, sweep() pre-acquired the execution lock and then called
      * workflowExecutor.decide(workflowId), which acquires the same lock internally. With a
-     * non-reentrant lock backend (Postgres advisory locks), the inner acquisition always
-     * returned false, decide() returned null, and the sweeper re-queued the workflow with a
-     * backoff delay — stalling workflows containing a SUB_WORKFLOW task forever after the
-     * sub-workflow completed.
+     * non-reentrant lock backend (Postgres advisory locks), the inner acquisition always returned
+     * false, decide() returned null, and the sweeper re-queued the workflow with a backoff delay —
+     * stalling workflows containing a SUB_WORKFLOW task forever after the sub-workflow completed.
      *
-     * <p>After the fix, sweep() no longer pre-acquires the lock; decide() handles locking
-     * itself. A SUB_WORKFLOW parent whose child has completed must advance to terminal in a
-     * single sweep cycle, with no backoff push to the decider queue.
+     * <p>After the fix, sweep() no longer pre-acquires the lock; decide() handles locking itself. A
+     * SUB_WORKFLOW parent whose child has completed must advance to terminal in a single sweep
+     * cycle, with no backoff push to the decider queue.
      */
     @Test
     public void sweepAdvancesParentWhenSubWorkflowCompletedWithNonReentrantLock() {

--- a/core/src/test/java/org/conductoross/conductor/core/execution/WorkflowSweeperTest.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/WorkflowSweeperTest.java
@@ -29,10 +29,10 @@ import com.netflix.conductor.dao.ExecutionDAO;
 import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
-import com.netflix.conductor.service.ExecutionLockService;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -53,7 +53,6 @@ public class WorkflowSweeperTest {
     private SweeperProperties sweeperProperties;
     private SystemTaskRegistry systemTaskRegistry;
     private ObjectMapper objectMapper;
-    private ExecutionLockService executionLockService;
     private WorkflowSweeper workflowSweeper;
 
     @Before
@@ -66,7 +65,6 @@ public class WorkflowSweeperTest {
         sweeperProperties = mock(SweeperProperties.class);
         systemTaskRegistry = mock(SystemTaskRegistry.class);
         objectMapper = mock(ObjectMapper.class);
-        executionLockService = mock(ExecutionLockService.class);
 
         when(properties.getWorkflowOffsetTimeout()).thenReturn(Duration.ofSeconds(30));
         when(properties.getMaxPostponeDurationSeconds()).thenReturn(Duration.ofSeconds(3600));
@@ -82,8 +80,7 @@ public class WorkflowSweeperTest {
                         properties,
                         sweeperProperties,
                         systemTaskRegistry,
-                        objectMapper,
-                        executionLockService);
+                        objectMapper);
     }
 
     @Test
@@ -95,7 +92,6 @@ public class WorkflowSweeperTest {
         runningWaitTask.setWaitTimeout(System.currentTimeMillis() + 60_000);
         WorkflowModel workflow = newWorkflow(List.of(completedTask, runningWaitTask));
 
-        when(executionLockService.acquireLock(WORKFLOW_ID)).thenReturn(true);
         when(workflowExecutor.getWorkflow(WORKFLOW_ID, true)).thenReturn(workflow);
         when(workflowExecutor.decide(WORKFLOW_ID)).thenReturn(workflow);
         when(systemTaskRegistry.isSystemTask(anyString())).thenReturn(false);
@@ -105,7 +101,6 @@ public class WorkflowSweeperTest {
         workflowSweeper.sweep(WORKFLOW_ID);
 
         verify(queueDAO, never()).push(TaskType.TASK_TYPE_SIMPLE, completedTask.getTaskId(), 0L);
-        verify(executionLockService).releaseLock(WORKFLOW_ID);
     }
 
     @Test
@@ -114,7 +109,6 @@ public class WorkflowSweeperTest {
                 newTask("simple-task", TaskType.TASK_TYPE_SIMPLE, TaskModel.Status.IN_PROGRESS);
         WorkflowModel workflow = newWorkflow(List.of(simpleInProgressTask));
 
-        when(executionLockService.acquireLock(WORKFLOW_ID)).thenReturn(true);
         when(workflowExecutor.getWorkflow(WORKFLOW_ID, true)).thenReturn(workflow);
         when(workflowExecutor.decide(WORKFLOW_ID)).thenReturn(workflow);
         when(systemTaskRegistry.isSystemTask(anyString())).thenReturn(false);
@@ -123,7 +117,6 @@ public class WorkflowSweeperTest {
 
         verify(queueDAO, never())
                 .push(TaskType.TASK_TYPE_SIMPLE, simpleInProgressTask.getTaskId(), 0L);
-        verify(executionLockService).releaseLock(WORKFLOW_ID);
     }
 
     @Test
@@ -133,7 +126,6 @@ public class WorkflowSweeperTest {
         scheduledTask.setCallbackAfterSeconds(7L);
         WorkflowModel workflow = newWorkflow(List.of(scheduledTask));
 
-        when(executionLockService.acquireLock(WORKFLOW_ID)).thenReturn(true);
         when(workflowExecutor.getWorkflow(WORKFLOW_ID, true)).thenReturn(workflow);
         when(workflowExecutor.decide(WORKFLOW_ID)).thenReturn(workflow);
         when(systemTaskRegistry.isSystemTask(anyString())).thenReturn(false);
@@ -147,7 +139,6 @@ public class WorkflowSweeperTest {
                         TaskType.TASK_TYPE_SIMPLE,
                         scheduledTask.getTaskId(),
                         scheduledTask.getCallbackAfterSeconds());
-        verify(executionLockService).releaseLock(WORKFLOW_ID);
     }
 
     @Test
@@ -168,7 +159,6 @@ public class WorkflowSweeperTest {
         terminalWorkflow.setWorkflowId(WORKFLOW_ID);
         terminalWorkflow.setStatus(WorkflowModel.Status.COMPLETED);
 
-        when(executionLockService.acquireLock(WORKFLOW_ID)).thenReturn(true);
         when(workflowExecutor.getWorkflow(WORKFLOW_ID, true)).thenReturn(workflow);
         when(workflowExecutor.decide(WORKFLOW_ID)).thenReturn(workflow, terminalWorkflow);
         when(systemTaskRegistry.isSystemTask(TaskType.TASK_TYPE_SUB_WORKFLOW)).thenReturn(true);
@@ -183,7 +173,53 @@ public class WorkflowSweeperTest {
         verify(executionDAO).updateTask(subWorkflowTask);
         verify(workflowExecutor, times(2)).decide(WORKFLOW_ID);
         verify(queueDAO, never()).push(anyString(), anyString(), anyLong());
-        verify(executionLockService).releaseLock(WORKFLOW_ID);
+    }
+
+    /**
+     * Regression test for conductor-oss/conductor#1058.
+     *
+     * <p>Previously, sweep() pre-acquired the execution lock and then called
+     * workflowExecutor.decide(workflowId), which acquires the same lock internally. With a
+     * non-reentrant lock backend (Postgres advisory locks), the inner acquisition always
+     * returned false, decide() returned null, and the sweeper re-queued the workflow with a
+     * backoff delay — stalling workflows containing a SUB_WORKFLOW task forever after the
+     * sub-workflow completed.
+     *
+     * <p>After the fix, sweep() no longer pre-acquires the lock; decide() handles locking
+     * itself. A SUB_WORKFLOW parent whose child has completed must advance to terminal in a
+     * single sweep cycle, with no backoff push to the decider queue.
+     */
+    @Test
+    public void sweepAdvancesParentWhenSubWorkflowCompletedWithNonReentrantLock() {
+        TaskModel subWorkflowTask =
+                newTask(
+                        "sub-workflow-task",
+                        TaskType.TASK_TYPE_SUB_WORKFLOW,
+                        TaskModel.Status.IN_PROGRESS);
+        subWorkflowTask.setSubWorkflowId("sub-workflow-id");
+        WorkflowModel workflow = newWorkflow(List.of(subWorkflowTask));
+
+        WorkflowSystemTask workflowSystemTask = mock(WorkflowSystemTask.class);
+        WorkflowModel subWorkflow = new WorkflowModel();
+        subWorkflow.setStatus(WorkflowModel.Status.COMPLETED);
+        subWorkflow.setOutput(Map.of("result", "ok"));
+        WorkflowModel terminalWorkflow = new WorkflowModel();
+        terminalWorkflow.setWorkflowId(WORKFLOW_ID);
+        terminalWorkflow.setStatus(WorkflowModel.Status.COMPLETED);
+
+        when(workflowExecutor.getWorkflow(WORKFLOW_ID, true)).thenReturn(workflow);
+        when(workflowExecutor.decide(WORKFLOW_ID)).thenReturn(workflow, terminalWorkflow);
+        when(systemTaskRegistry.isSystemTask(TaskType.TASK_TYPE_SUB_WORKFLOW)).thenReturn(true);
+        when(systemTaskRegistry.get(TaskType.TASK_TYPE_SUB_WORKFLOW))
+                .thenReturn(workflowSystemTask);
+        when(workflowSystemTask.isAsync()).thenReturn(true);
+        when(workflowSystemTask.isAsyncComplete(subWorkflowTask)).thenReturn(true);
+        when(executionDAO.getWorkflow("sub-workflow-id", false)).thenReturn(subWorkflow);
+
+        workflowSweeper.sweep(WORKFLOW_ID);
+
+        verify(queueDAO, never()).push(anyString(), anyString(), anyInt(), anyLong());
+        verify(queueDAO).remove(com.netflix.conductor.core.utils.Utils.DECIDER_QUEUE, WORKFLOW_ID);
     }
 
     private WorkflowModel newWorkflow(List<TaskModel> tasks) {


### PR DESCRIPTION
## Summary

- Remove the redundant execution-lock pre-acquire from `WorkflowSweeper.sweep()`. `WorkflowExecutorOps.decide(String)` already acquires/releases the same lock internally, so the sweeper's pre-acquire is both redundant and actively harmful with non-reentrant lock backends.
- Drop the now-unused `ExecutionLockService` field and constructor parameter.
- Update existing `WorkflowSweeperTest` cases to stop mocking/verifying the removed lock calls, and add a regression test for the SUB_WORKFLOW deadlock scenario.

Fixes conductor-oss/conductor#1058.

## Root cause

`WorkflowSweeper.sweep()` did this:

```java
if (!executionLockService.acquireLock(workflowId)) { return; }   // sweeper's own pre-acquire
try {
    workflow = workflowExecutor.decide(workflowId);              // calls acquireLock() AGAIN internally
    if (workflow == null) {
        // misread as external contention -> backoff push
        queueDAO.push(DECIDER_QUEUE, workflowId, 0, backoffSeconds);
        return;
    }
    ...
} finally {
    executionLockService.releaseLock(workflowId);
}
```

Postgres advisory locks are non-reentrant by design. The inner `acquireLock` inside `decide()` therefore always returned `false`, `decide()` returned `null`, and the sweeper pushed the workflow back to the decider queue with a backoff delay — forever.

`SUB_WORKFLOW` is the common trigger because the child's completion does not re-enqueue the parent directly; the parent relies on the next sweep cycle to detect completion and advance — and that sweep cycle is exactly where the deadlock fires.

## User impact

First-time users running a Conductor stack on Postgres with the lock enabled — including anyone following a Postgres-backed quickstart — would see workflows with a `SUB_WORKFLOW` task get stuck in `RUNNING` indefinitely once the sub-workflow completed, with the sweeper logging `can't get a lock on <id>, will try after 30 seconds` on a loop. After this fix, those workflows advance to terminal in the next sweep cycle as expected.

## Credit

Diagnosis, failing unit test, and a working docker-compose reproduction by @NicolasBissig in #1058 and https://github.com/NicolasBissig/conductor-oss-lock-bug-repro — thank you.

## Test plan

- [x] `./gradlew :conductor-core:compileJava :conductor-core:compileTestJava` — clean
- [x] `./gradlew :conductor-core:test --tests org.conductoross.conductor.core.execution.WorkflowSweeperTest` — all 5 tests pass (4 existing + 1 new regression test)
- [ ] Run @NicolasBissig's docker-compose repro against a build with this fix and confirm the parent workflow completes within seconds instead of stalling

🤖 Generated with [Claude Code](https://claude.com/claude-code)