### PR TITLE
hot-fix:show task doc URL for non-MCP task types

### DIFF
--- a/ui-next/src/pages/definition/EditorPanel/TaskFormTab/TaskFormContent.tsx
+++ b/ui-next/src/pages/definition/EditorPanel/TaskFormTab/TaskFormContent.tsx
@@ -351,10 +351,7 @@ const TaskFormContent: FunctionComponent = () => {
       ? "CONNECTED APP"
       : taskType;
   const taskTypeLabel = taskType === TaskType.MCP ? "CONNECTED APP" : taskType;
-  const taskDocUrl =
-    taskType === TaskType.MCP && mcpIntegrationType
-      ? getTaskDocUrl(mcpIntegrationType) || getTaskDocUrl(TaskType.HTTP)
-      : "";
+  const taskDocUrl = getTaskDocUrl(mcpIntegrationType ?? taskType) ?? "";
 
   return (
     <Box


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

- [x] non-MCP task doc urls was not rendering properly