### PR TITLE
fix(ui): crash on New Workflow Definition (null key in useFetch)

### DIFF
--- a/ui/src/data/workflow.js
+++ b/ui/src/data/workflow.js
@@ -161,7 +161,7 @@ export function useWorkflowNamesAndVersions() {
 
 export function useWorkflowVersions(workflowName) {
   return useFetch(
-    workflowName ? ["workflowVersions", workflowName] : null,
+    ["workflowVersions", workflowName],
     workflowName ? `/metadata/workflow/${workflowName}/versions` : null,
     {
       enabled: !!workflowName,


### PR DESCRIPTION
### Steps to reproduce
1. Run UI on `main`.
2. Navigate to **Definitions → Workflows**.
3. Click **+ New Workflow Definition**.
4. Page crashes — console shows `TypeError: key is not iterable`.

### Root cause
useWorkflowVersions (`ui/src/data/workflow.js`) passes null when workflowName is undefined.

### Fix
Always pass an array as the key; let `enabled: !!workflowName` gate the fetch — matching every other `useFetch` caller in the codebase (`task.js`, `misc.js`, `eventHandler.js`, `scheduler.js`, and the rest of `workflow.js`).

### Introduced by
#1019 — *"perf: Add per-workflow /versions API with lazy UI version loading"* (commit \`5e96c7abd\`).

### How to test
1. `cd ui && WF_SERVER=http://localhost:8080 yarn start`
2. Click **+ New Workflow Definition** — page renders the editor, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)