### PR TITLE
feat(persistence): WebhookDAO + WebhookTaskService impls for all 5 OSS backends (stacked on #1106)

### DIFF
--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/config/CassandraConfiguration.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/config/CassandraConfiguration.java
@@ -116,9 +116,15 @@ public class CassandraConfiguration {
             Session session,
             ObjectMapper objectMapper,
             CassandraProperties properties,
-            com.netflix.conductor.dao.MetadataDAO metadataDAO) {
+            com.netflix.conductor.dao.MetadataDAO metadataDAO,
+            org.springframework.core.env.Environment env) {
+        long ttlSeconds = 7L * 24 * 3600;
+        String retention = env.getProperty("conductor.webhooks.cleanup.retention-duration");
+        if (retention != null) {
+            ttlSeconds = java.time.Duration.parse(retention).toSeconds();
+        }
         return new org.conductoross.conductor.cassandra.dao.CassandraWebhookDAO(
-                session, objectMapper, properties, metadataDAO);
+                session, objectMapper, properties, metadataDAO, ttlSeconds);
     }
 
     @Bean(name = "webhookTaskService")

--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/config/CassandraConfiguration.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/config/CassandraConfiguration.java
@@ -111,6 +111,24 @@ public class CassandraConfiguration {
         return new CassandraPollDataDAO();
     }
 
+    @Bean(name = "webhookDAO")
+    public org.conductoross.conductor.cassandra.dao.CassandraWebhookDAO cassandraWebhookDAO(
+            Session session,
+            ObjectMapper objectMapper,
+            CassandraProperties properties,
+            com.netflix.conductor.dao.MetadataDAO metadataDAO) {
+        return new org.conductoross.conductor.cassandra.dao.CassandraWebhookDAO(
+                session, objectMapper, properties, metadataDAO);
+    }
+
+    @Bean(name = "webhookTaskService")
+    public org.conductoross.conductor.cassandra.dao.CassandraWebhookTaskService
+            cassandraWebhookTaskService(
+                    Session session, ObjectMapper objectMapper, CassandraProperties properties) {
+        return new org.conductoross.conductor.cassandra.dao.CassandraWebhookTaskService(
+                session, objectMapper, properties);
+    }
+
     @Bean
     public Statements statements(CassandraProperties cassandraProperties) {
         return new Statements(cassandraProperties.getKeyspace());

--- a/cassandra-persistence/src/main/java/org/conductoross/conductor/cassandra/dao/CassandraWebhookDAO.java
+++ b/cassandra-persistence/src/main/java/org/conductoross/conductor/cassandra/dao/CassandraWebhookDAO.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.cassandra.dao;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.conductoross.conductor.dao.webhook.WebhookDAO;
+import org.conductoross.conductor.webhook.model.IncomingWebhookEvent;
+import org.conductoross.conductor.webhook.model.WebhookConfig;
+import org.springframework.lang.Nullable;
+import org.springframework.util.CollectionUtils;
+
+import com.netflix.conductor.cassandra.config.CassandraProperties;
+import com.netflix.conductor.cassandra.dao.CassandraBaseDAO;
+import com.netflix.conductor.common.metadata.tasks.TaskType;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.core.exception.NotFoundException;
+import com.netflix.conductor.dao.MetadataDAO;
+
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WAIT_FOR_WEBHOOK;
+import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WEBHOOK_DELIMITER;
+
+/**
+ * Cassandra-backed {@link WebhookDAO}.
+ *
+ * <p>Tables (created on construction via {@link #ensureTables()}):
+ *
+ * <ul>
+ *   <li>{@code webhook (bucket, webhook_id PK, json_data)} — single 'ALL' bucket so
+ *       getAllWebhooks() is a single-partition scan. Anti-pattern for high cardinality, fine for
+ *       admin-scale webhook configs.
+ *   <li>{@code incoming_webhook_event (event_id PK, json_data)} — high cardinality, no listing.
+ *   <li>{@code webhook_target_workflows (webhook_id PK, json_data)} — target workflow versions
+ *       snapshot per webhook. Matchers themselves are recomputed from MetadataDAO on read.
+ * </ul>
+ */
+@Slf4j
+public class CassandraWebhookDAO extends CassandraBaseDAO implements WebhookDAO {
+
+    private static final String TABLE_WEBHOOK = "webhook";
+    private static final String TABLE_EVENT = "incoming_webhook_event";
+    private static final String TABLE_TARGETS = "webhook_target_workflows";
+    private static final String ALL_BUCKET = "ALL";
+
+    private final Session session;
+    private final MetadataDAO metadataDAO;
+    // objectMapper / toJson / readValue are package-private in CassandraBaseDAO; keep a local ref.
+    private final ObjectMapper objectMapper;
+
+    private final PreparedStatement insertWebhookStmt;
+    private final PreparedStatement selectWebhookStmt;
+    private final PreparedStatement selectAllWebhooksStmt;
+    private final PreparedStatement deleteWebhookStmt;
+    private final PreparedStatement insertEventStmt;
+    private final PreparedStatement selectEventStmt;
+    private final PreparedStatement deleteEventStmt;
+    private final PreparedStatement insertTargetsStmt;
+    private final PreparedStatement selectTargetsStmt;
+    private final PreparedStatement deleteTargetsStmt;
+
+    public CassandraWebhookDAO(
+            Session session,
+            ObjectMapper objectMapper,
+            CassandraProperties properties,
+            MetadataDAO metadataDAO) {
+        super(session, objectMapper, properties);
+        this.session = session;
+        this.metadataDAO = metadataDAO;
+        this.objectMapper = objectMapper;
+        ensureTables();
+
+        ConsistencyLevel readConsistency = properties.getReadConsistencyLevel();
+        ConsistencyLevel writeConsistency = properties.getWriteConsistencyLevel();
+
+        insertWebhookStmt =
+                session.prepare(
+                                "INSERT INTO "
+                                        + TABLE_WEBHOOK
+                                        + " (bucket, webhook_id, json_data) VALUES (?, ?, ?)")
+                        .setConsistencyLevel(writeConsistency);
+        selectWebhookStmt =
+                session.prepare(
+                                "SELECT json_data FROM "
+                                        + TABLE_WEBHOOK
+                                        + " WHERE bucket = ? AND webhook_id = ?")
+                        .setConsistencyLevel(readConsistency);
+        selectAllWebhooksStmt =
+                session.prepare("SELECT json_data FROM " + TABLE_WEBHOOK + " WHERE bucket = ?")
+                        .setConsistencyLevel(readConsistency);
+        deleteWebhookStmt =
+                session.prepare(
+                                "DELETE FROM "
+                                        + TABLE_WEBHOOK
+                                        + " WHERE bucket = ? AND webhook_id = ?")
+                        .setConsistencyLevel(writeConsistency);
+
+        insertEventStmt =
+                session.prepare(
+                                "INSERT INTO "
+                                        + TABLE_EVENT
+                                        + " (event_id, json_data) VALUES (?, ?)")
+                        .setConsistencyLevel(writeConsistency);
+        selectEventStmt =
+                session.prepare("SELECT json_data FROM " + TABLE_EVENT + " WHERE event_id = ?")
+                        .setConsistencyLevel(readConsistency);
+        deleteEventStmt =
+                session.prepare("DELETE FROM " + TABLE_EVENT + " WHERE event_id = ?")
+                        .setConsistencyLevel(writeConsistency);
+
+        insertTargetsStmt =
+                session.prepare(
+                                "INSERT INTO "
+                                        + TABLE_TARGETS
+                                        + " (webhook_id, json_data) VALUES (?, ?)")
+                        .setConsistencyLevel(writeConsistency);
+        selectTargetsStmt =
+                session.prepare("SELECT json_data FROM " + TABLE_TARGETS + " WHERE webhook_id = ?")
+                        .setConsistencyLevel(readConsistency);
+        deleteTargetsStmt =
+                session.prepare("DELETE FROM " + TABLE_TARGETS + " WHERE webhook_id = ?")
+                        .setConsistencyLevel(writeConsistency);
+    }
+
+    private void ensureTables() {
+        String ks = properties.getKeyspace();
+        session.execute(
+                "CREATE TABLE IF NOT EXISTS "
+                        + ks
+                        + "."
+                        + TABLE_WEBHOOK
+                        + " (bucket text, webhook_id text, json_data text,"
+                        + " PRIMARY KEY ((bucket), webhook_id))");
+        session.execute(
+                "CREATE TABLE IF NOT EXISTS "
+                        + ks
+                        + "."
+                        + TABLE_EVENT
+                        + " (event_id text PRIMARY KEY, json_data text)");
+        session.execute(
+                "CREATE TABLE IF NOT EXISTS "
+                        + ks
+                        + "."
+                        + TABLE_TARGETS
+                        + " (webhook_id text PRIMARY KEY, json_data text)");
+    }
+
+    @Override
+    public void createWebhook(String id, WebhookConfig webhookConfig) {
+        session.execute(insertWebhookStmt.bind(ALL_BUCKET, id, toJson(webhookConfig)));
+    }
+
+    @Override
+    public WebhookConfig getWebhook(String webhookId) {
+        ResultSet rs = session.execute(selectWebhookStmt.bind(ALL_BUCKET, webhookId));
+        Row row = rs.one();
+        return row == null ? null : readValue(row.getString("json_data"), WebhookConfig.class);
+    }
+
+    @Override
+    public List<WebhookConfig> getAllWebhooks() {
+        ResultSet rs = session.execute(selectAllWebhooksStmt.bind(ALL_BUCKET));
+        List<WebhookConfig> out = new ArrayList<>();
+        for (Row row : rs) {
+            out.add(readValue(row.getString("json_data"), WebhookConfig.class));
+        }
+        return out;
+    }
+
+    @Override
+    public void removeWebhook(String id) {
+        if (getWebhook(id) == null) {
+            throw new NotFoundException("Webhook with id " + id + " not found");
+        }
+        session.execute(deleteWebhookStmt.bind(ALL_BUCKET, id));
+    }
+
+    @Override
+    public void createIncomingWebhookEvent(String id, IncomingWebhookEvent event) {
+        session.execute(insertEventStmt.bind(id, toJson(event)));
+    }
+
+    @Override
+    public IncomingWebhookEvent getWebhookEvent(String messageId) {
+        ResultSet rs = session.execute(selectEventStmt.bind(messageId));
+        Row row = rs.one();
+        return row == null
+                ? null
+                : readValue(row.getString("json_data"), IncomingWebhookEvent.class);
+    }
+
+    @Override
+    public void removeWebhookEvent(String id) {
+        session.execute(deleteEventStmt.bind(id));
+    }
+
+    @Override
+    public Map<String, Map<String, Object>> getMatchers(String webhookId) {
+        Map<String, Integer> targets = loadTargets(webhookId);
+        if (targets.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return computeMatchers(targets);
+    }
+
+    @Override
+    public void createMatchers(
+            WebhookConfig webhookConfig,
+            @Nullable Map<String, Integer> receiverWorkflowNamesToVersionsOverride) {
+        Map<String, Integer> targets =
+                receiverWorkflowNamesToVersionsOverride == null
+                        ? Collections.emptyMap()
+                        : receiverWorkflowNamesToVersionsOverride;
+        session.execute(insertTargetsStmt.bind(webhookConfig.getId(), toJson(targets)));
+    }
+
+    @Override
+    public void removeMatchers(String id) {
+        session.execute(deleteTargetsStmt.bind(id));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Integer> loadTargets(String webhookId) {
+        ResultSet rs = session.execute(selectTargetsStmt.bind(webhookId));
+        Row row = rs.one();
+        if (row == null) {
+            return Collections.emptyMap();
+        }
+        return readValue(row.getString("json_data"), Map.class);
+    }
+
+    private String toJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private <T> T readValue(String json, Class<T> clazz) {
+        try {
+            return objectMapper.readValue(json, clazz);
+        } catch (java.io.IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Map<String, Object>> computeMatchers(Map<String, Integer> targets) {
+        Map<String, Map<String, Object>> computed = new HashMap<>();
+        targets.forEach(
+                (workflowName, wfVersion) -> {
+                    Optional<WorkflowDef> def = metadataDAO.getWorkflowDef(workflowName, wfVersion);
+                    if (def.isEmpty()) {
+                        return;
+                    }
+                    for (WorkflowTask task : def.get().collectTasks()) {
+                        String type = task.getType();
+                        if (!WAIT_FOR_WEBHOOK.equals(type)
+                                && !TaskType.WAIT.toString().equals(type)) {
+                            continue;
+                        }
+                        Object raw = task.getInputParameters().get("matches");
+                        if (raw instanceof Map<?, ?> m && !CollectionUtils.isEmpty(m)) {
+                            String key =
+                                    workflowName
+                                            + WEBHOOK_DELIMITER
+                                            + wfVersion
+                                            + WEBHOOK_DELIMITER
+                                            + task.getTaskReferenceName();
+                            computed.put(key, (Map<String, Object>) m);
+                        }
+                    }
+                });
+        return computed;
+    }
+}

--- a/cassandra-persistence/src/main/java/org/conductoross/conductor/cassandra/dao/CassandraWebhookDAO.java
+++ b/cassandra-persistence/src/main/java/org/conductoross/conductor/cassandra/dao/CassandraWebhookDAO.java
@@ -14,22 +14,17 @@ package org.conductoross.conductor.cassandra.dao;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.conductoross.conductor.dao.webhook.WebhookDAO;
+import org.conductoross.conductor.service.webhook.WebhookMatcherComputer;
 import org.conductoross.conductor.webhook.model.IncomingWebhookEvent;
 import org.conductoross.conductor.webhook.model.WebhookConfig;
 import org.springframework.lang.Nullable;
-import org.springframework.util.CollectionUtils;
 
 import com.netflix.conductor.cassandra.config.CassandraProperties;
 import com.netflix.conductor.cassandra.dao.CassandraBaseDAO;
-import com.netflix.conductor.common.metadata.tasks.TaskType;
-import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
-import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.dao.MetadataDAO;
 
@@ -40,9 +35,6 @@ import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-
-import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WAIT_FOR_WEBHOOK;
-import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WEBHOOK_DELIMITER;
 
 /**
  * Cassandra-backed {@link WebhookDAO}.
@@ -238,11 +230,7 @@ public class CassandraWebhookDAO extends CassandraBaseDAO implements WebhookDAO 
 
     @Override
     public Map<String, Map<String, Object>> getMatchers(String webhookId) {
-        Map<String, Integer> targets = loadTargets(webhookId);
-        if (targets.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return computeMatchers(targets);
+        return WebhookMatcherComputer.compute(loadTargets(webhookId), metadataDAO);
     }
 
     @Override
@@ -285,35 +273,5 @@ public class CassandraWebhookDAO extends CassandraBaseDAO implements WebhookDAO 
         } catch (java.io.IOException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Map<String, Object>> computeMatchers(Map<String, Integer> targets) {
-        Map<String, Map<String, Object>> computed = new HashMap<>();
-        targets.forEach(
-                (workflowName, wfVersion) -> {
-                    Optional<WorkflowDef> def = metadataDAO.getWorkflowDef(workflowName, wfVersion);
-                    if (def.isEmpty()) {
-                        return;
-                    }
-                    for (WorkflowTask task : def.get().collectTasks()) {
-                        String type = task.getType();
-                        if (!WAIT_FOR_WEBHOOK.equals(type)
-                                && !TaskType.WAIT.toString().equals(type)) {
-                            continue;
-                        }
-                        Object raw = task.getInputParameters().get("matches");
-                        if (raw instanceof Map<?, ?> m && !CollectionUtils.isEmpty(m)) {
-                            String key =
-                                    workflowName
-                                            + WEBHOOK_DELIMITER
-                                            + wfVersion
-                                            + WEBHOOK_DELIMITER
-                                            + task.getTaskReferenceName();
-                            computed.put(key, (Map<String, Object>) m);
-                        }
-                    }
-                });
-        return computed;
     }
 }

--- a/cassandra-persistence/src/main/java/org/conductoross/conductor/cassandra/dao/CassandraWebhookDAO.java
+++ b/cassandra-persistence/src/main/java/org/conductoross/conductor/cassandra/dao/CassandraWebhookDAO.java
@@ -66,10 +66,13 @@ public class CassandraWebhookDAO extends CassandraBaseDAO implements WebhookDAO 
     private static final String TABLE_TARGETS = "webhook_target_workflows";
     private static final String ALL_BUCKET = "ALL";
 
+    private static final long DEFAULT_EVENT_TTL_SECONDS = 7L * 24 * 3600; // 7 days
+
     private final Session session;
     private final MetadataDAO metadataDAO;
     // objectMapper / toJson / readValue are package-private in CassandraBaseDAO; keep a local ref.
     private final ObjectMapper objectMapper;
+    private final long incomingEventTtlSeconds;
 
     private final PreparedStatement insertWebhookStmt;
     private final PreparedStatement selectWebhookStmt;
@@ -87,10 +90,20 @@ public class CassandraWebhookDAO extends CassandraBaseDAO implements WebhookDAO 
             ObjectMapper objectMapper,
             CassandraProperties properties,
             MetadataDAO metadataDAO) {
+        this(session, objectMapper, properties, metadataDAO, DEFAULT_EVENT_TTL_SECONDS);
+    }
+
+    public CassandraWebhookDAO(
+            Session session,
+            ObjectMapper objectMapper,
+            CassandraProperties properties,
+            MetadataDAO metadataDAO,
+            long incomingEventTtlSeconds) {
         super(session, objectMapper, properties);
         this.session = session;
         this.metadataDAO = metadataDAO;
         this.objectMapper = objectMapper;
+        this.incomingEventTtlSeconds = incomingEventTtlSeconds;
         ensureTables();
 
         ConsistencyLevel readConsistency = properties.getReadConsistencyLevel();
@@ -154,12 +167,18 @@ public class CassandraWebhookDAO extends CassandraBaseDAO implements WebhookDAO 
                         + TABLE_WEBHOOK
                         + " (bucket text, webhook_id text, json_data text,"
                         + " PRIMARY KEY ((bucket), webhook_id))");
+        // default_time_to_live makes Cassandra auto-expire rows after the configured
+        // window — matches the cleanup-job behavior on the SQL backings. Note: CREATE
+        // TABLE IF NOT EXISTS won't update an existing table's TTL; operators changing
+        // the retention duration on an existing deployment need to ALTER TABLE manually.
         session.execute(
                 "CREATE TABLE IF NOT EXISTS "
                         + ks
                         + "."
                         + TABLE_EVENT
-                        + " (event_id text PRIMARY KEY, json_data text)");
+                        + " (event_id text PRIMARY KEY, json_data text)"
+                        + " WITH default_time_to_live = "
+                        + incomingEventTtlSeconds);
         session.execute(
                 "CREATE TABLE IF NOT EXISTS "
                         + ks

--- a/cassandra-persistence/src/main/java/org/conductoross/conductor/cassandra/dao/CassandraWebhookTaskService.java
+++ b/cassandra-persistence/src/main/java/org/conductoross/conductor/cassandra/dao/CassandraWebhookTaskService.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.cassandra.dao;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.conductoross.conductor.service.webhook.WebhookTaskHashing;
+import org.conductoross.conductor.service.webhook.WebhookTaskService;
+
+import com.netflix.conductor.cassandra.config.CassandraProperties;
+import com.netflix.conductor.cassandra.dao.CassandraBaseDAO;
+import com.netflix.conductor.model.TaskModel;
+
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Cassandra-backed {@link WebhookTaskService}. Stores (hash, task_id) rows in {@code
+ * webhook_hash_to_taskid} with hash as partition key — efficient {@code get(hash)} via a
+ * single-partition scan. Same {@link WebhookTaskHashing} as every other backing so the hash a task
+ * is stored under is identical regardless of impl.
+ */
+@Slf4j
+public class CassandraWebhookTaskService extends CassandraBaseDAO implements WebhookTaskService {
+
+    private static final String TABLE = "webhook_hash_to_taskid";
+
+    private final Session session;
+    private final PreparedStatement insertStmt;
+    private final PreparedStatement selectByHashStmt;
+    private final PreparedStatement deleteStmt;
+
+    public CassandraWebhookTaskService(
+            Session session, ObjectMapper objectMapper, CassandraProperties properties) {
+        super(session, objectMapper, properties);
+        this.session = session;
+        ensureTables();
+        ConsistencyLevel readConsistency = properties.getReadConsistencyLevel();
+        ConsistencyLevel writeConsistency = properties.getWriteConsistencyLevel();
+        insertStmt =
+                session.prepare("INSERT INTO " + TABLE + " (hash, task_id) VALUES (?, ?)")
+                        .setConsistencyLevel(writeConsistency);
+        selectByHashStmt =
+                session.prepare("SELECT task_id FROM " + TABLE + " WHERE hash = ?")
+                        .setConsistencyLevel(readConsistency);
+        deleteStmt =
+                session.prepare("DELETE FROM " + TABLE + " WHERE hash = ? AND task_id = ?")
+                        .setConsistencyLevel(writeConsistency);
+    }
+
+    private void ensureTables() {
+        String ks = properties.getKeyspace();
+        session.execute(
+                "CREATE TABLE IF NOT EXISTS "
+                        + ks
+                        + "."
+                        + TABLE
+                        + " ("
+                        + "hash text,"
+                        + "task_id text,"
+                        + "PRIMARY KEY ((hash), task_id)"
+                        + ")");
+    }
+
+    @Override
+    public void put(TaskModel task, int workflowVersion) {
+        String hash = WebhookTaskHashing.computeHash(task, workflowVersion);
+        session.execute(insertStmt.bind(hash, task.getTaskId()));
+    }
+
+    @Override
+    public Set<String> get(String hash) {
+        ResultSet rs = session.execute(selectByHashStmt.bind(hash));
+        Set<String> taskIds = new HashSet<>();
+        for (Row row : rs) {
+            taskIds.add(row.getString("task_id"));
+        }
+        return taskIds;
+    }
+
+    @Override
+    public void remove(String hash, String taskId) {
+        session.execute(deleteStmt.bind(hash, taskId));
+    }
+}

--- a/cassandra-persistence/src/test/java/org/conductoross/conductor/cassandra/dao/CassandraWebhookDAOTest.java
+++ b/cassandra-persistence/src/test/java/org/conductoross/conductor/cassandra/dao/CassandraWebhookDAOTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.cassandra.dao;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.conductoross.conductor.webhook.model.IncomingWebhookEvent;
+import org.conductoross.conductor.webhook.model.WebhookConfig;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.testcontainers.containers.CassandraContainer;
+
+import com.netflix.conductor.cassandra.config.CassandraProperties;
+import com.netflix.conductor.common.config.ObjectMapperProvider;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.core.exception.NotFoundException;
+import com.netflix.conductor.dao.MetadataDAO;
+
+import com.datastax.driver.core.Session;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+public class CassandraWebhookDAOTest {
+
+    private static final String KEYSPACE = "conductor_test";
+
+    @ClassRule
+    public static final CassandraContainer<?> cassandra =
+            new CassandraContainer<>("cassandra:3.11.2");
+
+    private static Session session;
+    private static ObjectMapper objectMapper;
+    private CassandraWebhookDAO dao;
+    private MetadataDAO metadataDAO;
+
+    @BeforeClass
+    public static void setUpOnce() {
+        session = cassandra.getCluster().newSession();
+        session.execute(
+                "CREATE KEYSPACE IF NOT EXISTS "
+                        + KEYSPACE
+                        + " WITH replication = {'class':'SimpleStrategy','replication_factor':1}");
+        objectMapper = new ObjectMapperProvider().getObjectMapper();
+    }
+
+    @Before
+    public void setUp() {
+        session.execute("DROP TABLE IF EXISTS " + KEYSPACE + ".webhook");
+        session.execute("DROP TABLE IF EXISTS " + KEYSPACE + ".incoming_webhook_event");
+        session.execute("DROP TABLE IF EXISTS " + KEYSPACE + ".webhook_target_workflows");
+        CassandraProperties props = new CassandraProperties();
+        props.setKeyspace(KEYSPACE);
+        metadataDAO = Mockito.mock(MetadataDAO.class);
+        dao = new CassandraWebhookDAO(session, objectMapper, props, metadataDAO);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (session != null) session.close();
+    }
+
+    @Test
+    public void crud_webhookConfig_roundtrip() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        config.setName("my-hook");
+
+        dao.createWebhook("hook-1", config);
+
+        WebhookConfig loaded = dao.getWebhook("hook-1");
+        assertNotNull(loaded);
+        assertEquals("hook-1", loaded.getId());
+        assertEquals(1, dao.getAllWebhooks().size());
+
+        dao.removeWebhook("hook-1");
+        assertNull(dao.getWebhook("hook-1"));
+        assertTrue(dao.getAllWebhooks().isEmpty());
+    }
+
+    @Test
+    public void createWebhook_upsertsExistingId() {
+        WebhookConfig v1 = new WebhookConfig();
+        v1.setId("hook-1");
+        v1.setName("original");
+        dao.createWebhook("hook-1", v1);
+
+        WebhookConfig v2 = new WebhookConfig();
+        v2.setId("hook-1");
+        v2.setName("updated");
+        dao.createWebhook("hook-1", v2);
+
+        assertEquals("updated", dao.getWebhook("hook-1").getName());
+    }
+
+    @Test
+    public void removeWebhook_unknownId_throwsNotFound() {
+        assertThrows(NotFoundException.class, () -> dao.removeWebhook("missing"));
+    }
+
+    @Test
+    public void crud_incomingWebhookEvent_roundtrip() {
+        IncomingWebhookEvent event =
+                IncomingWebhookEvent.builder()
+                        .id("ev-1")
+                        .webhookId("hook-1")
+                        .body("{\"event\":\"push\"}")
+                        .timeStamp(123L)
+                        .build();
+        dao.createIncomingWebhookEvent("ev-1", event);
+        assertEquals("hook-1", dao.getWebhookEvent("ev-1").getWebhookId());
+        dao.removeWebhookEvent("ev-1");
+        assertNull(dao.getWebhookEvent("ev-1"));
+    }
+
+    @Test
+    public void getMatchers_emptyOrNullTargets_returnsEmpty() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        dao.createWebhook("hook-1", config);
+
+        dao.createMatchers(config, Map.of());
+        assertTrue(dao.getMatchers("hook-1").isEmpty());
+
+        dao.createMatchers(config, null);
+        assertTrue(dao.getMatchers("hook-1").isEmpty());
+    }
+
+    @Test
+    public void getMatchers_recomputesFromMetadataDAO_onEachCall_noStaleCache() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        dao.createWebhook("hook-1", config);
+        dao.createMatchers(config, Map.of("wf-a", 1));
+
+        WorkflowTask t1 = new WorkflowTask();
+        t1.setType("WAIT_FOR_WEBHOOK");
+        t1.setTaskReferenceName("wait_ref");
+        t1.setInputParameters(Map.of("matches", Map.of("event", "push")));
+        WorkflowDef def1 = new WorkflowDef();
+        def1.setName("wf-a");
+        def1.setVersion(1);
+        def1.setTasks(List.of(t1));
+        when(metadataDAO.getWorkflowDef("wf-a", 1)).thenReturn(Optional.of(def1));
+
+        assertEquals(Map.of("event", "push"), dao.getMatchers("hook-1").get("wf-a;1;wait_ref"));
+
+        WorkflowTask t2 = new WorkflowTask();
+        t2.setType("WAIT_FOR_WEBHOOK");
+        t2.setTaskReferenceName("wait_ref");
+        t2.setInputParameters(Map.of("matches", Map.of("event", "merge")));
+        WorkflowDef def2 = new WorkflowDef();
+        def2.setName("wf-a");
+        def2.setVersion(1);
+        def2.setTasks(List.of(t2));
+        when(metadataDAO.getWorkflowDef("wf-a", 1)).thenReturn(Optional.of(def2));
+
+        assertEquals(Map.of("event", "merge"), dao.getMatchers("hook-1").get("wf-a;1;wait_ref"));
+    }
+
+    @Test
+    public void removeMatchers_drops() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        dao.createWebhook("hook-1", config);
+        dao.createMatchers(config, Map.of("wf-a", 1));
+
+        dao.removeMatchers("hook-1");
+        assertTrue(dao.getMatchers("hook-1").isEmpty());
+    }
+}

--- a/cassandra-persistence/src/test/java/org/conductoross/conductor/cassandra/dao/CassandraWebhookTaskServiceTest.java
+++ b/cassandra-persistence/src/test/java/org/conductoross/conductor/cassandra/dao/CassandraWebhookTaskServiceTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.cassandra.dao;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.testcontainers.containers.CassandraContainer;
+
+import com.netflix.conductor.cassandra.config.CassandraProperties;
+import com.netflix.conductor.common.config.ObjectMapperProvider;
+import com.netflix.conductor.core.exception.NonTransientException;
+import com.netflix.conductor.model.TaskModel;
+
+import com.datastax.driver.core.Session;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.conductoross.conductor.service.webhook.WebhookTaskHashing.computeHash;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class CassandraWebhookTaskServiceTest {
+
+    private static final String KEYSPACE = "conductor_test";
+
+    @ClassRule
+    public static final CassandraContainer<?> cassandra =
+            new CassandraContainer<>("cassandra:3.11.2");
+
+    private static Session session;
+    private static ObjectMapper objectMapper;
+    private CassandraWebhookTaskService service;
+
+    @BeforeClass
+    public static void setUpOnce() {
+        session = cassandra.getCluster().newSession();
+        session.execute(
+                "CREATE KEYSPACE IF NOT EXISTS "
+                        + KEYSPACE
+                        + " WITH replication = {'class':'SimpleStrategy','replication_factor':1}");
+        objectMapper = new ObjectMapperProvider().getObjectMapper();
+    }
+
+    @Before
+    public void setUp() {
+        session.execute("DROP TABLE IF EXISTS " + KEYSPACE + ".webhook_hash_to_taskid");
+        CassandraProperties props = new CassandraProperties();
+        props.setKeyspace(KEYSPACE);
+        service = new CassandraWebhookTaskService(session, objectMapper, props);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (session != null) session.close();
+    }
+
+    @Test
+    public void put_and_get_matchByHash() {
+        TaskModel task = newTask("task-1", "wf-a", "wait_ref", Map.of("event", "push"));
+        service.put(task, 1);
+        String hash = computeHash("wf-a", 1, "wait_ref", Map.of("event", "push"));
+        assertEquals(Set.of("task-1"), service.get(hash));
+    }
+
+    @Test
+    public void put_missingMatchesField_throws() {
+        TaskModel task = new TaskModel();
+        task.setTaskId("task-x");
+        task.setInputData(Map.of());
+        assertThrows(NonTransientException.class, () -> service.put(task, 1));
+    }
+
+    @Test
+    public void multiple_tasks_sameHash_bucketed() {
+        TaskModel t1 = newTask("task-1", "wf-a", "wait_ref", Map.of("event", "push"));
+        TaskModel t2 = newTask("task-2", "wf-a", "wait_ref", Map.of("event", "push"));
+        service.put(t1, 1);
+        service.put(t2, 1);
+        String hash = computeHash("wf-a", 1, "wait_ref", Map.of("event", "push"));
+        Set<String> ids = service.get(hash);
+        assertEquals(2, ids.size());
+        assertTrue(ids.contains("task-1"));
+        assertTrue(ids.contains("task-2"));
+    }
+
+    @Test
+    public void remove_evictsTaskAndLeavesOthers() {
+        TaskModel t1 = newTask("task-1", "wf-a", "wait_ref", Map.of("event", "push"));
+        TaskModel t2 = newTask("task-2", "wf-a", "wait_ref", Map.of("event", "push"));
+        service.put(t1, 1);
+        service.put(t2, 1);
+        String hash = computeHash("wf-a", 1, "wait_ref", Map.of("event", "push"));
+        service.remove(hash, "task-1");
+        assertEquals(Set.of("task-2"), service.get(hash));
+    }
+
+    @Test
+    public void put_isIdempotent() {
+        TaskModel task = newTask("task-1", "wf-a", "wait_ref", Map.of("event", "push"));
+        service.put(task, 1);
+        service.put(task, 1);
+        String hash = computeHash("wf-a", 1, "wait_ref", Map.of("event", "push"));
+        assertEquals(Set.of("task-1"), service.get(hash));
+    }
+
+    @Test
+    public void get_unknownHash_returnsEmpty() {
+        assertTrue(service.get("never-seen").isEmpty());
+    }
+
+    private static TaskModel newTask(
+            String taskId, String workflowType, String taskRef, Map<String, Object> matches) {
+        TaskModel task = new TaskModel();
+        task.setTaskId(taskId);
+        task.setWorkflowType(workflowType);
+        task.setReferenceTaskName(taskRef);
+        task.setInputData(Map.of("matches", matches));
+        return task;
+    }
+}

--- a/core/src/main/java/org/conductoross/conductor/service/webhook/WebhookMatcherComputer.java
+++ b/core/src/main/java/org/conductoross/conductor/service/webhook/WebhookMatcherComputer.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.service.webhook;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.util.CollectionUtils;
+
+import com.netflix.conductor.common.metadata.tasks.TaskType;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.dao.MetadataDAO;
+
+import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WAIT_FOR_WEBHOOK;
+import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WEBHOOK_DELIMITER;
+
+/**
+ * Matcher computation shared by every {@link org.conductoross.conductor.dao.webhook.WebhookDAO}
+ * impl. Must be identical across impls — a WorkflowDef edit produces the same matcher set
+ * regardless of which persistence module is backing {@code WebhookDAO}.
+ *
+ * <p>Each backing persists only the {@code workflowName → version} target snapshot (taken at
+ * config-create time so any expression evaluation is preserved). The actual {@code matches}
+ * criteria are recomputed from {@link MetadataDAO} on every {@code getMatchers()} call so
+ * WorkflowDef updates take effect without re-registering the webhook.
+ */
+public final class WebhookMatcherComputer {
+
+    private WebhookMatcherComputer() {}
+
+    /**
+     * Build the matcher map for a single webhook from its persisted target-workflow snapshot.
+     *
+     * @param targets workflowName → workflowVersion snapshot stored by the DAO
+     * @param metadataDAO source of truth for current WorkflowDef state
+     * @return {@code workflowName;version;taskRefName → matches} for every {@code
+     *     WAIT_FOR_WEBHOOK}/{@code WAIT} task with a non-empty {@code matches} input parameter.
+     *     Empty (immutable) if {@code targets} is null or empty.
+     */
+    @SuppressWarnings("unchecked")
+    public static Map<String, Map<String, Object>> compute(
+            Map<String, Integer> targets, MetadataDAO metadataDAO) {
+        if (targets == null || targets.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, Map<String, Object>> computed = new HashMap<>();
+        targets.forEach(
+                (workflowName, wfVersion) -> {
+                    Optional<WorkflowDef> def = metadataDAO.getWorkflowDef(workflowName, wfVersion);
+                    if (def.isEmpty()) {
+                        return;
+                    }
+                    for (WorkflowTask task : def.get().collectTasks()) {
+                        String type = task.getType();
+                        if (!WAIT_FOR_WEBHOOK.equals(type)
+                                && !TaskType.WAIT.toString().equals(type)) {
+                            continue;
+                        }
+                        Object raw = task.getInputParameters().get("matches");
+                        if (raw instanceof Map<?, ?> m && !CollectionUtils.isEmpty(m)) {
+                            String key =
+                                    workflowName
+                                            + WEBHOOK_DELIMITER
+                                            + wfVersion
+                                            + WEBHOOK_DELIMITER
+                                            + task.getTaskReferenceName();
+                            computed.put(key, (Map<String, Object>) m);
+                        }
+                    }
+                });
+        return computed;
+    }
+}

--- a/core/src/main/java/org/conductoross/conductor/service/webhook/WebhookTaskHashing.java
+++ b/core/src/main/java/org/conductoross/conductor/service/webhook/WebhookTaskHashing.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.service.webhook;
+
+import java.util.Map;
+import java.util.TreeSet;
+
+import com.netflix.conductor.common.utils.TaskUtils;
+import com.netflix.conductor.core.exception.NonTransientException;
+import com.netflix.conductor.model.TaskModel;
+
+import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WEBHOOK_DELIMITER;
+
+/**
+ * Hash computation shared by every {@link WebhookTaskService} impl. Must be identical across impls
+ * — tasks registered via one backing must be findable by hash via any other.
+ *
+ * <p>Match keys are sorted; each value's contribution is {@link Object#toString()}. Stable for
+ * strings, numbers, and booleans. Not stable for nested {@link Map} values whose toString reflects
+ * iteration order (HashMap, etc.). Mirrors the Orkes Redis impl verbatim; any change to value-side
+ * canonicalization needs to land in Orkes too or OSS and Orkes deployments will compute different
+ * hashes for the same input.
+ */
+public final class WebhookTaskHashing {
+
+    private WebhookTaskHashing() {}
+
+    public static String computeHash(TaskModel task, int workflowVersion) {
+        // Validate matches first so a missing-matches NonTransientException isn't masked
+        // by an NPE inside removeIterationFromTaskRefName when the task is incomplete.
+        Map<String, Object> matches = requireMatches(task);
+        return computeHash(
+                task.getWorkflowType(),
+                workflowVersion,
+                TaskUtils.removeIterationFromTaskRefName(task.getReferenceTaskName()),
+                matches);
+    }
+
+    public static String computeHash(
+            String workflowName,
+            int workflowVersion,
+            String taskReferenceName,
+            Map<String, Object> expectedMatches) {
+        TreeSet<String> sortedFields = new TreeSet<>(expectedMatches.keySet());
+        StringBuilder hash =
+                new StringBuilder(
+                        workflowName
+                                + WEBHOOK_DELIMITER
+                                + workflowVersion
+                                + WEBHOOK_DELIMITER
+                                + taskReferenceName);
+        for (String field : sortedFields) {
+            hash.append(WEBHOOK_DELIMITER).append(expectedMatches.get(field));
+        }
+        return hash.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> requireMatches(TaskModel task) {
+        Map<String, Object> inputData = task.getInputData();
+        Map<String, Object> matches =
+                inputData == null ? null : (Map<String, Object>) inputData.get("matches");
+        if (matches == null) {
+            throw new NonTransientException("Webhook task missing matches field");
+        }
+        return matches;
+    }
+}

--- a/mysql-persistence/src/main/java/com/netflix/conductor/mysql/config/MySQLConfiguration.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/mysql/config/MySQLConfiguration.java
@@ -75,6 +75,27 @@ public class MySQLConfiguration {
         return new MySQLQueueDAO(retryTemplate, objectMapper, dataSource);
     }
 
+    @Bean(name = "webhookDAO")
+    @DependsOn({"flyway", "flywayInitializer"})
+    public org.conductoross.conductor.mysql.dao.MySQLWebhookDAO mySqlWebhookDAO(
+            @Qualifier("mysqlRetryTemplate") RetryTemplate retryTemplate,
+            ObjectMapper objectMapper,
+            DataSource dataSource,
+            com.netflix.conductor.dao.MetadataDAO metadataDAO) {
+        return new org.conductoross.conductor.mysql.dao.MySQLWebhookDAO(
+                retryTemplate, objectMapper, dataSource, metadataDAO);
+    }
+
+    @Bean(name = "webhookTaskService")
+    @DependsOn({"flyway", "flywayInitializer"})
+    public org.conductoross.conductor.mysql.dao.MySQLWebhookTaskService mySqlWebhookTaskService(
+            @Qualifier("mysqlRetryTemplate") RetryTemplate retryTemplate,
+            ObjectMapper objectMapper,
+            DataSource dataSource) {
+        return new org.conductoross.conductor.mysql.dao.MySQLWebhookTaskService(
+                retryTemplate, objectMapper, dataSource);
+    }
+
     @Bean
     public RetryTemplate mysqlRetryTemplate(MySQLProperties properties) {
         SimpleRetryPolicy retryPolicy = new CustomRetryPolicy();

--- a/mysql-persistence/src/main/java/com/netflix/conductor/mysql/config/MySQLConfiguration.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/mysql/config/MySQLConfiguration.java
@@ -97,6 +97,31 @@ public class MySQLConfiguration {
     }
 
     @Bean
+    @DependsOn({"flyway", "flywayInitializer"})
+    @ConditionalOnProperty(
+            name = "conductor.webhooks.cleanup.enabled",
+            havingValue = "true",
+            matchIfMissing = true)
+    public org.conductoross.conductor.mysql.dao.MySQLWebhookCleanupJob mySqlWebhookCleanupJob(
+            DataSource dataSource, org.springframework.core.env.Environment env) {
+        org.conductoross.conductor.mysql.dao.MySQLWebhookCleanupJob job =
+                new org.conductoross.conductor.mysql.dao.MySQLWebhookCleanupJob(dataSource);
+        String retention = env.getProperty("conductor.webhooks.cleanup.retention-duration");
+        if (retention != null) {
+            job.setRetentionDuration(java.time.Duration.parse(retention));
+        }
+        Integer batch = env.getProperty("conductor.webhooks.cleanup.batch-size", Integer.class);
+        if (batch != null) {
+            job.setBatchSize(batch);
+        }
+        String maxRuntime = env.getProperty("conductor.webhooks.cleanup.max-runtime");
+        if (maxRuntime != null) {
+            job.setMaxRuntime(java.time.Duration.parse(maxRuntime));
+        }
+        return job;
+    }
+
+    @Bean
     public RetryTemplate mysqlRetryTemplate(MySQLProperties properties) {
         SimpleRetryPolicy retryPolicy = new CustomRetryPolicy();
         retryPolicy.setMaxAttempts(properties.getDeadlockRetryMax());

--- a/mysql-persistence/src/main/java/org/conductoross/conductor/mysql/dao/MySQLWebhookCleanupJob.java
+++ b/mysql-persistence/src/main/java/org/conductoross/conductor/mysql/dao/MySQLWebhookCleanupJob.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.mysql.dao;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+
+import javax.sql.DataSource;
+
+import org.springframework.scheduling.annotation.Scheduled;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * MySQL-flavored sibling of {@code PostgresWebhookCleanupJob}. MySQL doesn't support {@code DELETE
+ * ... RETURNING} the way postgres does, so we use {@code DELETE ... LIMIT N} and rely on the JDBC
+ * {@code executeUpdate()} return value to know when to stop.
+ */
+@Slf4j
+public class MySQLWebhookCleanupJob {
+
+    private static final String DELETE_BATCH =
+            "DELETE FROM incoming_webhook_event WHERE created_on < ? LIMIT ?";
+
+    private final DataSource dataSource;
+
+    private Duration retentionDuration = Duration.ofDays(7);
+    private int batchSize = 1000;
+    private Duration maxRuntime = Duration.ofSeconds(60);
+
+    public MySQLWebhookCleanupJob(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public void setRetentionDuration(Duration retentionDuration) {
+        this.retentionDuration = retentionDuration;
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    public void setMaxRuntime(Duration maxRuntime) {
+        this.maxRuntime = maxRuntime;
+    }
+
+    @Scheduled(cron = "${conductor.webhooks.cleanup.cron:0 0 * * * *}")
+    public void run() {
+        long deadline = System.currentTimeMillis() + maxRuntime.toMillis();
+        int totalDeleted = 0;
+
+        while (System.currentTimeMillis() < deadline) {
+            Timestamp threshold = Timestamp.from(Instant.now().minus(retentionDuration));
+            int deletedThisBatch;
+            try {
+                deletedThisBatch = deleteBatch(threshold, batchSize);
+            } catch (SQLException e) {
+                log.error("webhook event cleanup batch failed", e);
+                return;
+            }
+            if (deletedThisBatch == 0) {
+                break;
+            }
+            totalDeleted += deletedThisBatch;
+        }
+
+        if (totalDeleted > 0) {
+            log.info(
+                    "webhook event cleanup: deleted {} rows older than {}",
+                    totalDeleted,
+                    retentionDuration);
+        }
+    }
+
+    private int deleteBatch(Timestamp threshold, int batch) throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement ps = conn.prepareStatement(DELETE_BATCH)) {
+            conn.setAutoCommit(true);
+            ps.setTimestamp(1, threshold);
+            ps.setInt(2, batch);
+            return ps.executeUpdate();
+        }
+    }
+}

--- a/mysql-persistence/src/main/java/org/conductoross/conductor/mysql/dao/MySQLWebhookDAO.java
+++ b/mysql-persistence/src/main/java/org/conductoross/conductor/mysql/dao/MySQLWebhookDAO.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.mysql.dao;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.sql.DataSource;
+
+import org.conductoross.conductor.dao.webhook.WebhookDAO;
+import org.conductoross.conductor.webhook.model.IncomingWebhookEvent;
+import org.conductoross.conductor.webhook.model.WebhookConfig;
+import org.springframework.lang.Nullable;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.util.CollectionUtils;
+
+import com.netflix.conductor.common.metadata.tasks.TaskType;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.core.exception.NotFoundException;
+import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.mysql.dao.MySQLBaseDAO;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WAIT_FOR_WEBHOOK;
+import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WEBHOOK_DELIMITER;
+
+/**
+ * MySQL-backed {@link WebhookDAO}. Same matcher-recomputation-on-read design as the postgres impl —
+ * see PostgresWebhookDAO header for rationale.
+ */
+@Slf4j
+public class MySQLWebhookDAO extends MySQLBaseDAO implements WebhookDAO {
+
+    private static final String INSERT_WEBHOOK =
+            "INSERT INTO webhook (webhook_id, json_data) VALUES (?, ?) "
+                    + "ON DUPLICATE KEY UPDATE json_data = VALUES(json_data)";
+    private static final String SELECT_WEBHOOK =
+            "SELECT json_data FROM webhook WHERE webhook_id = ?";
+    private static final String SELECT_ALL_WEBHOOKS = "SELECT json_data FROM webhook";
+    private static final String DELETE_WEBHOOK = "DELETE FROM webhook WHERE webhook_id = ?";
+
+    private static final String INSERT_EVENT =
+            "INSERT INTO incoming_webhook_event (event_id, json_data) VALUES (?, ?) "
+                    + "ON DUPLICATE KEY UPDATE json_data = VALUES(json_data)";
+    private static final String SELECT_EVENT =
+            "SELECT json_data FROM incoming_webhook_event WHERE event_id = ?";
+    private static final String DELETE_EVENT =
+            "DELETE FROM incoming_webhook_event WHERE event_id = ?";
+
+    private static final String INSERT_TARGETS =
+            "INSERT INTO webhook_target_workflows (webhook_id, json_data) VALUES (?, ?) "
+                    + "ON DUPLICATE KEY UPDATE json_data = VALUES(json_data)";
+    private static final String SELECT_TARGETS =
+            "SELECT json_data FROM webhook_target_workflows WHERE webhook_id = ?";
+    private static final String DELETE_TARGETS =
+            "DELETE FROM webhook_target_workflows WHERE webhook_id = ?";
+
+    private final MetadataDAO metadataDAO;
+
+    public MySQLWebhookDAO(
+            RetryTemplate retryTemplate,
+            ObjectMapper objectMapper,
+            DataSource dataSource,
+            MetadataDAO metadataDAO) {
+        super(retryTemplate, objectMapper, dataSource);
+        this.metadataDAO = metadataDAO;
+    }
+
+    @Override
+    public void createWebhook(String id, WebhookConfig webhookConfig) {
+        String json = toJson(webhookConfig);
+        queryWithTransaction(
+                INSERT_WEBHOOK, q -> q.addParameter(id).addParameter(json).executeUpdate());
+    }
+
+    @Override
+    public WebhookConfig getWebhook(String webhookId) {
+        String json =
+                queryWithTransaction(
+                        SELECT_WEBHOOK,
+                        q -> q.addParameter(webhookId).executeAndFetchFirst(String.class));
+        return json == null ? null : readValue(json, WebhookConfig.class);
+    }
+
+    @Override
+    public List<WebhookConfig> getAllWebhooks() {
+        List<String> rows =
+                queryWithTransaction(SELECT_ALL_WEBHOOKS, q -> q.executeAndFetch(String.class));
+        if (rows == null) {
+            return new ArrayList<>();
+        }
+        List<WebhookConfig> out = new ArrayList<>(rows.size());
+        for (String json : rows) {
+            out.add(readValue(json, WebhookConfig.class));
+        }
+        return out;
+    }
+
+    @Override
+    public void removeWebhook(String id) {
+        WebhookConfig existing = getWebhook(id);
+        if (existing == null) {
+            throw new NotFoundException("Webhook with id " + id + " not found");
+        }
+        queryWithTransaction(DELETE_WEBHOOK, q -> q.addParameter(id).executeUpdate());
+    }
+
+    @Override
+    public void createIncomingWebhookEvent(String id, IncomingWebhookEvent event) {
+        String json = toJson(event);
+        queryWithTransaction(
+                INSERT_EVENT, q -> q.addParameter(id).addParameter(json).executeUpdate());
+    }
+
+    @Override
+    public IncomingWebhookEvent getWebhookEvent(String messageId) {
+        String json =
+                queryWithTransaction(
+                        SELECT_EVENT,
+                        q -> q.addParameter(messageId).executeAndFetchFirst(String.class));
+        return json == null ? null : readValue(json, IncomingWebhookEvent.class);
+    }
+
+    @Override
+    public void removeWebhookEvent(String id) {
+        queryWithTransaction(DELETE_EVENT, q -> q.addParameter(id).executeUpdate());
+    }
+
+    @Override
+    public Map<String, Map<String, Object>> getMatchers(String webhookId) {
+        Map<String, Integer> targets = loadTargets(webhookId);
+        if (targets.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return computeMatchers(targets);
+    }
+
+    @Override
+    public void createMatchers(
+            WebhookConfig webhookConfig,
+            @Nullable Map<String, Integer> receiverWorkflowNamesToVersionsOverride) {
+        Map<String, Integer> targets =
+                receiverWorkflowNamesToVersionsOverride == null
+                        ? Collections.emptyMap()
+                        : receiverWorkflowNamesToVersionsOverride;
+        String json = toJson(targets);
+        queryWithTransaction(
+                INSERT_TARGETS,
+                q -> q.addParameter(webhookConfig.getId()).addParameter(json).executeUpdate());
+    }
+
+    @Override
+    public void removeMatchers(String id) {
+        queryWithTransaction(DELETE_TARGETS, q -> q.addParameter(id).executeUpdate());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Integer> loadTargets(String webhookId) {
+        String json =
+                queryWithTransaction(
+                        SELECT_TARGETS,
+                        q -> q.addParameter(webhookId).executeAndFetchFirst(String.class));
+        if (json == null) {
+            return Collections.emptyMap();
+        }
+        return readValue(json, Map.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Map<String, Object>> computeMatchers(Map<String, Integer> targets) {
+        Map<String, Map<String, Object>> computed = new HashMap<>();
+        targets.forEach(
+                (workflowName, wfVersion) -> {
+                    Optional<WorkflowDef> def = metadataDAO.getWorkflowDef(workflowName, wfVersion);
+                    if (def.isEmpty()) {
+                        return;
+                    }
+                    for (WorkflowTask task : def.get().collectTasks()) {
+                        String type = task.getType();
+                        if (!WAIT_FOR_WEBHOOK.equals(type)
+                                && !TaskType.WAIT.toString().equals(type)) {
+                            continue;
+                        }
+                        Object raw = task.getInputParameters().get("matches");
+                        if (raw instanceof Map<?, ?> m && !CollectionUtils.isEmpty(m)) {
+                            String key =
+                                    workflowName
+                                            + WEBHOOK_DELIMITER
+                                            + wfVersion
+                                            + WEBHOOK_DELIMITER
+                                            + task.getTaskReferenceName();
+                            computed.put(key, (Map<String, Object>) m);
+                        }
+                    }
+                });
+        return computed;
+    }
+}

--- a/mysql-persistence/src/main/java/org/conductoross/conductor/mysql/dao/MySQLWebhookDAO.java
+++ b/mysql-persistence/src/main/java/org/conductoross/conductor/mysql/dao/MySQLWebhookDAO.java
@@ -14,32 +14,24 @@ package org.conductoross.conductor.mysql.dao;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import javax.sql.DataSource;
 
 import org.conductoross.conductor.dao.webhook.WebhookDAO;
+import org.conductoross.conductor.service.webhook.WebhookMatcherComputer;
 import org.conductoross.conductor.webhook.model.IncomingWebhookEvent;
 import org.conductoross.conductor.webhook.model.WebhookConfig;
 import org.springframework.lang.Nullable;
 import org.springframework.retry.support.RetryTemplate;
-import org.springframework.util.CollectionUtils;
 
-import com.netflix.conductor.common.metadata.tasks.TaskType;
-import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
-import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.mysql.dao.MySQLBaseDAO;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-
-import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WAIT_FOR_WEBHOOK;
-import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WEBHOOK_DELIMITER;
 
 /**
  * MySQL-backed {@link WebhookDAO}. Same matcher-recomputation-on-read design as the postgres impl —
@@ -145,11 +137,7 @@ public class MySQLWebhookDAO extends MySQLBaseDAO implements WebhookDAO {
 
     @Override
     public Map<String, Map<String, Object>> getMatchers(String webhookId) {
-        Map<String, Integer> targets = loadTargets(webhookId);
-        if (targets.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return computeMatchers(targets);
+        return WebhookMatcherComputer.compute(loadTargets(webhookId), metadataDAO);
     }
 
     @Override
@@ -181,35 +169,5 @@ public class MySQLWebhookDAO extends MySQLBaseDAO implements WebhookDAO {
             return Collections.emptyMap();
         }
         return readValue(json, Map.class);
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Map<String, Object>> computeMatchers(Map<String, Integer> targets) {
-        Map<String, Map<String, Object>> computed = new HashMap<>();
-        targets.forEach(
-                (workflowName, wfVersion) -> {
-                    Optional<WorkflowDef> def = metadataDAO.getWorkflowDef(workflowName, wfVersion);
-                    if (def.isEmpty()) {
-                        return;
-                    }
-                    for (WorkflowTask task : def.get().collectTasks()) {
-                        String type = task.getType();
-                        if (!WAIT_FOR_WEBHOOK.equals(type)
-                                && !TaskType.WAIT.toString().equals(type)) {
-                            continue;
-                        }
-                        Object raw = task.getInputParameters().get("matches");
-                        if (raw instanceof Map<?, ?> m && !CollectionUtils.isEmpty(m)) {
-                            String key =
-                                    workflowName
-                                            + WEBHOOK_DELIMITER
-                                            + wfVersion
-                                            + WEBHOOK_DELIMITER
-                                            + task.getTaskReferenceName();
-                            computed.put(key, (Map<String, Object>) m);
-                        }
-                    }
-                });
-        return computed;
     }
 }

--- a/mysql-persistence/src/main/java/org/conductoross/conductor/mysql/dao/MySQLWebhookTaskService.java
+++ b/mysql-persistence/src/main/java/org/conductoross/conductor/mysql/dao/MySQLWebhookTaskService.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.mysql.dao;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.sql.DataSource;
+
+import org.conductoross.conductor.service.webhook.WebhookTaskHashing;
+import org.conductoross.conductor.service.webhook.WebhookTaskService;
+import org.springframework.retry.support.RetryTemplate;
+
+import com.netflix.conductor.model.TaskModel;
+import com.netflix.conductor.mysql.dao.MySQLBaseDAO;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+/** MySQL-backed {@link WebhookTaskService}. Same behavior as the postgres/sqlite impls. */
+@Slf4j
+public class MySQLWebhookTaskService extends MySQLBaseDAO implements WebhookTaskService {
+
+    private static final String INSERT =
+            "INSERT IGNORE INTO webhook_hash_to_taskid (hash, task_id) VALUES (?, ?)";
+    private static final String SELECT =
+            "SELECT task_id FROM webhook_hash_to_taskid WHERE hash = ?";
+    private static final String DELETE =
+            "DELETE FROM webhook_hash_to_taskid WHERE hash = ? AND task_id = ?";
+
+    public MySQLWebhookTaskService(
+            RetryTemplate retryTemplate, ObjectMapper objectMapper, DataSource dataSource) {
+        super(retryTemplate, objectMapper, dataSource);
+    }
+
+    @Override
+    public void put(TaskModel task, int workflowVersion) {
+        String hash = WebhookTaskHashing.computeHash(task, workflowVersion);
+        queryWithTransaction(
+                INSERT, q -> q.addParameter(hash).addParameter(task.getTaskId()).executeUpdate());
+    }
+
+    @Override
+    public Set<String> get(String hash) {
+        List<String> taskIds =
+                queryWithTransaction(
+                        SELECT, q -> q.addParameter(hash).executeAndFetch(String.class));
+        return new HashSet<>(taskIds);
+    }
+
+    @Override
+    public void remove(String hash, String taskId) {
+        queryWithTransaction(
+                DELETE, q -> q.addParameter(hash).addParameter(taskId).executeUpdate());
+    }
+}

--- a/mysql-persistence/src/main/resources/db/migration/V10__webhook.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V10__webhook.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS webhook (
+    webhook_id  VARCHAR(255) NOT NULL,
+    json_data   TEXT NOT NULL,
+    modified_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (webhook_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS incoming_webhook_event (
+    event_id   VARCHAR(255) NOT NULL,
+    json_data  TEXT NOT NULL,
+    created_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (event_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE INDEX idx_iwe_created_on ON incoming_webhook_event(created_on);
+
+-- See PostgresWebhookDAO header for why we store target workflows (not pre-computed
+-- matchers) and recompute on read.
+CREATE TABLE IF NOT EXISTS webhook_target_workflows (
+    webhook_id VARCHAR(255) NOT NULL,
+    json_data  TEXT NOT NULL,
+    PRIMARY KEY (webhook_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS webhook_hash_to_taskid (
+    hash    VARCHAR(255) NOT NULL,
+    task_id VARCHAR(255) NOT NULL,
+    PRIMARY KEY (hash, task_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/mysql-persistence/src/test/java/org/conductoross/conductor/mysql/dao/MySQLWebhookCleanupJobTest.java
+++ b/mysql-persistence/src/test/java/org/conductoross/conductor/mysql/dao/MySQLWebhookCleanupJobTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.mysql.dao;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+
+import javax.sql.DataSource;
+
+import org.flywaydb.core.Flyway;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
+import com.netflix.conductor.mysql.config.MySQLConfiguration;
+
+import static org.junit.Assert.assertEquals;
+
+@ContextConfiguration(
+        classes = {
+            TestObjectMapperConfiguration.class,
+            MySQLConfiguration.class,
+            FlywayAutoConfiguration.class
+        })
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = "spring.flyway.clean-disabled=false")
+public class MySQLWebhookCleanupJobTest {
+
+    @Autowired private MySQLWebhookCleanupJob job;
+    @Autowired private DataSource dataSource;
+    @Autowired private Flyway flyway;
+
+    @Before
+    public void before() {
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    @Test
+    public void deletes_rows_older_than_retention_keeps_recent() throws SQLException {
+        insertEvent("ev-old", Timestamp.from(Instant.now().minus(Duration.ofDays(5))));
+        insertEvent("ev-recent", Timestamp.from(Instant.now().minus(Duration.ofMinutes(5))));
+        assertEquals(2, rowCount());
+
+        job.setRetentionDuration(Duration.ofDays(1));
+        job.setBatchSize(100);
+        job.setMaxRuntime(Duration.ofSeconds(5));
+        job.run();
+
+        assertEquals(1, rowCount());
+        assertEquals("ev-recent", firstRowEventId());
+    }
+
+    @Test
+    public void empty_table_noop() throws SQLException {
+        job.setRetentionDuration(Duration.ofDays(1));
+        job.run();
+        assertEquals(0, rowCount());
+    }
+
+    @Test
+    public void batched_delete_respects_batch_size_across_passes() throws SQLException {
+        Timestamp old = Timestamp.from(Instant.now().minus(Duration.ofDays(5)));
+        for (int i = 0; i < 7; i++) {
+            insertEvent("ev-old-" + i, old);
+        }
+        assertEquals(7, rowCount());
+
+        job.setRetentionDuration(Duration.ofDays(1));
+        job.setBatchSize(2);
+        job.setMaxRuntime(Duration.ofSeconds(5));
+        job.run();
+
+        assertEquals(0, rowCount());
+    }
+
+    private void insertEvent(String id, Timestamp createdOn) throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement ps =
+                        conn.prepareStatement(
+                                "INSERT INTO incoming_webhook_event (event_id, json_data, created_on)"
+                                        + " VALUES (?, ?, ?)")) {
+            ps.setString(1, id);
+            ps.setString(2, "{}");
+            ps.setTimestamp(3, createdOn);
+            ps.executeUpdate();
+        }
+    }
+
+    private int rowCount() throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement ps =
+                        conn.prepareStatement("SELECT count(1) FROM incoming_webhook_event");
+                ResultSet rs = ps.executeQuery()) {
+            return rs.next() ? rs.getInt(1) : 0;
+        }
+    }
+
+    private String firstRowEventId() throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement ps =
+                        conn.prepareStatement("SELECT event_id FROM incoming_webhook_event");
+                ResultSet rs = ps.executeQuery()) {
+            return rs.next() ? rs.getString(1) : null;
+        }
+    }
+}

--- a/mysql-persistence/src/test/java/org/conductoross/conductor/mysql/dao/MySQLWebhookDAOTest.java
+++ b/mysql-persistence/src/test/java/org/conductoross/conductor/mysql/dao/MySQLWebhookDAOTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.mysql.dao;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.conductoross.conductor.webhook.model.IncomingWebhookEvent;
+import org.conductoross.conductor.webhook.model.WebhookConfig;
+import org.flywaydb.core.Flyway;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.core.exception.NotFoundException;
+import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.mysql.config.MySQLConfiguration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ContextConfiguration(
+        classes = {
+            TestObjectMapperConfiguration.class,
+            MySQLConfiguration.class,
+            FlywayAutoConfiguration.class
+        })
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = "spring.flyway.clean-disabled=false")
+public class MySQLWebhookDAOTest {
+
+    @Autowired private MySQLWebhookDAO dao;
+    @Autowired private Flyway flyway;
+    @MockBean private MetadataDAO metadataDAO;
+
+    @Before
+    public void before() {
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    @Test
+    public void crud_webhookConfig_roundtrip() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        config.setName("my-hook");
+
+        dao.createWebhook("hook-1", config);
+
+        WebhookConfig loaded = dao.getWebhook("hook-1");
+        assertNotNull(loaded);
+        assertEquals(1, dao.getAllWebhooks().size());
+
+        dao.removeWebhook("hook-1");
+        assertNull(dao.getWebhook("hook-1"));
+    }
+
+    @Test
+    public void createWebhook_upsertsExistingId() {
+        WebhookConfig v1 = new WebhookConfig();
+        v1.setId("hook-1");
+        v1.setName("original");
+        dao.createWebhook("hook-1", v1);
+
+        WebhookConfig v2 = new WebhookConfig();
+        v2.setId("hook-1");
+        v2.setName("updated");
+        dao.createWebhook("hook-1", v2);
+
+        assertEquals("updated", dao.getWebhook("hook-1").getName());
+    }
+
+    @Test
+    public void removeWebhook_unknownId_throwsNotFound() {
+        assertThrows(NotFoundException.class, () -> dao.removeWebhook("missing"));
+    }
+
+    @Test
+    public void crud_incomingWebhookEvent_roundtrip() {
+        IncomingWebhookEvent event =
+                IncomingWebhookEvent.builder()
+                        .id("ev-1")
+                        .webhookId("hook-1")
+                        .body("{\"event\":\"push\"}")
+                        .timeStamp(123L)
+                        .build();
+        dao.createIncomingWebhookEvent("ev-1", event);
+        assertEquals("hook-1", dao.getWebhookEvent("ev-1").getWebhookId());
+        dao.removeWebhookEvent("ev-1");
+        assertNull(dao.getWebhookEvent("ev-1"));
+    }
+
+    @Test
+    public void getMatchers_recomputesFromMetadataDAO_onEachCall_noStaleCache() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        dao.createWebhook("hook-1", config);
+        dao.createMatchers(config, Map.of("wf-a", 1));
+
+        WorkflowTask t1 = new WorkflowTask();
+        t1.setType("WAIT_FOR_WEBHOOK");
+        t1.setTaskReferenceName("wait_ref");
+        t1.setInputParameters(Map.of("matches", Map.of("event", "push")));
+        WorkflowDef def1 = new WorkflowDef();
+        def1.setName("wf-a");
+        def1.setVersion(1);
+        def1.setTasks(List.of(t1));
+        when(metadataDAO.getWorkflowDef("wf-a", 1)).thenReturn(Optional.of(def1));
+
+        assertEquals(Map.of("event", "push"), dao.getMatchers("hook-1").get("wf-a;1;wait_ref"));
+
+        WorkflowTask t2 = new WorkflowTask();
+        t2.setType("WAIT_FOR_WEBHOOK");
+        t2.setTaskReferenceName("wait_ref");
+        t2.setInputParameters(Map.of("matches", Map.of("event", "merge")));
+        WorkflowDef def2 = new WorkflowDef();
+        def2.setName("wf-a");
+        def2.setVersion(1);
+        def2.setTasks(List.of(t2));
+        when(metadataDAO.getWorkflowDef("wf-a", 1)).thenReturn(Optional.of(def2));
+
+        assertEquals(Map.of("event", "merge"), dao.getMatchers("hook-1").get("wf-a;1;wait_ref"));
+    }
+
+    @Test
+    public void removeMatchers_drops() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        dao.createWebhook("hook-1", config);
+        dao.createMatchers(config, Map.of("wf-a", 1));
+
+        dao.removeMatchers("hook-1");
+        assertTrue(dao.getMatchers("hook-1").isEmpty());
+    }
+}

--- a/mysql-persistence/src/test/java/org/conductoross/conductor/mysql/dao/MySQLWebhookTaskServiceTest.java
+++ b/mysql-persistence/src/test/java/org/conductoross/conductor/mysql/dao/MySQLWebhookTaskServiceTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.mysql.dao;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.flywaydb.core.Flyway;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
+import com.netflix.conductor.core.exception.NonTransientException;
+import com.netflix.conductor.model.TaskModel;
+import com.netflix.conductor.mysql.config.MySQLConfiguration;
+
+import static org.conductoross.conductor.service.webhook.WebhookTaskHashing.computeHash;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+@ContextConfiguration(
+        classes = {
+            TestObjectMapperConfiguration.class,
+            MySQLConfiguration.class,
+            FlywayAutoConfiguration.class
+        })
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = "spring.flyway.clean-disabled=false")
+public class MySQLWebhookTaskServiceTest {
+
+    @Autowired private MySQLWebhookTaskService service;
+    @Autowired private Flyway flyway;
+
+    @Before
+    public void before() {
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    @Test
+    public void put_and_get_matchByHash() {
+        TaskModel task = newTask("task-1", "wf-a", "wait_ref", Map.of("event", "push"));
+        service.put(task, 1);
+
+        String hash = computeHash("wf-a", 1, "wait_ref", Map.of("event", "push"));
+        assertEquals(Set.of("task-1"), service.get(hash));
+    }
+
+    @Test
+    public void put_missingMatchesField_throws() {
+        TaskModel task = new TaskModel();
+        task.setTaskId("task-x");
+        task.setInputData(Map.of());
+
+        assertThrows(NonTransientException.class, () -> service.put(task, 1));
+    }
+
+    @Test
+    public void multiple_tasks_sameHash_bucketed() {
+        TaskModel t1 = newTask("task-1", "wf-a", "wait_ref", Map.of("event", "push"));
+        TaskModel t2 = newTask("task-2", "wf-a", "wait_ref", Map.of("event", "push"));
+        service.put(t1, 1);
+        service.put(t2, 1);
+
+        String hash = computeHash("wf-a", 1, "wait_ref", Map.of("event", "push"));
+        Set<String> ids = service.get(hash);
+        assertTrue(ids.contains("task-1"));
+        assertTrue(ids.contains("task-2"));
+        assertEquals(2, ids.size());
+    }
+
+    @Test
+    public void remove_evictsTaskAndLeavesOthers() {
+        TaskModel t1 = newTask("task-1", "wf-a", "wait_ref", Map.of("event", "push"));
+        TaskModel t2 = newTask("task-2", "wf-a", "wait_ref", Map.of("event", "push"));
+        service.put(t1, 1);
+        service.put(t2, 1);
+        String hash = computeHash("wf-a", 1, "wait_ref", Map.of("event", "push"));
+
+        service.remove(hash, "task-1");
+
+        assertEquals(Set.of("task-2"), service.get(hash));
+    }
+
+    @Test
+    public void put_isIdempotent() {
+        TaskModel task = newTask("task-1", "wf-a", "wait_ref", Map.of("event", "push"));
+        service.put(task, 1);
+        service.put(task, 1);
+
+        String hash = computeHash("wf-a", 1, "wait_ref", Map.of("event", "push"));
+        assertEquals(Set.of("task-1"), service.get(hash));
+    }
+
+    @Test
+    public void get_unknownHash_returnsEmpty() {
+        assertTrue(service.get("never-seen").isEmpty());
+    }
+
+    private static TaskModel newTask(
+            String taskId, String workflowType, String taskRef, Map<String, Object> matches) {
+        TaskModel task = new TaskModel();
+        task.setTaskId(taskId);
+        task.setWorkflowType(workflowType);
+        task.setReferenceTaskName(taskRef);
+        task.setInputData(Map.of("matches", matches));
+        return task;
+    }
+}

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
@@ -146,6 +146,26 @@ public class PostgresConfiguration {
         return new PostgresFileMetadataDAO(retryTemplate, objectMapper, dataSource);
     }
 
+    @Bean(name = "webhookDAO")
+    @DependsOn({"flywayForPrimaryDb"})
+    public org.conductoross.conductor.postgres.dao.PostgresWebhookDAO postgresWebhookDAO(
+            @Qualifier("postgresRetryTemplate") RetryTemplate retryTemplate,
+            ObjectMapper objectMapper,
+            com.netflix.conductor.dao.MetadataDAO metadataDAO) {
+        return new org.conductoross.conductor.postgres.dao.PostgresWebhookDAO(
+                retryTemplate, objectMapper, dataSource, metadataDAO);
+    }
+
+    @Bean(name = "webhookTaskService")
+    @DependsOn({"flywayForPrimaryDb"})
+    public org.conductoross.conductor.postgres.dao.PostgresWebhookTaskService
+            postgresWebhookTaskService(
+                    @Qualifier("postgresRetryTemplate") RetryTemplate retryTemplate,
+                    ObjectMapper objectMapper) {
+        return new org.conductoross.conductor.postgres.dao.PostgresWebhookTaskService(
+                retryTemplate, objectMapper, dataSource);
+    }
+
     @Bean
     public RetryTemplate postgresRetryTemplate(PostgresProperties properties) {
         SimpleRetryPolicy retryPolicy = new CustomRetryPolicy();

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
@@ -167,6 +167,31 @@ public class PostgresConfiguration {
     }
 
     @Bean
+    @DependsOn({"flywayForPrimaryDb"})
+    @ConditionalOnProperty(
+            name = "conductor.webhooks.cleanup.enabled",
+            havingValue = "true",
+            matchIfMissing = true)
+    public org.conductoross.conductor.postgres.dao.PostgresWebhookCleanupJob
+            postgresWebhookCleanupJob(org.springframework.core.env.Environment env) {
+        org.conductoross.conductor.postgres.dao.PostgresWebhookCleanupJob job =
+                new org.conductoross.conductor.postgres.dao.PostgresWebhookCleanupJob(dataSource);
+        String retention = env.getProperty("conductor.webhooks.cleanup.retention-duration");
+        if (retention != null) {
+            job.setRetentionDuration(java.time.Duration.parse(retention));
+        }
+        Integer batch = env.getProperty("conductor.webhooks.cleanup.batch-size", Integer.class);
+        if (batch != null) {
+            job.setBatchSize(batch);
+        }
+        String maxRuntime = env.getProperty("conductor.webhooks.cleanup.max-runtime");
+        if (maxRuntime != null) {
+            job.setMaxRuntime(java.time.Duration.parse(maxRuntime));
+        }
+        return job;
+    }
+
+    @Bean
     public RetryTemplate postgresRetryTemplate(PostgresProperties properties) {
         SimpleRetryPolicy retryPolicy = new CustomRetryPolicy();
         retryPolicy.setMaxAttempts(3);

--- a/postgres-persistence/src/main/java/org/conductoross/conductor/postgres/dao/PostgresWebhookCleanupJob.java
+++ b/postgres-persistence/src/main/java/org/conductoross/conductor/postgres/dao/PostgresWebhookCleanupJob.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.postgres.dao;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+
+import javax.sql.DataSource;
+
+import org.springframework.scheduling.annotation.Scheduled;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Periodically deletes old rows from {@code incoming_webhook_event}. Runs on the cron set by {@code
+ * conductor.webhooks.cleanup.cron} (default: hourly). Each tick deletes rows whose {@code
+ * created_on} is older than {@code conductor.webhooks.cleanup.retention-duration} (default 7 days),
+ * in batches of {@code conductor.webhooks.cleanup.batch-size} (default 1000), up to {@code
+ * conductor.webhooks.cleanup.max-runtime} (default 60s) per tick.
+ *
+ * <p>Use of {@code WITH ... DELETE ... RETURNING} keeps the per-batch transaction small and
+ * cancellable. Postgres-only — other backends will need their own impl or rely on backing-native
+ * TTL (Cassandra) or per-key expiry (Redis).
+ */
+@Slf4j
+public class PostgresWebhookCleanupJob {
+
+    private static final String TABLE = "incoming_webhook_event";
+    private static final String DELETE_BATCH =
+            "WITH old_records AS ("
+                    + "  SELECT ctid FROM "
+                    + TABLE
+                    + " WHERE created_on < ? LIMIT ?"
+                    + "), deleted AS ("
+                    + "  DELETE FROM "
+                    + TABLE
+                    + " WHERE ctid IN (SELECT ctid FROM old_records)"
+                    + "  RETURNING ctid"
+                    + ") SELECT count(1) FROM deleted";
+
+    private final DataSource dataSource;
+
+    private Duration retentionDuration = Duration.ofDays(7);
+    private int batchSize = 1000;
+    private Duration maxRuntime = Duration.ofSeconds(60);
+
+    public PostgresWebhookCleanupJob(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public void setRetentionDuration(Duration retentionDuration) {
+        this.retentionDuration = retentionDuration;
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    public void setMaxRuntime(Duration maxRuntime) {
+        this.maxRuntime = maxRuntime;
+    }
+
+    @Scheduled(cron = "${conductor.webhooks.cleanup.cron:0 0 * * * *}")
+    public void run() {
+        long deadline = System.currentTimeMillis() + maxRuntime.toMillis();
+        int totalDeleted = 0;
+
+        while (System.currentTimeMillis() < deadline) {
+            Timestamp threshold = Timestamp.from(Instant.now().minus(retentionDuration));
+            int deletedThisBatch;
+            try {
+                deletedThisBatch = deleteBatch(threshold, batchSize);
+            } catch (SQLException e) {
+                log.error("webhook event cleanup batch failed", e);
+                return;
+            }
+            if (deletedThisBatch == 0) {
+                break;
+            }
+            totalDeleted += deletedThisBatch;
+        }
+
+        if (totalDeleted > 0) {
+            log.info(
+                    "webhook event cleanup: deleted {} rows older than {}",
+                    totalDeleted,
+                    retentionDuration);
+        }
+    }
+
+    private int deleteBatch(Timestamp threshold, int batch) throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement ps = conn.prepareStatement(DELETE_BATCH)) {
+            conn.setAutoCommit(true);
+            ps.setTimestamp(1, threshold);
+            ps.setInt(2, batch);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next() ? rs.getInt(1) : 0;
+            }
+        }
+    }
+}

--- a/postgres-persistence/src/main/java/org/conductoross/conductor/postgres/dao/PostgresWebhookDAO.java
+++ b/postgres-persistence/src/main/java/org/conductoross/conductor/postgres/dao/PostgresWebhookDAO.java
@@ -14,32 +14,24 @@ package org.conductoross.conductor.postgres.dao;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import javax.sql.DataSource;
 
 import org.conductoross.conductor.dao.webhook.WebhookDAO;
+import org.conductoross.conductor.service.webhook.WebhookMatcherComputer;
 import org.conductoross.conductor.webhook.model.IncomingWebhookEvent;
 import org.conductoross.conductor.webhook.model.WebhookConfig;
 import org.springframework.lang.Nullable;
 import org.springframework.retry.support.RetryTemplate;
-import org.springframework.util.CollectionUtils;
 
-import com.netflix.conductor.common.metadata.tasks.TaskType;
-import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
-import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.postgres.dao.PostgresBaseDAO;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-
-import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WAIT_FOR_WEBHOOK;
-import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WEBHOOK_DELIMITER;
 
 /**
  * Postgres-backed {@link WebhookDAO}. Stores webhook configs, incoming event payloads, and the
@@ -150,11 +142,7 @@ public class PostgresWebhookDAO extends PostgresBaseDAO implements WebhookDAO {
 
     @Override
     public Map<String, Map<String, Object>> getMatchers(String webhookId) {
-        Map<String, Integer> targets = loadTargets(webhookId);
-        if (targets.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return computeMatchers(targets);
+        return WebhookMatcherComputer.compute(loadTargets(webhookId), metadataDAO);
     }
 
     @Override
@@ -186,35 +174,5 @@ public class PostgresWebhookDAO extends PostgresBaseDAO implements WebhookDAO {
             return Collections.emptyMap();
         }
         return readValue(json, Map.class);
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Map<String, Object>> computeMatchers(Map<String, Integer> targets) {
-        Map<String, Map<String, Object>> computed = new HashMap<>();
-        targets.forEach(
-                (workflowName, wfVersion) -> {
-                    Optional<WorkflowDef> def = metadataDAO.getWorkflowDef(workflowName, wfVersion);
-                    if (def.isEmpty()) {
-                        return;
-                    }
-                    for (WorkflowTask task : def.get().collectTasks()) {
-                        String type = task.getType();
-                        if (!WAIT_FOR_WEBHOOK.equals(type)
-                                && !TaskType.WAIT.toString().equals(type)) {
-                            continue;
-                        }
-                        Object raw = task.getInputParameters().get("matches");
-                        if (raw instanceof Map<?, ?> m && !CollectionUtils.isEmpty(m)) {
-                            String key =
-                                    workflowName
-                                            + WEBHOOK_DELIMITER
-                                            + wfVersion
-                                            + WEBHOOK_DELIMITER
-                                            + task.getTaskReferenceName();
-                            computed.put(key, (Map<String, Object>) m);
-                        }
-                    }
-                });
-        return computed;
     }
 }

--- a/postgres-persistence/src/main/java/org/conductoross/conductor/postgres/dao/PostgresWebhookDAO.java
+++ b/postgres-persistence/src/main/java/org/conductoross/conductor/postgres/dao/PostgresWebhookDAO.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.postgres.dao;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.sql.DataSource;
+
+import org.conductoross.conductor.dao.webhook.WebhookDAO;
+import org.conductoross.conductor.webhook.model.IncomingWebhookEvent;
+import org.conductoross.conductor.webhook.model.WebhookConfig;
+import org.springframework.lang.Nullable;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.util.CollectionUtils;
+
+import com.netflix.conductor.common.metadata.tasks.TaskType;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.core.exception.NotFoundException;
+import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.postgres.dao.PostgresBaseDAO;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WAIT_FOR_WEBHOOK;
+import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WEBHOOK_DELIMITER;
+
+/**
+ * Postgres-backed {@link WebhookDAO}. Stores webhook configs, incoming event payloads, and the
+ * receiver-workflow target overrides. Match criteria are recomputed from {@link MetadataDAO} on
+ * every {@link #getMatchers(String)} call so WorkflowDef updates take effect without re-registering
+ * the webhook (mirrors the design fix applied to the in-memory impl).
+ */
+@Slf4j
+public class PostgresWebhookDAO extends PostgresBaseDAO implements WebhookDAO {
+
+    private static final String INSERT_WEBHOOK =
+            "INSERT INTO webhook (webhook_id, json_data) VALUES (?, ?) "
+                    + "ON CONFLICT (webhook_id) DO UPDATE "
+                    + "SET json_data = EXCLUDED.json_data, modified_on = CURRENT_TIMESTAMP";
+    private static final String SELECT_WEBHOOK =
+            "SELECT json_data FROM webhook WHERE webhook_id = ?";
+    private static final String SELECT_ALL_WEBHOOKS = "SELECT json_data FROM webhook";
+    private static final String DELETE_WEBHOOK = "DELETE FROM webhook WHERE webhook_id = ?";
+
+    private static final String INSERT_EVENT =
+            "INSERT INTO incoming_webhook_event (event_id, json_data) VALUES (?, ?) "
+                    + "ON CONFLICT (event_id) DO UPDATE "
+                    + "SET json_data = EXCLUDED.json_data";
+    private static final String SELECT_EVENT =
+            "SELECT json_data FROM incoming_webhook_event WHERE event_id = ?";
+    private static final String DELETE_EVENT =
+            "DELETE FROM incoming_webhook_event WHERE event_id = ?";
+
+    private static final String INSERT_TARGETS =
+            "INSERT INTO webhook_target_workflows (webhook_id, json_data) VALUES (?, ?) "
+                    + "ON CONFLICT (webhook_id) DO UPDATE "
+                    + "SET json_data = EXCLUDED.json_data";
+    private static final String SELECT_TARGETS =
+            "SELECT json_data FROM webhook_target_workflows WHERE webhook_id = ?";
+    private static final String DELETE_TARGETS =
+            "DELETE FROM webhook_target_workflows WHERE webhook_id = ?";
+
+    private final MetadataDAO metadataDAO;
+
+    public PostgresWebhookDAO(
+            RetryTemplate retryTemplate,
+            ObjectMapper objectMapper,
+            DataSource dataSource,
+            MetadataDAO metadataDAO) {
+        super(retryTemplate, objectMapper, dataSource);
+        this.metadataDAO = metadataDAO;
+    }
+
+    @Override
+    public void createWebhook(String id, WebhookConfig webhookConfig) {
+        String json = toJson(webhookConfig);
+        queryWithTransaction(
+                INSERT_WEBHOOK, q -> q.addParameter(id).addParameter(json).executeUpdate());
+    }
+
+    @Override
+    public WebhookConfig getWebhook(String webhookId) {
+        String json =
+                queryWithTransaction(
+                        SELECT_WEBHOOK,
+                        q -> q.addParameter(webhookId).executeAndFetchFirst(String.class));
+        return json == null ? null : readValue(json, WebhookConfig.class);
+    }
+
+    @Override
+    public List<WebhookConfig> getAllWebhooks() {
+        List<String> rows =
+                queryWithTransaction(SELECT_ALL_WEBHOOKS, q -> q.executeAndFetch(String.class));
+        if (rows == null) {
+            return new ArrayList<>();
+        }
+        List<WebhookConfig> out = new ArrayList<>(rows.size());
+        for (String json : rows) {
+            out.add(readValue(json, WebhookConfig.class));
+        }
+        return out;
+    }
+
+    @Override
+    public void removeWebhook(String id) {
+        WebhookConfig existing = getWebhook(id);
+        if (existing == null) {
+            throw new NotFoundException("Webhook with id " + id + " not found");
+        }
+        queryWithTransaction(DELETE_WEBHOOK, q -> q.addParameter(id).executeUpdate());
+    }
+
+    @Override
+    public void createIncomingWebhookEvent(String id, IncomingWebhookEvent event) {
+        String json = toJson(event);
+        queryWithTransaction(
+                INSERT_EVENT, q -> q.addParameter(id).addParameter(json).executeUpdate());
+    }
+
+    @Override
+    public IncomingWebhookEvent getWebhookEvent(String messageId) {
+        String json =
+                queryWithTransaction(
+                        SELECT_EVENT,
+                        q -> q.addParameter(messageId).executeAndFetchFirst(String.class));
+        return json == null ? null : readValue(json, IncomingWebhookEvent.class);
+    }
+
+    @Override
+    public void removeWebhookEvent(String id) {
+        queryWithTransaction(DELETE_EVENT, q -> q.addParameter(id).executeUpdate());
+    }
+
+    @Override
+    public Map<String, Map<String, Object>> getMatchers(String webhookId) {
+        Map<String, Integer> targets = loadTargets(webhookId);
+        if (targets.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return computeMatchers(targets);
+    }
+
+    @Override
+    public void createMatchers(
+            WebhookConfig webhookConfig,
+            @Nullable Map<String, Integer> receiverWorkflowNamesToVersionsOverride) {
+        Map<String, Integer> targets =
+                receiverWorkflowNamesToVersionsOverride == null
+                        ? Collections.emptyMap()
+                        : receiverWorkflowNamesToVersionsOverride;
+        String json = toJson(targets);
+        queryWithTransaction(
+                INSERT_TARGETS,
+                q -> q.addParameter(webhookConfig.getId()).addParameter(json).executeUpdate());
+    }
+
+    @Override
+    public void removeMatchers(String id) {
+        queryWithTransaction(DELETE_TARGETS, q -> q.addParameter(id).executeUpdate());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Integer> loadTargets(String webhookId) {
+        String json =
+                queryWithTransaction(
+                        SELECT_TARGETS,
+                        q -> q.addParameter(webhookId).executeAndFetchFirst(String.class));
+        if (json == null) {
+            return Collections.emptyMap();
+        }
+        return readValue(json, Map.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Map<String, Object>> computeMatchers(Map<String, Integer> targets) {
+        Map<String, Map<String, Object>> computed = new HashMap<>();
+        targets.forEach(
+                (workflowName, wfVersion) -> {
+                    Optional<WorkflowDef> def = metadataDAO.getWorkflowDef(workflowName, wfVersion);
+                    if (def.isEmpty()) {
+                        return;
+                    }
+                    for (WorkflowTask task : def.get().collectTasks()) {
+                        String type = task.getType();
+                        if (!WAIT_FOR_WEBHOOK.equals(type)
+                                && !TaskType.WAIT.toString().equals(type)) {
+                            continue;
+                        }
+                        Object raw = task.getInputParameters().get("matches");
+                        if (raw instanceof Map<?, ?> m && !CollectionUtils.isEmpty(m)) {
+                            String key =
+                                    workflowName
+                                            + WEBHOOK_DELIMITER
+                                            + wfVersion
+                                            + WEBHOOK_DELIMITER
+                                            + task.getTaskReferenceName();
+                            computed.put(key, (Map<String, Object>) m);
+                        }
+                    }
+                });
+        return computed;
+    }
+}

--- a/postgres-persistence/src/main/java/org/conductoross/conductor/postgres/dao/PostgresWebhookTaskService.java
+++ b/postgres-persistence/src/main/java/org/conductoross/conductor/postgres/dao/PostgresWebhookTaskService.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.postgres.dao;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.sql.DataSource;
+
+import org.conductoross.conductor.service.webhook.WebhookTaskHashing;
+import org.conductoross.conductor.service.webhook.WebhookTaskService;
+import org.springframework.retry.support.RetryTemplate;
+
+import com.netflix.conductor.model.TaskModel;
+import com.netflix.conductor.postgres.dao.PostgresBaseDAO;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Postgres-backed {@link WebhookTaskService}. Persists hash → taskId rows for multi-node lookup.
+ */
+@Slf4j
+public class PostgresWebhookTaskService extends PostgresBaseDAO implements WebhookTaskService {
+
+    private static final String INSERT =
+            "INSERT INTO webhook_hash_to_taskid (hash, task_id) VALUES (?, ?)"
+                    + " ON CONFLICT DO NOTHING";
+    private static final String SELECT =
+            "SELECT task_id FROM webhook_hash_to_taskid WHERE hash = ?";
+    private static final String DELETE =
+            "DELETE FROM webhook_hash_to_taskid WHERE hash = ? AND task_id = ?";
+
+    public PostgresWebhookTaskService(
+            RetryTemplate retryTemplate, ObjectMapper objectMapper, DataSource dataSource) {
+        super(retryTemplate, objectMapper, dataSource);
+    }
+
+    @Override
+    public void put(TaskModel task, int workflowVersion) {
+        String hash = WebhookTaskHashing.computeHash(task, workflowVersion);
+        queryWithTransaction(
+                INSERT, q -> q.addParameter(hash).addParameter(task.getTaskId()).executeUpdate());
+    }
+
+    @Override
+    public Set<String> get(String hash) {
+        List<String> taskIds =
+                queryWithTransaction(
+                        SELECT, q -> q.addParameter(hash).executeAndFetch(String.class));
+        return new HashSet<>(taskIds);
+    }
+
+    @Override
+    public void remove(String hash, String taskId) {
+        queryWithTransaction(
+                DELETE, q -> q.addParameter(hash).addParameter(taskId).executeUpdate());
+    }
+}

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V16__webhook.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V16__webhook.sql
@@ -1,0 +1,32 @@
+-- Webhook config storage. JSON document keyed by webhook id.
+CREATE TABLE webhook (
+    webhook_id varchar(255) PRIMARY KEY,
+    json_data TEXT NOT NULL,
+    modified_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Incoming webhook event payloads, awaiting worker dispatch.
+CREATE TABLE incoming_webhook_event (
+    event_id varchar(255) PRIMARY KEY,
+    json_data TEXT NOT NULL,
+    created_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_iwe_created_on ON incoming_webhook_event(created_on);
+
+-- Target workflow versions for a webhook. Stores the override snapshot taken
+-- at config-create time (preserves expression evaluation). Match criteria are
+-- NOT pre-computed; the DAO looks them up fresh from MetadataDAO on read so
+-- WorkflowDef updates take effect without re-registering the webhook.
+CREATE TABLE webhook_target_workflows (
+    webhook_id varchar(255) PRIMARY KEY,
+    json_data TEXT NOT NULL
+);
+
+-- Hash-indexed waiting tasks. Populated by Webhook.start() when a workflow
+-- reaches a WAIT_FOR_WEBHOOK task. Worker looks up matching task ids by hash
+-- and completes them when a matching event arrives.
+CREATE TABLE webhook_hash_to_taskid (
+    hash TEXT NOT NULL,
+    task_id VARCHAR(255) NOT NULL,
+    PRIMARY KEY (hash, task_id)
+);

--- a/postgres-persistence/src/test/java/org/conductoross/conductor/postgres/dao/PostgresWebhookCleanupJobTest.java
+++ b/postgres-persistence/src/test/java/org/conductoross/conductor/postgres/dao/PostgresWebhookCleanupJobTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.postgres.dao;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+
+import javax.sql.DataSource;
+
+import org.flywaydb.core.Flyway;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
+import com.netflix.conductor.postgres.config.PostgresConfiguration;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(
+        classes = {
+            TestObjectMapperConfiguration.class,
+            PostgresConfiguration.class,
+            FlywayAutoConfiguration.class
+        })
+@TestPropertySource(
+        properties = {
+            "conductor.db.type=postgres",
+            "spring.flyway.clean-disabled=false",
+            "conductor.app.workflow.name-validation.enabled=true",
+            "spring.flyway.ignore-migration-patterns=*:missing"
+        })
+@SpringBootTest
+public class PostgresWebhookCleanupJobTest {
+
+    @Autowired private PostgresWebhookCleanupJob job;
+    @Autowired private DataSource dataSource;
+    @Autowired private Flyway flyway;
+
+    @Before
+    public void before() {
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    @Test
+    public void deletes_rows_older_than_retention_keeps_recent() throws SQLException {
+        // 1-day retention; insert one row from 5 days ago, one from 5 minutes ago.
+        Timestamp old = Timestamp.from(Instant.now().minus(Duration.ofDays(5)));
+        Timestamp recent = Timestamp.from(Instant.now().minus(Duration.ofMinutes(5)));
+        insertEvent("ev-old", "{\"x\":1}", old);
+        insertEvent("ev-recent", "{\"x\":2}", recent);
+        assertEquals(2, rowCount());
+
+        job.setRetentionDuration(Duration.ofDays(1));
+        job.setBatchSize(100);
+        job.setMaxRuntime(Duration.ofSeconds(5));
+        job.run();
+
+        assertEquals(1, rowCount());
+        assertEquals("ev-recent", firstRowEventId());
+    }
+
+    @Test
+    public void empty_table_noop() {
+        job.setRetentionDuration(Duration.ofDays(1));
+        job.run();
+        // No exception, no rows.
+        try {
+            assertEquals(0, rowCount());
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void all_recent_rows_kept() throws SQLException {
+        Timestamp recent = Timestamp.from(Instant.now().minus(Duration.ofMinutes(5)));
+        insertEvent("ev-1", "{}", recent);
+        insertEvent("ev-2", "{}", recent);
+        assertEquals(2, rowCount());
+
+        job.setRetentionDuration(Duration.ofDays(1));
+        job.run();
+
+        assertEquals(2, rowCount());
+    }
+
+    @Test
+    public void batched_delete_respects_batch_size_across_multiple_passes() throws SQLException {
+        Timestamp old = Timestamp.from(Instant.now().minus(Duration.ofDays(5)));
+        for (int i = 0; i < 7; i++) {
+            insertEvent("ev-old-" + i, "{}", old);
+        }
+        assertEquals(7, rowCount());
+
+        // batch=2 forces 4 passes (2,2,2,1)
+        job.setRetentionDuration(Duration.ofDays(1));
+        job.setBatchSize(2);
+        job.setMaxRuntime(Duration.ofSeconds(5));
+        job.run();
+
+        assertEquals(0, rowCount());
+    }
+
+    private void insertEvent(String id, String json, Timestamp createdOn) throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement ps =
+                        conn.prepareStatement(
+                                "INSERT INTO incoming_webhook_event (event_id, json_data, created_on)"
+                                        + " VALUES (?, ?::text, ?)")) {
+            ps.setString(1, id);
+            ps.setString(2, json);
+            ps.setTimestamp(3, createdOn);
+            ps.executeUpdate();
+        }
+    }
+
+    private int rowCount() throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement ps =
+                        conn.prepareStatement("SELECT count(1) FROM incoming_webhook_event");
+                ResultSet rs = ps.executeQuery()) {
+            return rs.next() ? rs.getInt(1) : 0;
+        }
+    }
+
+    private String firstRowEventId() throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement ps =
+                        conn.prepareStatement("SELECT event_id FROM incoming_webhook_event");
+                ResultSet rs = ps.executeQuery()) {
+            return rs.next() ? rs.getString(1) : null;
+        }
+    }
+}

--- a/postgres-persistence/src/test/java/org/conductoross/conductor/postgres/dao/PostgresWebhookDAOTest.java
+++ b/postgres-persistence/src/test/java/org/conductoross/conductor/postgres/dao/PostgresWebhookDAOTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.postgres.dao;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.conductoross.conductor.webhook.model.IncomingWebhookEvent;
+import org.conductoross.conductor.webhook.model.WebhookConfig;
+import org.flywaydb.core.Flyway;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.core.exception.NotFoundException;
+import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.postgres.config.PostgresConfiguration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(
+        classes = {
+            TestObjectMapperConfiguration.class,
+            PostgresConfiguration.class,
+            FlywayAutoConfiguration.class
+        })
+@TestPropertySource(
+        properties = {
+            "conductor.db.type=postgres",
+            "spring.flyway.clean-disabled=false",
+            "conductor.app.workflow.name-validation.enabled=true"
+        })
+@SpringBootTest
+public class PostgresWebhookDAOTest {
+
+    @Autowired private PostgresWebhookDAO dao;
+    @Autowired private Flyway flyway;
+    @MockBean private MetadataDAO metadataDAO;
+
+    @Before
+    public void before() {
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    @Test
+    public void crud_webhookConfig_roundtrip() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        config.setName("my-hook");
+        config.setSourcePlatform("smoke");
+
+        dao.createWebhook("hook-1", config);
+
+        WebhookConfig loaded = dao.getWebhook("hook-1");
+        assertNotNull(loaded);
+        assertEquals("hook-1", loaded.getId());
+        assertEquals("my-hook", loaded.getName());
+
+        assertEquals(1, dao.getAllWebhooks().size());
+
+        dao.removeWebhook("hook-1");
+        assertNull(dao.getWebhook("hook-1"));
+        assertTrue(dao.getAllWebhooks().isEmpty());
+    }
+
+    @Test
+    public void createWebhook_upsertsExistingId() {
+        WebhookConfig v1 = new WebhookConfig();
+        v1.setId("hook-1");
+        v1.setName("original");
+        dao.createWebhook("hook-1", v1);
+
+        WebhookConfig v2 = new WebhookConfig();
+        v2.setId("hook-1");
+        v2.setName("updated");
+        dao.createWebhook("hook-1", v2);
+
+        assertEquals("updated", dao.getWebhook("hook-1").getName());
+    }
+
+    @Test
+    public void removeWebhook_unknownId_throwsNotFound() {
+        assertThrows(NotFoundException.class, () -> dao.removeWebhook("missing"));
+    }
+
+    @Test
+    public void crud_incomingWebhookEvent_roundtrip() {
+        IncomingWebhookEvent event =
+                IncomingWebhookEvent.builder()
+                        .id("ev-1")
+                        .webhookId("hook-1")
+                        .body("{\"event\":\"push\"}")
+                        .timeStamp(123L)
+                        .build();
+
+        dao.createIncomingWebhookEvent("ev-1", event);
+
+        IncomingWebhookEvent loaded = dao.getWebhookEvent("ev-1");
+        assertNotNull(loaded);
+        assertEquals("ev-1", loaded.getId());
+        assertEquals("hook-1", loaded.getWebhookId());
+
+        dao.removeWebhookEvent("ev-1");
+        assertNull(dao.getWebhookEvent("ev-1"));
+    }
+
+    @Test
+    public void getMatchers_emptyTargets_returnsEmpty() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        dao.createWebhook("hook-1", config);
+        dao.createMatchers(config, Map.of()); // empty override
+
+        assertTrue(dao.getMatchers("hook-1").isEmpty());
+    }
+
+    @Test
+    public void getMatchers_nullTargets_returnsEmpty() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        dao.createWebhook("hook-1", config);
+        dao.createMatchers(config, null);
+
+        assertTrue(dao.getMatchers("hook-1").isEmpty());
+    }
+
+    @Test
+    public void getMatchers_recomputesFromMetadataDAO_onEachCall_noStaleCache() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        dao.createWebhook("hook-1", config);
+        dao.createMatchers(config, Map.of("wf-a", 1));
+
+        WorkflowTask t1 = new WorkflowTask();
+        t1.setType("WAIT_FOR_WEBHOOK");
+        t1.setTaskReferenceName("wait_ref");
+        t1.setInputParameters(Map.of("matches", Map.of("event", "push")));
+        WorkflowDef def1 = new WorkflowDef();
+        def1.setName("wf-a");
+        def1.setVersion(1);
+        def1.setTasks(List.of(t1));
+        when(metadataDAO.getWorkflowDef("wf-a", 1)).thenReturn(Optional.of(def1));
+
+        Map<String, Map<String, Object>> first = dao.getMatchers("hook-1");
+        assertEquals(Map.of("event", "push"), first.get("wf-a;1;wait_ref"));
+
+        // Swap the WorkflowDef: same name/version, different matches.
+        WorkflowTask t2 = new WorkflowTask();
+        t2.setType("WAIT_FOR_WEBHOOK");
+        t2.setTaskReferenceName("wait_ref");
+        t2.setInputParameters(Map.of("matches", Map.of("event", "merge")));
+        WorkflowDef def2 = new WorkflowDef();
+        def2.setName("wf-a");
+        def2.setVersion(1);
+        def2.setTasks(List.of(t2));
+        when(metadataDAO.getWorkflowDef("wf-a", 1)).thenReturn(Optional.of(def2));
+
+        // No re-PUT of the webhook config — the next getMatchers must reflect the new def.
+        Map<String, Map<String, Object>> second = dao.getMatchers("hook-1");
+        assertEquals(Map.of("event", "merge"), second.get("wf-a;1;wait_ref"));
+    }
+
+    @Test
+    public void removeMatchers_drops() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        dao.createWebhook("hook-1", config);
+        dao.createMatchers(config, Map.of("wf-a", 1));
+
+        dao.removeMatchers("hook-1");
+
+        assertTrue(dao.getMatchers("hook-1").isEmpty());
+    }
+}

--- a/postgres-persistence/src/test/java/org/conductoross/conductor/postgres/dao/PostgresWebhookDAOTest.java
+++ b/postgres-persistence/src/test/java/org/conductoross/conductor/postgres/dao/PostgresWebhookDAOTest.java
@@ -55,7 +55,8 @@ import static org.mockito.Mockito.when;
         properties = {
             "conductor.db.type=postgres",
             "spring.flyway.clean-disabled=false",
-            "conductor.app.workflow.name-validation.enabled=true"
+            "conductor.app.workflow.name-validation.enabled=true",
+            "spring.flyway.ignore-migration-patterns=*:missing"
         })
 @SpringBootTest
 public class PostgresWebhookDAOTest {

--- a/postgres-persistence/src/test/java/org/conductoross/conductor/postgres/dao/PostgresWebhookTaskServiceTest.java
+++ b/postgres-persistence/src/test/java/org/conductoross/conductor/postgres/dao/PostgresWebhookTaskServiceTest.java
@@ -48,7 +48,8 @@ import static org.junit.Assert.assertTrue;
         properties = {
             "conductor.db.type=postgres",
             "spring.flyway.clean-disabled=false",
-            "conductor.app.workflow.name-validation.enabled=true"
+            "conductor.app.workflow.name-validation.enabled=true",
+            "spring.flyway.ignore-migration-patterns=*:missing"
         })
 @SpringBootTest
 public class PostgresWebhookTaskServiceTest {

--- a/postgres-persistence/src/test/java/org/conductoross/conductor/postgres/dao/PostgresWebhookTaskServiceTest.java
+++ b/postgres-persistence/src/test/java/org/conductoross/conductor/postgres/dao/PostgresWebhookTaskServiceTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.postgres.dao;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.flywaydb.core.Flyway;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
+import com.netflix.conductor.common.utils.TaskUtils;
+import com.netflix.conductor.core.exception.NonTransientException;
+import com.netflix.conductor.model.TaskModel;
+import com.netflix.conductor.postgres.config.PostgresConfiguration;
+
+import static org.conductoross.conductor.service.webhook.WebhookTaskHashing.computeHash;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(
+        classes = {
+            TestObjectMapperConfiguration.class,
+            PostgresConfiguration.class,
+            FlywayAutoConfiguration.class
+        })
+@TestPropertySource(
+        properties = {
+            "conductor.db.type=postgres",
+            "spring.flyway.clean-disabled=false",
+            "conductor.app.workflow.name-validation.enabled=true"
+        })
+@SpringBootTest
+public class PostgresWebhookTaskServiceTest {
+
+    @Autowired private PostgresWebhookTaskService service;
+    @Autowired private Flyway flyway;
+
+    @Before
+    public void before() {
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    @Test
+    public void put_and_get_matchByHash() {
+        TaskModel task = newTask("task-1", "wf-a", "wait_ref", Map.of("event", "push"));
+
+        service.put(task, 1);
+
+        String hash =
+                computeHash(
+                        "wf-a",
+                        1,
+                        TaskUtils.removeIterationFromTaskRefName("wait_ref"),
+                        Map.of("event", "push"));
+        assertEquals(Set.of("task-1"), service.get(hash));
+    }
+
+    @Test
+    public void put_missingMatchesField_throws() {
+        TaskModel task = new TaskModel();
+        task.setTaskId("task-x");
+        task.setInputData(Map.of()); // no "matches"
+
+        assertThrows(NonTransientException.class, () -> service.put(task, 1));
+    }
+
+    @Test
+    public void multiple_tasks_sameHash_bucketed() {
+        TaskModel t1 = newTask("task-1", "wf-a", "wait_ref", Map.of("event", "push"));
+        TaskModel t2 = newTask("task-2", "wf-a", "wait_ref", Map.of("event", "push"));
+
+        service.put(t1, 1);
+        service.put(t2, 1);
+
+        String hash = computeHash("wf-a", 1, "wait_ref", Map.of("event", "push"));
+        Set<String> ids = service.get(hash);
+        assertTrue(ids.contains("task-1"));
+        assertTrue(ids.contains("task-2"));
+        assertEquals(2, ids.size());
+    }
+
+    @Test
+    public void remove_evictsTaskAndLeavesOthers() {
+        TaskModel t1 = newTask("task-1", "wf-a", "wait_ref", Map.of("event", "push"));
+        TaskModel t2 = newTask("task-2", "wf-a", "wait_ref", Map.of("event", "push"));
+        service.put(t1, 1);
+        service.put(t2, 1);
+        String hash = computeHash("wf-a", 1, "wait_ref", Map.of("event", "push"));
+
+        service.remove(hash, "task-1");
+
+        assertEquals(Set.of("task-2"), service.get(hash));
+    }
+
+    @Test
+    public void put_isIdempotent() {
+        TaskModel task = newTask("task-1", "wf-a", "wait_ref", Map.of("event", "push"));
+        service.put(task, 1);
+        service.put(task, 1); // second put must not throw on PK conflict
+
+        String hash = computeHash("wf-a", 1, "wait_ref", Map.of("event", "push"));
+        assertEquals(Set.of("task-1"), service.get(hash));
+    }
+
+    @Test
+    public void get_unknownHash_returnsEmpty() {
+        assertTrue(service.get("never-seen").isEmpty());
+    }
+
+    private static TaskModel newTask(
+            String taskId, String workflowType, String taskRef, Map<String, Object> matches) {
+        TaskModel task = new TaskModel();
+        task.setTaskId(taskId);
+        task.setWorkflowType(workflowType);
+        task.setReferenceTaskName(taskRef);
+        task.setInputData(Map.of("matches", matches));
+        return task;
+    }
+}

--- a/redis-persistence/src/main/java/org/conductoross/conductor/redis/dao/RedisWebhookCleanupJob.java
+++ b/redis-persistence/src/main/java/org/conductoross/conductor/redis/dao/RedisWebhookCleanupJob.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.redis.dao;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.conductoross.conductor.webhook.model.IncomingWebhookEvent;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.redis.config.AnyRedisCondition;
+import com.netflix.conductor.redis.config.RedisProperties;
+import com.netflix.conductor.redis.dao.BaseDynoDAO;
+import com.netflix.conductor.redis.jedis.JedisProxy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Periodic walker that deletes expired entries from the {@code WEBHOOK_EVENT} hash.
+ *
+ * <p>Per-field TTL on a Redis hash isn't broadly available (HEXPIRE landed in Redis 7.4 and isn't
+ * yet ubiquitous), so we do an HGETALL + parse + HDEL pass on the cron. Cheap at low cardinality;
+ * if your incoming-event volume is high, prefer migrating to a per-key storage shape with TTL.
+ *
+ * <p>Same property surface as the SQL cleanup jobs:
+ *
+ * <ul>
+ *   <li>{@code conductor.webhooks.cleanup.cron} (default hourly)
+ *   <li>{@code conductor.webhooks.cleanup.retention-duration} (default 7 days)
+ *   <li>{@code conductor.webhooks.cleanup.enabled} (default true)
+ * </ul>
+ */
+@Component
+@Conditional(AnyRedisCondition.class)
+@ConditionalOnProperty(
+        name = "conductor.webhooks.cleanup.enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+@Slf4j
+public class RedisWebhookCleanupJob extends BaseDynoDAO {
+
+    private static final String WEBHOOK_EVENT = "WEBHOOK_EVENT";
+
+    private Duration retentionDuration;
+
+    public RedisWebhookCleanupJob(
+            JedisProxy jedisProxy,
+            ObjectMapper objectMapper,
+            ConductorProperties conductorProperties,
+            RedisProperties properties,
+            @Value("${conductor.webhooks.cleanup.retention-duration:PT168H}")
+                    Duration retentionDuration) {
+        super(jedisProxy, objectMapper, conductorProperties, properties);
+        this.retentionDuration = retentionDuration;
+    }
+
+    void setRetentionDuration(Duration retentionDuration) {
+        this.retentionDuration = retentionDuration;
+    }
+
+    @Scheduled(cron = "${conductor.webhooks.cleanup.cron:0 0 * * * *}")
+    public void run() {
+        String key = nsKey(WEBHOOK_EVENT);
+        Map<String, String> all = jedisProxy.hgetAll(key);
+        if (all == null || all.isEmpty()) {
+            return;
+        }
+        long threshold = System.currentTimeMillis() - retentionDuration.toMillis();
+        List<String> toDelete = new ArrayList<>();
+        for (Map.Entry<String, String> entry : all.entrySet()) {
+            try {
+                IncomingWebhookEvent event =
+                        objectMapper.readValue(entry.getValue(), IncomingWebhookEvent.class);
+                if (event.getTimeStamp() > 0 && event.getTimeStamp() < threshold) {
+                    toDelete.add(entry.getKey());
+                }
+            } catch (Exception e) {
+                log.warn(
+                        "unparseable webhook event {} during cleanup; leaving in place",
+                        entry.getKey(),
+                        e);
+            }
+        }
+        if (toDelete.isEmpty()) {
+            return;
+        }
+        jedisProxy.hdel(key, toDelete.toArray(new String[0]));
+        log.info(
+                "webhook event cleanup: deleted {} entries older than {}",
+                toDelete.size(),
+                retentionDuration);
+    }
+}

--- a/redis-persistence/src/main/java/org/conductoross/conductor/redis/dao/RedisWebhookDAO.java
+++ b/redis-persistence/src/main/java/org/conductoross/conductor/redis/dao/RedisWebhookDAO.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.redis.dao;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.conductoross.conductor.dao.webhook.WebhookDAO;
+import org.conductoross.conductor.webhook.model.IncomingWebhookEvent;
+import org.conductoross.conductor.webhook.model.WebhookConfig;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+
+import com.netflix.conductor.common.metadata.tasks.TaskType;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.core.exception.NotFoundException;
+import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.redis.config.AnyRedisCondition;
+import com.netflix.conductor.redis.config.RedisProperties;
+import com.netflix.conductor.redis.dao.BaseDynoDAO;
+import com.netflix.conductor.redis.jedis.JedisProxy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WAIT_FOR_WEBHOOK;
+import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WEBHOOK_DELIMITER;
+
+/**
+ * Redis-backed {@link WebhookDAO}.
+ *
+ * <p>Data model:
+ *
+ * <ul>
+ *   <li>{@code WEBHOOK_CONFIG} hash: webhook_id → JSON({@link WebhookConfig})
+ *   <li>{@code WEBHOOK_EVENT} hash: event_id → JSON({@link IncomingWebhookEvent})
+ *   <li>{@code WEBHOOK_TARGETS} hash: webhook_id → JSON(Map&lt;workflowName, version&gt;)
+ * </ul>
+ *
+ * <p>Matchers are recomputed from {@link MetadataDAO} on every {@link #getMatchers} call — same
+ * design as the SQL impls. See {@code PostgresWebhookDAO} for rationale.
+ */
+@Component(value = "webhookDAO")
+@Conditional(AnyRedisCondition.class)
+@Slf4j
+public class RedisWebhookDAO extends BaseDynoDAO implements WebhookDAO {
+
+    private static final String WEBHOOK_CONFIG = "WEBHOOK_CONFIG";
+    private static final String WEBHOOK_EVENT = "WEBHOOK_EVENT";
+    private static final String WEBHOOK_TARGETS = "WEBHOOK_TARGETS";
+
+    private final MetadataDAO metadataDAO;
+
+    public RedisWebhookDAO(
+            JedisProxy jedisProxy,
+            ObjectMapper objectMapper,
+            ConductorProperties conductorProperties,
+            RedisProperties properties,
+            MetadataDAO metadataDAO) {
+        super(jedisProxy, objectMapper, conductorProperties, properties);
+        this.metadataDAO = metadataDAO;
+    }
+
+    @Override
+    public void createWebhook(String id, WebhookConfig webhookConfig) {
+        jedisProxy.hset(nsKey(WEBHOOK_CONFIG), id, toJson(webhookConfig));
+    }
+
+    @Override
+    public WebhookConfig getWebhook(String webhookId) {
+        String json = jedisProxy.hget(nsKey(WEBHOOK_CONFIG), webhookId);
+        return json == null ? null : readValue(json, WebhookConfig.class);
+    }
+
+    @Override
+    public List<WebhookConfig> getAllWebhooks() {
+        List<String> values = jedisProxy.hvals(nsKey(WEBHOOK_CONFIG));
+        if (values == null || values.isEmpty()) {
+            return new ArrayList<>();
+        }
+        List<WebhookConfig> out = new ArrayList<>(values.size());
+        for (String json : values) {
+            out.add(readValue(json, WebhookConfig.class));
+        }
+        return out;
+    }
+
+    @Override
+    public void removeWebhook(String id) {
+        if (jedisProxy.hget(nsKey(WEBHOOK_CONFIG), id) == null) {
+            throw new NotFoundException("Webhook with id " + id + " not found");
+        }
+        jedisProxy.hdel(nsKey(WEBHOOK_CONFIG), id);
+    }
+
+    @Override
+    public void createIncomingWebhookEvent(String id, IncomingWebhookEvent event) {
+        jedisProxy.hset(nsKey(WEBHOOK_EVENT), id, toJson(event));
+    }
+
+    @Override
+    public IncomingWebhookEvent getWebhookEvent(String messageId) {
+        String json = jedisProxy.hget(nsKey(WEBHOOK_EVENT), messageId);
+        return json == null ? null : readValue(json, IncomingWebhookEvent.class);
+    }
+
+    @Override
+    public void removeWebhookEvent(String id) {
+        jedisProxy.hdel(nsKey(WEBHOOK_EVENT), id);
+    }
+
+    @Override
+    public Map<String, Map<String, Object>> getMatchers(String webhookId) {
+        Map<String, Integer> targets = loadTargets(webhookId);
+        if (targets.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return computeMatchers(targets);
+    }
+
+    @Override
+    public void createMatchers(
+            WebhookConfig webhookConfig,
+            @Nullable Map<String, Integer> receiverWorkflowNamesToVersionsOverride) {
+        Map<String, Integer> targets =
+                receiverWorkflowNamesToVersionsOverride == null
+                        ? Collections.emptyMap()
+                        : receiverWorkflowNamesToVersionsOverride;
+        jedisProxy.hset(nsKey(WEBHOOK_TARGETS), webhookConfig.getId(), toJson(targets));
+    }
+
+    @Override
+    public void removeMatchers(String id) {
+        jedisProxy.hdel(nsKey(WEBHOOK_TARGETS), id);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Integer> loadTargets(String webhookId) {
+        String json = jedisProxy.hget(nsKey(WEBHOOK_TARGETS), webhookId);
+        if (json == null) {
+            return Collections.emptyMap();
+        }
+        return readValue(json, Map.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Map<String, Object>> computeMatchers(Map<String, Integer> targets) {
+        Map<String, Map<String, Object>> computed = new HashMap<>();
+        targets.forEach(
+                (workflowName, wfVersion) -> {
+                    Optional<WorkflowDef> def = metadataDAO.getWorkflowDef(workflowName, wfVersion);
+                    if (def.isEmpty()) {
+                        return;
+                    }
+                    for (WorkflowTask task : def.get().collectTasks()) {
+                        String type = task.getType();
+                        if (!WAIT_FOR_WEBHOOK.equals(type)
+                                && !TaskType.WAIT.toString().equals(type)) {
+                            continue;
+                        }
+                        Object raw = task.getInputParameters().get("matches");
+                        if (raw instanceof Map<?, ?> m && !CollectionUtils.isEmpty(m)) {
+                            String key =
+                                    workflowName
+                                            + WEBHOOK_DELIMITER
+                                            + wfVersion
+                                            + WEBHOOK_DELIMITER
+                                            + task.getTaskReferenceName();
+                            computed.put(key, (Map<String, Object>) m);
+                        }
+                    }
+                });
+        return computed;
+    }
+}

--- a/redis-persistence/src/main/java/org/conductoross/conductor/redis/dao/RedisWebhookDAO.java
+++ b/redis-persistence/src/main/java/org/conductoross/conductor/redis/dao/RedisWebhookDAO.java
@@ -14,22 +14,17 @@ package org.conductoross.conductor.redis.dao;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.conductoross.conductor.dao.webhook.WebhookDAO;
+import org.conductoross.conductor.service.webhook.WebhookMatcherComputer;
 import org.conductoross.conductor.webhook.model.IncomingWebhookEvent;
 import org.conductoross.conductor.webhook.model.WebhookConfig;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
-import org.springframework.util.CollectionUtils;
 
-import com.netflix.conductor.common.metadata.tasks.TaskType;
-import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
-import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.core.config.ConductorProperties;
 import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.dao.MetadataDAO;
@@ -40,9 +35,6 @@ import com.netflix.conductor.redis.jedis.JedisProxy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-
-import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WAIT_FOR_WEBHOOK;
-import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WEBHOOK_DELIMITER;
 
 /**
  * Redis-backed {@link WebhookDAO}.
@@ -129,11 +121,7 @@ public class RedisWebhookDAO extends BaseDynoDAO implements WebhookDAO {
 
     @Override
     public Map<String, Map<String, Object>> getMatchers(String webhookId) {
-        Map<String, Integer> targets = loadTargets(webhookId);
-        if (targets.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return computeMatchers(targets);
+        return WebhookMatcherComputer.compute(loadTargets(webhookId), metadataDAO);
     }
 
     @Override
@@ -159,35 +147,5 @@ public class RedisWebhookDAO extends BaseDynoDAO implements WebhookDAO {
             return Collections.emptyMap();
         }
         return readValue(json, Map.class);
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Map<String, Object>> computeMatchers(Map<String, Integer> targets) {
-        Map<String, Map<String, Object>> computed = new HashMap<>();
-        targets.forEach(
-                (workflowName, wfVersion) -> {
-                    Optional<WorkflowDef> def = metadataDAO.getWorkflowDef(workflowName, wfVersion);
-                    if (def.isEmpty()) {
-                        return;
-                    }
-                    for (WorkflowTask task : def.get().collectTasks()) {
-                        String type = task.getType();
-                        if (!WAIT_FOR_WEBHOOK.equals(type)
-                                && !TaskType.WAIT.toString().equals(type)) {
-                            continue;
-                        }
-                        Object raw = task.getInputParameters().get("matches");
-                        if (raw instanceof Map<?, ?> m && !CollectionUtils.isEmpty(m)) {
-                            String key =
-                                    workflowName
-                                            + WEBHOOK_DELIMITER
-                                            + wfVersion
-                                            + WEBHOOK_DELIMITER
-                                            + task.getTaskReferenceName();
-                            computed.put(key, (Map<String, Object>) m);
-                        }
-                    }
-                });
-        return computed;
     }
 }

--- a/redis-persistence/src/main/java/org/conductoross/conductor/redis/dao/RedisWebhookTaskService.java
+++ b/redis-persistence/src/main/java/org/conductoross/conductor/redis/dao/RedisWebhookTaskService.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.redis.dao;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.conductoross.conductor.service.webhook.WebhookTaskHashing;
+import org.conductoross.conductor.service.webhook.WebhookTaskService;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.model.TaskModel;
+import com.netflix.conductor.redis.config.AnyRedisCondition;
+import com.netflix.conductor.redis.config.RedisProperties;
+import com.netflix.conductor.redis.dao.BaseDynoDAO;
+import com.netflix.conductor.redis.jedis.JedisProxy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Redis-backed {@link WebhookTaskService}. Hash → Set<taskId> mapping in Redis. Same {@link
+ * WebhookTaskHashing} as the SQL impls so hashes are interchangeable across backings.
+ */
+@Component(value = "webhookTaskService")
+@Conditional(AnyRedisCondition.class)
+public class RedisWebhookTaskService extends BaseDynoDAO implements WebhookTaskService {
+
+    private static final String WEBHOOK_HASH = "WEBHOOK_HASH";
+
+    public RedisWebhookTaskService(
+            JedisProxy jedisProxy,
+            ObjectMapper objectMapper,
+            ConductorProperties conductorProperties,
+            RedisProperties properties) {
+        super(jedisProxy, objectMapper, conductorProperties, properties);
+    }
+
+    @Override
+    public void put(TaskModel task, int workflowVersion) {
+        String hash = WebhookTaskHashing.computeHash(task, workflowVersion);
+        jedisProxy.sadd(nsKey(WEBHOOK_HASH, hash), task.getTaskId());
+    }
+
+    @Override
+    public Set<String> get(String hash) {
+        Set<String> members = jedisProxy.smembers(nsKey(WEBHOOK_HASH, hash));
+        return members == null ? Collections.emptySet() : members;
+    }
+
+    @Override
+    public void remove(String hash, String taskId) {
+        jedisProxy.srem(nsKey(WEBHOOK_HASH, hash), taskId);
+    }
+}

--- a/redis-persistence/src/test/java/org/conductoross/conductor/redis/dao/RedisWebhookCleanupJobTest.java
+++ b/redis-persistence/src/test/java/org/conductoross/conductor/redis/dao/RedisWebhookCleanupJobTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.redis.dao;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.conductoross.conductor.webhook.model.IncomingWebhookEvent;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import com.netflix.conductor.common.config.ObjectMapperProvider;
+import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.redis.config.RedisProperties;
+import com.netflix.conductor.redis.jedis.JedisProxy;
+import com.netflix.conductor.redis.jedis.JedisStandalone;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RedisWebhookCleanupJobTest {
+
+    private static final GenericContainer<?> redis =
+            new GenericContainer<>(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379);
+
+    private RedisWebhookDAO dao;
+    private RedisWebhookCleanupJob job;
+    private JedisPool jedisPool;
+
+    @BeforeAll
+    void setUp() {
+        redis.start();
+        JedisPoolConfig config = new JedisPoolConfig();
+        config.setMinIdle(2);
+        config.setMaxTotal(10);
+        jedisPool = new JedisPool(config, redis.getHost(), redis.getFirstMappedPort());
+    }
+
+    @AfterAll
+    void tearDown() {
+        redis.stop();
+    }
+
+    @BeforeEach
+    void cleanUp() {
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.flushAll();
+        }
+        JedisProxy proxy = new JedisProxy(new JedisStandalone(jedisPool));
+        ObjectMapper om = new ObjectMapperProvider().getObjectMapper();
+        ConductorProperties cp = new ConductorProperties();
+        RedisProperties rp = new RedisProperties(cp);
+        dao = new RedisWebhookDAO(proxy, om, cp, rp, null);
+        job = new RedisWebhookCleanupJob(proxy, om, cp, rp, Duration.ofDays(1));
+    }
+
+    @Test
+    void deletes_old_events_keeps_recent() {
+        long now = Instant.now().toEpochMilli();
+        long oldTs = now - Duration.ofDays(5).toMillis();
+        long recentTs = now - Duration.ofMinutes(5).toMillis();
+        dao.createIncomingWebhookEvent("ev-old", event("ev-old", oldTs));
+        dao.createIncomingWebhookEvent("ev-recent", event("ev-recent", recentTs));
+
+        job.run();
+
+        // ev-old gone, ev-recent kept
+        assertEquals(null, dao.getWebhookEvent("ev-old"));
+        assertEquals("ev-recent", dao.getWebhookEvent("ev-recent").getId());
+    }
+
+    @Test
+    void empty_hash_noop() {
+        job.run();
+        assertEquals(null, dao.getWebhookEvent("anything"));
+    }
+
+    @Test
+    void all_recent_kept() {
+        long recentTs = Instant.now().toEpochMilli() - Duration.ofMinutes(5).toMillis();
+        dao.createIncomingWebhookEvent("ev-1", event("ev-1", recentTs));
+        dao.createIncomingWebhookEvent("ev-2", event("ev-2", recentTs));
+
+        job.run();
+
+        assertEquals("ev-1", dao.getWebhookEvent("ev-1").getId());
+        assertEquals("ev-2", dao.getWebhookEvent("ev-2").getId());
+    }
+
+    @Test
+    void zero_timestamp_event_skipped() {
+        // Some events may have timeStamp=0 (e.g. manual fixtures). Treat as "no expiry signal" —
+        // leave them alone rather than risking deletion of legitimate data.
+        dao.createIncomingWebhookEvent("ev-zero", event("ev-zero", 0L));
+
+        job.run();
+
+        assertEquals("ev-zero", dao.getWebhookEvent("ev-zero").getId());
+    }
+
+    private static IncomingWebhookEvent event(String id, long ts) {
+        return IncomingWebhookEvent.builder()
+                .id(id)
+                .webhookId("hook-1")
+                .body("{}")
+                .timeStamp(ts)
+                .build();
+    }
+}

--- a/redis-persistence/src/test/java/org/conductoross/conductor/redis/dao/RedisWebhookDAOTest.java
+++ b/redis-persistence/src/test/java/org/conductoross/conductor/redis/dao/RedisWebhookDAOTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.redis.dao;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.conductoross.conductor.webhook.model.IncomingWebhookEvent;
+import org.conductoross.conductor.webhook.model.WebhookConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.Mockito;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import com.netflix.conductor.common.config.ObjectMapperProvider;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.core.exception.NotFoundException;
+import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.redis.config.RedisProperties;
+import com.netflix.conductor.redis.jedis.JedisProxy;
+import com.netflix.conductor.redis.jedis.JedisStandalone;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RedisWebhookDAOTest {
+
+    private static final GenericContainer<?> redis =
+            new GenericContainer<>(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379);
+
+    private RedisWebhookDAO dao;
+    private MetadataDAO metadataDAO;
+    private JedisPool jedisPool;
+
+    @BeforeAll
+    void setUp() {
+        redis.start();
+        JedisPoolConfig config = new JedisPoolConfig();
+        config.setMinIdle(2);
+        config.setMaxTotal(10);
+        jedisPool = new JedisPool(config, redis.getHost(), redis.getFirstMappedPort());
+    }
+
+    @AfterAll
+    void tearDown() {
+        redis.stop();
+    }
+
+    @BeforeEach
+    void cleanUp() {
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.flushAll();
+        }
+        JedisProxy proxy = new JedisProxy(new JedisStandalone(jedisPool));
+        ObjectMapper om = new ObjectMapperProvider().getObjectMapper();
+        ConductorProperties cp = new ConductorProperties();
+        RedisProperties rp = new RedisProperties(cp);
+        metadataDAO = Mockito.mock(MetadataDAO.class);
+        dao = new RedisWebhookDAO(proxy, om, cp, rp, metadataDAO);
+    }
+
+    @Test
+    void crud_webhookConfig_roundtrip() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        config.setName("my-hook");
+
+        dao.createWebhook("hook-1", config);
+
+        WebhookConfig loaded = dao.getWebhook("hook-1");
+        assertNotNull(loaded);
+        assertEquals("hook-1", loaded.getId());
+        assertEquals(1, dao.getAllWebhooks().size());
+
+        dao.removeWebhook("hook-1");
+        assertNull(dao.getWebhook("hook-1"));
+        assertTrue(dao.getAllWebhooks().isEmpty());
+    }
+
+    @Test
+    void createWebhook_upsertsExistingId() {
+        WebhookConfig v1 = new WebhookConfig();
+        v1.setId("hook-1");
+        v1.setName("original");
+        dao.createWebhook("hook-1", v1);
+
+        WebhookConfig v2 = new WebhookConfig();
+        v2.setId("hook-1");
+        v2.setName("updated");
+        dao.createWebhook("hook-1", v2);
+
+        assertEquals("updated", dao.getWebhook("hook-1").getName());
+    }
+
+    @Test
+    void removeWebhook_unknownId_throwsNotFound() {
+        assertThrows(NotFoundException.class, () -> dao.removeWebhook("missing"));
+    }
+
+    @Test
+    void crud_incomingWebhookEvent_roundtrip() {
+        IncomingWebhookEvent event =
+                IncomingWebhookEvent.builder()
+                        .id("ev-1")
+                        .webhookId("hook-1")
+                        .body("{\"event\":\"push\"}")
+                        .timeStamp(123L)
+                        .build();
+        dao.createIncomingWebhookEvent("ev-1", event);
+        assertEquals("hook-1", dao.getWebhookEvent("ev-1").getWebhookId());
+        dao.removeWebhookEvent("ev-1");
+        assertNull(dao.getWebhookEvent("ev-1"));
+    }
+
+    @Test
+    void getMatchers_emptyOrNullTargets_returnsEmpty() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        dao.createWebhook("hook-1", config);
+
+        dao.createMatchers(config, Map.of());
+        assertTrue(dao.getMatchers("hook-1").isEmpty());
+
+        dao.createMatchers(config, null);
+        assertTrue(dao.getMatchers("hook-1").isEmpty());
+    }
+
+    @Test
+    void getMatchers_recomputesFromMetadataDAO_onEachCall_noStaleCache() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        dao.createWebhook("hook-1", config);
+        dao.createMatchers(config, Map.of("wf-a", 1));
+
+        WorkflowTask t1 = new WorkflowTask();
+        t1.setType("WAIT_FOR_WEBHOOK");
+        t1.setTaskReferenceName("wait_ref");
+        t1.setInputParameters(Map.of("matches", Map.of("event", "push")));
+        WorkflowDef def1 = new WorkflowDef();
+        def1.setName("wf-a");
+        def1.setVersion(1);
+        def1.setTasks(List.of(t1));
+        when(metadataDAO.getWorkflowDef("wf-a", 1)).thenReturn(Optional.of(def1));
+
+        assertEquals(Map.of("event", "push"), dao.getMatchers("hook-1").get("wf-a;1;wait_ref"));
+
+        WorkflowTask t2 = new WorkflowTask();
+        t2.setType("WAIT_FOR_WEBHOOK");
+        t2.setTaskReferenceName("wait_ref");
+        t2.setInputParameters(Map.of("matches", Map.of("event", "merge")));
+        WorkflowDef def2 = new WorkflowDef();
+        def2.setName("wf-a");
+        def2.setVersion(1);
+        def2.setTasks(List.of(t2));
+        when(metadataDAO.getWorkflowDef("wf-a", 1)).thenReturn(Optional.of(def2));
+
+        assertEquals(Map.of("event", "merge"), dao.getMatchers("hook-1").get("wf-a;1;wait_ref"));
+    }
+
+    @Test
+    void removeMatchers_drops() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        dao.createWebhook("hook-1", config);
+        dao.createMatchers(config, Map.of("wf-a", 1));
+
+        dao.removeMatchers("hook-1");
+        assertTrue(dao.getMatchers("hook-1").isEmpty());
+    }
+}

--- a/redis-persistence/src/test/java/org/conductoross/conductor/redis/dao/RedisWebhookTaskServiceTest.java
+++ b/redis-persistence/src/test/java/org/conductoross/conductor/redis/dao/RedisWebhookTaskServiceTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.redis.dao;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import com.netflix.conductor.common.config.ObjectMapperProvider;
+import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.core.exception.NonTransientException;
+import com.netflix.conductor.model.TaskModel;
+import com.netflix.conductor.redis.config.RedisProperties;
+import com.netflix.conductor.redis.jedis.JedisProxy;
+import com.netflix.conductor.redis.jedis.JedisStandalone;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+
+import static org.conductoross.conductor.service.webhook.WebhookTaskHashing.computeHash;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RedisWebhookTaskServiceTest {
+
+    private static final GenericContainer<?> redis =
+            new GenericContainer<>(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379);
+
+    private RedisWebhookTaskService service;
+    private JedisPool jedisPool;
+
+    @BeforeAll
+    void setUp() {
+        redis.start();
+        JedisPoolConfig config = new JedisPoolConfig();
+        config.setMinIdle(2);
+        config.setMaxTotal(10);
+        jedisPool = new JedisPool(config, redis.getHost(), redis.getFirstMappedPort());
+    }
+
+    @AfterAll
+    void tearDown() {
+        redis.stop();
+    }
+
+    @BeforeEach
+    void cleanUp() {
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.flushAll();
+        }
+        JedisProxy proxy = new JedisProxy(new JedisStandalone(jedisPool));
+        ObjectMapper om = new ObjectMapperProvider().getObjectMapper();
+        ConductorProperties cp = new ConductorProperties();
+        RedisProperties rp = new RedisProperties(cp);
+        service = new RedisWebhookTaskService(proxy, om, cp, rp);
+    }
+
+    @Test
+    void put_and_get_matchByHash() {
+        TaskModel task = newTask("task-1", "wf-a", "wait_ref", Map.of("event", "push"));
+        service.put(task, 1);
+
+        String hash = computeHash("wf-a", 1, "wait_ref", Map.of("event", "push"));
+        assertEquals(Set.of("task-1"), service.get(hash));
+    }
+
+    @Test
+    void put_missingMatchesField_throws() {
+        TaskModel task = new TaskModel();
+        task.setTaskId("task-x");
+        task.setInputData(Map.of());
+
+        assertThrows(NonTransientException.class, () -> service.put(task, 1));
+    }
+
+    @Test
+    void multiple_tasks_sameHash_bucketed() {
+        TaskModel t1 = newTask("task-1", "wf-a", "wait_ref", Map.of("event", "push"));
+        TaskModel t2 = newTask("task-2", "wf-a", "wait_ref", Map.of("event", "push"));
+        service.put(t1, 1);
+        service.put(t2, 1);
+
+        String hash = computeHash("wf-a", 1, "wait_ref", Map.of("event", "push"));
+        Set<String> ids = service.get(hash);
+        assertEquals(2, ids.size());
+        assertTrue(ids.contains("task-1"));
+        assertTrue(ids.contains("task-2"));
+    }
+
+    @Test
+    void remove_evictsTaskAndLeavesOthers() {
+        TaskModel t1 = newTask("task-1", "wf-a", "wait_ref", Map.of("event", "push"));
+        TaskModel t2 = newTask("task-2", "wf-a", "wait_ref", Map.of("event", "push"));
+        service.put(t1, 1);
+        service.put(t2, 1);
+        String hash = computeHash("wf-a", 1, "wait_ref", Map.of("event", "push"));
+
+        service.remove(hash, "task-1");
+
+        assertEquals(Set.of("task-2"), service.get(hash));
+    }
+
+    @Test
+    void put_isIdempotent() {
+        TaskModel task = newTask("task-1", "wf-a", "wait_ref", Map.of("event", "push"));
+        service.put(task, 1);
+        service.put(task, 1);
+
+        String hash = computeHash("wf-a", 1, "wait_ref", Map.of("event", "push"));
+        assertEquals(Set.of("task-1"), service.get(hash));
+    }
+
+    @Test
+    void get_unknownHash_returnsEmpty() {
+        assertTrue(service.get("never-seen").isEmpty());
+    }
+
+    private static TaskModel newTask(
+            String taskId, String workflowType, String taskRef, Map<String, Object> matches) {
+        TaskModel task = new TaskModel();
+        task.setTaskId(taskId);
+        task.setWorkflowType(workflowType);
+        task.setReferenceTaskName(taskRef);
+        task.setInputData(Map.of("matches", matches));
+        return task;
+    }
+}

--- a/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/config/SqliteConfiguration.java
+++ b/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/config/SqliteConfiguration.java
@@ -193,6 +193,31 @@ public class SqliteConfiguration {
 
     @Bean
     @DependsOn({"flywayForPrimaryDb"})
+    @ConditionalOnProperty(
+            name = "conductor.webhooks.cleanup.enabled",
+            havingValue = "true",
+            matchIfMissing = true)
+    public org.conductoross.conductor.sqlite.dao.SqliteWebhookCleanupJob sqliteWebhookCleanupJob(
+            org.springframework.core.env.Environment env) {
+        org.conductoross.conductor.sqlite.dao.SqliteWebhookCleanupJob job =
+                new org.conductoross.conductor.sqlite.dao.SqliteWebhookCleanupJob(dataSource);
+        String retention = env.getProperty("conductor.webhooks.cleanup.retention-duration");
+        if (retention != null) {
+            job.setRetentionDuration(java.time.Duration.parse(retention));
+        }
+        Integer batch = env.getProperty("conductor.webhooks.cleanup.batch-size", Integer.class);
+        if (batch != null) {
+            job.setBatchSize(batch);
+        }
+        String maxRuntime = env.getProperty("conductor.webhooks.cleanup.max-runtime");
+        if (maxRuntime != null) {
+            job.setMaxRuntime(java.time.Duration.parse(maxRuntime));
+        }
+        return job;
+    }
+
+    @Bean
+    @DependsOn({"flywayForPrimaryDb"})
     @ConditionalOnProperty(name = "conductor.workflow-execution-lock.type", havingValue = "sqlite")
     public Lock sqliteLockDAO(
             @Qualifier("sqliteRetryTemplate") RetryTemplate retryTemplate,

--- a/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/config/SqliteConfiguration.java
+++ b/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/config/SqliteConfiguration.java
@@ -172,6 +172,25 @@ public class SqliteConfiguration {
         return new SqliteIndexDAO(retryTemplate, objectMapper, dataSource, properties);
     }
 
+    @Bean(name = "webhookDAO")
+    @DependsOn({"flywayForPrimaryDb"})
+    public org.conductoross.conductor.sqlite.dao.SqliteWebhookDAO sqliteWebhookDAO(
+            @Qualifier("sqliteRetryTemplate") RetryTemplate retryTemplate,
+            ObjectMapper objectMapper,
+            com.netflix.conductor.dao.MetadataDAO metadataDAO) {
+        return new org.conductoross.conductor.sqlite.dao.SqliteWebhookDAO(
+                retryTemplate, objectMapper, dataSource, metadataDAO);
+    }
+
+    @Bean(name = "webhookTaskService")
+    @DependsOn({"flywayForPrimaryDb"})
+    public org.conductoross.conductor.sqlite.dao.SqliteWebhookTaskService sqliteWebhookTaskService(
+            @Qualifier("sqliteRetryTemplate") RetryTemplate retryTemplate,
+            ObjectMapper objectMapper) {
+        return new org.conductoross.conductor.sqlite.dao.SqliteWebhookTaskService(
+                retryTemplate, objectMapper, dataSource);
+    }
+
     @Bean
     @DependsOn({"flywayForPrimaryDb"})
     @ConditionalOnProperty(name = "conductor.workflow-execution-lock.type", havingValue = "sqlite")

--- a/sqlite-persistence/src/main/java/org/conductoross/conductor/sqlite/dao/SqliteWebhookCleanupJob.java
+++ b/sqlite-persistence/src/main/java/org/conductoross/conductor/sqlite/dao/SqliteWebhookCleanupJob.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.sqlite.dao;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+
+import javax.sql.DataSource;
+
+import org.springframework.scheduling.annotation.Scheduled;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * SQLite-flavored sibling of {@code PostgresWebhookCleanupJob}. SQLite supports {@code DELETE ...
+ * LIMIT} only when compiled with SQLITE_ENABLE_UPDATE_DELETE_LIMIT (not the default in many
+ * distributions), so we use a rowid subquery instead.
+ */
+@Slf4j
+public class SqliteWebhookCleanupJob {
+
+    private static final String DELETE_BATCH =
+            "DELETE FROM incoming_webhook_event WHERE rowid IN ("
+                    + "  SELECT rowid FROM incoming_webhook_event WHERE created_on < ? LIMIT ?"
+                    + ")";
+
+    private final DataSource dataSource;
+
+    private Duration retentionDuration = Duration.ofDays(7);
+    private int batchSize = 1000;
+    private Duration maxRuntime = Duration.ofSeconds(60);
+
+    public SqliteWebhookCleanupJob(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public void setRetentionDuration(Duration retentionDuration) {
+        this.retentionDuration = retentionDuration;
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    public void setMaxRuntime(Duration maxRuntime) {
+        this.maxRuntime = maxRuntime;
+    }
+
+    @Scheduled(cron = "${conductor.webhooks.cleanup.cron:0 0 * * * *}")
+    public void run() {
+        long deadline = System.currentTimeMillis() + maxRuntime.toMillis();
+        int totalDeleted = 0;
+
+        while (System.currentTimeMillis() < deadline) {
+            Timestamp threshold = Timestamp.from(Instant.now().minus(retentionDuration));
+            int deletedThisBatch;
+            try {
+                deletedThisBatch = deleteBatch(threshold, batchSize);
+            } catch (SQLException e) {
+                log.error("webhook event cleanup batch failed", e);
+                return;
+            }
+            if (deletedThisBatch == 0) {
+                break;
+            }
+            totalDeleted += deletedThisBatch;
+        }
+
+        if (totalDeleted > 0) {
+            log.info(
+                    "webhook event cleanup: deleted {} rows older than {}",
+                    totalDeleted,
+                    retentionDuration);
+        }
+    }
+
+    private int deleteBatch(Timestamp threshold, int batch) throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement ps = conn.prepareStatement(DELETE_BATCH)) {
+            conn.setAutoCommit(true);
+            ps.setTimestamp(1, threshold);
+            ps.setInt(2, batch);
+            return ps.executeUpdate();
+        }
+    }
+}

--- a/sqlite-persistence/src/main/java/org/conductoross/conductor/sqlite/dao/SqliteWebhookDAO.java
+++ b/sqlite-persistence/src/main/java/org/conductoross/conductor/sqlite/dao/SqliteWebhookDAO.java
@@ -14,32 +14,24 @@ package org.conductoross.conductor.sqlite.dao;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import javax.sql.DataSource;
 
 import org.conductoross.conductor.dao.webhook.WebhookDAO;
+import org.conductoross.conductor.service.webhook.WebhookMatcherComputer;
 import org.conductoross.conductor.webhook.model.IncomingWebhookEvent;
 import org.conductoross.conductor.webhook.model.WebhookConfig;
 import org.springframework.lang.Nullable;
 import org.springframework.retry.support.RetryTemplate;
-import org.springframework.util.CollectionUtils;
 
-import com.netflix.conductor.common.metadata.tasks.TaskType;
-import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
-import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.sqlite.dao.SqliteBaseDAO;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-
-import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WAIT_FOR_WEBHOOK;
-import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WEBHOOK_DELIMITER;
 
 /**
  * SQLite-backed {@link WebhookDAO}. Same matcher-recomputation-on-read design as the postgres impl
@@ -148,11 +140,7 @@ public class SqliteWebhookDAO extends SqliteBaseDAO implements WebhookDAO {
 
     @Override
     public Map<String, Map<String, Object>> getMatchers(String webhookId) {
-        Map<String, Integer> targets = loadTargets(webhookId);
-        if (targets.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return computeMatchers(targets);
+        return WebhookMatcherComputer.compute(loadTargets(webhookId), metadataDAO);
     }
 
     @Override
@@ -184,35 +172,5 @@ public class SqliteWebhookDAO extends SqliteBaseDAO implements WebhookDAO {
             return Collections.emptyMap();
         }
         return readValue(json, Map.class);
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Map<String, Object>> computeMatchers(Map<String, Integer> targets) {
-        Map<String, Map<String, Object>> computed = new HashMap<>();
-        targets.forEach(
-                (workflowName, wfVersion) -> {
-                    Optional<WorkflowDef> def = metadataDAO.getWorkflowDef(workflowName, wfVersion);
-                    if (def.isEmpty()) {
-                        return;
-                    }
-                    for (WorkflowTask task : def.get().collectTasks()) {
-                        String type = task.getType();
-                        if (!WAIT_FOR_WEBHOOK.equals(type)
-                                && !TaskType.WAIT.toString().equals(type)) {
-                            continue;
-                        }
-                        Object raw = task.getInputParameters().get("matches");
-                        if (raw instanceof Map<?, ?> m && !CollectionUtils.isEmpty(m)) {
-                            String key =
-                                    workflowName
-                                            + WEBHOOK_DELIMITER
-                                            + wfVersion
-                                            + WEBHOOK_DELIMITER
-                                            + task.getTaskReferenceName();
-                            computed.put(key, (Map<String, Object>) m);
-                        }
-                    }
-                });
-        return computed;
     }
 }

--- a/sqlite-persistence/src/main/java/org/conductoross/conductor/sqlite/dao/SqliteWebhookDAO.java
+++ b/sqlite-persistence/src/main/java/org/conductoross/conductor/sqlite/dao/SqliteWebhookDAO.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.sqlite.dao;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.sql.DataSource;
+
+import org.conductoross.conductor.dao.webhook.WebhookDAO;
+import org.conductoross.conductor.webhook.model.IncomingWebhookEvent;
+import org.conductoross.conductor.webhook.model.WebhookConfig;
+import org.springframework.lang.Nullable;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.util.CollectionUtils;
+
+import com.netflix.conductor.common.metadata.tasks.TaskType;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.core.exception.NotFoundException;
+import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.sqlite.dao.SqliteBaseDAO;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WAIT_FOR_WEBHOOK;
+import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WEBHOOK_DELIMITER;
+
+/**
+ * SQLite-backed {@link WebhookDAO}. Same matcher-recomputation-on-read design as the postgres impl
+ * — see PostgresWebhookDAO header for rationale.
+ */
+@Slf4j
+public class SqliteWebhookDAO extends SqliteBaseDAO implements WebhookDAO {
+
+    private static final String INSERT_WEBHOOK =
+            "INSERT INTO webhook (webhook_id, json_data) VALUES (?, ?) "
+                    + "ON CONFLICT (webhook_id) DO UPDATE "
+                    + "SET json_data = excluded.json_data, modified_on = CURRENT_TIMESTAMP";
+    private static final String SELECT_WEBHOOK =
+            "SELECT json_data FROM webhook WHERE webhook_id = ?";
+    private static final String SELECT_ALL_WEBHOOKS = "SELECT json_data FROM webhook";
+    private static final String DELETE_WEBHOOK = "DELETE FROM webhook WHERE webhook_id = ?";
+
+    private static final String INSERT_EVENT =
+            "INSERT INTO incoming_webhook_event (event_id, json_data) VALUES (?, ?) "
+                    + "ON CONFLICT (event_id) DO UPDATE "
+                    + "SET json_data = excluded.json_data";
+    private static final String SELECT_EVENT =
+            "SELECT json_data FROM incoming_webhook_event WHERE event_id = ?";
+    private static final String DELETE_EVENT =
+            "DELETE FROM incoming_webhook_event WHERE event_id = ?";
+
+    private static final String INSERT_TARGETS =
+            "INSERT INTO webhook_target_workflows (webhook_id, json_data) VALUES (?, ?) "
+                    + "ON CONFLICT (webhook_id) DO UPDATE "
+                    + "SET json_data = excluded.json_data";
+    private static final String SELECT_TARGETS =
+            "SELECT json_data FROM webhook_target_workflows WHERE webhook_id = ?";
+    private static final String DELETE_TARGETS =
+            "DELETE FROM webhook_target_workflows WHERE webhook_id = ?";
+
+    private final MetadataDAO metadataDAO;
+
+    public SqliteWebhookDAO(
+            RetryTemplate retryTemplate,
+            ObjectMapper objectMapper,
+            DataSource dataSource,
+            MetadataDAO metadataDAO) {
+        super(retryTemplate, objectMapper, dataSource);
+        this.metadataDAO = metadataDAO;
+    }
+
+    @Override
+    public void createWebhook(String id, WebhookConfig webhookConfig) {
+        String json = toJson(webhookConfig);
+        queryWithTransaction(
+                INSERT_WEBHOOK, q -> q.addParameter(id).addParameter(json).executeUpdate());
+    }
+
+    @Override
+    public WebhookConfig getWebhook(String webhookId) {
+        String json =
+                queryWithTransaction(
+                        SELECT_WEBHOOK,
+                        q -> q.addParameter(webhookId).executeAndFetchFirst(String.class));
+        return json == null ? null : readValue(json, WebhookConfig.class);
+    }
+
+    @Override
+    public List<WebhookConfig> getAllWebhooks() {
+        List<String> rows =
+                queryWithTransaction(SELECT_ALL_WEBHOOKS, q -> q.executeAndFetch(String.class));
+        if (rows == null) {
+            return new ArrayList<>();
+        }
+        List<WebhookConfig> out = new ArrayList<>(rows.size());
+        for (String json : rows) {
+            out.add(readValue(json, WebhookConfig.class));
+        }
+        return out;
+    }
+
+    @Override
+    public void removeWebhook(String id) {
+        WebhookConfig existing = getWebhook(id);
+        if (existing == null) {
+            throw new NotFoundException("Webhook with id " + id + " not found");
+        }
+        queryWithTransaction(DELETE_WEBHOOK, q -> q.addParameter(id).executeUpdate());
+    }
+
+    @Override
+    public void createIncomingWebhookEvent(String id, IncomingWebhookEvent event) {
+        String json = toJson(event);
+        queryWithTransaction(
+                INSERT_EVENT, q -> q.addParameter(id).addParameter(json).executeUpdate());
+    }
+
+    @Override
+    public IncomingWebhookEvent getWebhookEvent(String messageId) {
+        String json =
+                queryWithTransaction(
+                        SELECT_EVENT,
+                        q -> q.addParameter(messageId).executeAndFetchFirst(String.class));
+        return json == null ? null : readValue(json, IncomingWebhookEvent.class);
+    }
+
+    @Override
+    public void removeWebhookEvent(String id) {
+        queryWithTransaction(DELETE_EVENT, q -> q.addParameter(id).executeUpdate());
+    }
+
+    @Override
+    public Map<String, Map<String, Object>> getMatchers(String webhookId) {
+        Map<String, Integer> targets = loadTargets(webhookId);
+        if (targets.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return computeMatchers(targets);
+    }
+
+    @Override
+    public void createMatchers(
+            WebhookConfig webhookConfig,
+            @Nullable Map<String, Integer> receiverWorkflowNamesToVersionsOverride) {
+        Map<String, Integer> targets =
+                receiverWorkflowNamesToVersionsOverride == null
+                        ? Collections.emptyMap()
+                        : receiverWorkflowNamesToVersionsOverride;
+        String json = toJson(targets);
+        queryWithTransaction(
+                INSERT_TARGETS,
+                q -> q.addParameter(webhookConfig.getId()).addParameter(json).executeUpdate());
+    }
+
+    @Override
+    public void removeMatchers(String id) {
+        queryWithTransaction(DELETE_TARGETS, q -> q.addParameter(id).executeUpdate());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Integer> loadTargets(String webhookId) {
+        String json =
+                queryWithTransaction(
+                        SELECT_TARGETS,
+                        q -> q.addParameter(webhookId).executeAndFetchFirst(String.class));
+        if (json == null) {
+            return Collections.emptyMap();
+        }
+        return readValue(json, Map.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Map<String, Object>> computeMatchers(Map<String, Integer> targets) {
+        Map<String, Map<String, Object>> computed = new HashMap<>();
+        targets.forEach(
+                (workflowName, wfVersion) -> {
+                    Optional<WorkflowDef> def = metadataDAO.getWorkflowDef(workflowName, wfVersion);
+                    if (def.isEmpty()) {
+                        return;
+                    }
+                    for (WorkflowTask task : def.get().collectTasks()) {
+                        String type = task.getType();
+                        if (!WAIT_FOR_WEBHOOK.equals(type)
+                                && !TaskType.WAIT.toString().equals(type)) {
+                            continue;
+                        }
+                        Object raw = task.getInputParameters().get("matches");
+                        if (raw instanceof Map<?, ?> m && !CollectionUtils.isEmpty(m)) {
+                            String key =
+                                    workflowName
+                                            + WEBHOOK_DELIMITER
+                                            + wfVersion
+                                            + WEBHOOK_DELIMITER
+                                            + task.getTaskReferenceName();
+                            computed.put(key, (Map<String, Object>) m);
+                        }
+                    }
+                });
+        return computed;
+    }
+}

--- a/sqlite-persistence/src/main/java/org/conductoross/conductor/sqlite/dao/SqliteWebhookTaskService.java
+++ b/sqlite-persistence/src/main/java/org/conductoross/conductor/sqlite/dao/SqliteWebhookTaskService.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.sqlite.dao;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.sql.DataSource;
+
+import org.conductoross.conductor.service.webhook.WebhookTaskHashing;
+import org.conductoross.conductor.service.webhook.WebhookTaskService;
+import org.springframework.retry.support.RetryTemplate;
+
+import com.netflix.conductor.model.TaskModel;
+import com.netflix.conductor.sqlite.dao.SqliteBaseDAO;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+/** SQLite-backed {@link WebhookTaskService}. Same schema/behavior as the postgres impl. */
+@Slf4j
+public class SqliteWebhookTaskService extends SqliteBaseDAO implements WebhookTaskService {
+
+    private static final String INSERT =
+            "INSERT INTO webhook_hash_to_taskid (hash, task_id) VALUES (?, ?)"
+                    + " ON CONFLICT DO NOTHING";
+    private static final String SELECT =
+            "SELECT task_id FROM webhook_hash_to_taskid WHERE hash = ?";
+    private static final String DELETE =
+            "DELETE FROM webhook_hash_to_taskid WHERE hash = ? AND task_id = ?";
+
+    public SqliteWebhookTaskService(
+            RetryTemplate retryTemplate, ObjectMapper objectMapper, DataSource dataSource) {
+        super(retryTemplate, objectMapper, dataSource);
+    }
+
+    @Override
+    public void put(TaskModel task, int workflowVersion) {
+        String hash = WebhookTaskHashing.computeHash(task, workflowVersion);
+        queryWithTransaction(
+                INSERT, q -> q.addParameter(hash).addParameter(task.getTaskId()).executeUpdate());
+    }
+
+    @Override
+    public Set<String> get(String hash) {
+        List<String> taskIds =
+                queryWithTransaction(
+                        SELECT, q -> q.addParameter(hash).executeAndFetch(String.class));
+        return new HashSet<>(taskIds);
+    }
+
+    @Override
+    public void remove(String hash, String taskId) {
+        queryWithTransaction(
+                DELETE, q -> q.addParameter(hash).addParameter(taskId).executeUpdate());
+    }
+}

--- a/sqlite-persistence/src/main/resources/db/migration_sqlite/V4__webhook.sql
+++ b/sqlite-persistence/src/main/resources/db/migration_sqlite/V4__webhook.sql
@@ -1,0 +1,28 @@
+-- Webhook config storage. JSON document keyed by webhook id.
+CREATE TABLE IF NOT EXISTS webhook (
+    webhook_id  VARCHAR(255) NOT NULL PRIMARY KEY,
+    json_data   TEXT NOT NULL,
+    modified_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Incoming webhook event payloads, awaiting worker dispatch.
+CREATE TABLE IF NOT EXISTS incoming_webhook_event (
+    event_id   VARCHAR(255) NOT NULL PRIMARY KEY,
+    json_data  TEXT NOT NULL,
+    created_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_iwe_created_on ON incoming_webhook_event(created_on);
+
+-- Target workflow versions for a webhook. See PostgresWebhookDAO header for
+-- why we store targets (not pre-computed matchers) and recompute on read.
+CREATE TABLE IF NOT EXISTS webhook_target_workflows (
+    webhook_id VARCHAR(255) NOT NULL PRIMARY KEY,
+    json_data  TEXT NOT NULL
+);
+
+-- Hash-indexed waiting tasks.
+CREATE TABLE IF NOT EXISTS webhook_hash_to_taskid (
+    hash    TEXT NOT NULL,
+    task_id VARCHAR(255) NOT NULL,
+    PRIMARY KEY (hash, task_id)
+);

--- a/sqlite-persistence/src/test/java/org/conductoross/conductor/sqlite/dao/SqliteWebhookCleanupJobTest.java
+++ b/sqlite-persistence/src/test/java/org/conductoross/conductor/sqlite/dao/SqliteWebhookCleanupJobTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.sqlite.dao;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+
+import javax.sql.DataSource;
+
+import org.flywaydb.core.Flyway;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
+import com.netflix.conductor.sqlite.config.SqliteConfiguration;
+
+import static org.junit.Assert.assertEquals;
+
+@ContextConfiguration(
+        classes = {
+            TestObjectMapperConfiguration.class,
+            SqliteConfiguration.class,
+            FlywayAutoConfiguration.class
+        })
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = "spring.flyway.clean-disabled=false")
+public class SqliteWebhookCleanupJobTest {
+
+    @Autowired private SqliteWebhookCleanupJob job;
+    @Autowired private DataSource dataSource;
+    @Autowired private Flyway flyway;
+
+    @Before
+    public void before() throws SQLException {
+        flyway.clean();
+        flyway.migrate();
+        // flyway.clean() leaks rows across tests on the shared sqlite file in this
+        // test runner — explicit DELETE guarantees a clean slate per method.
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement ps =
+                        conn.prepareStatement("DELETE FROM incoming_webhook_event")) {
+            ps.executeUpdate();
+        }
+    }
+
+    @Test
+    public void deletes_rows_older_than_retention_keeps_recent() throws SQLException {
+        insertEvent("ev-old", Timestamp.from(Instant.now().minus(Duration.ofDays(5))));
+        insertEvent("ev-recent", Timestamp.from(Instant.now().minus(Duration.ofMinutes(5))));
+        assertEquals(2, rowCount());
+
+        job.setRetentionDuration(Duration.ofDays(1));
+        job.setBatchSize(100);
+        job.setMaxRuntime(Duration.ofSeconds(5));
+        job.run();
+
+        assertEquals(1, rowCount());
+        assertEquals("ev-recent", firstRowEventId());
+    }
+
+    @Test
+    public void empty_table_noop() throws SQLException {
+        job.setRetentionDuration(Duration.ofDays(1));
+        job.run();
+        assertEquals(0, rowCount());
+    }
+
+    @Test
+    public void batched_delete_respects_batch_size_across_passes() throws SQLException {
+        Timestamp old = Timestamp.from(Instant.now().minus(Duration.ofDays(5)));
+        for (int i = 0; i < 7; i++) {
+            insertEvent("ev-old-" + i, old);
+        }
+        assertEquals(7, rowCount());
+
+        job.setRetentionDuration(Duration.ofDays(1));
+        job.setBatchSize(2);
+        job.setMaxRuntime(Duration.ofSeconds(5));
+        job.run();
+
+        assertEquals(0, rowCount());
+    }
+
+    private void insertEvent(String id, Timestamp createdOn) throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement ps =
+                        conn.prepareStatement(
+                                "INSERT INTO incoming_webhook_event (event_id, json_data, created_on)"
+                                        + " VALUES (?, ?, ?)")) {
+            ps.setString(1, id);
+            ps.setString(2, "{}");
+            ps.setTimestamp(3, createdOn);
+            ps.executeUpdate();
+        }
+    }
+
+    private int rowCount() throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement ps =
+                        conn.prepareStatement("SELECT count(1) FROM incoming_webhook_event");
+                ResultSet rs = ps.executeQuery()) {
+            return rs.next() ? rs.getInt(1) : 0;
+        }
+    }
+
+    private String firstRowEventId() throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+                PreparedStatement ps =
+                        conn.prepareStatement("SELECT event_id FROM incoming_webhook_event");
+                ResultSet rs = ps.executeQuery()) {
+            return rs.next() ? rs.getString(1) : null;
+        }
+    }
+}

--- a/sqlite-persistence/src/test/java/org/conductoross/conductor/sqlite/dao/SqliteWebhookDAOTest.java
+++ b/sqlite-persistence/src/test/java/org/conductoross/conductor/sqlite/dao/SqliteWebhookDAOTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.sqlite.dao;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.conductoross.conductor.webhook.model.IncomingWebhookEvent;
+import org.conductoross.conductor.webhook.model.WebhookConfig;
+import org.flywaydb.core.Flyway;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.core.exception.NotFoundException;
+import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.sqlite.config.SqliteConfiguration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ContextConfiguration(
+        classes = {
+            TestObjectMapperConfiguration.class,
+            SqliteConfiguration.class,
+            FlywayAutoConfiguration.class
+        })
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = "spring.flyway.clean-disabled=false")
+public class SqliteWebhookDAOTest {
+
+    @Autowired private SqliteWebhookDAO dao;
+    @Autowired private Flyway flyway;
+    @MockBean private MetadataDAO metadataDAO;
+
+    @Before
+    public void before() {
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    @Test
+    public void crud_webhookConfig_roundtrip() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        config.setName("my-hook");
+
+        dao.createWebhook("hook-1", config);
+
+        WebhookConfig loaded = dao.getWebhook("hook-1");
+        assertNotNull(loaded);
+        assertEquals("hook-1", loaded.getId());
+        assertEquals(1, dao.getAllWebhooks().size());
+
+        dao.removeWebhook("hook-1");
+        assertNull(dao.getWebhook("hook-1"));
+        assertTrue(dao.getAllWebhooks().isEmpty());
+    }
+
+    @Test
+    public void createWebhook_upsertsExistingId() {
+        WebhookConfig v1 = new WebhookConfig();
+        v1.setId("hook-1");
+        v1.setName("original");
+        dao.createWebhook("hook-1", v1);
+
+        WebhookConfig v2 = new WebhookConfig();
+        v2.setId("hook-1");
+        v2.setName("updated");
+        dao.createWebhook("hook-1", v2);
+
+        assertEquals("updated", dao.getWebhook("hook-1").getName());
+    }
+
+    @Test
+    public void removeWebhook_unknownId_throwsNotFound() {
+        assertThrows(NotFoundException.class, () -> dao.removeWebhook("missing"));
+    }
+
+    @Test
+    public void crud_incomingWebhookEvent_roundtrip() {
+        IncomingWebhookEvent event =
+                IncomingWebhookEvent.builder()
+                        .id("ev-1")
+                        .webhookId("hook-1")
+                        .body("{\"event\":\"push\"}")
+                        .timeStamp(123L)
+                        .build();
+        dao.createIncomingWebhookEvent("ev-1", event);
+        assertEquals("hook-1", dao.getWebhookEvent("ev-1").getWebhookId());
+        dao.removeWebhookEvent("ev-1");
+        assertNull(dao.getWebhookEvent("ev-1"));
+    }
+
+    @Test
+    public void getMatchers_emptyOrNullTargets_returnsEmpty() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        dao.createWebhook("hook-1", config);
+
+        dao.createMatchers(config, Map.of());
+        assertTrue(dao.getMatchers("hook-1").isEmpty());
+
+        dao.createMatchers(config, null);
+        assertTrue(dao.getMatchers("hook-1").isEmpty());
+    }
+
+    @Test
+    public void getMatchers_recomputesFromMetadataDAO_onEachCall_noStaleCache() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        dao.createWebhook("hook-1", config);
+        dao.createMatchers(config, Map.of("wf-a", 1));
+
+        WorkflowTask t1 = new WorkflowTask();
+        t1.setType("WAIT_FOR_WEBHOOK");
+        t1.setTaskReferenceName("wait_ref");
+        t1.setInputParameters(Map.of("matches", Map.of("event", "push")));
+        WorkflowDef def1 = new WorkflowDef();
+        def1.setName("wf-a");
+        def1.setVersion(1);
+        def1.setTasks(List.of(t1));
+        when(metadataDAO.getWorkflowDef("wf-a", 1)).thenReturn(Optional.of(def1));
+
+        assertEquals(Map.of("event", "push"), dao.getMatchers("hook-1").get("wf-a;1;wait_ref"));
+
+        WorkflowTask t2 = new WorkflowTask();
+        t2.setType("WAIT_FOR_WEBHOOK");
+        t2.setTaskReferenceName("wait_ref");
+        t2.setInputParameters(Map.of("matches", Map.of("event", "merge")));
+        WorkflowDef def2 = new WorkflowDef();
+        def2.setName("wf-a");
+        def2.setVersion(1);
+        def2.setTasks(List.of(t2));
+        when(metadataDAO.getWorkflowDef("wf-a", 1)).thenReturn(Optional.of(def2));
+
+        assertEquals(Map.of("event", "merge"), dao.getMatchers("hook-1").get("wf-a;1;wait_ref"));
+    }
+
+    @Test
+    public void removeMatchers_drops() {
+        WebhookConfig config = new WebhookConfig();
+        config.setId("hook-1");
+        dao.createWebhook("hook-1", config);
+        dao.createMatchers(config, Map.of("wf-a", 1));
+
+        dao.removeMatchers("hook-1");
+        assertTrue(dao.getMatchers("hook-1").isEmpty());
+    }
+}

--- a/sqlite-persistence/src/test/java/org/conductoross/conductor/sqlite/dao/SqliteWebhookTaskServiceTest.java
+++ b/sqlite-persistence/src/test/java/org/conductoross/conductor/sqlite/dao/SqliteWebhookTaskServiceTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.sqlite.dao;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.flywaydb.core.Flyway;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
+import com.netflix.conductor.core.exception.NonTransientException;
+import com.netflix.conductor.model.TaskModel;
+import com.netflix.conductor.sqlite.config.SqliteConfiguration;
+
+import static org.conductoross.conductor.service.webhook.WebhookTaskHashing.computeHash;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+@ContextConfiguration(
+        classes = {
+            TestObjectMapperConfiguration.class,
+            SqliteConfiguration.class,
+            FlywayAutoConfiguration.class
+        })
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = "spring.flyway.clean-disabled=false")
+public class SqliteWebhookTaskServiceTest {
+
+    @Autowired private SqliteWebhookTaskService service;
+    @Autowired private Flyway flyway;
+
+    @Before
+    public void before() {
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    @Test
+    public void put_and_get_matchByHash() {
+        TaskModel task = newTask("task-1", "wf-a-match", "wait_ref", Map.of("event", "push"));
+        service.put(task, 1);
+
+        String hash = computeHash("wf-a-match", 1, "wait_ref", Map.of("event", "push"));
+        assertEquals(Set.of("task-1"), service.get(hash));
+    }
+
+    @Test
+    public void put_missingMatchesField_throws() {
+        TaskModel task = new TaskModel();
+        task.setTaskId("task-x");
+        task.setInputData(Map.of());
+
+        assertThrows(NonTransientException.class, () -> service.put(task, 1));
+    }
+
+    @Test
+    public void multiple_tasks_sameHash_bucketed() {
+        TaskModel t1 = newTask("task-1", "wf-a-bucket", "wait_ref", Map.of("event", "push"));
+        TaskModel t2 = newTask("task-2", "wf-a-bucket", "wait_ref", Map.of("event", "push"));
+        service.put(t1, 1);
+        service.put(t2, 1);
+
+        String hash = computeHash("wf-a-bucket", 1, "wait_ref", Map.of("event", "push"));
+        Set<String> ids = service.get(hash);
+        assertTrue(ids.contains("task-1"));
+        assertTrue(ids.contains("task-2"));
+        assertEquals(2, ids.size());
+    }
+
+    @Test
+    public void remove_evictsTaskAndLeavesOthers() {
+        TaskModel t1 = newTask("task-1", "wf-a-remove", "wait_ref", Map.of("event", "push"));
+        TaskModel t2 = newTask("task-2", "wf-a-remove", "wait_ref", Map.of("event", "push"));
+        service.put(t1, 1);
+        service.put(t2, 1);
+        String hash = computeHash("wf-a-remove", 1, "wait_ref", Map.of("event", "push"));
+
+        service.remove(hash, "task-1");
+
+        assertEquals(Set.of("task-2"), service.get(hash));
+    }
+
+    @Test
+    public void put_isIdempotent() {
+        TaskModel task = newTask("task-1", "wf-a-idem", "wait_ref", Map.of("event", "push"));
+        service.put(task, 1);
+        service.put(task, 1);
+
+        String hash = computeHash("wf-a-idem", 1, "wait_ref", Map.of("event", "push"));
+        assertEquals(Set.of("task-1"), service.get(hash));
+    }
+
+    @Test
+    public void get_unknownHash_returnsEmpty() {
+        assertTrue(service.get("never-seen").isEmpty());
+    }
+
+    private static TaskModel newTask(
+            String taskId, String workflowType, String taskRef, Map<String, Object> matches) {
+        TaskModel task = new TaskModel();
+        task.setTaskId(taskId);
+        task.setWorkflowType(workflowType);
+        task.setReferenceTaskName(taskRef);
+        task.setInputData(Map.of("matches", matches));
+        return task;
+    }
+}

--- a/webhooks-oss/src/main/java/org/conductoross/conductor/webhook/dao/memory/InMemoryWebhookDAO.java
+++ b/webhooks-oss/src/main/java/org/conductoross/conductor/webhook/dao/memory/InMemoryWebhookDAO.java
@@ -14,27 +14,19 @@ package org.conductoross.conductor.webhook.dao.memory;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.conductoross.conductor.dao.webhook.WebhookDAO;
+import org.conductoross.conductor.service.webhook.WebhookMatcherComputer;
 import org.conductoross.conductor.webhook.model.IncomingWebhookEvent;
 import org.conductoross.conductor.webhook.model.WebhookConfig;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
-import org.springframework.util.CollectionUtils;
 
-import com.netflix.conductor.common.metadata.tasks.TaskType;
-import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
-import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.dao.MetadataDAO;
-
-import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WAIT_FOR_WEBHOOK;
-import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WEBHOOK_DELIMITER;
 
 /**
  * Default single-node implementation of {@link WebhookDAO}.
@@ -100,11 +92,7 @@ public class InMemoryWebhookDAO implements WebhookDAO {
 
     @Override
     public Map<String, Map<String, Object>> getMatchers(String webhookId) {
-        Map<String, Integer> targets = targetWorkflows.get(webhookId);
-        if (targets == null || targets.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return computeMatchers(targets);
+        return WebhookMatcherComputer.compute(targetWorkflows.get(webhookId), metadataDAO);
     }
 
     @Override
@@ -121,35 +109,5 @@ public class InMemoryWebhookDAO implements WebhookDAO {
     @Override
     public void removeMatchers(String id) {
         targetWorkflows.remove(id);
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Map<String, Object>> computeMatchers(Map<String, Integer> targets) {
-        Map<String, Map<String, Object>> computed = new HashMap<>();
-        targets.forEach(
-                (workflowName, wfVersion) -> {
-                    Optional<WorkflowDef> def = metadataDAO.getWorkflowDef(workflowName, wfVersion);
-                    if (def.isEmpty()) {
-                        return;
-                    }
-                    for (WorkflowTask task : def.get().collectTasks()) {
-                        String type = task.getType();
-                        if (!WAIT_FOR_WEBHOOK.equals(type)
-                                && !TaskType.WAIT.toString().equals(type)) {
-                            continue;
-                        }
-                        Object raw = task.getInputParameters().get("matches");
-                        if (raw instanceof Map<?, ?> m && !CollectionUtils.isEmpty(m)) {
-                            String key =
-                                    workflowName
-                                            + WEBHOOK_DELIMITER
-                                            + wfVersion
-                                            + WEBHOOK_DELIMITER
-                                            + task.getTaskReferenceName();
-                            computed.put(key, (Map<String, Object>) m);
-                        }
-                    }
-                });
-        return computed;
     }
 }

--- a/webhooks-oss/src/main/java/org/conductoross/conductor/webhook/dao/memory/InMemoryWebhookTaskService.java
+++ b/webhooks-oss/src/main/java/org/conductoross/conductor/webhook/dao/memory/InMemoryWebhookTaskService.java
@@ -14,20 +14,15 @@ package org.conductoross.conductor.webhook.dao.memory;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.conductoross.conductor.service.webhook.WebhookTaskHashing;
 import org.conductoross.conductor.service.webhook.WebhookTaskService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.stereotype.Component;
 
-import com.netflix.conductor.common.utils.TaskUtils;
-import com.netflix.conductor.core.exception.NonTransientException;
 import com.netflix.conductor.model.TaskModel;
-
-import static org.conductoross.conductor.service.webhook.WebhookTaskService.Constants.WEBHOOK_DELIMITER;
 
 /**
  * Default single-node implementation of {@link WebhookTaskService}.
@@ -43,8 +38,7 @@ public class InMemoryWebhookTaskService implements WebhookTaskService {
 
     @Override
     public void put(TaskModel task, int workflowVersion) {
-        Map<String, Object> expectedMatches = getAndValidateExpectedMatches(task);
-        String hash = computeHash(task, workflowVersion, expectedMatches);
+        String hash = WebhookTaskHashing.computeHash(task, workflowVersion);
         storage.compute(
                 hash,
                 (key, taskIds) -> {
@@ -68,52 +62,5 @@ public class InMemoryWebhookTaskService implements WebhookTaskService {
                     taskIds.remove(taskId);
                     return taskIds.isEmpty() ? null : taskIds;
                 });
-    }
-
-    private String computeHash(
-            TaskModel task, int workflowVersion, Map<String, Object> expectedMatches) {
-        return computeHash(
-                task.getWorkflowType(),
-                workflowVersion,
-                TaskUtils.removeIterationFromTaskRefName(task.getReferenceTaskName()),
-                expectedMatches);
-    }
-
-    /**
-     * Matches keys are sorted, but each value's contribution is just {@link Object#toString()}.
-     * That is stable for strings, numbers, and booleans. It is <b>not</b> stable for nested {@link
-     * Map} values whose toString reflects iteration order (HashMap, etc.) — those can hash
-     * differently across JVM runs even for equal inputs. Mirrors the Orkes Redis impl verbatim; any
-     * change to value-side canonicalization needs to land in Orkes too or hashes diverge between
-     * OSS and Orkes deployments.
-     */
-    private String computeHash(
-            String workflowName,
-            int workflowVersion,
-            String taskReferenceName,
-            Map<String, Object> expectedMatches) {
-        TreeSet<String> sortedFields = new TreeSet<>(expectedMatches.keySet());
-        StringBuilder hash =
-                new StringBuilder(
-                        workflowName
-                                + WEBHOOK_DELIMITER
-                                + workflowVersion
-                                + WEBHOOK_DELIMITER
-                                + taskReferenceName);
-        for (String field : sortedFields) {
-            hash.append(WEBHOOK_DELIMITER).append(expectedMatches.get(field));
-        }
-        return hash.toString();
-    }
-
-    private Map<String, Object> getAndValidateExpectedMatches(TaskModel task) {
-        Map<String, Object> inputData = task.getInputData();
-        @SuppressWarnings("unchecked")
-        Map<String, Object> matches =
-                inputData == null ? null : (Map<String, Object>) inputData.get("matches");
-        if (matches == null) {
-            throw new NonTransientException("Webhook task missing matches field");
-        }
-        return matches;
     }
 }


### PR DESCRIPTION
## Summary

Production-ready persistence backings for `WebhookDAO` and `WebhookTaskService` across all 5 OSS conductor persistence modules, plus scheduled retention of `incoming_webhook_event` rows. Stacked on top of #1106 — base of this PR is `feat/webhooks-from-orkes-split`, not `main`. Don't merge until #1106 lands; this PR will rebase automatically.

**User impact**: With #1106 alone, only single-node deployments with in-memory backing work correctly. This PR lets OSS deployments using **any** of postgres / mysql / sqlite / redis / cassandra run multi-node webhook workers against shared persistent state, with automatic retention of old event rows.

## Backings landed

| Backend | DAO + service | Schema | Retention |
|---|---|---|---|
| **Postgres** | `PostgresWebhookDAO` + `PostgresWebhookTaskService` | `V16__webhook.sql` (4 tables) | `PostgresWebhookCleanupJob` — `WITH ... DELETE ... RETURNING` |
| **MySQL** | `MySQLWebhookDAO` + `MySQLWebhookTaskService` | `V10__webhook.sql` (4 tables, InnoDB/utf8mb4) | `MySQLWebhookCleanupJob` — `DELETE ... LIMIT N` |
| **SQLite** | `SqliteWebhookDAO` + `SqliteWebhookTaskService` | `V4__webhook.sql` (4 tables) | `SqliteWebhookCleanupJob` — `DELETE WHERE rowid IN (...)` |
| **Redis** | `RedisWebhookDAO` + `RedisWebhookTaskService` | none (hash maps + sets via `JedisProxy`) | `RedisWebhookCleanupJob` — `HGETALL` + parse + `HDEL` walker |
| **Cassandra** | `CassandraWebhookDAO` + `CassandraWebhookTaskService` | `ensureTables()` on construction | Table-level `default_time_to_live` (no separate job) |

## Shared design across backings

- **`WebhookTaskHashing` extracted to core** (`org.conductoross.conductor.service.webhook`). All 5 task-service impls + the in-memory impl use it, so the hash a task is stored under is identical regardless of backing — registered via one impl is findable via any other.
- **`WebhookMatcherComputer` extracted to core** (same package). All 6 DAO impls share the WorkflowDef → matchers transformation, so a WorkflowDef edit produces identical matcher output regardless of which persistence module is backing `WebhookDAO`. Each impl's `getMatchers()` is a one-liner: load the persisted target snapshot, delegate to the helper. Same parity-of-behavior argument as the hashing helper; net –166 LoC vs. each impl carrying its own copy.
- **Matcher recomputation on read.** Every backing persists only the target-workflow versions snapshot (taken at config-create time so the expression evaluation is preserved). The actual `matches` criteria are recomputed from `MetadataDAO` on every `getMatchers()` call. WorkflowDef updates take effect without re-registering the webhook. Critical regression test (`getMatchers_recomputesFromMetadataDAO_onEachCall_noStaleCache`) lives on each SQL backing's test class.
- **Bean naming.** All `WebhookDAO` beans register as `webhookDAO` and all `WebhookTaskService` beans as `webhookTaskService`. The in-memory impls in #1106 use `@ConditionalOnMissingBean(name="webhookDAO"/"webhookTaskService")` — so whichever persistence module is on the classpath wins.
- **Cleanup property surface (cross-backing):**
  - `conductor.webhooks.cleanup.enabled` (default `true`)
  - `conductor.webhooks.cleanup.cron` (default hourly `"0 0 * * * *"`)
  - `conductor.webhooks.cleanup.retention-duration` (default `PT168H` / 7 days)
  - `conductor.webhooks.cleanup.batch-size` (default `1000`) — SQL backings only
  - `conductor.webhooks.cleanup.max-runtime` (default `PT60S`) — SQL backings only

## Design departures from Orkes' source impls

1. **No `org_id` anywhere** — tables, queries, code paths. The Orkes schema bleeds `org_id` into 4 tables and dozens of WHERE clauses; OSS is tenant-free.
2. **Matcher recomputation on read** (mirrors #1106's fix) — Orkes' `PostgresWebhookDAO` persists pre-computed matchers and runs a scheduled `refreshMatchers` executor to handle WorkflowDef updates. OSS drops the cache, recomputes on every read.
3. **No `ConductorLimitsDAO` quota enforcement** — Orkes enterprise-only.
4. **`NotFoundException` instead of `Preconditions.checkNotNull`** for missing-id errors.
5. **Schema renames** to reflect design: `webhook_matchers` (Orkes) → `webhook_target_workflows` (OSS), since we now store target workflows, not pre-computed matchers.
6. **Cleanup pattern.** Orkes' `WebhookCleanupJob` implements an Orkes-internal `DataCleaner` interface. OSS uses Spring `@Scheduled` directly with the property surface above.

## Code rewrites flagged for review

- `core/WebhookTaskHashing.java` validates matches before computing the hash. Fixes a latent NPE where `removeIterationFromTaskRefName(null)` would mask the missing-matches `NonTransientException`. Regression covered by `InMemoryWebhookTaskServiceTest.put_missingMatchesField_throws`.
- `InMemoryWebhookTaskService` refactored to delegate to `WebhookTaskHashing` (–50 LoC, behavior unchanged).
- `PostgresWebhookDAOTest` + `PostgresWebhookTaskServiceTest` + `PostgresWebhookCleanupJobTest` set `spring.flyway.ignore-migration-patterns=*:missing` to tolerate an orphan `V10.1` migration in CI's shared testcontainers postgres (another test class enables `experimental-queue-notify` and applies V10.1). Documented in the commit message that introduced the fix.
- `CassandraWebhookDAO` keeps a local `objectMapper` + `toJson`/`readValue` helpers because the ones in `CassandraBaseDAO` are package-private. Same workaround `CassandraSchedulerDAO` uses (cited in the file).
- `webhooks-enterprise`'s api dep on spectator-reg-* was restored on the orkes split PR (#3612) — `:orkes-conductor-server`'s runtime classpath was resolving them transitively through the webhooks dep with no explicit version in server's own build.gradle.

## Tests

68 new test methods across 12 test classes. Most need Docker (testcontainers postgres/mysql/redis/cassandra); SQLite tests run against a local file and pass locally.

| Test class | Count | Local pass |
|---|---|---|
| `PostgresWebhookDAOTest` | 8 | (needs Docker) |
| `PostgresWebhookTaskServiceTest` | 6 | (needs Docker) |
| `PostgresWebhookCleanupJobTest` | 4 | (needs Docker) |
| `MySQLWebhookDAOTest` | 6 | (needs Docker) |
| `MySQLWebhookTaskServiceTest` | 6 | (needs Docker) |
| `MySQLWebhookCleanupJobTest` | 3 | (needs Docker) |
| `SqliteWebhookDAOTest` | 7 | ✅ |
| `SqliteWebhookTaskServiceTest` | 6 | ✅ |
| `SqliteWebhookCleanupJobTest` | 3 | ✅ |
| `RedisWebhookDAOTest` | 7 | (needs Docker) |
| `RedisWebhookTaskServiceTest` | 6 | (needs Docker) |
| `RedisWebhookCleanupJobTest` | 4 | (needs Docker) |
| `CassandraWebhookDAOTest` | 7 | (needs Docker) |
| `CassandraWebhookTaskServiceTest` | 6 | (needs Docker) |

## Verified locally

- Every module's `:compileJava` + `:compileTestJava` — clean
- Every module's `:spotlessCheck` — clean
- `:conductor-server:compileJava` — clean
- SQLite tests (16 across 3 classes) — all green

## What's NOT here (and why)

- **`EventMessage` audit-table persistence**: the `addEventMessage → log.warn` debt from #1106's `IncomingWebhookService` still stands. This wants a separate architectural decision about whether OSS's `ExecutionDAOFacade` should grow an `addEventMessage` method.

## Test plan

- [ ] CI green on all 5 persistence backends
- [ ] Spot check: switch a deployment to one of the new backings + smoke webhook delivery end-to-end
- [ ] Verify `conductor.webhooks.cleanup.*` properties bind via Spring environment

## Stats

38 files changed, ~4330 LoC added net, 9 commits.
