### PR TITLE
perf(ai): unified OkHttp3 transport with shared bean, retry, and Gemini REST migration

### DIFF
--- a/ai/build.gradle
+++ b/ai/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     api "org.springframework.boot:spring-boot-starter-jdbc"
 
 
+    testImplementation "com.squareup.okhttp3:mockwebserver:4.12.0"
     testImplementation "org.testcontainers:mongodb:${revTestContainer}"
     testImplementation "org.testcontainers:postgresql:${revTestContainer}"
     testImplementation "org.postgresql:postgresql:${revPostgres}"

--- a/ai/build.gradle
+++ b/ai/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     api "org.springframework.ai:spring-ai-bedrock-converse:${revSpringAI}"
     api "org.springframework.ai:spring-ai-ollama:${revSpringAI}"
 
-    api "com.google.genai:google-genai:1.28.0"
+    api "com.google.auth:google-auth-library-oauth2-http:1.33.0"
     api "com.networknt:json-schema-validator:${revJSonSchemaValidator}"
 
     api("io.modelcontextprotocol.sdk:mcp-core:${revMCP}")

--- a/ai/build.gradle
+++ b/ai/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     api "org.springframework.ai:spring-ai-model:${revSpringAI}"
     api "org.springframework.ai:spring-ai-client-chat:${revSpringAI}"
     api "org.springframework.ai:spring-ai-mistral-ai:${revSpringAI}"
-    api "org.springframework.ai:spring-ai-huggingface:${revSpringAI}"
     api "org.springframework.ai:spring-ai-bedrock-converse:${revSpringAI}"
     api "org.springframework.ai:spring-ai-ollama:${revSpringAI}"
 

--- a/ai/build.gradle
+++ b/ai/build.gradle
@@ -13,7 +13,6 @@ dependencies {
     implementation project(':conductor-common')
     implementation project(':conductor-core')
 
-    api "org.springframework.ai:spring-ai-commons:${revSpringAI}"
     api "org.springframework.ai:spring-ai-model:${revSpringAI}"
     api "org.springframework.ai:spring-ai-client-chat:${revSpringAI}"
     api "org.springframework.ai:spring-ai-mistral-ai:${revSpringAI}"
@@ -25,16 +24,11 @@ dependencies {
 
     api("io.modelcontextprotocol.sdk:mcp-core:${revMCP}")
     api "com.squareup.okhttp3:okhttp:4.12.0"
+    api "org.apache.commons:commons-lang3"
 
-    // Markdown parsing for PDF generation
+    // Markdown parsing and PDF generation
     implementation "com.vladsch.flexmark:flexmark-all:${revFlexmark}"
-
-    //Document reader and parsers
-    // Source: https://mvnrepository.com/artifact/org.springframework.ai/spring-ai-pdf-document-reader
-    api "org.springframework.ai:spring-ai-pdf-document-reader:${revSpringAI}"
-    api "org.springframework.ai:spring-ai-tika-document-reader:${revSpringAI}"
-    api "org.springframework.ai:spring-ai-markdown-document-reader:${revSpringAI}"
-    api "org.springframework.ai:spring-ai-jsoup-document-reader:${revSpringAI}"
+    implementation "org.apache.pdfbox:pdfbox:3.0.5"
 
     //Vector Databases
 

--- a/ai/src/main/java/org/conductoross/conductor/ai/LLMHelper.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/LLMHelper.java
@@ -93,11 +93,14 @@ public class LLMHelper {
     private final List<DocumentLoader> documentLoaders;
     private final OkHttpClient httpClient;
 
-    public LLMHelper(JsonSchemaValidator jsonSchemaValidator, List<DocumentLoader> documentLoaders) {
+    public LLMHelper(
+            JsonSchemaValidator jsonSchemaValidator, List<DocumentLoader> documentLoaders) {
         this(jsonSchemaValidator, documentLoaders, new OkHttpClient());
     }
 
-    public LLMHelper(JsonSchemaValidator jsonSchemaValidator, List<DocumentLoader> documentLoaders,
+    public LLMHelper(
+            JsonSchemaValidator jsonSchemaValidator,
+            List<DocumentLoader> documentLoaders,
             OkHttpClient httpClient) {
         this.jsonSchemaValidator = jsonSchemaValidator;
         this.documentLoaders = documentLoaders;

--- a/ai/src/main/java/org/conductoross/conductor/ai/LLMHelper.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/LLMHelper.java
@@ -69,7 +69,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.networknt.schema.JsonSchemaException;
 import com.networknt.schema.ValidationMessage;
-import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
@@ -83,7 +82,6 @@ import static org.conductoross.conductor.ai.MimeExtensionResolver.getExtension;
 import static org.conductoross.conductor.ai.MimeExtensionResolver.getMimeTypeFromUrl;
 
 @Slf4j
-@RequiredArgsConstructor
 public class LLMHelper {
     private static final TypeReference<Map<String, Object>> MAP_OF_STRING_TO_OBJ =
             new TypeReference<>() {};
@@ -93,6 +91,18 @@ public class LLMHelper {
 
     private final JsonSchemaValidator jsonSchemaValidator;
     private final List<DocumentLoader> documentLoaders;
+    private final OkHttpClient httpClient;
+
+    public LLMHelper(JsonSchemaValidator jsonSchemaValidator, List<DocumentLoader> documentLoaders) {
+        this(jsonSchemaValidator, documentLoaders, new OkHttpClient());
+    }
+
+    public LLMHelper(JsonSchemaValidator jsonSchemaValidator, List<DocumentLoader> documentLoaders,
+            OkHttpClient httpClient) {
+        this.jsonSchemaValidator = jsonSchemaValidator;
+        this.documentLoaders = documentLoaders;
+        this.httpClient = httpClient;
+    }
 
     public LLMResponse chatComplete(
             Task task,
@@ -535,15 +545,9 @@ public class LLMHelper {
      */
     private byte[] downloadImageFromUrl(String url) {
         try {
-            OkHttpClient client =
-                    new OkHttpClient.Builder()
-                            .connectTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
-                            .readTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
-                            .build();
-
             Request request = new Request.Builder().url(url).get().build();
 
-            try (Response response = client.newCall(request).execute()) {
+            try (Response response = httpClient.newCall(request).execute()) {
                 if (!response.isSuccessful()) {
                     log.error(
                             "Failed to download image from URL {}: HTTP {}", url, response.code());

--- a/ai/src/main/java/org/conductoross/conductor/ai/LLMs.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/LLMs.java
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Component;
 import com.netflix.conductor.common.metadata.tasks.Task;
 
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
 
 @Component
 @Conditional(AIIntegrationEnabledCondition.class)
@@ -50,9 +51,10 @@ public class LLMs {
     public LLMs(
             List<DocumentLoader> documentLoaders,
             JsonSchemaValidator jsonSchemaValidator,
-            AIModelProvider modelProvider) {
+            AIModelProvider modelProvider,
+            OkHttpClient conductorAiHttpClient) {
         this.modelProvider = modelProvider;
-        this.helper = new LLMHelper(jsonSchemaValidator, documentLoaders);
+        this.helper = new LLMHelper(jsonSchemaValidator, documentLoaders, conductorAiHttpClient);
         this.payloadStoreLocation = modelProvider.getPayloadStoreLocation();
     }
 

--- a/ai/src/main/java/org/conductoross/conductor/ai/http/AIHttpClientConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/http/AIHttpClientConfiguration.java
@@ -1,12 +1,23 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.conductoross.conductor.ai.http;
 
 import java.util.concurrent.TimeUnit;
 
-import jakarta.annotation.PreDestroy;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import jakarta.annotation.PreDestroy;
 import okhttp3.ConnectionPool;
 import okhttp3.OkHttpClient;
 
@@ -17,14 +28,16 @@ public class AIHttpClientConfiguration {
 
     @Bean
     public OkHttpClient conductorAiHttpClient(AIHttpClientProperties props) {
-        OkHttpClient.Builder builder = new OkHttpClient.Builder()
-                .connectTimeout(props.getConnectTimeout())
-                .readTimeout(props.getReadTimeout())
-                .writeTimeout(props.getWriteTimeout())
-                .connectionPool(new ConnectionPool(
-                        props.getMaxIdleConnections(),
-                        props.getKeepAlive().toMillis(),
-                        TimeUnit.MILLISECONDS));
+        OkHttpClient.Builder builder =
+                new OkHttpClient.Builder()
+                        .connectTimeout(props.getConnectTimeout())
+                        .readTimeout(props.getReadTimeout())
+                        .writeTimeout(props.getWriteTimeout())
+                        .connectionPool(
+                                new ConnectionPool(
+                                        props.getMaxIdleConnections(),
+                                        props.getKeepAlive().toMillis(),
+                                        TimeUnit.MILLISECONDS));
 
         if (props.getMaxRetries() > 0) {
             builder.addInterceptor(new RetryInterceptor(props.getMaxRetries()));

--- a/ai/src/main/java/org/conductoross/conductor/ai/http/AIHttpClientConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/http/AIHttpClientConfiguration.java
@@ -2,6 +2,8 @@ package org.conductoross.conductor.ai.http;
 
 import java.util.concurrent.TimeUnit;
 
+import jakarta.annotation.PreDestroy;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,17 +13,32 @@ import okhttp3.OkHttpClient;
 @Configuration
 public class AIHttpClientConfiguration {
 
+    private OkHttpClient client;
+
     @Bean
     public OkHttpClient conductorAiHttpClient(AIHttpClientProperties props) {
-        return new OkHttpClient.Builder()
+        OkHttpClient.Builder builder = new OkHttpClient.Builder()
                 .connectTimeout(props.getConnectTimeout())
                 .readTimeout(props.getReadTimeout())
                 .writeTimeout(props.getWriteTimeout())
                 .connectionPool(new ConnectionPool(
                         props.getMaxIdleConnections(),
                         props.getKeepAlive().toMillis(),
-                        TimeUnit.MILLISECONDS))
-                .addInterceptor(new RetryInterceptor(props.getMaxRetries()))
-                .build();
+                        TimeUnit.MILLISECONDS));
+
+        if (props.getMaxRetries() > 0) {
+            builder.addInterceptor(new RetryInterceptor(props.getMaxRetries()));
+        }
+
+        client = builder.build();
+        return client;
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        if (client != null) {
+            client.dispatcher().executorService().shutdown();
+            client.connectionPool().evictAll();
+        }
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/http/AIHttpClientConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/http/AIHttpClientConfiguration.java
@@ -1,0 +1,27 @@
+package org.conductoross.conductor.ai.http;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import okhttp3.ConnectionPool;
+import okhttp3.OkHttpClient;
+
+@Configuration
+public class AIHttpClientConfiguration {
+
+    @Bean
+    public OkHttpClient conductorAiHttpClient(AIHttpClientProperties props) {
+        return new OkHttpClient.Builder()
+                .connectTimeout(props.getConnectTimeout())
+                .readTimeout(props.getReadTimeout())
+                .writeTimeout(props.getWriteTimeout())
+                .connectionPool(new ConnectionPool(
+                        props.getMaxIdleConnections(),
+                        props.getKeepAlive().toMillis(),
+                        TimeUnit.MILLISECONDS))
+                .addInterceptor(new RetryInterceptor(props.getMaxRetries()))
+                .build();
+    }
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/http/AIHttpClientProperties.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/http/AIHttpClientProperties.java
@@ -1,0 +1,21 @@
+package org.conductoross.conductor.ai.http;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Data;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "conductor.ai.http")
+public class AIHttpClientProperties {
+
+    private Duration connectTimeout = Duration.ofSeconds(60);
+    private Duration readTimeout = Duration.ofSeconds(120);
+    private Duration writeTimeout = Duration.ofSeconds(60);
+    private int maxIdleConnections = 50;
+    private Duration keepAlive = Duration.ofMinutes(5);
+    private int maxRetries = 3;
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/http/AIHttpClientProperties.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/http/AIHttpClientProperties.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.conductoross.conductor.ai.http;
 
 import java.time.Duration;

--- a/ai/src/main/java/org/conductoross/conductor/ai/http/AIHttpClientProperties.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/http/AIHttpClientProperties.java
@@ -13,7 +13,7 @@ import lombok.Data;
 public class AIHttpClientProperties {
 
     private Duration connectTimeout = Duration.ofSeconds(60);
-    private Duration readTimeout = Duration.ofSeconds(120);
+    private Duration readTimeout = Duration.ofSeconds(600);
     private Duration writeTimeout = Duration.ofSeconds(60);
     private int maxIdleConnections = 50;
     private Duration keepAlive = Duration.ofMinutes(5);

--- a/ai/src/main/java/org/conductoross/conductor/ai/http/RetryInterceptor.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/http/RetryInterceptor.java
@@ -13,7 +13,7 @@
 package org.conductoross.conductor.ai.http;
 
 import java.io.IOException;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import okhttp3.Interceptor;
 import okhttp3.Request;
@@ -33,8 +33,9 @@ import okhttp3.Response;
  *
  * <p>Backoff formula: {@code min(baseDelayMs * 2^attempt, 30_000ms) + uniform jitter [0, 500ms]}
  *
- * <p>If the request body is one-shot (cannot be replayed), no retry is attempted. On retry
- * exhaustion the last response is returned rather than throwing.
+ * <p>If the request body is one-shot (cannot be replayed), no retry is attempted. On exhaustion,
+ * the last HTTP response is returned if one was received; an IOException is re-thrown if the final
+ * attempt was a network failure.
  */
 public class RetryInterceptor implements Interceptor {
 
@@ -44,7 +45,6 @@ public class RetryInterceptor implements Interceptor {
 
     private final int maxRetries;
     private final long baseDelayMs;
-    private final Random random = new Random();
 
     /**
      * Creates a {@code RetryInterceptor} with the default base delay of 1 second.
@@ -83,14 +83,14 @@ public class RetryInterceptor implements Interceptor {
         IOException lastException = null;
 
         for (int attempt = 0; attempt <= maxRetries; attempt++) {
-            // Close any previous non-successful response before retrying
-            if (lastResponse != null) {
-                lastResponse.close();
-            }
-
-            // Apply backoff delay for all attempts after the first
+            // Apply backoff delay for all attempts after the first, before closing the response
+            // so that header values are still accessible when computing the delay.
             if (attempt > 0) {
                 long delayMs = computeDelay(attempt - 1, lastResponse);
+                // Close any previous non-successful response before retrying
+                if (lastResponse != null) {
+                    lastResponse.close();
+                }
                 sleepUninterrupted(delayMs);
             }
 
@@ -149,7 +149,7 @@ public class RetryInterceptor implements Interceptor {
                 try {
                     long seconds = Long.parseLong(retryAfter.trim());
                     if (seconds >= 0) {
-                        return seconds * 1_000L + jitter();
+                        return Math.min(seconds * 1_000L, MAX_DELAY_MS) + jitter();
                     }
                 } catch (NumberFormatException ignored) {
                     // Fall through to exponential backoff
@@ -166,7 +166,7 @@ public class RetryInterceptor implements Interceptor {
     }
 
     private long jitter() {
-        return (long) (random.nextDouble() * JITTER_MAX_MS);
+        return (long) (ThreadLocalRandom.current().nextDouble() * JITTER_MAX_MS);
     }
 
     private static void sleepUninterrupted(long millis) {

--- a/ai/src/main/java/org/conductoross/conductor/ai/http/RetryInterceptor.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/http/RetryInterceptor.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.http;
+
+import java.io.IOException;
+import java.util.Random;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * OkHttp interceptor that retries requests on transient failures.
+ *
+ * <p>Retries on:
+ *
+ * <ul>
+ *   <li>{@link IOException} — network failure, connection reset, timeout
+ *   <li>HTTP 429 — rate limited; honours {@code Retry-After} header (seconds), falls back to
+ *       exponential backoff
+ *   <li>HTTP 5xx except 501 — server error (501 Not Implemented is non-transient)
+ * </ul>
+ *
+ * <p>Backoff formula: {@code min(baseDelayMs * 2^attempt, 30_000ms) + uniform jitter [0, 500ms]}
+ *
+ * <p>If the request body is one-shot (cannot be replayed), no retry is attempted. On retry
+ * exhaustion the last response is returned rather than throwing.
+ */
+public class RetryInterceptor implements Interceptor {
+
+    private static final long MAX_DELAY_MS = 30_000L;
+    private static final long JITTER_MAX_MS = 500L;
+    private static final long DEFAULT_BASE_DELAY_MS = 1_000L;
+
+    private final int maxRetries;
+    private final long baseDelayMs;
+    private final Random random = new Random();
+
+    /**
+     * Creates a {@code RetryInterceptor} with the default base delay of 1 second.
+     *
+     * @param maxRetries maximum number of retry attempts (not counting the initial request)
+     */
+    public RetryInterceptor(int maxRetries) {
+        this(maxRetries, DEFAULT_BASE_DELAY_MS);
+    }
+
+    /**
+     * Creates a {@code RetryInterceptor} with a custom base delay. Intended for testing so that
+     * backoff waits can be reduced to near-zero.
+     *
+     * @param maxRetries maximum number of retry attempts (not counting the initial request)
+     * @param baseDelayMs base delay in milliseconds used for exponential backoff
+     */
+    RetryInterceptor(int maxRetries, long baseDelayMs) {
+        if (maxRetries < 0) {
+            throw new IllegalArgumentException("maxRetries must be >= 0, got: " + maxRetries);
+        }
+        this.maxRetries = maxRetries;
+        this.baseDelayMs = baseDelayMs;
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Request request = chain.request();
+
+        // One-shot bodies cannot be replayed — skip retry entirely
+        if (request.body() != null && request.body().isOneShot()) {
+            return chain.proceed(request);
+        }
+
+        Response lastResponse = null;
+        IOException lastException = null;
+
+        for (int attempt = 0; attempt <= maxRetries; attempt++) {
+            // Close any previous non-successful response before retrying
+            if (lastResponse != null) {
+                lastResponse.close();
+            }
+
+            // Apply backoff delay for all attempts after the first
+            if (attempt > 0) {
+                long delayMs = computeDelay(attempt - 1, lastResponse);
+                sleepUninterrupted(delayMs);
+            }
+
+            try {
+                lastResponse = chain.proceed(request);
+                lastException = null;
+            } catch (IOException e) {
+                lastException = e;
+                lastResponse = null;
+                // Will retry unless we've exhausted attempts
+                continue;
+            }
+
+            if (!shouldRetry(lastResponse)) {
+                return lastResponse;
+            }
+            // shouldRetry == true → loop continues
+        }
+
+        // Exhausted retries
+        if (lastException != null) {
+            throw lastException;
+        }
+        // lastResponse is non-null here (shouldRetry returned true for it)
+        return lastResponse;
+    }
+
+    /**
+     * Returns {@code true} when the response code represents a transient error that warrants a
+     * retry.
+     */
+    private static boolean shouldRetry(Response response) {
+        int code = response.code();
+        if (code == 429) {
+            return true;
+        }
+        // 5xx except 501 (Not Implemented — non-transient)
+        if (code >= 500 && code < 600 && code != 501) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Computes the delay before the next retry attempt.
+     *
+     * @param retryIndex zero-based index of the retry (0 = first retry)
+     * @param response the last response received, or {@code null} on {@code IOException}
+     * @return delay in milliseconds
+     */
+    private long computeDelay(int retryIndex, Response response) {
+        // For 429, try to use Retry-After header first
+        if (response != null && response.code() == 429) {
+            String retryAfter = response.header("Retry-After");
+            if (retryAfter != null) {
+                try {
+                    long seconds = Long.parseLong(retryAfter.trim());
+                    if (seconds >= 0) {
+                        return seconds * 1_000L + jitter();
+                    }
+                } catch (NumberFormatException ignored) {
+                    // Fall through to exponential backoff
+                }
+            }
+        }
+        return exponentialBackoff(retryIndex);
+    }
+
+    private long exponentialBackoff(int retryIndex) {
+        long exponential = baseDelayMs * (1L << retryIndex); // baseDelayMs * 2^retryIndex
+        long capped = Math.min(exponential, MAX_DELAY_MS);
+        return capped + jitter();
+    }
+
+    private long jitter() {
+        return (long) (random.nextDouble() * JITTER_MAX_MS);
+    }
+
+    private static void sleepUninterrupted(long millis) {
+        if (millis <= 0) {
+            return;
+        }
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/models/LLMWorkerInput.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/models/LLMWorkerInput.java
@@ -36,7 +36,7 @@ public class LLMWorkerInput {
     private Integer topK;
     private Double presencePenalty;
     private List<String> stopWords;
-    private Integer maxTokens;
+    private Integer maxTokens = 8192;
     private int maxResults = 1;
     private boolean allowRawPrompts;
 

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/Anthropic.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/Anthropic.java
@@ -22,6 +22,8 @@ import org.conductoross.conductor.ai.models.EmbeddingGenRequest;
 import org.conductoross.conductor.ai.models.ToolSpec;
 import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi;
 import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.Tool;
+
+import okhttp3.OkHttpClient;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.image.ImageModel;
@@ -38,14 +40,16 @@ public class Anthropic implements AIModel {
     private final AnthropicMessagesApi messagesApi;
     private final AnthropicChatModel chatModel;
 
-    @SuppressWarnings("unchecked")
     public Anthropic(AnthropicConfiguration config) {
-        this.config = config;
-        long timeoutSecs = config.getTimeout() != null ? config.getTimeout().getSeconds() : 600;
+        this(config, new OkHttpClient());
+    }
 
+    @SuppressWarnings("unchecked")
+    public Anthropic(AnthropicConfiguration config, OkHttpClient httpClient) {
+        this.config = config;
         this.messagesApi =
                 new AnthropicMessagesApi(
-                        config.getApiKey(), config.getBaseURL(), config.getVersion(), timeoutSecs);
+                        httpClient, config.getApiKey(), config.getBaseURL(), config.getVersion());
         this.chatModel = new AnthropicChatModel(messagesApi);
     }
 

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/Anthropic.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/Anthropic.java
@@ -22,13 +22,12 @@ import org.conductoross.conductor.ai.models.EmbeddingGenRequest;
 import org.conductoross.conductor.ai.models.ToolSpec;
 import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi;
 import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.Tool;
-
-import okhttp3.OkHttpClient;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.image.ImageModel;
 
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
 
 @Slf4j
 public class Anthropic implements AIModel {

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicConfiguration.java
@@ -19,9 +19,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import okhttp3.OkHttpClient;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import okhttp3.OkHttpClient;
 
 @Data
 @Component

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicConfiguration.java
@@ -15,9 +15,11 @@ package org.conductoross.conductor.ai.providers.anthropic;
 import java.time.Duration;
 
 import org.conductoross.conductor.ai.ModelConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import okhttp3.OkHttpClient;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -39,6 +41,8 @@ public class AnthropicConfiguration implements ModelConfiguration<Anthropic> {
 
     private Duration timeout = Duration.ofSeconds(600);
 
+    @Autowired private OkHttpClient conductorAiHttpClient;
+
     public AnthropicConfiguration(
             String apiKey,
             String baseURL,
@@ -58,6 +62,6 @@ public class AnthropicConfiguration implements ModelConfiguration<Anthropic> {
 
     @Override
     public Anthropic get() {
-        return new Anthropic(this);
+        return new Anthropic(this, conductorAiHttpClient);
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/api/AnthropicMessagesApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/api/AnthropicMessagesApi.java
@@ -15,7 +15,6 @@ package org.conductoross.conductor.ai.providers.anthropic.api;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import com.netflix.conductor.common.config.ObjectMapperProvider;
 
@@ -50,21 +49,16 @@ public class AnthropicMessagesApi {
     private final OkHttpClient httpClient;
     private final ObjectMapper objectMapper;
 
-    public AnthropicMessagesApi(String apiKey, String baseUrl, long timeoutSeconds) {
-        this(apiKey, baseUrl, null, timeoutSeconds);
+    public AnthropicMessagesApi(OkHttpClient httpClient, String apiKey, String baseUrl) {
+        this(httpClient, apiKey, baseUrl, null);
     }
 
     public AnthropicMessagesApi(
-            String apiKey, String baseUrl, String anthropicVersion, long timeoutSeconds) {
+            OkHttpClient httpClient, String apiKey, String baseUrl, String anthropicVersion) {
         this.baseUrl = baseUrl != null ? baseUrl : "https://api.anthropic.com";
         this.apiKey = apiKey;
         this.anthropicVersion = anthropicVersion != null ? anthropicVersion : DEFAULT_VERSION;
-        this.httpClient =
-                new OkHttpClient.Builder()
-                        .connectTimeout(60, TimeUnit.SECONDS)
-                        .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
-                        .writeTimeout(60, TimeUnit.SECONDS)
-                        .build();
+        this.httpClient = httpClient;
         this.objectMapper = new ObjectMapperProvider().getObjectMapper();
     }
 

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/api/AnthropicMessagesApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/api/AnthropicMessagesApi.java
@@ -132,8 +132,18 @@ public class AnthropicMessagesApi {
 
         /** Returns a copy of this request with temperature removed. */
         public MessagesRequest withoutTemperature() {
-            return new MessagesRequest(model, maxTokens, messages, system, null,
-                    topP, topK, stopSequences, tools, thinking, betaFeatures);
+            return new MessagesRequest(
+                    model,
+                    maxTokens,
+                    messages,
+                    system,
+                    null,
+                    topP,
+                    topK,
+                    stopSequences,
+                    tools,
+                    thinking,
+                    betaFeatures);
         }
 
         public static class Builder {

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/api/AnthropicMessagesApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/api/AnthropicMessagesApi.java
@@ -88,6 +88,12 @@ public class AnthropicMessagesApi {
         try (Response response = httpClient.newCall(httpBuilder.build()).execute()) {
             String responseBody = readBody(response);
             if (!response.isSuccessful()) {
+                // Newer Anthropic models deprecate temperature — retry once without it.
+                if (response.code() == 400
+                        && responseBody.contains("temperature")
+                        && request.temperature() != null) {
+                    return createMessage(request.withoutTemperature());
+                }
                 throw new IOException(
                         "Anthropic Messages API failed with status %d: %s"
                                 .formatted(response.code(), responseBody));
@@ -122,6 +128,12 @@ public class AnthropicMessagesApi {
 
         public static Builder builder() {
             return new Builder();
+        }
+
+        /** Returns a copy of this request with temperature removed. */
+        public MessagesRequest withoutTemperature() {
+            return new MessagesRequest(model, maxTokens, messages, system, null,
+                    topP, topK, stopSequences, tools, thinking, betaFeatures);
         }
 
         public static class Builder {

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAI.java
@@ -31,6 +31,7 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.image.ImageModel;
 
+import okhttp3.OkHttpClient;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -51,17 +52,13 @@ public class AzureOpenAI implements AIModel {
     private final OpenAIResponsesChatModel chatModel;
     private final OpenAIHttpImageModel imageModel;
 
-    public AzureOpenAI(AzureOpenAIConfiguration config) {
+    public AzureOpenAI(AzureOpenAIConfiguration config, OkHttpClient httpClient) {
         this.config = config;
-        long timeoutSecs = config.getTimeout() != null ? config.getTimeout().getSeconds() : 600;
-
-        // Azure base URL format: https://RESOURCE.openai.azure.com/openai/v1
         String baseUrl = toAzureV1Url(config.getBaseURL());
 
-        this.responsesApi = new OpenAIResponsesApi(config.getApiKey(), baseUrl, true, timeoutSecs);
-        this.embeddingsApi =
-                new OpenAIEmbeddingsApi(config.getApiKey(), baseUrl, true, timeoutSecs);
-        this.imageGenApi = new OpenAIImageGenApi(config.getApiKey(), baseUrl, true, timeoutSecs);
+        this.responsesApi = new OpenAIResponsesApi(httpClient, config.getApiKey(), baseUrl, true);
+        this.embeddingsApi = new OpenAIEmbeddingsApi(httpClient, config.getApiKey(), baseUrl, true);
+        this.imageGenApi = new OpenAIImageGenApi(httpClient, config.getApiKey(), baseUrl, true);
         this.chatModel = new OpenAIResponsesChatModel(responsesApi);
         this.imageModel = new OpenAIHttpImageModel(imageGenApi);
     }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAI.java
@@ -31,8 +31,8 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.image.ImageModel;
 
-import okhttp3.OkHttpClient;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
 
 /**
  * Azure OpenAI provider backed by OkHttp calls to the Azure OpenAI Responses API.

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAI.java
@@ -52,6 +52,10 @@ public class AzureOpenAI implements AIModel {
     private final OpenAIResponsesChatModel chatModel;
     private final OpenAIHttpImageModel imageModel;
 
+    public AzureOpenAI(AzureOpenAIConfiguration config) {
+        this(config, new OkHttpClient());
+    }
+
     public AzureOpenAI(AzureOpenAIConfiguration config, OkHttpClient httpClient) {
         this.config = config;
         String baseUrl = toAzureV1Url(config.getBaseURL());

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAIConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAIConfiguration.java
@@ -15,9 +15,11 @@ package org.conductoross.conductor.ai.providers.azureopenai;
 import java.time.Duration;
 
 import org.conductoross.conductor.ai.ModelConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import okhttp3.OkHttpClient;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -33,6 +35,8 @@ public class AzureOpenAIConfiguration implements ModelConfiguration<AzureOpenAI>
     private String deploymentName;
     private Duration timeout = Duration.ofSeconds(600);
 
+    @Autowired private OkHttpClient conductorAiHttpClient;
+
     public AzureOpenAIConfiguration(
             String apiKey, String baseURL, String user, String deploymentName) {
         this.apiKey = apiKey;
@@ -43,6 +47,6 @@ public class AzureOpenAIConfiguration implements ModelConfiguration<AzureOpenAI>
 
     @Override
     public AzureOpenAI get() {
-        return new AzureOpenAI(this);
+        return new AzureOpenAI(this, conductorAiHttpClient);
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAIConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAIConfiguration.java
@@ -19,9 +19,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import okhttp3.OkHttpClient;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import okhttp3.OkHttpClient;
 
 @Data
 @NoArgsConstructor

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/cohere/CohereAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/cohere/CohereAI.java
@@ -21,8 +21,9 @@ import org.conductoross.conductor.ai.providers.cohere.api.CohereApi;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.image.ImageModel;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
+
+import okhttp3.OkHttpClient;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -41,8 +42,12 @@ public class CohereAI implements AIModel {
     private final CohereChatModel chatModel;
 
     public CohereAI(CohereAIConfiguration config) {
+        this(config, new OkHttpClient());
+    }
+
+    public CohereAI(CohereAIConfiguration config, OkHttpClient httpClient) {
         this.config = config;
-        this.cohereApi = createCohereApi();
+        this.cohereApi = createCohereApi(httpClient);
         this.chatModel = createChatModel();
     }
 
@@ -102,10 +107,8 @@ public class CohereAI implements AIModel {
 
     // Initialization helpers
 
-    private CohereApi createCohereApi() {
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setReadTimeout(config.getTimeout());
-
+    private CohereApi createCohereApi(OkHttpClient httpClient) {
+        var factory = new org.springframework.http.client.OkHttp3ClientHttpRequestFactory(httpClient);
         CohereApi.Builder builder =
                 CohereApi.builder()
                         .apiKey(config.getApiKey())

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/cohere/CohereAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/cohere/CohereAI.java
@@ -108,7 +108,10 @@ public class CohereAI implements AIModel {
     // Initialization helpers
 
     private CohereApi createCohereApi(OkHttpClient httpClient) {
-        var factory = new org.springframework.http.client.OkHttp3ClientHttpRequestFactory(httpClient);
+        OkHttpClient effective = (config.getTimeout() != null)
+                ? httpClient.newBuilder().readTimeout(config.getTimeout()).build()
+                : httpClient;
+        var factory = new org.springframework.http.client.OkHttp3ClientHttpRequestFactory(effective);
         CohereApi.Builder builder =
                 CohereApi.builder()
                         .apiKey(config.getApiKey())

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/cohere/CohereAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/cohere/CohereAI.java
@@ -23,9 +23,8 @@ import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.image.ImageModel;
 import org.springframework.web.client.RestClient;
 
-import okhttp3.OkHttpClient;
-
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
 
 /**
  * Cohere AI provider using native SDK (not OpenAI-compatible). Uses CohereApi, CohereChatModel, and
@@ -108,10 +107,12 @@ public class CohereAI implements AIModel {
     // Initialization helpers
 
     private CohereApi createCohereApi(OkHttpClient httpClient) {
-        OkHttpClient effective = (config.getTimeout() != null)
-                ? httpClient.newBuilder().readTimeout(config.getTimeout()).build()
-                : httpClient;
-        var factory = new org.springframework.http.client.OkHttp3ClientHttpRequestFactory(effective);
+        OkHttpClient effective =
+                (config.getTimeout() != null)
+                        ? httpClient.newBuilder().readTimeout(config.getTimeout()).build()
+                        : httpClient;
+        var factory =
+                new org.springframework.http.client.OkHttp3ClientHttpRequestFactory(effective);
         CohereApi.Builder builder =
                 CohereApi.builder()
                         .apiKey(config.getApiKey())

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/cohere/CohereAIConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/cohere/CohereAIConfiguration.java
@@ -19,10 +19,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import okhttp3.OkHttpClient;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
 
 @Data
 @Component
@@ -35,8 +35,7 @@ public class CohereAIConfiguration implements ModelConfiguration<CohereAI> {
     private String baseURL = "https://api.cohere.ai";
     private Duration timeout = Duration.ofSeconds(600);
 
-    @Autowired
-    private OkHttpClient conductorAiHttpClient;
+    @Autowired private OkHttpClient conductorAiHttpClient;
 
     public CohereAIConfiguration(String apiKey, String baseURL) {
         this.apiKey = apiKey;

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/cohere/CohereAIConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/cohere/CohereAIConfiguration.java
@@ -45,6 +45,8 @@ public class CohereAIConfiguration implements ModelConfiguration<CohereAI> {
 
     @Override
     public CohereAI get() {
-        return new CohereAI(this, conductorAiHttpClient != null ? conductorAiHttpClient : new okhttp3.OkHttpClient());
+        return conductorAiHttpClient != null
+                ? new CohereAI(this, conductorAiHttpClient)
+                : new CohereAI(this);
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/cohere/CohereAIConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/cohere/CohereAIConfiguration.java
@@ -15,9 +15,11 @@ package org.conductoross.conductor.ai.providers.cohere;
 import java.time.Duration;
 
 import org.conductoross.conductor.ai.ModelConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import okhttp3.OkHttpClient;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +35,9 @@ public class CohereAIConfiguration implements ModelConfiguration<CohereAI> {
     private String baseURL = "https://api.cohere.ai";
     private Duration timeout = Duration.ofSeconds(600);
 
+    @Autowired
+    private OkHttpClient conductorAiHttpClient;
+
     public CohereAIConfiguration(String apiKey, String baseURL) {
         this.apiKey = apiKey;
         this.baseURL = baseURL;
@@ -40,6 +45,6 @@ public class CohereAIConfiguration implements ModelConfiguration<CohereAI> {
 
     @Override
     public CohereAI get() {
-        return new CohereAI(this);
+        return new CohereAI(this, conductorAiHttpClient != null ? conductorAiHttpClient : new okhttp3.OkHttpClient());
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiChatModel.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiChatModel.java
@@ -84,8 +84,9 @@ public class GeminiChatModel implements ChatModel {
         // Build system instruction content (if any)
         GeminiApi.Content systemInstruction = null;
         if (!systemBuilder.isEmpty()) {
-            systemInstruction = new GeminiApi.Content(
-                    null, List.of(GeminiApi.Part.text(systemBuilder.toString())));
+            systemInstruction =
+                    new GeminiApi.Content(
+                            null, List.of(GeminiApi.Part.text(systemBuilder.toString())));
         }
 
         // Build tools
@@ -116,9 +117,10 @@ public class GeminiChatModel implements ChatModel {
             boolean includeThoughts =
                     opts.getIncludeThoughts() != null && opts.getIncludeThoughts();
             if (hasBudget || includeThoughts) {
-                thinkingConfig = new GeminiApi.ThinkingConfig(
-                        hasBudget ? opts.getThinkingBudgetTokens() : null,
-                        includeThoughts ? true : null);
+                thinkingConfig =
+                        new GeminiApi.ThinkingConfig(
+                                hasBudget ? opts.getThinkingBudgetTokens() : null,
+                                includeThoughts ? true : null);
             }
         } else if (options != null) {
             temperature = options.getTemperature();
@@ -130,33 +132,36 @@ public class GeminiChatModel implements ChatModel {
             presencePenalty = options.getPresencePenalty();
         }
 
-        GeminiApi.GenerationConfig config = new GeminiApi.GenerationConfig(
-                temperature,
-                topP,
-                topK,
-                maxOutputTokens,
-                stopSequences,
-                frequencyPenalty,
-                presencePenalty,
-                null,  // responseMimeType
-                null,  // responseModalities
-                thinkingConfig,
-                null   // speechConfig
-        );
+        GeminiApi.GenerationConfig config =
+                new GeminiApi.GenerationConfig(
+                        temperature,
+                        topP,
+                        topK,
+                        maxOutputTokens,
+                        stopSequences,
+                        frequencyPenalty,
+                        presencePenalty,
+                        null, // responseMimeType
+                        null, // responseModalities
+                        thinkingConfig,
+                        null // speechConfig
+                        );
 
-        String model = opts != null ? opts.getModel() : (options != null ? options.getModel() : null);
+        String model =
+                opts != null ? opts.getModel() : (options != null ? options.getModel() : null);
         if (model == null) {
             model = "gemini-2.5-flash";
         }
 
         GeminiApi.GenerateContentResponse result;
         try {
-            result = api.generateContent(
-                    model,
-                    contents,
-                    systemInstruction,
-                    toolList.isEmpty() ? null : toolList,
-                    config);
+            result =
+                    api.generateContent(
+                            model,
+                            contents,
+                            systemInstruction,
+                            toolList.isEmpty() ? null : toolList,
+                            config);
         } catch (java.io.IOException e) {
             throw new RuntimeException("Gemini generateContent failed: " + e.getMessage(), e);
         }
@@ -184,13 +189,15 @@ public class GeminiChatModel implements ChatModel {
         if (opts.getTools() != null && !opts.getTools().isEmpty()) {
             List<GeminiApi.FunctionDeclaration> declarations = new ArrayList<>();
             for (ToolSpec toolSpec : opts.getTools()) {
-                Object schema = (toolSpec.getInputSchema() != null && !toolSpec.getInputSchema().isEmpty())
-                        ? toolSpec.getInputSchema()
-                        : null;
-                declarations.add(new GeminiApi.FunctionDeclaration(
-                        toolSpec.getName(),
-                        toolSpec.getDescription() != null ? toolSpec.getDescription() : "",
-                        schema));
+                Object schema =
+                        (toolSpec.getInputSchema() != null && !toolSpec.getInputSchema().isEmpty())
+                                ? toolSpec.getInputSchema()
+                                : null;
+                declarations.add(
+                        new GeminiApi.FunctionDeclaration(
+                                toolSpec.getName(),
+                                toolSpec.getDescription() != null ? toolSpec.getDescription() : "",
+                                schema));
             }
             tools.add(GeminiApi.Tool.withFunctionDeclarations(declarations));
         }
@@ -199,14 +206,16 @@ public class GeminiChatModel implements ChatModel {
     }
 
     @SuppressWarnings("unchecked")
-    private List<GeminiApi.Content> convertMessage(org.springframework.ai.chat.messages.Message msg) {
+    private List<GeminiApi.Content> convertMessage(
+            org.springframework.ai.chat.messages.Message msg) {
         List<GeminiApi.Content> contents = new ArrayList<>();
 
         switch (msg.getMessageType()) {
             case USER -> {
                 UserMessage userMsg = (UserMessage) msg;
-                contents.add(new GeminiApi.Content(
-                        "user", List.of(GeminiApi.Part.text(userMsg.getText()))));
+                contents.add(
+                        new GeminiApi.Content(
+                                "user", List.of(GeminiApi.Part.text(userMsg.getText()))));
             }
 
             case ASSISTANT -> {
@@ -301,8 +310,9 @@ public class GeminiChatModel implements ChatModel {
                 String id = fc.name(); // FunctionCallPart has no separate id field
                 String argsJson;
                 try {
-                    argsJson = objectMapper.writeValueAsString(
-                            fc.args() != null ? fc.args() : Map.of());
+                    argsJson =
+                            objectMapper.writeValueAsString(
+                                    fc.args() != null ? fc.args() : Map.of());
                 } catch (Exception e) {
                     argsJson = "{}";
                 }
@@ -334,7 +344,8 @@ public class GeminiChatModel implements ChatModel {
         GeminiApi.UsageMetadata usageMeta = result.usageMetadata();
         if (usageMeta != null) {
             inputTok = usageMeta.promptTokenCount() != null ? usageMeta.promptTokenCount() : 0;
-            outputTok = usageMeta.candidatesTokenCount() != null ? usageMeta.candidatesTokenCount() : 0;
+            outputTok =
+                    usageMeta.candidatesTokenCount() != null ? usageMeta.candidatesTokenCount() : 0;
             thoughtsTok = usageMeta.thoughtsTokenCount();
         }
         DefaultUsage springUsage = new DefaultUsage(inputTok, outputTok, inputTok + outputTok);

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiChatModel.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiChatModel.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.conductoross.conductor.ai.models.ToolSpec;
+import org.conductoross.conductor.ai.providers.gemini.api.GeminiApi;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.SystemMessage;
@@ -33,36 +34,22 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.genai.Client;
-import com.google.genai.types.Candidate;
-import com.google.genai.types.Content;
-import com.google.genai.types.FunctionCall;
-import com.google.genai.types.FunctionDeclaration;
-import com.google.genai.types.GenerateContentConfig;
-import com.google.genai.types.GenerateContentResponse;
-import com.google.genai.types.GenerateContentResponseUsageMetadata;
-import com.google.genai.types.GoogleSearch;
-import com.google.genai.types.Part;
-import com.google.genai.types.ThinkingConfig;
-import com.google.genai.types.Tool;
-import com.google.genai.types.ToolCodeExecution;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Spring AI {@link ChatModel} implementation backed by the Google GenAI SDK.
+ * Spring AI {@link ChatModel} implementation backed by the OkHttp-based {@link GeminiApi} client.
  *
- * <p>Converts Spring AI {@link Prompt} messages to GenAI {@link Content} objects, calls {@code
- * Client.models.generateContent()}, and converts the response back to Spring AI's {@link
- * ChatResponse}.
+ * <p>Converts Spring AI {@link Prompt} messages to {@link GeminiApi.Content} objects, calls {@code
+ * GeminiApi.generateContent()}, and converts the response back to Spring AI's {@link ChatResponse}.
  */
 @Slf4j
 public class GeminiChatModel implements ChatModel {
 
-    private final Client client;
+    private final GeminiApi api;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    public GeminiChatModel(Client client) {
-        this.client = client;
+    public GeminiChatModel(GeminiApi api) {
+        this.api = api;
     }
 
     @Override
@@ -86,145 +73,147 @@ public class GeminiChatModel implements ChatModel {
             }
         }
 
-        // Convert messages to GenAI Content
-        List<Content> contents = new ArrayList<>();
+        // Convert messages to GeminiApi Content
+        List<GeminiApi.Content> contents = new ArrayList<>();
         for (org.springframework.ai.chat.messages.Message msg : nonSystemMessages) {
             contents.addAll(convertMessage(msg));
         }
 
-        // Build config
-        GenerateContentConfig.Builder configBuilder = GenerateContentConfig.builder();
-
-        if (!systemBuilder.isEmpty()) {
-            configBuilder.systemInstruction(
-                    Content.builder()
-                            .parts(List.of(Part.fromText(systemBuilder.toString())))
-                            .build());
-        }
-
         GeminiChatOptions opts = options instanceof GeminiChatOptions gco ? gco : null;
 
+        // Build system instruction content (if any)
+        GeminiApi.Content systemInstruction = null;
+        if (!systemBuilder.isEmpty()) {
+            systemInstruction = new GeminiApi.Content(
+                    null, List.of(GeminiApi.Part.text(systemBuilder.toString())));
+        }
+
+        // Build tools
+        List<GeminiApi.Tool> toolList = buildTools(opts);
+
+        // Build GenerationConfig
+        Double temperature = null;
+        Double topP = null;
+        Integer topK = null;
+        Integer maxOutputTokens = null;
+        List<String> stopSequences = null;
+        Double frequencyPenalty = null;
+        Double presencePenalty = null;
+        GeminiApi.ThinkingConfig thinkingConfig = null;
+
         if (opts != null) {
-            if (opts.getMaxTokens() != null) configBuilder.maxOutputTokens(opts.getMaxTokens());
-            if (opts.getTemperature() != null)
-                configBuilder.temperature(opts.getTemperature().floatValue());
-            if (opts.getTopP() != null) configBuilder.topP(opts.getTopP().floatValue());
-            if (opts.getTopK() != null) configBuilder.topK(opts.getTopK().floatValue());
-            if (opts.getStopSequences() != null)
-                configBuilder.stopSequences(opts.getStopSequences());
-            if (opts.getFrequencyPenalty() != null)
-                configBuilder.frequencyPenalty(opts.getFrequencyPenalty().floatValue());
-            if (opts.getPresencePenalty() != null)
-                configBuilder.presencePenalty(opts.getPresencePenalty().floatValue());
+            temperature = opts.getTemperature();
+            topP = opts.getTopP();
+            topK = opts.getTopK();
+            maxOutputTokens = opts.getMaxTokens();
+            stopSequences = opts.getStopSequences();
+            frequencyPenalty = opts.getFrequencyPenalty();
+            presencePenalty = opts.getPresencePenalty();
 
-            // Tools
-            List<Tool> tools = buildTools(opts);
-            if (!tools.isEmpty()) {
-                configBuilder.tools(tools);
-            }
-
-            // Thinking. ``includeThoughts`` is the gate that controls whether
-            // the model returns thought summary parts; the budget controls how
-            // much reasoning capacity it can spend. Either can be configured
-            // independently — callers who set ``includeThoughts`` without a
-            // budget get whatever the model defaults to; callers who set a
-            // budget without ``includeThoughts`` get reasoning under the hood
-            // with no visible summary.
+            // Thinking config
             boolean hasBudget =
                     opts.getThinkingBudgetTokens() != null && opts.getThinkingBudgetTokens() > 0;
             boolean includeThoughts =
                     opts.getIncludeThoughts() != null && opts.getIncludeThoughts();
             if (hasBudget || includeThoughts) {
-                ThinkingConfig.Builder thinkingBuilder = ThinkingConfig.builder();
-                if (hasBudget) {
-                    thinkingBuilder.thinkingBudget(opts.getThinkingBudgetTokens());
-                }
-                if (includeThoughts) {
-                    thinkingBuilder.includeThoughts(true);
-                }
-                configBuilder.thinkingConfig(thinkingBuilder.build());
+                thinkingConfig = new GeminiApi.ThinkingConfig(
+                        hasBudget ? opts.getThinkingBudgetTokens() : null,
+                        includeThoughts ? true : null);
             }
         } else if (options != null) {
-            if (options.getMaxTokens() != null)
-                configBuilder.maxOutputTokens(options.getMaxTokens());
-            if (options.getTemperature() != null)
-                configBuilder.temperature(options.getTemperature().floatValue());
-            if (options.getTopP() != null) configBuilder.topP(options.getTopP().floatValue());
-            if (options.getTopK() != null) configBuilder.topK(options.getTopK().floatValue());
-            if (options.getStopSequences() != null)
-                configBuilder.stopSequences(options.getStopSequences());
-            if (options.getFrequencyPenalty() != null)
-                configBuilder.frequencyPenalty(options.getFrequencyPenalty().floatValue());
-            if (options.getPresencePenalty() != null)
-                configBuilder.presencePenalty(options.getPresencePenalty().floatValue());
+            temperature = options.getTemperature();
+            topP = options.getTopP();
+            topK = options.getTopK();
+            maxOutputTokens = options.getMaxTokens();
+            stopSequences = options.getStopSequences();
+            frequencyPenalty = options.getFrequencyPenalty();
+            presencePenalty = options.getPresencePenalty();
         }
 
-        String model =
-                opts != null ? opts.getModel() : (options != null ? options.getModel() : null);
+        GeminiApi.GenerationConfig config = new GeminiApi.GenerationConfig(
+                temperature,
+                topP,
+                topK,
+                maxOutputTokens,
+                stopSequences,
+                frequencyPenalty,
+                presencePenalty,
+                null,  // responseMimeType
+                null,  // responseModalities
+                thinkingConfig,
+                null   // speechConfig
+        );
+
+        String model = opts != null ? opts.getModel() : (options != null ? options.getModel() : null);
         if (model == null) {
             model = "gemini-2.5-flash";
         }
 
-        GenerateContentResponse result =
-                client.models.generateContent(model, contents, configBuilder.build());
+        GeminiApi.GenerateContentResponse result;
+        try {
+            result = api.generateContent(
+                    model,
+                    contents,
+                    systemInstruction,
+                    toolList.isEmpty() ? null : toolList,
+                    config);
+        } catch (java.io.IOException e) {
+            throw new RuntimeException("Gemini generateContent failed: " + e.getMessage(), e);
+        }
 
         return toSpringChatResponse(result, model);
     }
 
-    private List<Tool> buildTools(GeminiChatOptions opts) {
-        List<Tool> tools = new ArrayList<>();
+    private List<GeminiApi.Tool> buildTools(GeminiChatOptions opts) {
+        List<GeminiApi.Tool> tools = new ArrayList<>();
+        if (opts == null) {
+            return tools;
+        }
 
         // Google Search
         if (opts.isGoogleSearchRetrieval()) {
-            tools.add(Tool.builder().googleSearch(GoogleSearch.builder().build()).build());
+            tools.add(GeminiApi.Tool.withGoogleSearch());
         }
 
         // Code execution
         if (opts.isCodeExecution()) {
-            tools.add(Tool.builder().codeExecution(ToolCodeExecution.builder().build()).build());
+            tools.add(GeminiApi.Tool.withCodeExecution());
         }
 
         // Function tools
         if (opts.getTools() != null && !opts.getTools().isEmpty()) {
-            List<FunctionDeclaration> declarations = new ArrayList<>();
+            List<GeminiApi.FunctionDeclaration> declarations = new ArrayList<>();
             for (ToolSpec toolSpec : opts.getTools()) {
-                FunctionDeclaration.Builder declBuilder =
-                        FunctionDeclaration.builder()
-                                .name(toolSpec.getName())
-                                .description(
-                                        toolSpec.getDescription() != null
-                                                ? toolSpec.getDescription()
-                                                : "");
-                if (toolSpec.getInputSchema() != null && !toolSpec.getInputSchema().isEmpty()) {
-                    declBuilder.parametersJsonSchema(toolSpec.getInputSchema());
-                }
-                declarations.add(declBuilder.build());
+                Object schema = (toolSpec.getInputSchema() != null && !toolSpec.getInputSchema().isEmpty())
+                        ? toolSpec.getInputSchema()
+                        : null;
+                declarations.add(new GeminiApi.FunctionDeclaration(
+                        toolSpec.getName(),
+                        toolSpec.getDescription() != null ? toolSpec.getDescription() : "",
+                        schema));
             }
-            tools.add(Tool.builder().functionDeclarations(declarations).build());
+            tools.add(GeminiApi.Tool.withFunctionDeclarations(declarations));
         }
 
         return tools;
     }
 
     @SuppressWarnings("unchecked")
-    private List<Content> convertMessage(org.springframework.ai.chat.messages.Message msg) {
-        List<Content> contents = new ArrayList<>();
+    private List<GeminiApi.Content> convertMessage(org.springframework.ai.chat.messages.Message msg) {
+        List<GeminiApi.Content> contents = new ArrayList<>();
 
         switch (msg.getMessageType()) {
             case USER -> {
                 UserMessage userMsg = (UserMessage) msg;
-                contents.add(
-                        Content.builder()
-                                .role("user")
-                                .parts(List.of(Part.fromText(userMsg.getText())))
-                                .build());
+                contents.add(new GeminiApi.Content(
+                        "user", List.of(GeminiApi.Part.text(userMsg.getText()))));
             }
 
             case ASSISTANT -> {
                 AssistantMessage assistantMsg = (AssistantMessage) msg;
-                List<Part> parts = new ArrayList<>();
+                List<GeminiApi.Part> parts = new ArrayList<>();
                 if (assistantMsg.getText() != null && !assistantMsg.getText().isBlank()) {
-                    parts.add(Part.fromText(assistantMsg.getText()));
+                    parts.add(GeminiApi.Part.text(assistantMsg.getText()));
                 }
                 if (assistantMsg.hasToolCalls()) {
                     for (AssistantMessage.ToolCall tc : assistantMsg.getToolCalls()) {
@@ -234,17 +223,17 @@ public class GeminiChatModel implements ChatModel {
                         } catch (Exception e) {
                             args = Map.of();
                         }
-                        parts.add(Part.fromFunctionCall(tc.name(), args));
+                        parts.add(GeminiApi.Part.functionCall(tc.name(), args));
                     }
                 }
                 if (!parts.isEmpty()) {
-                    contents.add(Content.builder().role("model").parts(parts).build());
+                    contents.add(new GeminiApi.Content("model", parts));
                 }
             }
 
             case TOOL -> {
                 ToolResponseMessage toolMsg = (ToolResponseMessage) msg;
-                List<Part> parts = new ArrayList<>();
+                List<GeminiApi.Part> parts = new ArrayList<>();
                 for (ToolResponseMessage.ToolResponse tr : toolMsg.getResponses()) {
                     Map<String, Object> responseMap;
                     try {
@@ -252,9 +241,9 @@ public class GeminiChatModel implements ChatModel {
                     } catch (Exception e) {
                         responseMap = Map.of("result", tr.responseData());
                     }
-                    parts.add(Part.fromFunctionResponse(tr.name(), responseMap));
+                    parts.add(GeminiApi.Part.functionResponse(tr.name(), responseMap));
                 }
-                contents.add(Content.builder().role("user").parts(parts).build());
+                contents.add(new GeminiApi.Content("user", parts));
             }
 
             default -> log.warn("Unsupported message type: {}", msg.getMessageType());
@@ -263,7 +252,7 @@ public class GeminiChatModel implements ChatModel {
         return contents;
     }
 
-    ChatResponse toSpringChatResponse(GenerateContentResponse result, String model) {
+    ChatResponse toSpringChatResponse(GeminiApi.GenerateContentResponse result, String model) {
         List<Generation> generations = new ArrayList<>();
         List<AssistantMessage.ToolCall> toolCalls = new ArrayList<>();
         StringBuilder textBuilder = new StringBuilder();
@@ -271,33 +260,28 @@ public class GeminiChatModel implements ChatModel {
 
         // Extract finish reason
         String finishReason = "STOP";
-        var geminiFinishReason = result.finishReason();
+        String geminiFinishReason = result.finishReason();
         if (geminiFinishReason != null) {
-            finishReason = geminiFinishReason.toString();
+            finishReason = geminiFinishReason;
         }
 
-        // Extract text from response. ``result.text()`` returns concatenated
-        // text from non-thought parts only — the SDK filters out parts whose
-        // ``thought()`` flag is true. We separately iterate the candidates
-        // to surface those thought summaries as reasoning metadata.
-        try {
-            String text = result.text();
-            if (text != null && !text.isEmpty()) {
-                textBuilder.append(text);
-            }
-        } catch (Exception e) {
-            // text() throws if no text content
+        // Extract text from response. result.text() returns concatenated text from
+        // non-thought parts only — it filters out parts whose thought flag is true.
+        // We separately iterate the candidates to surface thought summaries as reasoning metadata.
+        String text = result.text();
+        if (text != null && !text.isEmpty()) {
+            textBuilder.append(text);
         }
 
-        // Collect thought summary text, if the model returned any. Each
-        // candidate's content carries a list of parts; a part is a "thought
-        // summary" when ``part.thought()`` is true. Concatenate these into a
-        // single reasoning blob mirroring the OpenAI behavior.
-        for (Candidate candidate : result.candidates().orElse(List.of())) {
-            for (Content content : candidate.content().stream().toList()) {
-                for (Part part : content.parts().orElse(List.of())) {
-                    if (part.thought().orElse(false)) {
-                        String thoughtText = part.text().orElse(null);
+        // Collect thought summary text from thought parts
+        List<GeminiApi.Candidate> candidates = result.candidates();
+        if (candidates != null) {
+            for (GeminiApi.Candidate candidate : candidates) {
+                GeminiApi.Content content = candidate.content();
+                if (content == null || content.parts() == null) continue;
+                for (GeminiApi.Part part : content.parts()) {
+                    if (Boolean.TRUE.equals(part.thought())) {
+                        String thoughtText = part.text();
                         if (thoughtText != null && !thoughtText.isBlank()) {
                             if (!reasoningBuilder.isEmpty()) {
                                 reasoningBuilder.append("\n\n");
@@ -310,14 +294,15 @@ public class GeminiChatModel implements ChatModel {
         }
 
         // Extract function calls
-        var functionCalls = result.functionCalls();
+        List<GeminiApi.FunctionCallPart> functionCalls = result.functionCalls();
         if (functionCalls != null && !functionCalls.isEmpty()) {
-            for (FunctionCall fc : functionCalls) {
-                String name = fc.name().orElse("");
-                String id = fc.id().orElse(name);
+            for (GeminiApi.FunctionCallPart fc : functionCalls) {
+                String name = fc.name();
+                String id = fc.name(); // FunctionCallPart has no separate id field
                 String argsJson;
                 try {
-                    argsJson = objectMapper.writeValueAsString(fc.args().orElse(Map.of()));
+                    argsJson = objectMapper.writeValueAsString(
+                            fc.args() != null ? fc.args() : Map.of());
                 } catch (Exception e) {
                     argsJson = "{}";
                 }
@@ -346,16 +331,15 @@ public class GeminiChatModel implements ChatModel {
         int inputTok = 0;
         int outputTok = 0;
         Integer thoughtsTok = null;
-        var usageMeta = result.usageMetadata();
-        if (usageMeta.isPresent()) {
-            GenerateContentResponseUsageMetadata usage = usageMeta.get();
-            inputTok = usage.promptTokenCount().orElse(0);
-            outputTok = usage.candidatesTokenCount().orElse(0);
-            thoughtsTok = usage.thoughtsTokenCount().orElse(null);
+        GeminiApi.UsageMetadata usageMeta = result.usageMetadata();
+        if (usageMeta != null) {
+            inputTok = usageMeta.promptTokenCount() != null ? usageMeta.promptTokenCount() : 0;
+            outputTok = usageMeta.candidatesTokenCount() != null ? usageMeta.candidatesTokenCount() : 0;
+            thoughtsTok = usageMeta.thoughtsTokenCount();
         }
         DefaultUsage springUsage = new DefaultUsage(inputTok, outputTok, inputTok + outputTok);
 
-        String responseId = result.responseId().orElse(null);
+        String responseId = result.responseId();
         ChatResponseMetadata.Builder metaBuilder =
                 ChatResponseMetadata.builder().model(model).usage(springUsage);
         if (responseId != null) {

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiGenAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiGenAI.java
@@ -35,10 +35,8 @@ public class GeminiGenAI implements ImageModel {
         String model = options.getModel();
         String promptText = request.getInstructions().getFirst().getText();
 
-        GeminiApi.GenerateImagesConfig config = new GeminiApi.GenerateImagesConfig(
-                options.getN(),
-                "image/png",
-                true);
+        GeminiApi.GenerateImagesConfig config =
+                new GeminiApi.GenerateImagesConfig(options.getN(), "image/png", true);
 
         GeminiApi.GenerateImagesResponse response;
         try {

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiGenAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiGenAI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Conductor Authors.
+ * Copyright 2026 Conductor Authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,55 +13,49 @@
 package org.conductoross.conductor.ai.providers.gemini;
 
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
 
+import org.conductoross.conductor.ai.providers.gemini.api.GeminiApi;
 import org.springframework.ai.image.ImageGeneration;
 import org.springframework.ai.image.ImageModel;
 import org.springframework.ai.image.ImagePrompt;
 import org.springframework.ai.image.ImageResponse;
 
-import com.google.genai.Client;
-import com.google.genai.types.GenerateImagesConfig;
-import com.google.genai.types.GenerateImagesResponse;
-import com.google.genai.types.GeneratedImage;
-
 public class GeminiGenAI implements ImageModel {
 
-    private final Client client;
+    private final GeminiApi api;
 
-    public GeminiGenAI(Client client) {
-        this.client = client;
+    public GeminiGenAI(GeminiApi api) {
+        this.api = api;
     }
 
     @Override
     public ImageResponse call(ImagePrompt request) {
         var options = request.getOptions();
-        GenerateImagesConfig config =
-                GenerateImagesConfig.builder()
-                        .numberOfImages(options.getN())
-                        .outputMimeType("image/png")
-                        .includeSafetyAttributes(true)
-                        .build();
+        String model = options.getModel();
+        String promptText = request.getInstructions().getFirst().getText();
 
-        GenerateImagesResponse response =
-                client.models.generateImages(
-                        options.getModel(), request.getInstructions().getFirst().getText(), config);
+        GeminiApi.GenerateImagesConfig config = new GeminiApi.GenerateImagesConfig(
+                options.getN(),
+                "image/png",
+                true);
 
-        List<GeneratedImage> generatedImages = response.generatedImages().orElse(new ArrayList<>());
+        GeminiApi.GenerateImagesResponse response;
+        try {
+            response = api.generateImages(model, promptText, config);
+        } catch (java.io.IOException e) {
+            throw new RuntimeException("Gemini generateImages failed: " + e.getMessage(), e);
+        }
+
+        List<GeminiApi.ImagePrediction> predictions =
+                response.predictions() != null ? response.predictions() : List.of();
         List<ImageGeneration> generations = new ArrayList<>();
-        for (GeneratedImage generatedImage : generatedImages) {
-            generatedImage
-                    .image()
-                    .ifPresent(
-                            image -> {
-                                byte[] data = image.imageBytes().orElse(new byte[0]);
-                                org.springframework.ai.image.Image img =
-                                        new org.springframework.ai.image.Image(
-                                                null, Base64.getEncoder().encodeToString(data));
-                                ImageGeneration imageGeneration = new ImageGeneration(img);
-                                generations.add(imageGeneration);
-                            });
+        for (GeminiApi.ImagePrediction pred : predictions) {
+            if (pred.bytesBase64Encoded() != null) {
+                org.springframework.ai.image.Image img =
+                        new org.springframework.ai.image.Image(null, pred.bytesBase64Encoded());
+                generations.add(new ImageGeneration(img));
+            }
         }
         return new ImageResponse(generations);
     }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertex.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertex.java
@@ -54,7 +54,10 @@ public class GeminiVertex implements AIModel {
 
     private GeminiApi createApi() {
         if (config.getApiKey() != null && !config.getApiKey().isBlank()) {
-            return GeminiApi.forApiKey(httpClient, config.getApiKey(), config.getBaseURL());
+            // For API key mode, only pass a custom base URL if explicitly configured.
+            // config.getBaseURL() defaults to a Vertex AI URL which is wrong for API key mode.
+            String customBase = config.getRawBaseURL(); // null if not explicitly set
+            return GeminiApi.forApiKey(httpClient, config.getApiKey(), customBase);
         }
         return GeminiApi.forVertex(httpClient, config.getProjectId(),
                 config.getLocation(), config.getGoogleCredentials());
@@ -199,7 +202,7 @@ public class GeminiVertex implements AIModel {
                 new GeminiApi.VoiceConfig(new GeminiApi.PrebuiltVoiceConfig(request.getVoice())));
         GeminiApi.GenerationConfig genConfig = new GeminiApi.GenerationConfig(
                 null, null, null, request.getMaxTokens(), request.getStopWords(),
-                request.getFrequencyPenalty() != null ? request.getFrequencyPenalty() : null,
+                request.getFrequencyPenalty(),
                 null, null, List.of("AUDIO"), null, speechConfig);
 
         try {
@@ -225,6 +228,8 @@ public class GeminiVertex implements AIModel {
                 }
             }
             return LLMResponse.builder().media(media).build();
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException("Gemini generateAudio failed", e);
         }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertex.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertex.java
@@ -23,6 +23,7 @@ import org.conductoross.conductor.ai.models.EmbeddingGenRequest;
 import org.conductoross.conductor.ai.models.LLMResponse;
 import org.conductoross.conductor.ai.models.Media;
 import org.conductoross.conductor.ai.models.VideoGenRequest;
+import org.conductoross.conductor.ai.providers.gemini.api.GeminiApi;
 import org.conductoross.conductor.ai.video.Video;
 import org.conductoross.conductor.ai.video.VideoGeneration;
 import org.conductoross.conductor.ai.video.VideoModel;
@@ -33,18 +34,7 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.image.ImageModel;
 
-import com.google.genai.Client;
-import com.google.genai.types.Blob;
-import com.google.genai.types.Candidate;
-import com.google.genai.types.Content;
-import com.google.genai.types.ContentEmbedding;
-import com.google.genai.types.EmbedContentConfig;
-import com.google.genai.types.EmbedContentResponse;
-import com.google.genai.types.GenerateContentConfig;
-import com.google.genai.types.GenerateContentResponse;
-import com.google.genai.types.PrebuiltVoiceConfig;
-import com.google.genai.types.SpeechConfig;
-import com.google.genai.types.VoiceConfig;
+import okhttp3.OkHttpClient;
 
 public class GeminiVertex implements AIModel {
 
@@ -53,9 +43,21 @@ public class GeminiVertex implements AIModel {
     public static final String ALIAS = "google_gemini";
 
     private final GeminiVertexConfiguration config;
+    private final OkHttpClient httpClient;
+    private final GeminiApi geminiApi;
 
-    public GeminiVertex(GeminiVertexConfiguration config) {
+    public GeminiVertex(GeminiVertexConfiguration config, OkHttpClient httpClient) {
         this.config = config;
+        this.httpClient = httpClient;
+        this.geminiApi = createApi();
+    }
+
+    private GeminiApi createApi() {
+        if (config.getApiKey() != null && !config.getApiKey().isBlank()) {
+            return GeminiApi.forApiKey(httpClient, config.getApiKey(), config.getBaseURL());
+        }
+        return GeminiApi.forVertex(httpClient, config.getProjectId(),
+                config.getLocation(), config.getGoogleCredentials());
     }
 
     @Override
@@ -70,29 +72,25 @@ public class GeminiVertex implements AIModel {
 
     @Override
     public List<Float> generateEmbeddings(EmbeddingGenRequest embeddingGenRequest) {
-        Client client = createGenAIClient();
-        EmbedContentConfig.Builder configBuilder = EmbedContentConfig.builder();
-        if (embeddingGenRequest.getDimensions() != null) {
-            configBuilder.outputDimensionality(embeddingGenRequest.getDimensions());
+        try {
+            GeminiApi.EmbedContentResponse resp = geminiApi.embedContent(
+                    embeddingGenRequest.getModel(),
+                    embeddingGenRequest.getText(),
+                    embeddingGenRequest.getDimensions());
+            if (resp.embedding() == null || resp.embedding().values() == null) {
+                throw new RuntimeException("No embeddings returned from Gemini API");
+            }
+            return resp.embedding().values();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Gemini embedContent failed", e);
         }
-        EmbedContentResponse response =
-                client.models.embedContent(
-                        embeddingGenRequest.getModel(),
-                        embeddingGenRequest.getText(),
-                        configBuilder.build());
-        return response.embeddings()
-                .flatMap(
-                        embeddings ->
-                                embeddings.isEmpty()
-                                        ? java.util.Optional.empty()
-                                        : java.util.Optional.of(embeddings.getFirst()))
-                .flatMap(ContentEmbedding::values)
-                .orElseThrow(() -> new RuntimeException("No embeddings returned from Gemini API"));
     }
 
     @Override
     public ChatModel getChatModel() {
-        return new GeminiChatModel(createGenAIClient());
+        return new GeminiChatModel(geminiApi);
     }
 
     @Override
@@ -127,19 +125,19 @@ public class GeminiVertex implements AIModel {
 
     @Override
     public ImageModel getImageModel() {
-        return new GeminiGenAI(createGenAIClient());
+        return new GeminiGenAI(geminiApi);
     }
 
     @Override
     public VideoModel getVideoModel() {
-        return new GeminiVideoModel(createGenAIClient());
+        return new GeminiVideoModel(geminiApi, httpClient);
     }
 
     @Override
     public LLMResponse generateVideo(VideoGenRequest request) {
         VideoOptions options = getVideoOptions(request);
         VideoPrompt videoPrompt = new VideoPrompt(request.getPrompt(), options);
-        GeminiVideoModel videoModel = new GeminiVideoModel(createGenAIClient());
+        GeminiVideoModel videoModel = new GeminiVideoModel(geminiApi, httpClient);
         VideoResponse response = videoModel.call(videoPrompt);
 
         return LLMResponse.builder()
@@ -150,7 +148,7 @@ public class GeminiVertex implements AIModel {
 
     @Override
     public LLMResponse checkVideoStatus(VideoGenRequest request) {
-        GeminiVideoModel videoModel = new GeminiVideoModel(createGenAIClient());
+        GeminiVideoModel videoModel = new GeminiVideoModel(geminiApi, httpClient);
         VideoResponse response = videoModel.checkStatus(request.getJobId());
         String status = response.getMetadata().getStatus();
 
@@ -181,26 +179,9 @@ public class GeminiVertex implements AIModel {
         return builder.build();
     }
 
-    /** Creates a Google GenAI Client, using API key when available, otherwise Vertex AI. */
-    private Client createGenAIClient() {
-        if (config.getApiKey() != null && !config.getApiKey().isBlank()) {
-            return Client.builder().apiKey(config.getApiKey()).build();
-        }
-        Client.Builder builder =
-                Client.builder()
-                        .vertexAI(true)
-                        .location(config.getLocation())
-                        .project(config.getProjectId());
-        if (config.getGoogleCredentials() != null) {
-            builder.credentials(config.getGoogleCredentials());
-        }
-        return builder.build();
-    }
-
     private byte[] downloadFromUrl(String url) {
-        okhttp3.OkHttpClient client = new okhttp3.OkHttpClient();
         okhttp3.Request request = new okhttp3.Request.Builder().url(url).get().build();
-        try (okhttp3.Response response = client.newCall(request).execute()) {
+        try (okhttp3.Response response = httpClient.newCall(request).execute()) {
             if (response.body() == null) {
                 throw new RuntimeException("Empty response downloading from " + url);
             }
@@ -214,54 +195,38 @@ public class GeminiVertex implements AIModel {
 
     @Override
     public LLMResponse generateAudio(AudioGenRequest request) {
-        var client = createGenAIClient();
-        GenerateContentConfig config =
-                GenerateContentConfig.builder()
-                        .speechConfig(
-                                SpeechConfig.builder()
-                                        .voiceConfig(
-                                                VoiceConfig.builder()
-                                                        .prebuiltVoiceConfig(
-                                                                PrebuiltVoiceConfig.builder()
-                                                                        .voiceName(
-                                                                                request.getVoice())
-                                                                        .build())
-                                                        .build())
-                                        .build())
-                        .responseModalities(List.of("AUDIO"))
-                        .frequencyPenalty(
-                                request.getFrequencyPenalty() != null
-                                        ? request.getFrequencyPenalty().floatValue()
-                                        : null)
-                        .maxOutputTokens(request.getMaxTokens())
-                        .stopSequences(request.getStopWords())
-                        .build();
-        GenerateContentResponse response =
-                client.models.generateContent(request.getModel(), request.getText(), config);
-        List<Candidate> candiates = response.candidates().orElse(new ArrayList<>());
-        List<Media> media = new ArrayList<>();
-        for (Candidate candiate : candiates) {
-            candiate.content()
-                    .flatMap(Content::parts)
-                    .ifPresent(
-                            parts -> {
-                                parts.forEach(
-                                        part ->
-                                                part.inlineData()
-                                                        .flatMap(Blob::data)
-                                                        .ifPresent(
-                                                                bytes -> {
-                                                                    media.add(
-                                                                            Media.builder()
-                                                                                    .data(bytes)
-                                                                                    .mimeType(
-                                                                                            "audio/"
-                                                                                                    + request
-                                                                                                            .getResponseFormat())
-                                                                                    .build());
-                                                                }));
-                            });
+        GeminiApi.SpeechConfig speechConfig = new GeminiApi.SpeechConfig(
+                new GeminiApi.VoiceConfig(new GeminiApi.PrebuiltVoiceConfig(request.getVoice())));
+        GeminiApi.GenerationConfig genConfig = new GeminiApi.GenerationConfig(
+                null, null, null, request.getMaxTokens(), request.getStopWords(),
+                request.getFrequencyPenalty() != null ? request.getFrequencyPenalty() : null,
+                null, null, List.of("AUDIO"), null, speechConfig);
+
+        try {
+            GeminiApi.Content userContent = new GeminiApi.Content("user",
+                    List.of(GeminiApi.Part.text(request.getText())));
+            GeminiApi.GenerateContentResponse result = geminiApi.generateContent(
+                    request.getModel(), List.of(userContent), null, null, genConfig);
+
+            List<Media> media = new ArrayList<>();
+            if (result.candidates() != null) {
+                for (GeminiApi.Candidate c : result.candidates()) {
+                    if (c.content() == null || c.content().parts() == null) continue;
+                    for (GeminiApi.Part p : c.content().parts()) {
+                        if (p.inlineData() != null && p.inlineData().data() != null) {
+                            byte[] bytes = java.util.Base64.getDecoder()
+                                    .decode(p.inlineData().data());
+                            media.add(Media.builder()
+                                    .data(bytes)
+                                    .mimeType("audio/" + request.getResponseFormat())
+                                    .build());
+                        }
+                    }
+                }
+            }
+            return LLMResponse.builder().media(media).build();
+        } catch (Exception e) {
+            throw new RuntimeException("Gemini generateAudio failed", e);
         }
-        return LLMResponse.builder().media(media).build();
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertex.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertex.java
@@ -59,8 +59,11 @@ public class GeminiVertex implements AIModel {
             String customBase = config.getRawBaseURL(); // null if not explicitly set
             return GeminiApi.forApiKey(httpClient, config.getApiKey(), customBase);
         }
-        return GeminiApi.forVertex(httpClient, config.getProjectId(),
-                config.getLocation(), config.getGoogleCredentials());
+        return GeminiApi.forVertex(
+                httpClient,
+                config.getProjectId(),
+                config.getLocation(),
+                config.getGoogleCredentials());
     }
 
     @Override
@@ -76,10 +79,11 @@ public class GeminiVertex implements AIModel {
     @Override
     public List<Float> generateEmbeddings(EmbeddingGenRequest embeddingGenRequest) {
         try {
-            GeminiApi.EmbedContentResponse resp = geminiApi.embedContent(
-                    embeddingGenRequest.getModel(),
-                    embeddingGenRequest.getText(),
-                    embeddingGenRequest.getDimensions());
+            GeminiApi.EmbedContentResponse resp =
+                    geminiApi.embedContent(
+                            embeddingGenRequest.getModel(),
+                            embeddingGenRequest.getText(),
+                            embeddingGenRequest.getDimensions());
             if (resp.embedding() == null || resp.embedding().values() == null) {
                 throw new RuntimeException("No embeddings returned from Gemini API");
             }
@@ -198,18 +202,30 @@ public class GeminiVertex implements AIModel {
 
     @Override
     public LLMResponse generateAudio(AudioGenRequest request) {
-        GeminiApi.SpeechConfig speechConfig = new GeminiApi.SpeechConfig(
-                new GeminiApi.VoiceConfig(new GeminiApi.PrebuiltVoiceConfig(request.getVoice())));
-        GeminiApi.GenerationConfig genConfig = new GeminiApi.GenerationConfig(
-                null, null, null, request.getMaxTokens(), request.getStopWords(),
-                request.getFrequencyPenalty(),
-                null, null, List.of("AUDIO"), null, speechConfig);
+        GeminiApi.SpeechConfig speechConfig =
+                new GeminiApi.SpeechConfig(
+                        new GeminiApi.VoiceConfig(
+                                new GeminiApi.PrebuiltVoiceConfig(request.getVoice())));
+        GeminiApi.GenerationConfig genConfig =
+                new GeminiApi.GenerationConfig(
+                        null,
+                        null,
+                        null,
+                        request.getMaxTokens(),
+                        request.getStopWords(),
+                        request.getFrequencyPenalty(),
+                        null,
+                        null,
+                        List.of("AUDIO"),
+                        null,
+                        speechConfig);
 
         try {
-            GeminiApi.Content userContent = new GeminiApi.Content("user",
-                    List.of(GeminiApi.Part.text(request.getText())));
-            GeminiApi.GenerateContentResponse result = geminiApi.generateContent(
-                    request.getModel(), List.of(userContent), null, null, genConfig);
+            GeminiApi.Content userContent =
+                    new GeminiApi.Content("user", List.of(GeminiApi.Part.text(request.getText())));
+            GeminiApi.GenerateContentResponse result =
+                    geminiApi.generateContent(
+                            request.getModel(), List.of(userContent), null, null, genConfig);
 
             List<Media> media = new ArrayList<>();
             if (result.candidates() != null) {
@@ -217,12 +233,13 @@ public class GeminiVertex implements AIModel {
                     if (c.content() == null || c.content().parts() == null) continue;
                     for (GeminiApi.Part p : c.content().parts()) {
                         if (p.inlineData() != null && p.inlineData().data() != null) {
-                            byte[] bytes = java.util.Base64.getDecoder()
-                                    .decode(p.inlineData().data());
-                            media.add(Media.builder()
-                                    .data(bytes)
-                                    .mimeType("audio/" + request.getResponseFormat())
-                                    .build());
+                            byte[] bytes =
+                                    java.util.Base64.getDecoder().decode(p.inlineData().data());
+                            media.add(
+                                    Media.builder()
+                                            .data(bytes)
+                                            .mimeType("audio/" + request.getResponseFormat())
+                                            .build());
                         }
                     }
                 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexConfiguration.java
@@ -13,6 +13,7 @@
 package org.conductoross.conductor.ai.providers.gemini;
 
 import org.conductoross.conductor.ai.ModelConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -20,6 +21,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import okhttp3.OkHttpClient;
 
 @Data
 @Component
@@ -35,6 +37,9 @@ public class GeminiVertexConfiguration implements ModelConfiguration<GeminiVerte
     private String apiKey;
     GoogleCredentials googleCredentials;
 
+    @Autowired(required = false)
+    private OkHttpClient conductorAiHttpClient;
+
     public String getBaseURL() {
         return baseURL == null
                 ? String.format("%s-aiplatform.googleapis.com:443", location)
@@ -43,6 +48,9 @@ public class GeminiVertexConfiguration implements ModelConfiguration<GeminiVerte
 
     @Override
     public GeminiVertex get() {
-        return new GeminiVertex(this);
+        OkHttpClient client = conductorAiHttpClient != null
+                ? conductorAiHttpClient
+                : new OkHttpClient();
+        return new GeminiVertex(this, client);
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexConfiguration.java
@@ -46,6 +46,14 @@ public class GeminiVertexConfiguration implements ModelConfiguration<GeminiVerte
                 : baseURL;
     }
 
+    /**
+     * Returns the raw configured baseURL without applying the Vertex AI default.
+     * Use this when the default would be incorrect (e.g. API key / AI Studio mode).
+     */
+    public String getRawBaseURL() {
+        return baseURL;
+    }
+
     @Override
     public GeminiVertex get() {
         OkHttpClient client = conductorAiHttpClient != null

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexConfiguration.java
@@ -47,8 +47,8 @@ public class GeminiVertexConfiguration implements ModelConfiguration<GeminiVerte
     }
 
     /**
-     * Returns the raw configured baseURL without applying the Vertex AI default.
-     * Use this when the default would be incorrect (e.g. API key / AI Studio mode).
+     * Returns the raw configured baseURL without applying the Vertex AI default. Use this when the
+     * default would be incorrect (e.g. API key / AI Studio mode).
      */
     public String getRawBaseURL() {
         return baseURL;
@@ -56,9 +56,8 @@ public class GeminiVertexConfiguration implements ModelConfiguration<GeminiVerte
 
     @Override
     public GeminiVertex get() {
-        OkHttpClient client = conductorAiHttpClient != null
-                ? conductorAiHttpClient
-                : new OkHttpClient();
+        OkHttpClient client =
+                conductorAiHttpClient != null ? conductorAiHttpClient : new OkHttpClient();
         return new GeminiVertex(this, client);
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVideoModel.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVideoModel.java
@@ -16,38 +16,35 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 
+import org.conductoross.conductor.ai.providers.gemini.api.GeminiApi;
 import org.conductoross.conductor.ai.video.*;
 
-import com.google.genai.Client;
-import com.google.genai.types.GenerateVideosConfig;
-import com.google.genai.types.GenerateVideosOperation;
-import com.google.genai.types.GenerateVideosResponse;
-import com.google.genai.types.GeneratedVideo;
-import com.google.genai.types.Image;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Gemini Veo video model implementation using the Google GenAI SDK.
+ * Gemini Veo video model implementation using the GeminiApi OkHttp client.
  *
  * <p>Implements {@link AsyncVideoModel} for Google's Veo video generation models (veo-2.0, veo-3.0,
- * veo-3.1). Supports text-to-video and image-to-video generation via Vertex AI.
+ * veo-3.1). Supports text-to-video and image-to-video generation via AI Studio or Vertex AI.
  *
  * <p>The async flow uses long-running operations:
  *
  * <ol>
- *   <li>{@link #call(VideoPrompt)} submits via {@code client.models.generateVideos()} returning an
+ *   <li>{@link #call(VideoPrompt)} submits via {@code api.generateVideos()} returning an
  *       operation name
- *   <li>{@link #checkStatus(String)} polls via {@code client.operations.getVideosOperation()}
+ *   <li>{@link #checkStatus(String)} polls via {@code api.getVideosOperation()}
  *   <li>When {@code operation.done()} is true, video bytes are extracted from the response
  * </ol>
  */
 @Slf4j
 public class GeminiVideoModel implements AsyncVideoModel {
 
-    private final Client client;
+    private final GeminiApi api;
+    private final okhttp3.OkHttpClient httpClient;
 
-    public GeminiVideoModel(Client client) {
-        this.client = client;
+    public GeminiVideoModel(GeminiApi api, okhttp3.OkHttpClient httpClient) {
+        this.api = api;
+        this.httpClient = httpClient;
     }
 
     @Override
@@ -57,48 +54,42 @@ public class GeminiVideoModel implements AsyncVideoModel {
             String text = prompt.getInstructions().getFirst().getText();
 
             // Build GenerateVideosConfig from VideoOptions
-            GenerateVideosConfig.Builder configBuilder =
-                    GenerateVideosConfig.builder()
-                            .numberOfVideos(opts.getN() != null ? opts.getN() : 1);
-
-            if (opts.getDuration() != null) {
-                configBuilder.durationSeconds(opts.getDuration());
-            }
-            if (opts.getAspectRatio() != null) {
-                configBuilder.aspectRatio(opts.getAspectRatio());
-            }
-            if (opts.getSeed() != null) {
-                configBuilder.seed(opts.getSeed());
-            }
-            if (opts.getNegativePrompt() != null) {
-                configBuilder.negativePrompt(opts.getNegativePrompt());
-            }
-            if (opts.getPersonGeneration() != null) {
-                configBuilder.personGeneration(opts.getPersonGeneration());
-            }
-            if (opts.getResolution() != null) {
-                configBuilder.resolution(opts.getResolution());
-            }
-            if (opts.getGenerateAudio() != null) {
-                configBuilder.generateAudio(opts.getGenerateAudio());
-            }
-            if (opts.getFps() != null) {
-                configBuilder.fps(opts.getFps());
-            }
-
-            GenerateVideosConfig config = configBuilder.build();
+            GeminiApi.GenerateVideosConfig config = new GeminiApi.GenerateVideosConfig(
+                    opts.getN() != null ? opts.getN() : 1,
+                    opts.getDuration(),
+                    opts.getAspectRatio(),
+                    opts.getSeed(),
+                    opts.getNegativePrompt(),
+                    opts.getPersonGeneration(),
+                    opts.getResolution(),
+                    opts.getGenerateAudio(),
+                    opts.getFps());
 
             // Resolve input image for image-to-video
-            Image inputImage = null;
+            byte[] inputBytes = null;
+            String inputMime = null;
             if (opts.getInputImage() != null && !opts.getInputImage().isBlank()) {
-                inputImage = resolveGeminiImage(opts.getInputImage());
+                String inputImage = opts.getInputImage();
+                if (inputImage.startsWith("data:")) {
+                    // data:image/png;base64,xxx
+                    inputMime = inputImage.substring(5, inputImage.indexOf(";"));
+                    String base64Part = inputImage.substring(inputImage.indexOf(",") + 1);
+                    inputBytes = Base64.getDecoder().decode(base64Part);
+                } else if (inputImage.startsWith("http://") || inputImage.startsWith("https://")) {
+                    inputBytes = downloadFromUrl(inputImage);
+                    inputMime = "image/png";
+                } else {
+                    // Assume raw base64 encoded image
+                    inputBytes = Base64.getDecoder().decode(inputImage);
+                    inputMime = "image/png";
+                }
             }
 
             // Submit the video generation operation (async)
-            GenerateVideosOperation operation =
-                    client.models.generateVideos(opts.getModel(), text, inputImage, config);
+            GeminiApi.GenerateVideosOperation operation =
+                    api.generateVideos(opts.getModel(), text, inputBytes, inputMime, config);
 
-            String operationName = operation.name().orElse(null);
+            String operationName = operation.name();
 
             log.info(
                     "Gemini Veo video job submitted: operation={}, model={}",
@@ -120,59 +111,39 @@ public class GeminiVideoModel implements AsyncVideoModel {
     @Override
     public VideoResponse checkStatus(String jobId) {
         try {
-            // Build a minimal operation reference for polling
-            GenerateVideosOperation opRef = GenerateVideosOperation.builder().name(jobId).build();
-
-            GenerateVideosOperation operation = client.operations.getVideosOperation(opRef, null);
-
-            boolean isDone = operation.done().orElse(false);
+            GeminiApi.GenerateVideosOperation operation = api.getVideosOperation(jobId);
 
             VideoResponseMetadata metadata = new VideoResponseMetadata();
             metadata.setJobId(jobId);
 
-            if (isDone) {
+            if (Boolean.TRUE.equals(operation.done())) {
                 // Check for error
-                if (operation.error().isPresent()) {
+                if (operation.error() != null) {
                     metadata.setStatus("FAILED");
-                    metadata.setErrorMessage(operation.error().get().toString());
+                    metadata.setErrorMessage(operation.error().message());
                     log.error("Gemini Veo video failed: operation={}", jobId);
                     return new VideoResponse(List.of(), metadata);
                 }
 
                 // Extract generated videos from the response
-                GenerateVideosResponse response = operation.response().orElse(null);
                 List<VideoGeneration> generations = new ArrayList<>();
 
+                GeminiApi.GenerateVideosResult response = operation.response();
                 if (response != null) {
-                    List<GeneratedVideo> generatedVideos =
-                            response.generatedVideos().orElse(List.of());
+                    List<GeminiApi.GeneratedVideo> generatedVideos =
+                            response.videos() != null ? response.videos() : List.of();
 
-                    for (GeneratedVideo gv : generatedVideos) {
-                        gv.video()
-                                .ifPresent(
-                                        video -> {
-                                            byte[] bytes = video.videoBytes().orElse(null);
-                                            String url = video.uri().orElse(null);
-
-                                            // Use direct byte storage to avoid base64 encoding
-                                            // overhead
-                                            // Prefer bytes over URL to avoid potential
-                                            // re-downloading
-                                            org.conductoross.conductor.ai.video.Video videoObj;
-                                            if (bytes != null) {
-                                                videoObj =
-                                                        org.conductoross.conductor.ai.video.Video
-                                                                .fromBytes(bytes, "video/mp4");
-                                            } else {
-                                                // Fallback to URL if bytes not available
-                                                videoObj =
-                                                        new org.conductoross.conductor.ai.video
-                                                                .Video(
-                                                                url, null, null, "video/mp4");
-                                            }
-
-                                            generations.add(new VideoGeneration(videoObj));
-                                        });
+                    for (GeminiApi.GeneratedVideo gv : generatedVideos) {
+                        String mime = gv.mimeType() != null ? gv.mimeType() : "video/mp4";
+                        Video videoObj;
+                        if (gv.bytesBase64Encoded() != null) {
+                            byte[] bytes = Base64.getDecoder().decode(gv.bytesBase64Encoded());
+                            videoObj = Video.fromBytes(bytes, mime);
+                        } else {
+                            // Fallback to URL if bytes not available
+                            videoObj = new Video(gv.uri(), null, null, mime);
+                        }
+                        generations.add(new VideoGeneration(videoObj));
                     }
                 }
 
@@ -195,32 +166,9 @@ public class GeminiVideoModel implements AsyncVideoModel {
         }
     }
 
-    /**
-     * Resolves an input image specification to a Google GenAI Image object.
-     *
-     * <p>Supports data URIs, HTTP/HTTPS URLs, and raw base64 strings.
-     */
-    private Image resolveGeminiImage(String inputImage) {
-        if (inputImage.startsWith("data:")) {
-            // data:image/png;base64,xxx
-            String base64Part = inputImage.substring(inputImage.indexOf(",") + 1);
-            byte[] bytes = Base64.getDecoder().decode(base64Part);
-            String mimeType = inputImage.substring(5, inputImage.indexOf(";"));
-            return Image.builder().imageBytes(bytes).mimeType(mimeType).build();
-        } else if (inputImage.startsWith("http://") || inputImage.startsWith("https://")) {
-            byte[] bytes = downloadFromUrl(inputImage);
-            return Image.builder().imageBytes(bytes).mimeType("image/png").build();
-        } else {
-            // Assume raw base64 encoded image
-            byte[] bytes = Base64.getDecoder().decode(inputImage);
-            return Image.builder().imageBytes(bytes).mimeType("image/png").build();
-        }
-    }
-
     private byte[] downloadFromUrl(String url) {
-        okhttp3.OkHttpClient client = new okhttp3.OkHttpClient();
         okhttp3.Request request = new okhttp3.Request.Builder().url(url).get().build();
-        try (okhttp3.Response response = client.newCall(request).execute()) {
+        try (okhttp3.Response response = httpClient.newCall(request).execute()) {
             if (response.body() == null) {
                 throw new RuntimeException("Empty response downloading image from " + url);
             }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVideoModel.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/GeminiVideoModel.java
@@ -30,8 +30,8 @@ import lombok.extern.slf4j.Slf4j;
  * <p>The async flow uses long-running operations:
  *
  * <ol>
- *   <li>{@link #call(VideoPrompt)} submits via {@code api.generateVideos()} returning an
- *       operation name
+ *   <li>{@link #call(VideoPrompt)} submits via {@code api.generateVideos()} returning an operation
+ *       name
  *   <li>{@link #checkStatus(String)} polls via {@code api.getVideosOperation()}
  *   <li>When {@code operation.done()} is true, video bytes are extracted from the response
  * </ol>
@@ -54,16 +54,17 @@ public class GeminiVideoModel implements AsyncVideoModel {
             String text = prompt.getInstructions().getFirst().getText();
 
             // Build GenerateVideosConfig from VideoOptions
-            GeminiApi.GenerateVideosConfig config = new GeminiApi.GenerateVideosConfig(
-                    opts.getN() != null ? opts.getN() : 1,
-                    opts.getDuration(),
-                    opts.getAspectRatio(),
-                    opts.getSeed(),
-                    opts.getNegativePrompt(),
-                    opts.getPersonGeneration(),
-                    opts.getResolution(),
-                    opts.getGenerateAudio(),
-                    opts.getFps());
+            GeminiApi.GenerateVideosConfig config =
+                    new GeminiApi.GenerateVideosConfig(
+                            opts.getN() != null ? opts.getN() : 1,
+                            opts.getDuration(),
+                            opts.getAspectRatio(),
+                            opts.getSeed(),
+                            opts.getNegativePrompt(),
+                            opts.getPersonGeneration(),
+                            opts.getResolution(),
+                            opts.getGenerateAudio(),
+                            opts.getFps());
 
             // Resolve input image for image-to-video
             byte[] inputBytes = null;

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/api/GeminiApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/api/GeminiApi.java
@@ -19,9 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/**
- * DTO types for the Gemini REST API, plus an OkHttp-based HTTP client for all Gemini API calls.
- */
+/** DTO types for the Gemini REST API, plus an OkHttp-based HTTP client for all Gemini API calls. */
 public class GeminiApi {
 
     // ---- HTTP client state ----
@@ -32,34 +30,49 @@ public class GeminiApi {
 
     private final okhttp3.OkHttpClient httpClient;
     private final String endpointBase; // e.g. "https://generativelanguage.googleapis.com/v1beta"
-    private final String apiKey;       // null for Vertex
+    private final String apiKey; // null for Vertex
     private final com.google.auth.oauth2.GoogleCredentials credentials; // null for API key mode
     private final com.fasterxml.jackson.databind.ObjectMapper objectMapper;
 
     /** Factory: API-key mode (AI Studio / generativelanguage.googleapis.com). */
-    public static GeminiApi forApiKey(okhttp3.OkHttpClient httpClient, String apiKey, String customBase) {
-        String base = (customBase != null && !customBase.isBlank())
-                ? customBase + AI_STUDIO_VERSION : AI_STUDIO_BASE + AI_STUDIO_VERSION;
+    public static GeminiApi forApiKey(
+            okhttp3.OkHttpClient httpClient, String apiKey, String customBase) {
+        String base =
+                (customBase != null && !customBase.isBlank())
+                        ? customBase + AI_STUDIO_VERSION
+                        : AI_STUDIO_BASE + AI_STUDIO_VERSION;
         return new GeminiApi(httpClient, base, apiKey, null);
     }
 
     /** Factory: Vertex AI mode. */
-    public static GeminiApi forVertex(okhttp3.OkHttpClient httpClient,
-            String projectId, String location,
+    public static GeminiApi forVertex(
+            okhttp3.OkHttpClient httpClient,
+            String projectId,
+            String location,
             com.google.auth.oauth2.GoogleCredentials credentials) {
-        String base = "https://" + location + "-aiplatform.googleapis.com/v1"
-                + "/projects/" + projectId + "/locations/" + location + "/publishers/google";
+        String base =
+                "https://"
+                        + location
+                        + "-aiplatform.googleapis.com/v1"
+                        + "/projects/"
+                        + projectId
+                        + "/locations/"
+                        + location
+                        + "/publishers/google";
         return new GeminiApi(httpClient, base, null, credentials);
     }
 
-    private GeminiApi(okhttp3.OkHttpClient httpClient, String endpointBase,
-            String apiKey, com.google.auth.oauth2.GoogleCredentials credentials) {
+    private GeminiApi(
+            okhttp3.OkHttpClient httpClient,
+            String endpointBase,
+            String apiKey,
+            com.google.auth.oauth2.GoogleCredentials credentials) {
         this.httpClient = httpClient;
         this.endpointBase = endpointBase;
         this.apiKey = apiKey;
         this.credentials = credentials;
-        this.objectMapper = new com.netflix.conductor.common.config.ObjectMapperProvider()
-                .getObjectMapper();
+        this.objectMapper =
+                new com.netflix.conductor.common.config.ObjectMapperProvider().getObjectMapper();
     }
 
     // ---- URL helpers ----
@@ -93,17 +106,16 @@ public class GeminiApi {
             } else {
                 credentials.refreshIfExpired();
             }
-            builder.header("Authorization", "Bearer "
-                    + credentials.getAccessToken().getTokenValue());
+            builder.header(
+                    "Authorization", "Bearer " + credentials.getAccessToken().getTokenValue());
         }
         return builder;
     }
 
     private String executePost(String url, Object body) throws java.io.IOException {
         String json = objectMapper.writeValueAsString(body);
-        okhttp3.Request request = authRequest(url)
-                .post(okhttp3.RequestBody.create(json, JSON_MEDIA))
-                .build();
+        okhttp3.Request request =
+                authRequest(url).post(okhttp3.RequestBody.create(json, JSON_MEDIA)).build();
         try (okhttp3.Response response = httpClient.newCall(request).execute()) {
             String resp = response.body() != null ? response.body().string() : "";
             if (!response.isSuccessful()) {
@@ -129,16 +141,20 @@ public class GeminiApi {
     // ---- API methods ----
 
     public GenerateContentResponse generateContent(
-            String model, List<Content> contents, GenerationConfig config) throws java.io.IOException {
+            String model, List<Content> contents, GenerationConfig config)
+            throws java.io.IOException {
         return generateContent(model, contents, null, null, config);
     }
 
     public GenerateContentResponse generateContent(
-            String model, List<Content> contents,
-            Content systemInstruction, List<Tool> tools,
-            GenerationConfig config) throws java.io.IOException {
-        GenerateContentRequest req = new GenerateContentRequest(
-                contents, systemInstruction, tools, config);
+            String model,
+            List<Content> contents,
+            Content systemInstruction,
+            List<Tool> tools,
+            GenerationConfig config)
+            throws java.io.IOException {
+        GenerateContentRequest req =
+                new GenerateContentRequest(contents, systemInstruction, tools, config);
         return objectMapper.readValue(
                 executePost(modelUrl(model, "generateContent"), req),
                 GenerateContentResponse.class);
@@ -149,12 +165,12 @@ public class GeminiApi {
         Content content = new Content(null, List.of(Part.text(text)));
         EmbedContentRequest req = new EmbedContentRequest(content, null, outputDimensionality);
         return objectMapper.readValue(
-                executePost(modelUrl(model, "embedContent"), req),
-                EmbedContentResponse.class);
+                executePost(modelUrl(model, "embedContent"), req), EmbedContentResponse.class);
     }
 
     public GenerateImagesResponse generateImages(
-            String model, String promptText, GenerateImagesConfig config) throws java.io.IOException {
+            String model, String promptText, GenerateImagesConfig config)
+            throws java.io.IOException {
         GenerateImagesRequest req = new GenerateImagesRequest(new ImagePrompt(promptText), config);
         return objectMapper.readValue(
                 executePost(modelUrl(model, "generateImages", "predict"), req),
@@ -162,15 +178,22 @@ public class GeminiApi {
     }
 
     public GenerateVideosOperation generateVideos(
-            String model, String text, byte[] inputImageBytes, String inputMimeType,
-            GenerateVideosConfig config) throws java.io.IOException {
+            String model,
+            String text,
+            byte[] inputImageBytes,
+            String inputMimeType,
+            GenerateVideosConfig config)
+            throws java.io.IOException {
         java.util.Map<String, Object> instance = new java.util.LinkedHashMap<>();
         instance.put("prompt", text);
         if (inputImageBytes != null) {
-            instance.put("image", java.util.Map.of(
-                    "bytesBase64Encoded",
-                    java.util.Base64.getEncoder().encodeToString(inputImageBytes),
-                    "mimeType", inputMimeType != null ? inputMimeType : "image/png"));
+            instance.put(
+                    "image",
+                    java.util.Map.of(
+                            "bytesBase64Encoded",
+                            java.util.Base64.getEncoder().encodeToString(inputImageBytes),
+                            "mimeType",
+                            inputMimeType != null ? inputMimeType : "image/png"));
         }
         GenerateVideosRequest req = new GenerateVideosRequest(List.of(instance), config);
         return objectMapper.readValue(
@@ -178,19 +201,18 @@ public class GeminiApi {
                 GenerateVideosOperation.class);
     }
 
-    public GenerateVideosOperation getVideosOperation(String operationName) throws java.io.IOException {
+    public GenerateVideosOperation getVideosOperation(String operationName)
+            throws java.io.IOException {
         if (apiKey != null) {
             // AI Studio: GET the operation resource
             return objectMapper.readValue(
-                    executeGet(operationUrl(operationName)),
-                    GenerateVideosOperation.class);
+                    executeGet(operationUrl(operationName)), GenerateVideosOperation.class);
         } else {
             // Vertex AI: POST to fetchPredictOperation
             String vertexBase = endpointBase.replaceAll("/publishers/google$", "");
             String url = vertexBase + "/" + operationName + ":fetchPredictOperation";
             return objectMapper.readValue(
-                    executePost(url, java.util.Map.of()),
-                    GenerateVideosOperation.class);
+                    executePost(url, java.util.Map.of()), GenerateVideosOperation.class);
         }
     }
 
@@ -204,9 +226,7 @@ public class GeminiApi {
             @JsonProperty("generationConfig") GenerationConfig generationConfig) {}
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public record Content(
-            String role,
-            List<Part> parts) {}
+    public record Content(String role, List<Part> parts) {}
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record Part(
@@ -259,9 +279,7 @@ public class GeminiApi {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record FunctionDeclaration(
-            String name,
-            String description,
-            @JsonProperty("parameters") Object parameters) {}
+            String name, String description, @JsonProperty("parameters") Object parameters) {}
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record GenerationConfig(
@@ -283,16 +301,14 @@ public class GeminiApi {
             @JsonProperty("includeThoughts") Boolean includeThoughts) {}
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public record SpeechConfig(
-            @JsonProperty("voiceConfig") VoiceConfig voiceConfig) {}
+    public record SpeechConfig(@JsonProperty("voiceConfig") VoiceConfig voiceConfig) {}
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record VoiceConfig(
             @JsonProperty("prebuiltVoiceConfig") PrebuiltVoiceConfig prebuiltVoiceConfig) {}
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public record PrebuiltVoiceConfig(
-            @JsonProperty("voiceName") String voiceName) {}
+    public record PrebuiltVoiceConfig(@JsonProperty("voiceName") String voiceName) {}
 
     // --- Response DTOs ---
 
@@ -336,9 +352,7 @@ public class GeminiApi {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public record Candidate(
-            Content content,
-            @JsonProperty("finishReason") String finishReason) {}
+    public record Candidate(Content content, @JsonProperty("finishReason") String finishReason) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record UsageMetadata(
@@ -355,12 +369,10 @@ public class GeminiApi {
             @JsonProperty("outputDimensionality") Integer outputDimensionality) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public record EmbedContentResponse(
-            @JsonProperty("embedding") Embedding embedding) {}
+    public record EmbedContentResponse(@JsonProperty("embedding") Embedding embedding) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public record Embedding(
-            @JsonProperty("values") List<Float> values) {}
+    public record Embedding(@JsonProperty("values") List<Float> values) {}
 
     // --- Image generation ---
 
@@ -413,8 +425,7 @@ public class GeminiApi {
             @JsonProperty("response") GenerateVideosResult response) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public record GenerateVideosResult(
-            @JsonProperty("videos") List<GeneratedVideo> videos) {}
+    public record GenerateVideosResult(@JsonProperty("videos") List<GeneratedVideo> videos) {}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record GeneratedVideo(

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/api/GeminiApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/api/GeminiApi.java
@@ -157,8 +157,13 @@ public class GeminiApi {
                 new GenerateContentRequest(contents, systemInstruction, tools, config);
         String url = modelUrl(model, "generateContent");
         String json = objectMapper.writeValueAsString(req);
-        try (okhttp3.Response response = httpClient.newCall(authRequest(url)
-                .post(okhttp3.RequestBody.create(json, JSON_MEDIA)).build()).execute()) {
+        try (okhttp3.Response response =
+                httpClient
+                        .newCall(
+                                authRequest(url)
+                                        .post(okhttp3.RequestBody.create(json, JSON_MEDIA))
+                                        .build())
+                        .execute()) {
             String body = response.body() != null ? response.body().string() : "";
             if (!response.isSuccessful()) {
                 // Some Gemini thinking models reject temperature — retry without it.
@@ -166,8 +171,8 @@ public class GeminiApi {
                         && body.contains("temperature")
                         && config != null
                         && config.temperature() != null) {
-                    return generateContent(model, contents, systemInstruction, tools,
-                            config.withoutTemperature());
+                    return generateContent(
+                            model, contents, systemInstruction, tools, config.withoutTemperature());
                 }
                 throw new java.io.IOException(
                         "Gemini API error %d: %s".formatted(response.code(), body));
@@ -312,9 +317,18 @@ public class GeminiApi {
             @JsonProperty("speechConfig") SpeechConfig speechConfig) {
 
         public GenerationConfig withoutTemperature() {
-            return new GenerationConfig(null, topP, topK, maxOutputTokens, stopSequences,
-                    frequencyPenalty, presencePenalty, responseMimeType, responseModalities,
-                    thinkingConfig, speechConfig);
+            return new GenerationConfig(
+                    null,
+                    topP,
+                    topK,
+                    maxOutputTokens,
+                    stopSequences,
+                    frequencyPenalty,
+                    presencePenalty,
+                    responseMimeType,
+                    responseModalities,
+                    thinkingConfig,
+                    speechConfig);
         }
     }
 

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/api/GeminiApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/api/GeminiApi.java
@@ -64,9 +64,14 @@ public class GeminiApi {
 
     // ---- URL helpers ----
 
-    private String modelUrl(String model, String verb) {
+    private String modelUrl(String model, String aiStudioVerb, String vertexVerb) {
+        String verb = apiKey != null ? aiStudioVerb : vertexVerb;
         String url = endpointBase + "/models/" + model + ":" + verb;
         return apiKey != null ? url + "?key=" + apiKey : url;
+    }
+
+    private String modelUrl(String model, String verb) {
+        return modelUrl(model, verb, verb);
     }
 
     private String operationUrl(String operationName) {
@@ -83,7 +88,11 @@ public class GeminiApi {
     private okhttp3.Request.Builder authRequest(String url) throws java.io.IOException {
         okhttp3.Request.Builder builder = new okhttp3.Request.Builder().url(url);
         if (credentials != null) {
-            credentials.refreshIfExpired();
+            if (credentials.getAccessToken() == null) {
+                credentials.refresh();
+            } else {
+                credentials.refreshIfExpired();
+            }
             builder.header("Authorization", "Bearer "
                     + credentials.getAccessToken().getTokenValue());
         }
@@ -148,7 +157,7 @@ public class GeminiApi {
             String model, String promptText, GenerateImagesConfig config) throws java.io.IOException {
         GenerateImagesRequest req = new GenerateImagesRequest(new ImagePrompt(promptText), config);
         return objectMapper.readValue(
-                executePost(modelUrl(model, "generateImages"), req),
+                executePost(modelUrl(model, "generateImages", "predict"), req),
                 GenerateImagesResponse.class);
     }
 
@@ -165,14 +174,24 @@ public class GeminiApi {
         }
         GenerateVideosRequest req = new GenerateVideosRequest(List.of(instance), config);
         return objectMapper.readValue(
-                executePost(modelUrl(model, "generateVideos"), req),
+                executePost(modelUrl(model, "generateVideos", "predictLongRunning"), req),
                 GenerateVideosOperation.class);
     }
 
     public GenerateVideosOperation getVideosOperation(String operationName) throws java.io.IOException {
-        return objectMapper.readValue(
-                executeGet(operationUrl(operationName)),
-                GenerateVideosOperation.class);
+        if (apiKey != null) {
+            // AI Studio: GET the operation resource
+            return objectMapper.readValue(
+                    executeGet(operationUrl(operationName)),
+                    GenerateVideosOperation.class);
+        } else {
+            // Vertex AI: POST to fetchPredictOperation
+            String vertexBase = endpointBase.replaceAll("/publishers/google$", "");
+            String url = vertexBase + "/" + operationName + ":fetchPredictOperation";
+            return objectMapper.readValue(
+                    executePost(url, java.util.Map.of()),
+                    GenerateVideosOperation.class);
+        }
     }
 
     // --- Request DTOs ---

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/api/GeminiApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/api/GeminiApi.java
@@ -155,9 +155,25 @@ public class GeminiApi {
             throws java.io.IOException {
         GenerateContentRequest req =
                 new GenerateContentRequest(contents, systemInstruction, tools, config);
-        return objectMapper.readValue(
-                executePost(modelUrl(model, "generateContent"), req),
-                GenerateContentResponse.class);
+        String url = modelUrl(model, "generateContent");
+        String json = objectMapper.writeValueAsString(req);
+        try (okhttp3.Response response = httpClient.newCall(authRequest(url)
+                .post(okhttp3.RequestBody.create(json, JSON_MEDIA)).build()).execute()) {
+            String body = response.body() != null ? response.body().string() : "";
+            if (!response.isSuccessful()) {
+                // Some Gemini thinking models reject temperature — retry without it.
+                if (response.code() == 400
+                        && body.contains("temperature")
+                        && config != null
+                        && config.temperature() != null) {
+                    return generateContent(model, contents, systemInstruction, tools,
+                            config.withoutTemperature());
+                }
+                throw new java.io.IOException(
+                        "Gemini API error %d: %s".formatted(response.code(), body));
+            }
+            return objectMapper.readValue(body, GenerateContentResponse.class);
+        }
     }
 
     public EmbedContentResponse embedContent(
@@ -293,7 +309,14 @@ public class GeminiApi {
             @JsonProperty("responseMimeType") String responseMimeType,
             @JsonProperty("responseModalities") List<String> responseModalities,
             @JsonProperty("thinkingConfig") ThinkingConfig thinkingConfig,
-            @JsonProperty("speechConfig") SpeechConfig speechConfig) {}
+            @JsonProperty("speechConfig") SpeechConfig speechConfig) {
+
+        public GenerationConfig withoutTemperature() {
+            return new GenerationConfig(null, topP, topK, maxOutputTokens, stopSequences,
+                    frequencyPenalty, presencePenalty, responseMimeType, responseModalities,
+                    thinkingConfig, speechConfig);
+        }
+    }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record ThinkingConfig(

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/api/GeminiApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/api/GeminiApi.java
@@ -1,0 +1,242 @@
+package org.conductoross.conductor.ai.providers.gemini.api;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * OkHttp REST client for the Gemini REST API.
+ * Supports both API-key mode (generativelanguage.googleapis.com) and
+ * Vertex AI mode ({location}-aiplatform.googleapis.com).
+ */
+public class GeminiApi {
+
+    // --- Request DTOs ---
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record GenerateContentRequest(
+            List<Content> contents,
+            @JsonProperty("systemInstruction") Content systemInstruction,
+            List<Tool> tools,
+            @JsonProperty("generationConfig") GenerationConfig generationConfig) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Content(
+            String role,
+            List<Part> parts) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Part(
+            String text,
+            @JsonProperty("functionCall") FunctionCallPart functionCall,
+            @JsonProperty("functionResponse") FunctionResponsePart functionResponse,
+            @JsonProperty("inlineData") InlineData inlineData,
+            Boolean thought) {
+
+        public static Part text(String text) {
+            return new Part(text, null, null, null, null);
+        }
+
+        public static Part functionCall(String name, Map<String, Object> args) {
+            return new Part(null, new FunctionCallPart(name, args), null, null, null);
+        }
+
+        public static Part functionResponse(String name, Map<String, Object> response) {
+            return new Part(null, null, new FunctionResponsePart(name, response), null, null);
+        }
+    }
+
+    public record FunctionCallPart(String name, Map<String, Object> args) {}
+    public record FunctionResponsePart(String name, Map<String, Object> response) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record InlineData(String mimeType, String data) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Tool(
+            @JsonProperty("functionDeclarations") List<FunctionDeclaration> functionDeclarations,
+            @JsonProperty("googleSearch") Map<String, Object> googleSearch,
+            @JsonProperty("codeExecution") Map<String, Object> codeExecution) {
+
+        public static Tool withGoogleSearch() {
+            return new Tool(null, Map.of(), null);
+        }
+
+        public static Tool withCodeExecution() {
+            return new Tool(null, null, Map.of());
+        }
+
+        public static Tool withFunctionDeclarations(List<FunctionDeclaration> decls) {
+            return new Tool(decls, null, null);
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record FunctionDeclaration(
+            String name,
+            String description,
+            @JsonProperty("parameters") Object parameters) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record GenerationConfig(
+            Double temperature,
+            @JsonProperty("topP") Double topP,
+            @JsonProperty("topK") Double topK,
+            @JsonProperty("maxOutputTokens") Integer maxOutputTokens,
+            @JsonProperty("stopSequences") List<String> stopSequences,
+            @JsonProperty("frequencyPenalty") Double frequencyPenalty,
+            @JsonProperty("presencePenalty") Double presencePenalty,
+            @JsonProperty("responseMimeType") String responseMimeType,
+            @JsonProperty("responseModalities") List<String> responseModalities,
+            @JsonProperty("thinkingConfig") ThinkingConfig thinkingConfig,
+            @JsonProperty("speechConfig") SpeechConfig speechConfig) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record ThinkingConfig(
+            @JsonProperty("thinkingBudget") Integer thinkingBudget,
+            @JsonProperty("includeThoughts") Boolean includeThoughts) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record SpeechConfig(
+            @JsonProperty("voiceConfig") VoiceConfig voiceConfig) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record VoiceConfig(
+            @JsonProperty("prebuiltVoiceConfig") PrebuiltVoiceConfig prebuiltVoiceConfig) {}
+
+    public record PrebuiltVoiceConfig(
+            @JsonProperty("voiceName") String voiceName) {}
+
+    // --- Response DTOs ---
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record GenerateContentResponse(
+            List<Candidate> candidates,
+            @JsonProperty("usageMetadata") UsageMetadata usageMetadata,
+            @JsonProperty("responseId") String responseId) {
+
+        /** Concatenate text from non-thought parts, mirroring SDK result.text(). */
+        public String text() {
+            if (candidates == null || candidates.isEmpty()) return "";
+            StringBuilder sb = new StringBuilder();
+            for (Candidate c : candidates) {
+                if (c.content() == null || c.content().parts() == null) continue;
+                for (Part p : c.content().parts()) {
+                    if (!Boolean.TRUE.equals(p.thought()) && p.text() != null) {
+                        sb.append(p.text());
+                    }
+                }
+            }
+            return sb.toString();
+        }
+
+        /** Collect all functionCall parts from all candidates. */
+        public List<FunctionCallPart> functionCalls() {
+            if (candidates == null) return List.of();
+            return candidates.stream()
+                    .filter(c -> c.content() != null && c.content().parts() != null)
+                    .flatMap(c -> c.content().parts().stream())
+                    .filter(p -> p.functionCall() != null)
+                    .map(Part::functionCall)
+                    .toList();
+        }
+
+        /** Finish reason from first candidate. */
+        public String finishReason() {
+            if (candidates == null || candidates.isEmpty()) return "STOP";
+            return candidates.get(0).finishReason() != null
+                    ? candidates.get(0).finishReason() : "STOP";
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Candidate(
+            Content content,
+            @JsonProperty("finishReason") String finishReason) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record UsageMetadata(
+            @JsonProperty("promptTokenCount") Integer promptTokenCount,
+            @JsonProperty("candidatesTokenCount") Integer candidatesTokenCount,
+            @JsonProperty("thoughtsTokenCount") Integer thoughtsTokenCount) {}
+
+    // --- Embeddings ---
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record EmbedContentRequest(
+            Content content,
+            @JsonProperty("taskType") String taskType,
+            @JsonProperty("outputDimensionality") Integer outputDimensionality) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record EmbedContentResponse(
+            @JsonProperty("embedding") Embedding embedding) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Embedding(
+            @JsonProperty("values") List<Float> values) {}
+
+    // --- Image generation ---
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record GenerateImagesRequest(
+            Map<String, String> prompt,
+            @JsonProperty("generationConfig") GenerateImagesConfig generationConfig) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record GenerateImagesConfig(
+            @JsonProperty("numberOfImages") Integer numberOfImages,
+            @JsonProperty("outputMimeType") String outputMimeType,
+            @JsonProperty("includeSafetyAttributes") Boolean includeSafetyAttributes) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record GenerateImagesResponse(
+            @JsonProperty("predictions") List<ImagePrediction> predictions) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ImagePrediction(
+            @JsonProperty("bytesBase64Encoded") String bytesBase64Encoded,
+            @JsonProperty("mimeType") String mimeType) {}
+
+    // --- Video generation ---
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record GenerateVideosRequest(
+            Map<String, Object> instances,
+            @JsonProperty("parameters") GenerateVideosConfig parameters) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record GenerateVideosConfig(
+            @JsonProperty("numberOfVideos") Integer numberOfVideos,
+            @JsonProperty("durationSeconds") Integer durationSeconds,
+            @JsonProperty("aspectRatio") String aspectRatio,
+            Integer seed,
+            @JsonProperty("negativePrompt") String negativePrompt,
+            @JsonProperty("personGeneration") String personGeneration,
+            String resolution,
+            @JsonProperty("generateAudio") Boolean generateAudio,
+            Integer fps) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record GenerateVideosOperation(
+            String name,
+            Boolean done,
+            @JsonProperty("error") OperationError error,
+            @JsonProperty("response") GenerateVideosResult response) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record GenerateVideosResult(
+            @JsonProperty("videos") List<GeneratedVideo> videos) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record GeneratedVideo(
+            @JsonProperty("bytesBase64Encoded") String bytesBase64Encoded,
+            @JsonProperty("uri") String uri,
+            @JsonProperty("mimeType") String mimeType) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OperationError(Integer code, String message) {}
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/api/GeminiApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/api/GeminiApi.java
@@ -20,9 +20,160 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * DTO types for the Gemini REST API. HTTP client and request methods are added by subsequent tasks.
+ * DTO types for the Gemini REST API, plus an OkHttp-based HTTP client for all Gemini API calls.
  */
 public class GeminiApi {
+
+    // ---- HTTP client state ----
+
+    private static final String AI_STUDIO_BASE = "https://generativelanguage.googleapis.com";
+    private static final String AI_STUDIO_VERSION = "/v1beta";
+    private static final okhttp3.MediaType JSON_MEDIA = okhttp3.MediaType.parse("application/json");
+
+    private final okhttp3.OkHttpClient httpClient;
+    private final String endpointBase; // e.g. "https://generativelanguage.googleapis.com/v1beta"
+    private final String apiKey;       // null for Vertex
+    private final com.google.auth.oauth2.GoogleCredentials credentials; // null for API key mode
+    private final com.fasterxml.jackson.databind.ObjectMapper objectMapper;
+
+    /** Factory: API-key mode (AI Studio / generativelanguage.googleapis.com). */
+    public static GeminiApi forApiKey(okhttp3.OkHttpClient httpClient, String apiKey, String customBase) {
+        String base = (customBase != null && !customBase.isBlank())
+                ? customBase + AI_STUDIO_VERSION : AI_STUDIO_BASE + AI_STUDIO_VERSION;
+        return new GeminiApi(httpClient, base, apiKey, null);
+    }
+
+    /** Factory: Vertex AI mode. */
+    public static GeminiApi forVertex(okhttp3.OkHttpClient httpClient,
+            String projectId, String location,
+            com.google.auth.oauth2.GoogleCredentials credentials) {
+        String base = "https://" + location + "-aiplatform.googleapis.com/v1"
+                + "/projects/" + projectId + "/locations/" + location + "/publishers/google";
+        return new GeminiApi(httpClient, base, null, credentials);
+    }
+
+    private GeminiApi(okhttp3.OkHttpClient httpClient, String endpointBase,
+            String apiKey, com.google.auth.oauth2.GoogleCredentials credentials) {
+        this.httpClient = httpClient;
+        this.endpointBase = endpointBase;
+        this.apiKey = apiKey;
+        this.credentials = credentials;
+        this.objectMapper = new com.netflix.conductor.common.config.ObjectMapperProvider()
+                .getObjectMapper();
+    }
+
+    // ---- URL helpers ----
+
+    private String modelUrl(String model, String verb) {
+        String url = endpointBase + "/models/" + model + ":" + verb;
+        return apiKey != null ? url + "?key=" + apiKey : url;
+    }
+
+    private String operationUrl(String operationName) {
+        if (apiKey != null) {
+            // AI Studio: operationName is the bare operation id
+            return AI_STUDIO_BASE + AI_STUDIO_VERSION + "/" + operationName + "?key=" + apiKey;
+        }
+        // Vertex: operationName is a full resource path like "projects/.../operations/xxx"
+        // Strip the version prefix from endpointBase to get the Vertex host
+        String vertexBase = endpointBase.replaceAll("/v1/projects/.*", "");
+        return vertexBase + "/v1/" + operationName;
+    }
+
+    private okhttp3.Request.Builder authRequest(String url) throws java.io.IOException {
+        okhttp3.Request.Builder builder = new okhttp3.Request.Builder().url(url);
+        if (credentials != null) {
+            credentials.refreshIfExpired();
+            builder.header("Authorization", "Bearer "
+                    + credentials.getAccessToken().getTokenValue());
+        }
+        return builder;
+    }
+
+    private String executePost(String url, Object body) throws java.io.IOException {
+        String json = objectMapper.writeValueAsString(body);
+        okhttp3.Request request = authRequest(url)
+                .post(okhttp3.RequestBody.create(json, JSON_MEDIA))
+                .build();
+        try (okhttp3.Response response = httpClient.newCall(request).execute()) {
+            String resp = response.body() != null ? response.body().string() : "";
+            if (!response.isSuccessful()) {
+                throw new java.io.IOException(
+                        "Gemini API error %d: %s".formatted(response.code(), resp));
+            }
+            return resp;
+        }
+    }
+
+    private String executeGet(String url) throws java.io.IOException {
+        okhttp3.Request request = authRequest(url).get().build();
+        try (okhttp3.Response response = httpClient.newCall(request).execute()) {
+            String resp = response.body() != null ? response.body().string() : "";
+            if (!response.isSuccessful()) {
+                throw new java.io.IOException(
+                        "Gemini API error %d: %s".formatted(response.code(), resp));
+            }
+            return resp;
+        }
+    }
+
+    // ---- API methods ----
+
+    public GenerateContentResponse generateContent(
+            String model, List<Content> contents, GenerationConfig config) throws java.io.IOException {
+        return generateContent(model, contents, null, null, config);
+    }
+
+    public GenerateContentResponse generateContent(
+            String model, List<Content> contents,
+            Content systemInstruction, List<Tool> tools,
+            GenerationConfig config) throws java.io.IOException {
+        GenerateContentRequest req = new GenerateContentRequest(
+                contents, systemInstruction, tools, config);
+        return objectMapper.readValue(
+                executePost(modelUrl(model, "generateContent"), req),
+                GenerateContentResponse.class);
+    }
+
+    public EmbedContentResponse embedContent(
+            String model, String text, Integer outputDimensionality) throws java.io.IOException {
+        Content content = new Content(null, List.of(Part.text(text)));
+        EmbedContentRequest req = new EmbedContentRequest(content, null, outputDimensionality);
+        return objectMapper.readValue(
+                executePost(modelUrl(model, "embedContent"), req),
+                EmbedContentResponse.class);
+    }
+
+    public GenerateImagesResponse generateImages(
+            String model, String promptText, GenerateImagesConfig config) throws java.io.IOException {
+        GenerateImagesRequest req = new GenerateImagesRequest(new ImagePrompt(promptText), config);
+        return objectMapper.readValue(
+                executePost(modelUrl(model, "generateImages"), req),
+                GenerateImagesResponse.class);
+    }
+
+    public GenerateVideosOperation generateVideos(
+            String model, String text, byte[] inputImageBytes, String inputMimeType,
+            GenerateVideosConfig config) throws java.io.IOException {
+        java.util.Map<String, Object> instance = new java.util.LinkedHashMap<>();
+        instance.put("prompt", text);
+        if (inputImageBytes != null) {
+            instance.put("image", java.util.Map.of(
+                    "bytesBase64Encoded",
+                    java.util.Base64.getEncoder().encodeToString(inputImageBytes),
+                    "mimeType", inputMimeType != null ? inputMimeType : "image/png"));
+        }
+        GenerateVideosRequest req = new GenerateVideosRequest(List.of(instance), config);
+        return objectMapper.readValue(
+                executePost(modelUrl(model, "generateVideos"), req),
+                GenerateVideosOperation.class);
+    }
+
+    public GenerateVideosOperation getVideosOperation(String operationName) throws java.io.IOException {
+        return objectMapper.readValue(
+                executeGet(operationUrl(operationName)),
+                GenerateVideosOperation.class);
+    }
 
     // --- Request DTOs ---
 

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/api/GeminiApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/gemini/api/GeminiApi.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package org.conductoross.conductor.ai.providers.gemini.api;
 
 import java.util.List;
@@ -8,9 +20,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * OkHttp REST client for the Gemini REST API.
- * Supports both API-key mode (generativelanguage.googleapis.com) and
- * Vertex AI mode ({location}-aiplatform.googleapis.com).
+ * DTO types for the Gemini REST API. HTTP client and request methods are added by subsequent tasks.
  */
 public class GeminiApi {
 
@@ -49,7 +59,10 @@ public class GeminiApi {
         }
     }
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public record FunctionCallPart(String name, Map<String, Object> args) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public record FunctionResponsePart(String name, Map<String, Object> response) {}
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -84,7 +97,7 @@ public class GeminiApi {
     public record GenerationConfig(
             Double temperature,
             @JsonProperty("topP") Double topP,
-            @JsonProperty("topK") Double topK,
+            @JsonProperty("topK") Integer topK,
             @JsonProperty("maxOutputTokens") Integer maxOutputTokens,
             @JsonProperty("stopSequences") List<String> stopSequences,
             @JsonProperty("frequencyPenalty") Double frequencyPenalty,
@@ -107,6 +120,7 @@ public class GeminiApi {
     public record VoiceConfig(
             @JsonProperty("prebuiltVoiceConfig") PrebuiltVoiceConfig prebuiltVoiceConfig) {}
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public record PrebuiltVoiceConfig(
             @JsonProperty("voiceName") String voiceName) {}
 
@@ -146,9 +160,8 @@ public class GeminiApi {
 
         /** Finish reason from first candidate. */
         public String finishReason() {
-            if (candidates == null || candidates.isEmpty()) return "STOP";
-            return candidates.get(0).finishReason() != null
-                    ? candidates.get(0).finishReason() : "STOP";
+            if (candidates == null || candidates.isEmpty()) return null;
+            return candidates.get(0).finishReason();
         }
     }
 
@@ -183,8 +196,10 @@ public class GeminiApi {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record GenerateImagesRequest(
-            Map<String, String> prompt,
+            @JsonProperty("prompt") ImagePrompt prompt,
             @JsonProperty("generationConfig") GenerateImagesConfig generationConfig) {}
+
+    public record ImagePrompt(@JsonProperty("text") String text) {}
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record GenerateImagesConfig(
@@ -205,7 +220,7 @@ public class GeminiApi {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record GenerateVideosRequest(
-            Map<String, Object> instances,
+            @JsonProperty("instances") List<Map<String, Object>> instances,
             @JsonProperty("parameters") GenerateVideosConfig parameters) {}
 
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/grok/Grok.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/grok/Grok.java
@@ -21,13 +21,13 @@ import org.conductoross.conductor.ai.models.ChatCompletion;
 import org.conductoross.conductor.ai.models.EmbeddingGenRequest;
 import org.conductoross.conductor.ai.providers.openai.OpenAICompatChatModel;
 import org.conductoross.conductor.ai.providers.openai.api.OpenAIChatCompletionsApi;
-
-import okhttp3.OkHttpClient;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.image.ImageModel;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.tool.ToolCallback;
+
+import okhttp3.OkHttpClient;
 
 public class Grok implements AIModel {
 
@@ -43,7 +43,10 @@ public class Grok implements AIModel {
         this.config = config;
         OpenAIChatCompletionsApi api =
                 new OpenAIChatCompletionsApi(
-                        httpClient, config.getApiKey(), config.getBaseURL(), "/v1/chat/completions");
+                        httpClient,
+                        config.getApiKey(),
+                        config.getBaseURL(),
+                        "/v1/chat/completions");
         this.chatModel = new OpenAICompatChatModel(api);
     }
 

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/grok/Grok.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/grok/Grok.java
@@ -21,6 +21,8 @@ import org.conductoross.conductor.ai.models.ChatCompletion;
 import org.conductoross.conductor.ai.models.EmbeddingGenRequest;
 import org.conductoross.conductor.ai.providers.openai.OpenAICompatChatModel;
 import org.conductoross.conductor.ai.providers.openai.api.OpenAIChatCompletionsApi;
+
+import okhttp3.OkHttpClient;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.image.ImageModel;
@@ -34,14 +36,14 @@ public class Grok implements AIModel {
     private final OpenAICompatChatModel chatModel;
 
     public Grok(GrokAIConfiguration config) {
+        this(config, new OkHttpClient());
+    }
+
+    public Grok(GrokAIConfiguration config, OkHttpClient httpClient) {
         this.config = config;
-        long timeoutSecs = config.getTimeout() != null ? config.getTimeout().getSeconds() : 600;
         OpenAIChatCompletionsApi api =
                 new OpenAIChatCompletionsApi(
-                        config.getApiKey(),
-                        config.getBaseURL(),
-                        "/v1/chat/completions",
-                        timeoutSecs);
+                        httpClient, config.getApiKey(), config.getBaseURL(), "/v1/chat/completions");
         this.chatModel = new OpenAICompatChatModel(api);
     }
 

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/grok/GrokAIConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/grok/GrokAIConfiguration.java
@@ -20,9 +20,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import okhttp3.OkHttpClient;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import okhttp3.OkHttpClient;
 
 @Data
 @ConfigurationProperties(prefix = "conductor.ai.grok")

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/grok/GrokAIConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/grok/GrokAIConfiguration.java
@@ -16,9 +16,11 @@ import java.time.Duration;
 import java.util.Objects;
 
 import org.conductoross.conductor.ai.ModelConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import okhttp3.OkHttpClient;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -31,6 +33,8 @@ public class GrokAIConfiguration implements ModelConfiguration<Grok> {
     private String baseURL;
     private Duration timeout = Duration.ofSeconds(600);
 
+    @Autowired private OkHttpClient conductorAiHttpClient;
+
     public GrokAIConfiguration(String apiKey, String baseURL) {
         this.apiKey = apiKey;
         this.baseURL = baseURL;
@@ -42,6 +46,6 @@ public class GrokAIConfiguration implements ModelConfiguration<Grok> {
 
     @Override
     public Grok get() {
-        return new Grok(this);
+        return new Grok(this, conductorAiHttpClient);
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFace.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFace.java
@@ -63,7 +63,8 @@ public class HuggingFace implements AIModel {
 
     @Override
     public ChatModel getChatModel() {
-        HuggingFaceApi api = new HuggingFaceApi(httpClient, config.getApiKey(), config.getBaseURL());
+        HuggingFaceApi api =
+                new HuggingFaceApi(httpClient, config.getApiKey(), config.getBaseURL());
         return new HuggingFaceChatModel(api);
     }
 

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFace.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFace.java
@@ -30,6 +30,10 @@ public class HuggingFace implements AIModel {
     private final HuggingFaceConfiguration config;
     private final OkHttpClient httpClient;
 
+    public HuggingFace(HuggingFaceConfiguration config) {
+        this(config, new OkHttpClient());
+    }
+
     public HuggingFace(HuggingFaceConfiguration config, OkHttpClient httpClient) {
         this.config = config;
         this.httpClient = httpClient;

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFace.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFace.java
@@ -19,17 +19,20 @@ import org.conductoross.conductor.ai.models.ChatCompletion;
 import org.conductoross.conductor.ai.models.EmbeddingGenRequest;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
-import org.springframework.ai.huggingface.HuggingfaceChatModel;
 import org.springframework.ai.image.ImageModel;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
+
+import okhttp3.OkHttpClient;
 
 public class HuggingFace implements AIModel {
 
     public static final String NAME = "huggingface";
     private final HuggingFaceConfiguration config;
+    private final OkHttpClient httpClient;
 
-    public HuggingFace(HuggingFaceConfiguration config) {
+    public HuggingFace(HuggingFaceConfiguration config, OkHttpClient httpClient) {
         this.config = config;
+        this.httpClient = httpClient;
     }
 
     @Override
@@ -56,7 +59,8 @@ public class HuggingFace implements AIModel {
 
     @Override
     public ChatModel getChatModel() {
-        return new HuggingfaceChatModel(config.getApiKey(), config.getBaseURL());
+        HuggingFaceApi api = new HuggingFaceApi(httpClient, config.getApiKey(), config.getBaseURL());
+        return new HuggingFaceChatModel(api);
     }
 
     @Override

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFaceApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFaceApi.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.huggingface;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.netflix.conductor.common.config.ObjectMapperProvider;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+@Slf4j
+public class HuggingFaceApi {
+
+    private static final MediaType JSON = MediaType.parse("application/json");
+
+    private final OkHttpClient httpClient;
+    private final String token;
+    private final String apiUrl;
+    private final ObjectMapper objectMapper;
+
+    public HuggingFaceApi(OkHttpClient httpClient, String token, String apiUrl) {
+        this.httpClient = httpClient;
+        this.token = token;
+        this.apiUrl = apiUrl;
+        this.objectMapper = new ObjectMapperProvider().getObjectMapper();
+    }
+
+    public String generate(String inputs) throws IOException {
+        String body = objectMapper.writeValueAsString(new GenerationRequest(inputs));
+        Request request =
+                new Request.Builder()
+                        .url(apiUrl)
+                        .header("Authorization", "Bearer " + token)
+                        .header("Content-Type", "application/json")
+                        .post(RequestBody.create(body, JSON))
+                        .build();
+
+        try (Response response = httpClient.newCall(request).execute()) {
+            String responseBody = response.body() != null ? response.body().string() : "";
+            if (!response.isSuccessful()) {
+                throw new IOException(
+                        "HuggingFace API error %d: %s".formatted(response.code(), responseBody));
+            }
+            List<GenerationResult> results =
+                    objectMapper.readValue(
+                            responseBody,
+                            objectMapper
+                                    .getTypeFactory()
+                                    .constructCollectionType(List.class, GenerationResult.class));
+            if (results == null || results.isEmpty()) {
+                throw new IOException("Empty response from HuggingFace API");
+            }
+            return results.get(0).generatedText();
+        }
+    }
+
+    public record GenerationRequest(String inputs) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record GenerationResult(@JsonProperty("generated_text") String generatedText) {}
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFaceChatModel.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFaceChatModel.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.huggingface;
+
+import java.util.List;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+
+public class HuggingFaceChatModel implements ChatModel {
+
+    private final HuggingFaceApi api;
+
+    public HuggingFaceChatModel(HuggingFaceApi api) {
+        this.api = api;
+    }
+
+    @Override
+    public ChatResponse call(Prompt prompt) {
+        String inputs =
+                prompt.getInstructions().stream()
+                        .map(m -> m.getText())
+                        .reduce("", (a, b) -> a.isBlank() ? b : a + "\n" + b);
+        try {
+            String text = api.generate(inputs);
+            AssistantMessage msg = new AssistantMessage(text);
+            ChatGenerationMetadata meta =
+                    ChatGenerationMetadata.builder().finishReason("stop").build();
+            return new ChatResponse(List.of(new Generation(msg, meta)));
+        } catch (Exception e) {
+            throw new RuntimeException("HuggingFace generation failed", e);
+        }
+    }
+
+    @Override
+    public ChatOptions getDefaultOptions() {
+        return ToolCallingChatOptions.builder().build();
+    }
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFaceChatModel.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFaceChatModel.java
@@ -36,7 +36,8 @@ public class HuggingFaceChatModel implements ChatModel {
         String inputs =
                 prompt.getInstructions().stream()
                         .map(m -> m.getText())
-                        .reduce("", (a, b) -> a.isBlank() ? b : a + "\n" + b);
+                        .filter(t -> t != null && !t.isBlank())
+                        .collect(java.util.stream.Collectors.joining("\n"));
         try {
             String text = api.generate(inputs);
             AssistantMessage msg = new AssistantMessage(text);

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFaceConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFaceConfiguration.java
@@ -17,9 +17,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import okhttp3.OkHttpClient;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import okhttp3.OkHttpClient;
 
 @Data
 @NoArgsConstructor

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFaceConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFaceConfiguration.java
@@ -13,16 +13,16 @@
 package org.conductoross.conductor.ai.providers.huggingface;
 
 import org.conductoross.conductor.ai.ModelConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import lombok.AllArgsConstructor;
+import okhttp3.OkHttpClient;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 @Component
 @ConfigurationProperties(prefix = "conductor.ai.huggingface")
 public class HuggingFaceConfiguration implements ModelConfiguration<HuggingFace> {
@@ -31,12 +31,19 @@ public class HuggingFaceConfiguration implements ModelConfiguration<HuggingFace>
 
     private String baseURL;
 
+    @Autowired private OkHttpClient conductorAiHttpClient;
+
+    public HuggingFaceConfiguration(String apiKey, String baseURL) {
+        this.apiKey = apiKey;
+        this.baseURL = baseURL;
+    }
+
     public String getBaseURL() {
         return baseURL == null ? "https://huggingface.co/api" : baseURL; // changethis
     }
 
     @Override
     public HuggingFace get() {
-        return new HuggingFace(this);
+        return new HuggingFace(this, conductorAiHttpClient);
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/mistral/MistralAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/mistral/MistralAI.java
@@ -117,7 +117,10 @@ public class MistralAI implements AIModel {
     // Initialization helpers
 
     private MistralAiApi createMistralAiApi(OkHttpClient httpClient) {
-        var factory = new org.springframework.http.client.OkHttp3ClientHttpRequestFactory(httpClient);
+        OkHttpClient effective = (config.getTimeout() != null)
+                ? httpClient.newBuilder().readTimeout(config.getTimeout()).build()
+                : httpClient;
+        var factory = new org.springframework.http.client.OkHttp3ClientHttpRequestFactory(effective);
         // Needs accept-encoding headers
         // https://github.com/spring-projects/spring-ai/issues/372
         return MistralAiApi.builder()

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/mistral/MistralAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/mistral/MistralAI.java
@@ -33,9 +33,8 @@ import org.springframework.ai.mistralai.api.MistralAiApi;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.web.client.RestClient;
 
-import okhttp3.OkHttpClient;
-
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
 
 @Slf4j
 public class MistralAI implements AIModel {
@@ -117,10 +116,12 @@ public class MistralAI implements AIModel {
     // Initialization helpers
 
     private MistralAiApi createMistralAiApi(OkHttpClient httpClient) {
-        OkHttpClient effective = (config.getTimeout() != null)
-                ? httpClient.newBuilder().readTimeout(config.getTimeout()).build()
-                : httpClient;
-        var factory = new org.springframework.http.client.OkHttp3ClientHttpRequestFactory(effective);
+        OkHttpClient effective =
+                (config.getTimeout() != null)
+                        ? httpClient.newBuilder().readTimeout(config.getTimeout()).build()
+                        : httpClient;
+        var factory =
+                new org.springframework.http.client.OkHttp3ClientHttpRequestFactory(effective);
         // Needs accept-encoding headers
         // https://github.com/spring-projects/spring-ai/issues/372
         return MistralAiApi.builder()

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/mistral/MistralAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/mistral/MistralAI.java
@@ -31,8 +31,9 @@ import org.springframework.ai.mistralai.MistralAiChatOptions;
 import org.springframework.ai.mistralai.MistralAiEmbeddingModel;
 import org.springframework.ai.mistralai.api.MistralAiApi;
 import org.springframework.ai.tool.ToolCallback;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
+
+import okhttp3.OkHttpClient;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -48,8 +49,12 @@ public class MistralAI implements AIModel {
     private final MistralAiEmbeddingModel embeddingModel;
 
     public MistralAI(MistralAIConfiguration config) {
+        this(config, new OkHttpClient());
+    }
+
+    public MistralAI(MistralAIConfiguration config, OkHttpClient httpClient) {
         this.config = config;
-        this.mistralAiApi = createMistralAiApi();
+        this.mistralAiApi = createMistralAiApi(httpClient);
         this.chatModel = createChatModel();
         this.embeddingModel =
                 MistralAiEmbeddingModel.builder().mistralAiApi(this.mistralAiApi).build();
@@ -111,18 +116,13 @@ public class MistralAI implements AIModel {
 
     // Initialization helpers
 
-    private MistralAiApi createMistralAiApi() {
-        String apiKey = config.getApiKey();
-        String baseURL = config.getBaseURL();
-
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setReadTimeout(config.getTimeout());
-
+    private MistralAiApi createMistralAiApi(OkHttpClient httpClient) {
+        var factory = new org.springframework.http.client.OkHttp3ClientHttpRequestFactory(httpClient);
         // Needs accept-encoding headers
         // https://github.com/spring-projects/spring-ai/issues/372
         return MistralAiApi.builder()
-                .baseUrl(baseURL)
-                .apiKey(apiKey)
+                .baseUrl(config.getBaseURL())
+                .apiKey(config.getApiKey())
                 .restClientBuilder(
                         RestClient.builder()
                                 .requestFactory(factory)

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/mistral/MistralAIConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/mistral/MistralAIConfiguration.java
@@ -15,9 +15,11 @@ package org.conductoross.conductor.ai.providers.mistral;
 import java.time.Duration;
 
 import org.conductoross.conductor.ai.ModelConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import okhttp3.OkHttpClient;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -33,6 +35,9 @@ public class MistralAIConfiguration implements ModelConfiguration<MistralAI> {
 
     private Duration timeout = Duration.ofSeconds(600);
 
+    @Autowired
+    private OkHttpClient conductorAiHttpClient;
+
     public MistralAIConfiguration(String apiKey, String baseURL) {
         this.apiKey = apiKey;
         this.baseURL = baseURL;
@@ -44,6 +49,6 @@ public class MistralAIConfiguration implements ModelConfiguration<MistralAI> {
 
     @Override
     public MistralAI get() {
-        return new MistralAI(this);
+        return new MistralAI(this, conductorAiHttpClient != null ? conductorAiHttpClient : new okhttp3.OkHttpClient());
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/mistral/MistralAIConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/mistral/MistralAIConfiguration.java
@@ -19,9 +19,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import okhttp3.OkHttpClient;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import okhttp3.OkHttpClient;
 
 @Data
 @Component
@@ -35,8 +35,7 @@ public class MistralAIConfiguration implements ModelConfiguration<MistralAI> {
 
     private Duration timeout = Duration.ofSeconds(600);
 
-    @Autowired
-    private OkHttpClient conductorAiHttpClient;
+    @Autowired private OkHttpClient conductorAiHttpClient;
 
     public MistralAIConfiguration(String apiKey, String baseURL) {
         this.apiKey = apiKey;

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/mistral/MistralAIConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/mistral/MistralAIConfiguration.java
@@ -49,6 +49,8 @@ public class MistralAIConfiguration implements ModelConfiguration<MistralAI> {
 
     @Override
     public MistralAI get() {
-        return new MistralAI(this, conductorAiHttpClient != null ? conductorAiHttpClient : new okhttp3.OkHttpClient());
+        return conductorAiHttpClient != null
+                ? new MistralAI(this, conductorAiHttpClient)
+                : new MistralAI(this);
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/ollama/Ollama.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/ollama/Ollama.java
@@ -31,10 +31,9 @@ import org.springframework.ai.ollama.api.OllamaEmbeddingOptions;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.web.client.RestClient;
 
-import okhttp3.OkHttpClient;
-
 import com.google.common.primitives.Floats;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
 
 @Slf4j
 public class Ollama implements AIModel {
@@ -112,17 +111,16 @@ public class Ollama implements AIModel {
     }
 
     private OllamaApi buildOllamaApi() {
-        OkHttpClient effective = (config.getTimeout() != null)
-                ? httpClient.newBuilder().readTimeout(config.getTimeout()).build()
-                : httpClient;
-        var factory = new org.springframework.http.client.OkHttp3ClientHttpRequestFactory(effective);
+        OkHttpClient effective =
+                (config.getTimeout() != null)
+                        ? httpClient.newBuilder().readTimeout(config.getTimeout()).build()
+                        : httpClient;
+        var factory =
+                new org.springframework.http.client.OkHttp3ClientHttpRequestFactory(effective);
         RestClient.Builder builder = RestClient.builder().requestFactory(factory);
         if (StringUtils.isNotBlank(config.getAuthHeaderName())) {
             builder.defaultHeader(config.getAuthHeaderName(), config.getAuthHeader());
         }
-        return OllamaApi.builder()
-                .baseUrl(config.getBaseURL())
-                .restClientBuilder(builder)
-                .build();
+        return OllamaApi.builder().baseUrl(config.getBaseURL()).restClientBuilder(builder).build();
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/ollama/Ollama.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/ollama/Ollama.java
@@ -112,7 +112,10 @@ public class Ollama implements AIModel {
     }
 
     private OllamaApi buildOllamaApi() {
-        var factory = new org.springframework.http.client.OkHttp3ClientHttpRequestFactory(httpClient);
+        OkHttpClient effective = (config.getTimeout() != null)
+                ? httpClient.newBuilder().readTimeout(config.getTimeout()).build()
+                : httpClient;
+        var factory = new org.springframework.http.client.OkHttp3ClientHttpRequestFactory(effective);
         RestClient.Builder builder = RestClient.builder().requestFactory(factory);
         if (StringUtils.isNotBlank(config.getAuthHeaderName())) {
             builder.defaultHeader(config.getAuthHeaderName(), config.getAuthHeader());

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/ollama/Ollama.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/ollama/Ollama.java
@@ -29,8 +29,9 @@ import org.springframework.ai.ollama.api.OllamaApi;
 import org.springframework.ai.ollama.api.OllamaChatOptions;
 import org.springframework.ai.ollama.api.OllamaEmbeddingOptions;
 import org.springframework.ai.tool.ToolCallback;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
+
+import okhttp3.OkHttpClient;
 
 import com.google.common.primitives.Floats;
 import lombok.extern.slf4j.Slf4j;
@@ -40,9 +41,15 @@ public class Ollama implements AIModel {
 
     public static final String NAME = "ollama";
     private final OllamaConfiguration config;
+    private final OkHttpClient httpClient;
 
     public Ollama(OllamaConfiguration config) {
+        this(config, new OkHttpClient());
+    }
+
+    public Ollama(OllamaConfiguration config, OkHttpClient httpClient) {
         this.config = config;
+        this.httpClient = httpClient;
     }
 
     @Override
@@ -52,7 +59,7 @@ public class Ollama implements AIModel {
 
     @Override
     public List<Float> generateEmbeddings(EmbeddingGenRequest embeddingGenRequest) {
-        OllamaApi api = OllamaApi.builder().baseUrl(config.getBaseURL()).build();
+        OllamaApi api = buildOllamaApi();
         var options =
                 OllamaEmbeddingOptions.builder().model(embeddingGenRequest.getModel()).build();
         var embeddingModel =
@@ -96,24 +103,23 @@ public class Ollama implements AIModel {
 
     @Override
     public ChatModel getChatModel() {
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setReadTimeout(config.getTimeout());
-
-        RestClient.Builder restClientBuilder = RestClient.builder().requestFactory(factory);
-        if (StringUtils.isNotBlank(config.getAuthHeaderName())) {
-            restClientBuilder.defaultHeader(config.getAuthHeaderName(), config.getAuthHeader());
-        }
-
-        OllamaApi api =
-                OllamaApi.builder()
-                        .baseUrl(config.getBaseURL())
-                        .restClientBuilder(restClientBuilder)
-                        .build();
-        return OllamaChatModel.builder().ollamaApi(api).build();
+        return OllamaChatModel.builder().ollamaApi(buildOllamaApi()).build();
     }
 
     @Override
     public ImageModel getImageModel() {
         throw new UnsupportedOperationException("Image generation not supported by the model yet");
+    }
+
+    private OllamaApi buildOllamaApi() {
+        var factory = new org.springframework.http.client.OkHttp3ClientHttpRequestFactory(httpClient);
+        RestClient.Builder builder = RestClient.builder().requestFactory(factory);
+        if (StringUtils.isNotBlank(config.getAuthHeaderName())) {
+            builder.defaultHeader(config.getAuthHeaderName(), config.getAuthHeader());
+        }
+        return OllamaApi.builder()
+                .baseUrl(config.getBaseURL())
+                .restClientBuilder(builder)
+                .build();
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/ollama/OllamaConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/ollama/OllamaConfiguration.java
@@ -52,6 +52,8 @@ public class OllamaConfiguration implements ModelConfiguration<Ollama> {
 
     @Override
     public Ollama get() {
-        return new Ollama(this, conductorAiHttpClient != null ? conductorAiHttpClient : new okhttp3.OkHttpClient());
+        return conductorAiHttpClient != null
+                ? new Ollama(this, conductorAiHttpClient)
+                : new Ollama(this);
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/ollama/OllamaConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/ollama/OllamaConfiguration.java
@@ -15,9 +15,11 @@ package org.conductoross.conductor.ai.providers.ollama;
 import java.time.Duration;
 
 import org.conductoross.conductor.ai.ModelConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import okhttp3.OkHttpClient;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -35,6 +37,9 @@ public class OllamaConfiguration implements ModelConfiguration<Ollama> {
 
     private Duration timeout = Duration.ofSeconds(600);
 
+    @Autowired
+    private OkHttpClient conductorAiHttpClient;
+
     public OllamaConfiguration(String baseURL, String authHeaderName, String authHeader) {
         this.baseURL = baseURL;
         this.authHeaderName = authHeaderName;
@@ -47,6 +52,6 @@ public class OllamaConfiguration implements ModelConfiguration<Ollama> {
 
     @Override
     public Ollama get() {
-        return new Ollama(this);
+        return new Ollama(this, conductorAiHttpClient != null ? conductorAiHttpClient : new okhttp3.OkHttpClient());
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/ollama/OllamaConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/ollama/OllamaConfiguration.java
@@ -19,9 +19,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import okhttp3.OkHttpClient;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import okhttp3.OkHttpClient;
 
 @Data
 @Component
@@ -37,8 +37,7 @@ public class OllamaConfiguration implements ModelConfiguration<Ollama> {
 
     private Duration timeout = Duration.ofSeconds(600);
 
-    @Autowired
-    private OkHttpClient conductorAiHttpClient;
+    @Autowired private OkHttpClient conductorAiHttpClient;
 
     public OllamaConfiguration(String baseURL, String authHeaderName, String authHeader) {
         this.baseURL = baseURL;

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAI.java
@@ -38,9 +38,9 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.image.ImageModel;
 
-import okhttp3.OkHttpClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
 
 @Slf4j
 public class OpenAI implements AIModel {

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAI.java
@@ -38,6 +38,7 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.image.ImageModel;
 
+import okhttp3.OkHttpClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 
@@ -62,19 +63,20 @@ public class OpenAI implements AIModel {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     public OpenAI(OpenAIConfiguration config) {
+        this(config, new OkHttpClient());
+    }
+
+    public OpenAI(OpenAIConfiguration config, OkHttpClient httpClient) {
         this.config = config;
-        long timeoutSecs = config.getTimeout() != null ? config.getTimeout().getSeconds() : 600;
         String baseUrl = config.getBaseURL();
-
-        this.responsesApi = new OpenAIResponsesApi(config.getApiKey(), baseUrl, false, timeoutSecs);
-        this.embeddingsApi =
-                new OpenAIEmbeddingsApi(config.getApiKey(), baseUrl, false, timeoutSecs);
-        this.imageGenApi = new OpenAIImageGenApi(config.getApiKey(), baseUrl, false, timeoutSecs);
-
-        // Audio and Video APIs need base URL without /v1 suffix
         String baseUrlNoV1 = stripV1(baseUrl);
-        this.speechApi = new OpenAISpeechApi(config.getApiKey(), baseUrl, false, timeoutSecs);
-        this.videoApi = new OpenAIVideoApi(config.getApiKey(), baseUrlNoV1);
+
+        this.responsesApi = new OpenAIResponsesApi(httpClient, config.getApiKey(), baseUrl, false);
+        this.embeddingsApi =
+                new OpenAIEmbeddingsApi(httpClient, config.getApiKey(), baseUrl, false);
+        this.imageGenApi = new OpenAIImageGenApi(httpClient, config.getApiKey(), baseUrl, false);
+        this.speechApi = new OpenAISpeechApi(httpClient, config.getApiKey(), baseUrl, false);
+        this.videoApi = new OpenAIVideoApi(httpClient, config.getApiKey(), baseUrlNoV1);
 
         this.chatModel = new OpenAIResponsesChatModel(responsesApi);
         this.imageModel = new OpenAIHttpImageModel(imageGenApi);

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAIConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAIConfiguration.java
@@ -15,9 +15,11 @@ package org.conductoross.conductor.ai.providers.openai;
 import java.time.Duration;
 
 import org.conductoross.conductor.ai.ModelConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import okhttp3.OkHttpClient;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -35,6 +37,8 @@ public class OpenAIConfiguration implements ModelConfiguration<OpenAI> {
 
     private Duration timeout = Duration.ofSeconds(600);
 
+    @Autowired private OkHttpClient conductorAiHttpClient;
+
     public OpenAIConfiguration(String apiKey, String baseURL, String organizationId) {
         this.apiKey = apiKey;
         this.baseURL = baseURL;
@@ -47,6 +51,6 @@ public class OpenAIConfiguration implements ModelConfiguration<OpenAI> {
 
     @Override
     public OpenAI get() {
-        return new OpenAI(this);
+        return new OpenAI(this, conductorAiHttpClient);
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAIConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAIConfiguration.java
@@ -19,9 +19,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import okhttp3.OkHttpClient;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import okhttp3.OkHttpClient;
 
 @Data
 @Component

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIChatCompletionsApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIChatCompletionsApi.java
@@ -79,6 +79,12 @@ public class OpenAIChatCompletionsApi {
             ResponseBody body = response.body();
             String responseBody = body != null ? body.string() : "";
             if (!response.isSuccessful()) {
+                // Some models (e.g. o-series via compatible endpoints) reject temperature.
+                if (response.code() == 400
+                        && responseBody.contains("temperature")
+                        && request.temperature() != null) {
+                    return createChatCompletion(request.withoutTemperature());
+                }
                 throw new IOException(
                         "Chat Completions API failed with status %d: %s"
                                 .formatted(response.code(), responseBody));
@@ -107,6 +113,11 @@ public class OpenAIChatCompletionsApi {
 
         public static Builder builder() {
             return new Builder();
+        }
+
+        public ChatCompletionRequest withoutTemperature() {
+            return new ChatCompletionRequest(model, messages, null, topP, maxTokens,
+                    stop, frequencyPenalty, presencePenalty, topK, responseFormat, tools, toolChoice);
         }
 
         public static class Builder {

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIChatCompletionsApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIChatCompletionsApi.java
@@ -14,7 +14,6 @@ package org.conductoross.conductor.ai.providers.openai.api;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import com.netflix.conductor.common.config.ObjectMapperProvider;
 
@@ -48,24 +47,19 @@ public class OpenAIChatCompletionsApi {
     private final ObjectMapper objectMapper;
 
     public OpenAIChatCompletionsApi(
-            String apiKey, String baseUrl, String completionsPath, long timeoutSeconds) {
+            OkHttpClient httpClient, String apiKey, String baseUrl, String completionsPath) {
         this.baseUrl =
                 baseUrl != null && baseUrl.endsWith("/")
                         ? baseUrl.substring(0, baseUrl.length() - 1)
                         : baseUrl;
         this.apiKey = apiKey;
         this.completionsPath = completionsPath != null ? completionsPath : "/chat/completions";
-        this.httpClient =
-                new OkHttpClient.Builder()
-                        .connectTimeout(60, TimeUnit.SECONDS)
-                        .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
-                        .writeTimeout(60, TimeUnit.SECONDS)
-                        .build();
+        this.httpClient = httpClient;
         this.objectMapper = new ObjectMapperProvider().getObjectMapper();
     }
 
-    public OpenAIChatCompletionsApi(String apiKey, String baseUrl, long timeoutSeconds) {
-        this(apiKey, baseUrl, null, timeoutSeconds);
+    public OpenAIChatCompletionsApi(OkHttpClient httpClient, String apiKey, String baseUrl) {
+        this(httpClient, apiKey, baseUrl, null);
     }
 
     public ChatCompletionResult createChatCompletion(ChatCompletionRequest request)

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIChatCompletionsApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIChatCompletionsApi.java
@@ -116,8 +116,19 @@ public class OpenAIChatCompletionsApi {
         }
 
         public ChatCompletionRequest withoutTemperature() {
-            return new ChatCompletionRequest(model, messages, null, topP, maxTokens,
-                    stop, frequencyPenalty, presencePenalty, topK, responseFormat, tools, toolChoice);
+            return new ChatCompletionRequest(
+                    model,
+                    messages,
+                    null,
+                    topP,
+                    maxTokens,
+                    stop,
+                    frequencyPenalty,
+                    presencePenalty,
+                    topK,
+                    responseFormat,
+                    tools,
+                    toolChoice);
         }
 
         public static class Builder {

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIEmbeddingsApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIEmbeddingsApi.java
@@ -14,7 +14,6 @@ package org.conductoross.conductor.ai.providers.openai.api;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import com.netflix.conductor.common.config.ObjectMapperProvider;
 
@@ -46,21 +45,16 @@ public class OpenAIEmbeddingsApi {
     private final ObjectMapper objectMapper;
 
     public OpenAIEmbeddingsApi(
-            String apiKey, String baseUrl, boolean azureAuth, long timeoutSeconds) {
+            OkHttpClient httpClient, String apiKey, String baseUrl, boolean azureAuth) {
         this.baseUrl = baseUrl != null ? baseUrl : "https://api.openai.com/v1";
         this.authHeaderName = azureAuth ? "api-key" : "Authorization";
         this.authHeaderValue = azureAuth ? apiKey : "Bearer " + apiKey;
-        this.httpClient =
-                new OkHttpClient.Builder()
-                        .connectTimeout(60, TimeUnit.SECONDS)
-                        .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
-                        .writeTimeout(60, TimeUnit.SECONDS)
-                        .build();
+        this.httpClient = httpClient;
         this.objectMapper = new ObjectMapperProvider().getObjectMapper();
     }
 
-    public OpenAIEmbeddingsApi(String apiKey, String baseUrl, boolean azureAuth) {
-        this(apiKey, baseUrl, azureAuth, 120);
+    public OpenAIEmbeddingsApi(OkHttpClient httpClient, String apiKey, String baseUrl) {
+        this(httpClient, apiKey, baseUrl, false);
     }
 
     public EmbeddingResult createEmbeddings(EmbeddingRequest request) throws IOException {

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIImageGenApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIImageGenApi.java
@@ -14,7 +14,6 @@ package org.conductoross.conductor.ai.providers.openai.api;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import com.netflix.conductor.common.config.ObjectMapperProvider;
 
@@ -47,21 +46,16 @@ public class OpenAIImageGenApi {
     private final ObjectMapper objectMapper;
 
     public OpenAIImageGenApi(
-            String apiKey, String baseUrl, boolean azureAuth, long timeoutSeconds) {
+            OkHttpClient httpClient, String apiKey, String baseUrl, boolean azureAuth) {
         this.baseUrl = baseUrl != null ? baseUrl : "https://api.openai.com/v1";
         this.authHeaderName = azureAuth ? "api-key" : "Authorization";
         this.authHeaderValue = azureAuth ? apiKey : "Bearer " + apiKey;
-        this.httpClient =
-                new OkHttpClient.Builder()
-                        .connectTimeout(60, TimeUnit.SECONDS)
-                        .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
-                        .writeTimeout(60, TimeUnit.SECONDS)
-                        .build();
+        this.httpClient = httpClient;
         this.objectMapper = new ObjectMapperProvider().getObjectMapper();
     }
 
-    public OpenAIImageGenApi(String apiKey, String baseUrl, boolean azureAuth) {
-        this(apiKey, baseUrl, azureAuth, 120);
+    public OpenAIImageGenApi(OkHttpClient httpClient, String apiKey, String baseUrl) {
+        this(httpClient, apiKey, baseUrl, false);
     }
 
     public ImageResult createImage(ImageRequest request) throws IOException {

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIResponsesApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIResponsesApi.java
@@ -148,8 +148,19 @@ public class OpenAIResponsesApi {
         }
 
         public ResponseRequest withoutTemperature() {
-            return new ResponseRequest(model, input, instructions, tools, previousResponseId,
-                    null, topP, maxOutputTokens, reasoning, text, toolChoice, store);
+            return new ResponseRequest(
+                    model,
+                    input,
+                    instructions,
+                    tools,
+                    previousResponseId,
+                    null,
+                    topP,
+                    maxOutputTokens,
+                    reasoning,
+                    text,
+                    toolChoice,
+                    store);
         }
 
         public static class Builder {

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIResponsesApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIResponsesApi.java
@@ -15,7 +15,6 @@ package org.conductoross.conductor.ai.providers.openai.api;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import com.netflix.conductor.common.config.ObjectMapperProvider;
 
@@ -53,28 +52,23 @@ public class OpenAIResponsesApi {
     private final ObjectMapper objectMapper;
 
     /**
+     * @param httpClient Shared OkHttpClient instance
      * @param apiKey API key
      * @param baseUrl Base URL (e.g. "https://api.openai.com/v1" or
      *     "https://resource.openai.azure.com/openai/v1")
      * @param azureAuth true for Azure (api-key header), false for OpenAI (Bearer token)
-     * @param timeoutSeconds HTTP timeout in seconds
      */
     public OpenAIResponsesApi(
-            String apiKey, String baseUrl, boolean azureAuth, long timeoutSeconds) {
+            OkHttpClient httpClient, String apiKey, String baseUrl, boolean azureAuth) {
         this.baseUrl = baseUrl != null ? baseUrl : "https://api.openai.com/v1";
         this.authHeaderName = azureAuth ? "api-key" : "Authorization";
         this.authHeaderValue = azureAuth ? apiKey : "Bearer " + apiKey;
-        this.httpClient =
-                new OkHttpClient.Builder()
-                        .connectTimeout(60, TimeUnit.SECONDS)
-                        .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
-                        .writeTimeout(60, TimeUnit.SECONDS)
-                        .build();
+        this.httpClient = httpClient;
         this.objectMapper = new ObjectMapperProvider().getObjectMapper();
     }
 
-    public OpenAIResponsesApi(String apiKey, String baseUrl, boolean azureAuth) {
-        this(apiKey, baseUrl, azureAuth, 600);
+    public OpenAIResponsesApi(OkHttpClient httpClient, String apiKey, String baseUrl) {
+        this(httpClient, apiKey, baseUrl, false);
     }
 
     /**

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIResponsesApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIResponsesApi.java
@@ -92,6 +92,12 @@ public class OpenAIResponsesApi {
         try (Response response = httpClient.newCall(httpRequest).execute()) {
             String responseBody = readBody(response);
             if (!response.isSuccessful()) {
+                // o-series and some newer OpenAI models reject temperature — retry without it.
+                if (response.code() == 400
+                        && responseBody.contains("temperature")
+                        && request.temperature() != null) {
+                    return createResponse(request.withoutTemperature());
+                }
                 throw new IOException(
                         "Responses API failed with status %d: %s"
                                 .formatted(response.code(), responseBody));
@@ -139,6 +145,11 @@ public class OpenAIResponsesApi {
 
         public static Builder builder() {
             return new Builder();
+        }
+
+        public ResponseRequest withoutTemperature() {
+            return new ResponseRequest(model, input, instructions, tools, previousResponseId,
+                    null, topP, maxOutputTokens, reasoning, text, toolChoice, store);
         }
 
         public static class Builder {

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAISpeechApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAISpeechApi.java
@@ -43,7 +43,8 @@ public class OpenAISpeechApi {
     private final OkHttpClient httpClient;
     private final ObjectMapper objectMapper;
 
-    public OpenAISpeechApi(OkHttpClient httpClient, String apiKey, String baseUrl, boolean azureAuth) {
+    public OpenAISpeechApi(
+            OkHttpClient httpClient, String apiKey, String baseUrl, boolean azureAuth) {
         this.baseUrl = baseUrl != null ? baseUrl : "https://api.openai.com/v1";
         this.authHeaderName = azureAuth ? "api-key" : "Authorization";
         this.authHeaderValue = azureAuth ? apiKey : "Bearer " + apiKey;

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAISpeechApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAISpeechApi.java
@@ -13,7 +13,6 @@
 package org.conductoross.conductor.ai.providers.openai.api;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 import com.netflix.conductor.common.config.ObjectMapperProvider;
 
@@ -44,21 +43,16 @@ public class OpenAISpeechApi {
     private final OkHttpClient httpClient;
     private final ObjectMapper objectMapper;
 
-    public OpenAISpeechApi(String apiKey, String baseUrl, boolean azureAuth, long timeoutSeconds) {
+    public OpenAISpeechApi(OkHttpClient httpClient, String apiKey, String baseUrl, boolean azureAuth) {
         this.baseUrl = baseUrl != null ? baseUrl : "https://api.openai.com/v1";
         this.authHeaderName = azureAuth ? "api-key" : "Authorization";
         this.authHeaderValue = azureAuth ? apiKey : "Bearer " + apiKey;
-        this.httpClient =
-                new OkHttpClient.Builder()
-                        .connectTimeout(60, TimeUnit.SECONDS)
-                        .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
-                        .writeTimeout(60, TimeUnit.SECONDS)
-                        .build();
+        this.httpClient = httpClient;
         this.objectMapper = new ObjectMapperProvider().getObjectMapper();
     }
 
-    public OpenAISpeechApi(String apiKey, String baseUrl, boolean azureAuth) {
-        this(apiKey, baseUrl, azureAuth, 120);
+    public OpenAISpeechApi(OkHttpClient httpClient, String apiKey, String baseUrl) {
+        this(httpClient, apiKey, baseUrl, false);
     }
 
     /**

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIVideoApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIVideoApi.java
@@ -61,6 +61,7 @@ public class OpenAIVideoApi {
                 .connectTimeout(120, TimeUnit.SECONDS)
                 .readTimeout(5, TimeUnit.MINUTES)
                 .followRedirects(true)
+                // writeTimeout inherited from shared client (default 60s is sufficient for form upload)
                 .build();
         this.objectMapper = new ObjectMapperProvider().getObjectMapper();
     }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIVideoApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIVideoApi.java
@@ -57,12 +57,15 @@ public class OpenAIVideoApi {
         this.apiKey = apiKey;
         this.baseUrl = baseUrl != null ? baseUrl : "https://api.openai.com";
         // Video downloads take several minutes; override timeouts while sharing pool/dispatcher.
-        this.httpClient = httpClient.newBuilder()
-                .connectTimeout(120, TimeUnit.SECONDS)
-                .readTimeout(5, TimeUnit.MINUTES)
-                .followRedirects(true)
-                // writeTimeout inherited from shared client (default 60s is sufficient for form upload)
-                .build();
+        this.httpClient =
+                httpClient
+                        .newBuilder()
+                        .connectTimeout(120, TimeUnit.SECONDS)
+                        .readTimeout(5, TimeUnit.MINUTES)
+                        .followRedirects(true)
+                        // writeTimeout inherited from shared client (default 60s is sufficient for
+                        // form upload)
+                        .build();
         this.objectMapper = new ObjectMapperProvider().getObjectMapper();
     }
 

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIVideoApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/api/OpenAIVideoApi.java
@@ -53,16 +53,15 @@ public class OpenAIVideoApi {
     private final OkHttpClient httpClient;
     private final ObjectMapper objectMapper;
 
-    public OpenAIVideoApi(String apiKey, String baseUrl) {
+    public OpenAIVideoApi(OkHttpClient httpClient, String apiKey, String baseUrl) {
         this.apiKey = apiKey;
         this.baseUrl = baseUrl != null ? baseUrl : "https://api.openai.com";
-        this.httpClient =
-                new OkHttpClient.Builder()
-                        .connectTimeout(120, TimeUnit.SECONDS)
-                        .readTimeout(5, TimeUnit.MINUTES)
-                        .writeTimeout(60, TimeUnit.SECONDS)
-                        .followRedirects(true)
-                        .build();
+        // Video downloads take several minutes; override timeouts while sharing pool/dispatcher.
+        this.httpClient = httpClient.newBuilder()
+                .connectTimeout(120, TimeUnit.SECONDS)
+                .readTimeout(5, TimeUnit.MINUTES)
+                .followRedirects(true)
+                .build();
         this.objectMapper = new ObjectMapperProvider().getObjectMapper();
     }
 

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/perplexity/PerplexityAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/perplexity/PerplexityAI.java
@@ -19,6 +19,8 @@ import org.conductoross.conductor.ai.models.ChatCompletion;
 import org.conductoross.conductor.ai.models.EmbeddingGenRequest;
 import org.conductoross.conductor.ai.providers.openai.OpenAICompatChatModel;
 import org.conductoross.conductor.ai.providers.openai.api.OpenAIChatCompletionsApi;
+
+import okhttp3.OkHttpClient;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.image.ImageModel;
@@ -31,11 +33,14 @@ public class PerplexityAI implements AIModel {
     private final OpenAICompatChatModel chatModel;
 
     public PerplexityAI(PerplexityAIConfiguration config) {
+        this(config, new OkHttpClient());
+    }
+
+    public PerplexityAI(PerplexityAIConfiguration config, OkHttpClient httpClient) {
         this.config = config;
-        long timeoutSecs = config.getTimeout() != null ? config.getTimeout().getSeconds() : 600;
         OpenAIChatCompletionsApi api =
                 new OpenAIChatCompletionsApi(
-                        config.getApiKey(), config.getBaseURL(), "/chat/completions", timeoutSecs);
+                        httpClient, config.getApiKey(), config.getBaseURL(), "/chat/completions");
         this.chatModel = new OpenAICompatChatModel(api);
     }
 

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/perplexity/PerplexityAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/perplexity/PerplexityAI.java
@@ -19,12 +19,12 @@ import org.conductoross.conductor.ai.models.ChatCompletion;
 import org.conductoross.conductor.ai.models.EmbeddingGenRequest;
 import org.conductoross.conductor.ai.providers.openai.OpenAICompatChatModel;
 import org.conductoross.conductor.ai.providers.openai.api.OpenAIChatCompletionsApi;
-
-import okhttp3.OkHttpClient;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.image.ImageModel;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
+
+import okhttp3.OkHttpClient;
 
 public class PerplexityAI implements AIModel {
 

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/perplexity/PerplexityAIConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/perplexity/PerplexityAIConfiguration.java
@@ -16,9 +16,11 @@ import java.time.Duration;
 import java.util.Objects;
 
 import org.conductoross.conductor.ai.ModelConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import okhttp3.OkHttpClient;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -31,6 +33,8 @@ public class PerplexityAIConfiguration implements ModelConfiguration<PerplexityA
     private String baseURL;
     private Duration timeout = Duration.ofSeconds(600);
 
+    @Autowired private OkHttpClient conductorAiHttpClient;
+
     public PerplexityAIConfiguration(String apiKey, String baseURL) {
         this.apiKey = apiKey;
         this.baseURL = baseURL;
@@ -42,6 +46,6 @@ public class PerplexityAIConfiguration implements ModelConfiguration<PerplexityA
 
     @Override
     public PerplexityAI get() {
-        return new PerplexityAI(this);
+        return new PerplexityAI(this, conductorAiHttpClient);
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/perplexity/PerplexityAIConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/perplexity/PerplexityAIConfiguration.java
@@ -20,9 +20,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import okhttp3.OkHttpClient;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import okhttp3.OkHttpClient;
 
 @Data
 @NoArgsConstructor

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/stabilityai/StabilityAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/stabilityai/StabilityAI.java
@@ -26,8 +26,8 @@ import org.springframework.ai.image.ImageOptions;
 import org.springframework.ai.image.ImagePrompt;
 import org.springframework.ai.image.ImageResponse;
 
-import okhttp3.OkHttpClient;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
 
 /**
  * Stability AI provider for image generation using the v2beta REST API.

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/stabilityai/StabilityAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/stabilityai/StabilityAI.java
@@ -26,6 +26,7 @@ import org.springframework.ai.image.ImageOptions;
 import org.springframework.ai.image.ImagePrompt;
 import org.springframework.ai.image.ImageResponse;
 
+import okhttp3.OkHttpClient;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -69,8 +70,8 @@ public class StabilityAI implements AIModel {
      */
     private final ImageModel imageModel;
 
-    public StabilityAI(StabilityAIConfiguration config) {
-        this.api = new StabilityAiApi(config.getApiKey());
+    public StabilityAI(StabilityAIConfiguration config, OkHttpClient httpClient) {
+        this.api = new StabilityAiApi(httpClient, config.getApiKey(), null);
 
         // Create an ImageModel adapter that delegates to our v2beta API client.
         // The adapter translates Spring AI's ImagePrompt into StabilityAiApi calls,

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/stabilityai/StabilityAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/stabilityai/StabilityAI.java
@@ -70,6 +70,10 @@ public class StabilityAI implements AIModel {
      */
     private final ImageModel imageModel;
 
+    public StabilityAI(StabilityAIConfiguration config) {
+        this(config, new OkHttpClient());
+    }
+
     public StabilityAI(StabilityAIConfiguration config, OkHttpClient httpClient) {
         this.api = new StabilityAiApi(httpClient, config.getApiKey(), null);
 

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/stabilityai/StabilityAIConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/stabilityai/StabilityAIConfiguration.java
@@ -18,7 +18,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 import okhttp3.OkHttpClient;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -33,12 +32,15 @@ import lombok.NoArgsConstructor;
 @Component
 @ConfigurationProperties(prefix = "conductor.ai.stabilityai")
 @NoArgsConstructor
-@AllArgsConstructor
 public class StabilityAIConfiguration implements ModelConfiguration<StabilityAI> {
 
     private String apiKey;
 
     @Autowired private OkHttpClient conductorAiHttpClient;
+
+    public StabilityAIConfiguration(String apiKey) {
+        this.apiKey = apiKey;
+    }
 
     @Override
     public StabilityAI get() {

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/stabilityai/StabilityAIConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/stabilityai/StabilityAIConfiguration.java
@@ -13,9 +13,11 @@
 package org.conductoross.conductor.ai.providers.stabilityai;
 
 import org.conductoross.conductor.ai.ModelConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import okhttp3.OkHttpClient;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -36,8 +38,10 @@ public class StabilityAIConfiguration implements ModelConfiguration<StabilityAI>
 
     private String apiKey;
 
+    @Autowired private OkHttpClient conductorAiHttpClient;
+
     @Override
     public StabilityAI get() {
-        return new StabilityAI(this);
+        return new StabilityAI(this, conductorAiHttpClient);
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/stabilityai/StabilityAIConfiguration.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/stabilityai/StabilityAIConfiguration.java
@@ -17,9 +17,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import okhttp3.OkHttpClient;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import okhttp3.OkHttpClient;
 
 /**
  * Configuration for the Stability AI image generation provider.

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/stabilityai/StabilityAiApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/stabilityai/StabilityAiApi.java
@@ -14,11 +14,8 @@ package org.conductoross.conductor.ai.providers.stabilityai;
 
 import java.io.IOException;
 
-import com.netflix.conductor.common.config.ObjectMapperProvider;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.MultipartBody;
 import okhttp3.OkHttpClient;
@@ -54,13 +51,11 @@ public class StabilityAiApi {
     private final String apiKey;
     private final String baseUrl;
     private final OkHttpClient httpClient;
-    private final ObjectMapper objectMapper;
 
     public StabilityAiApi(OkHttpClient httpClient, String apiKey, String baseUrl) {
         this.apiKey = apiKey;
         this.baseUrl = baseUrl != null ? baseUrl : DEFAULT_BASE_URL;
         this.httpClient = httpClient;
-        this.objectMapper = new ObjectMapperProvider().getObjectMapper();
     }
 
     /**

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/stabilityai/StabilityAiApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/stabilityai/StabilityAiApi.java
@@ -13,10 +13,12 @@
 package org.conductoross.conductor.ai.providers.stabilityai;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+
+import com.netflix.conductor.common.config.ObjectMapperProvider;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.MultipartBody;
 import okhttp3.OkHttpClient;
@@ -52,21 +54,13 @@ public class StabilityAiApi {
     private final String apiKey;
     private final String baseUrl;
     private final OkHttpClient httpClient;
+    private final ObjectMapper objectMapper;
 
-    public StabilityAiApi(String apiKey) {
-        this(apiKey, DEFAULT_BASE_URL);
-    }
-
-    public StabilityAiApi(String apiKey, String baseUrl) {
+    public StabilityAiApi(OkHttpClient httpClient, String apiKey, String baseUrl) {
         this.apiKey = apiKey;
         this.baseUrl = baseUrl != null ? baseUrl : DEFAULT_BASE_URL;
-        this.httpClient =
-                new OkHttpClient.Builder()
-                        .connectTimeout(30, TimeUnit.SECONDS)
-                        .readTimeout(120, TimeUnit.SECONDS)
-                        .writeTimeout(30, TimeUnit.SECONDS)
-                        .followRedirects(true)
-                        .build();
+        this.httpClient = httpClient;
+        this.objectMapper = new ObjectMapperProvider().getObjectMapper();
     }
 
     /**

--- a/ai/src/main/java/org/conductoross/conductor/ai/sql/JDBCProvider.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/sql/JDBCProvider.java
@@ -16,12 +16,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.annotation.PreDestroy;
 import javax.sql.DataSource;
 
 import org.springframework.stereotype.Component;
 
 import com.zaxxer.hikari.HikariDataSource;
+import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/ai/src/main/java/org/conductoross/conductor/ai/tasks/mapper/AIModelTaskMapper.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/tasks/mapper/AIModelTaskMapper.java
@@ -73,6 +73,13 @@ public abstract class AIModelTaskMapper<T extends LLMWorkerInput> implements Tas
         if (taskDefinition == null) {
             taskDefinition = new TaskDef();
         }
+
+        if (taskDefinition.getRetryCount() < 1) {
+            taskDefinition.setRetryCount(3);
+            taskDefinition.setRetryDelaySeconds(2);
+            taskDefinition.setRetryLogic(TaskDef.RetryLogic.LINEAR_BACKOFF);
+        }
+
         TaskModel simpleTask = taskMapperContext.createTaskModel();
         simpleTask.setTaskType(workflowTask.getType());
         simpleTask.setStartDelayInSeconds(workflowTask.getStartDelay());

--- a/ai/src/test/java/org/conductoross/conductor/ai/LLMsTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/LLMsTest.java
@@ -36,7 +36,7 @@ class LLMsTest {
         when(mockModelProvider.getPayloadStoreLocation()).thenReturn("/tmp/test-payload");
         when(mockModelProvider.getModel(any())).thenReturn(mockModel);
 
-        llms = new LLMs(List.of(), null, mockModelProvider);
+        llms = new LLMs(List.of(), null, mockModelProvider, new okhttp3.OkHttpClient());
     }
 
     @Test

--- a/ai/src/test/java/org/conductoross/conductor/ai/http/RetryInterceptorTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/http/RetryInterceptorTest.java
@@ -19,11 +19,15 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.SocketPolicy;
+import okio.BufferedSink;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -148,6 +152,53 @@ class RetryInterceptorTest {
             assertEquals(501, response.code());
         }
 
+        assertEquals(1, server.getRequestCount());
+    }
+
+    @Test
+    void retriesOnIOExceptionThenSucceeds() throws IOException {
+        // First request: socket disconnect (simulates network failure)
+        server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+        // Second request: success
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
+
+        try (Response response = client.newCall(buildRequest()).execute()) {
+            assertEquals(200, response.code());
+        }
+
+        assertEquals(2, server.getRequestCount());
+    }
+
+    @Test
+    void noRetryForOneShotBody() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(503));
+
+        RequestBody oneShotBody =
+                new RequestBody() {
+                    @Override
+                    public MediaType contentType() {
+                        return MediaType.get("text/plain");
+                    }
+
+                    @Override
+                    public boolean isOneShot() {
+                        return true;
+                    }
+
+                    @Override
+                    public void writeTo(BufferedSink sink) throws IOException {
+                        sink.writeUtf8("payload");
+                    }
+                };
+
+        Request request =
+                new Request.Builder().url(server.url("/test")).post(oneShotBody).build();
+
+        try (Response response = client.newCall(request).execute()) {
+            assertEquals(503, response.code());
+        }
+
+        // No retry — one-shot body cannot be replayed
         assertEquals(1, server.getRequestCount());
     }
 }

--- a/ai/src/test/java/org/conductoross/conductor/ai/http/RetryInterceptorTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/http/RetryInterceptorTest.java
@@ -121,8 +121,7 @@ class RetryInterceptorTest {
 
     @Test
     void retriesOn429WithRetryAfterHeader() throws IOException {
-        server.enqueue(
-                new MockResponse().setResponseCode(429).addHeader("Retry-After", "1"));
+        server.enqueue(new MockResponse().setResponseCode(429).addHeader("Retry-After", "1"));
         server.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
 
         try (Response response = client.newCall(buildRequest()).execute()) {
@@ -191,8 +190,7 @@ class RetryInterceptorTest {
                     }
                 };
 
-        Request request =
-                new Request.Builder().url(server.url("/test")).post(oneShotBody).build();
+        Request request = new Request.Builder().url(server.url("/test")).post(oneShotBody).build();
 
         try (Response response = client.newCall(request).execute()) {
             assertEquals(503, response.code());

--- a/ai/src/test/java/org/conductoross/conductor/ai/http/RetryInterceptorTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/http/RetryInterceptorTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.http;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RetryInterceptorTest {
+
+    private MockWebServer server;
+    private OkHttpClient client;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+        client =
+                new OkHttpClient.Builder()
+                        .addInterceptor(new RetryInterceptor(3, 10))
+                        .connectTimeout(2, TimeUnit.SECONDS)
+                        .readTimeout(2, TimeUnit.SECONDS)
+                        .writeTimeout(2, TimeUnit.SECONDS)
+                        .build();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        server.shutdown();
+    }
+
+    private Request buildRequest() {
+        return new Request.Builder().url(server.url("/test")).build();
+    }
+
+    @Test
+    void noRetryOn200() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
+
+        try (Response response = client.newCall(buildRequest()).execute()) {
+            assertEquals(200, response.code());
+        }
+
+        assertEquals(1, server.getRequestCount());
+    }
+
+    @Test
+    void retriesOn503ThenSucceeds() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(503));
+        server.enqueue(new MockResponse().setResponseCode(503));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
+
+        try (Response response = client.newCall(buildRequest()).execute()) {
+            assertEquals(200, response.code());
+        }
+
+        assertEquals(3, server.getRequestCount());
+    }
+
+    @Test
+    void exhaustsRetriesAndReturnsLastResponse() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(503));
+        server.enqueue(new MockResponse().setResponseCode(503));
+        server.enqueue(new MockResponse().setResponseCode(503));
+        server.enqueue(new MockResponse().setResponseCode(503));
+
+        try (Response response = client.newCall(buildRequest()).execute()) {
+            assertEquals(503, response.code());
+        }
+
+        // 1 initial + 3 retries = 4 total requests
+        assertEquals(4, server.getRequestCount());
+    }
+
+    @Test
+    void noRetryOn400() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(400));
+
+        try (Response response = client.newCall(buildRequest()).execute()) {
+            assertEquals(400, response.code());
+        }
+
+        assertEquals(1, server.getRequestCount());
+    }
+
+    @Test
+    void noRetryOn404() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(404));
+
+        try (Response response = client.newCall(buildRequest()).execute()) {
+            assertEquals(404, response.code());
+        }
+
+        assertEquals(1, server.getRequestCount());
+    }
+
+    @Test
+    void retriesOn429WithRetryAfterHeader() throws IOException {
+        server.enqueue(
+                new MockResponse().setResponseCode(429).addHeader("Retry-After", "1"));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
+
+        try (Response response = client.newCall(buildRequest()).execute()) {
+            assertEquals(200, response.code());
+        }
+
+        assertEquals(2, server.getRequestCount());
+    }
+
+    @Test
+    void retriesOn500() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(500));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("ok"));
+
+        try (Response response = client.newCall(buildRequest()).execute()) {
+            assertEquals(200, response.code());
+        }
+
+        assertEquals(2, server.getRequestCount());
+    }
+
+    @Test
+    void noRetryOn501() throws IOException {
+        server.enqueue(new MockResponse().setResponseCode(501));
+
+        try (Response response = client.newCall(buildRequest()).execute()) {
+            assertEquals(501, response.code());
+        }
+
+        assertEquals(1, server.getRequestCount());
+    }
+}

--- a/ai/src/test/java/org/conductoross/conductor/ai/integration/AIModelIntegrationTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/integration/AIModelIntegrationTest.java
@@ -729,7 +729,7 @@ public class AIModelIntegrationTest {
                 }
             }
 
-            gemini = new GeminiVertex(config);
+            gemini = new GeminiVertex(config, new okhttp3.OkHttpClient());
         }
 
         @Test

--- a/ai/src/test/java/org/conductoross/conductor/ai/integration/AIModelIntegrationTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/integration/AIModelIntegrationTest.java
@@ -55,6 +55,7 @@ import org.springframework.ai.image.ImageOptionsBuilder;
 import org.springframework.ai.image.ImagePrompt;
 import org.springframework.ai.image.ImageResponse;
 
+import okhttp3.OkHttpClient;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -163,7 +164,7 @@ public class AIModelIntegrationTest {
             OpenAIConfiguration config = new OpenAIConfiguration();
             config.setApiKey(System.getenv("OPENAI_API_KEY"));
             config.setBaseURL(System.getenv("OPENAI_BASE_URL"));
-            openAI = new OpenAI(config);
+            openAI = new OpenAI(config, new OkHttpClient());
         }
 
         @Test
@@ -560,7 +561,7 @@ public class AIModelIntegrationTest {
             AnthropicConfiguration config = new AnthropicConfiguration();
             config.setApiKey(System.getenv("ANTHROPIC_API_KEY"));
             config.setBaseURL(System.getenv("ANTHROPIC_BASE_URL"));
-            anthropic = new Anthropic(config);
+            anthropic = new Anthropic(config, new OkHttpClient());
         }
 
         @Test
@@ -1134,7 +1135,7 @@ public class AIModelIntegrationTest {
             GrokAIConfiguration config = new GrokAIConfiguration();
             config.setApiKey(System.getenv("GROK_API_KEY"));
             config.setBaseURL(System.getenv("GROK_BASE_URL"));
-            grok = new Grok(config);
+            grok = new Grok(config, new OkHttpClient());
         }
 
         @Test
@@ -1297,7 +1298,7 @@ public class AIModelIntegrationTest {
             AzureOpenAIConfiguration config = new AzureOpenAIConfiguration();
             config.setApiKey(System.getenv("AZURE_OPENAI_API_KEY"));
             config.setBaseURL(System.getenv("AZURE_OPENAI_ENDPOINT"));
-            azureOpenAI = new AzureOpenAI(config);
+            azureOpenAI = new AzureOpenAI(config, new OkHttpClient());
         }
 
         @Test
@@ -1436,7 +1437,7 @@ public class AIModelIntegrationTest {
             PerplexityAIConfiguration config = new PerplexityAIConfiguration();
             config.setApiKey(System.getenv("PERPLEXITY_API_KEY"));
             config.setBaseURL(System.getenv("PERPLEXITY_BASE_URL"));
-            perplexity = new PerplexityAI(config);
+            perplexity = new PerplexityAI(config, new OkHttpClient());
         }
 
         @Test

--- a/ai/src/test/java/org/conductoross/conductor/ai/integration/AIModelIntegrationTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/integration/AIModelIntegrationTest.java
@@ -56,6 +56,7 @@ import org.springframework.ai.image.ImagePrompt;
 import org.springframework.ai.image.ImageResponse;
 
 import okhttp3.OkHttpClient;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicTest.java
@@ -25,6 +25,7 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 
 import okhttp3.OkHttpClient;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class AnthropicTest {

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 
+import okhttp3.OkHttpClient;
 import static org.junit.jupiter.api.Assertions.*;
 
 class AnthropicTest {
@@ -39,7 +40,7 @@ class AnthropicTest {
         void setUp() {
             AnthropicConfiguration config = new AnthropicConfiguration();
             config.setApiKey("test-api-key");
-            anthropic = new Anthropic(config);
+            anthropic = new Anthropic(config, new OkHttpClient());
         }
 
         @Test
@@ -204,7 +205,7 @@ class AnthropicTest {
         void setUp() {
             AnthropicConfiguration config = new AnthropicConfiguration();
             config.setApiKey(System.getenv(ENV_API_KEY));
-            anthropic = new Anthropic(config);
+            anthropic = new Anthropic(config, new OkHttpClient());
         }
 
         @Test

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAITest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAITest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 
+import okhttp3.OkHttpClient;
 import static org.junit.jupiter.api.Assertions.*;
 
 class AzureOpenAITest {
@@ -45,7 +46,7 @@ class AzureOpenAITest {
             config.setApiKey("test-api-key");
             config.setBaseURL("https://myresource.openai.azure.com");
             config.setDeploymentName("gpt-4");
-            azureOpenAI = new AzureOpenAI(config);
+            azureOpenAI = new AzureOpenAI(config, new OkHttpClient());
         }
 
         @Test
@@ -111,7 +112,7 @@ class AzureOpenAITest {
                     System.getenv("AZURE_OPENAI_DEPLOYMENT") != null
                             ? System.getenv("AZURE_OPENAI_DEPLOYMENT")
                             : "gpt-4o-mini");
-            azureOpenAI = new AzureOpenAI(config);
+            azureOpenAI = new AzureOpenAI(config, new OkHttpClient());
         }
 
         @Test

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAITest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAITest.java
@@ -28,6 +28,7 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 
 import okhttp3.OkHttpClient;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class AzureOpenAITest {

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiApiTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiApiTest.java
@@ -36,28 +36,31 @@ class GeminiApiTest {
     void setUp() throws Exception {
         server = new MockWebServer();
         server.start();
-        OkHttpClient client = new OkHttpClient.Builder()
-                .readTimeout(5, TimeUnit.SECONDS).build();
+        OkHttpClient client = new OkHttpClient.Builder().readTimeout(5, TimeUnit.SECONDS).build();
         // Use the server's host/port as customBase so requests go to MockWebServer
         String base = server.url("").toString().replaceAll("/$", "");
         api = GeminiApi.forApiKey(client, "test-key", base);
     }
 
     @AfterEach
-    void tearDown() throws Exception { server.shutdown(); }
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
 
     @Test
     void generateContentReturnsText() throws Exception {
-        server.enqueue(new MockResponse()
-                .setResponseCode(200)
-                .setBody("""
+        server.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setBody(
+                                """
                     {"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]},
                     "finishReason":"STOP"}],
                     "usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3}}""")
-                .addHeader("Content-Type", "application/json"));
+                        .addHeader("Content-Type", "application/json"));
 
-        var contents = List.of(new GeminiApi.Content("user",
-                List.of(GeminiApi.Part.text("Say hi"))));
+        var contents =
+                List.of(new GeminiApi.Content("user", List.of(GeminiApi.Part.text("Say hi"))));
         GeminiApi.GenerateContentResponse resp =
                 api.generateContent("gemini-2.5-flash", contents, null);
 
@@ -71,11 +74,12 @@ class GeminiApiTest {
 
     @Test
     void embedContentReturnsValues() throws Exception {
-        server.enqueue(new MockResponse()
-                .setResponseCode(200)
-                .setBody("""
+        server.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setBody("""
                     {"embedding":{"values":[0.1,0.2,0.3]}}""")
-                .addHeader("Content-Type", "application/json"));
+                        .addHeader("Content-Type", "application/json"));
 
         GeminiApi.EmbedContentResponse resp =
                 api.embedContent("text-embedding-004", "hello world", null);
@@ -89,12 +93,12 @@ class GeminiApiTest {
 
     @Test
     void generateContentThrowsOnError() {
-        server.enqueue(new MockResponse()
-                .setResponseCode(400)
-                .setBody("{\"error\":{\"message\":\"Invalid model\"}}"));
-        var contents = List.of(new GeminiApi.Content("user",
-                List.of(GeminiApi.Part.text("test"))));
-        assertThrows(java.io.IOException.class,
-                () -> api.generateContent("bad-model", contents, null));
+        server.enqueue(
+                new MockResponse()
+                        .setResponseCode(400)
+                        .setBody("{\"error\":{\"message\":\"Invalid model\"}}"));
+        var contents = List.of(new GeminiApi.Content("user", List.of(GeminiApi.Part.text("test"))));
+        assertThrows(
+                java.io.IOException.class, () -> api.generateContent("bad-model", contents, null));
     }
 }

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiApiTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiApiTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.gemini;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.conductoross.conductor.ai.providers.gemini.api.GeminiApi;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GeminiApiTest {
+
+    private MockWebServer server;
+    private GeminiApi api;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        OkHttpClient client = new OkHttpClient.Builder()
+                .readTimeout(5, TimeUnit.SECONDS).build();
+        // Use the server's host/port as customBase so requests go to MockWebServer
+        String base = server.url("").toString().replaceAll("/$", "");
+        api = GeminiApi.forApiKey(client, "test-key", base);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception { server.shutdown(); }
+
+    @Test
+    void generateContentReturnsText() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("""
+                    {"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]},
+                    "finishReason":"STOP"}],
+                    "usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3}}""")
+                .addHeader("Content-Type", "application/json"));
+
+        var contents = List.of(new GeminiApi.Content("user",
+                List.of(GeminiApi.Part.text("Say hi"))));
+        GeminiApi.GenerateContentResponse resp =
+                api.generateContent("gemini-2.5-flash", contents, null);
+
+        assertEquals("Hello", resp.text());
+        assertEquals("STOP", resp.finishReason());
+        RecordedRequest req = server.takeRequest();
+        assertEquals("POST", req.getMethod());
+        assertTrue(req.getPath().contains("gemini-2.5-flash:generateContent"));
+        assertTrue(req.getPath().contains("key=test-key"));
+    }
+
+    @Test
+    void embedContentReturnsValues() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("""
+                    {"embedding":{"values":[0.1,0.2,0.3]}}""")
+                .addHeader("Content-Type", "application/json"));
+
+        GeminiApi.EmbedContentResponse resp =
+                api.embedContent("text-embedding-004", "hello world", null);
+
+        assertNotNull(resp.embedding());
+        assertEquals(3, resp.embedding().values().size());
+        assertEquals(0.1f, resp.embedding().values().get(0), 0.001f);
+        RecordedRequest req = server.takeRequest();
+        assertTrue(req.getPath().contains("text-embedding-004:embedContent"));
+    }
+
+    @Test
+    void generateContentThrowsOnError() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(400)
+                .setBody("{\"error\":{\"message\":\"Invalid model\"}}"));
+        var contents = List.of(new GeminiApi.Content("user",
+                List.of(GeminiApi.Part.text("test"))));
+        assertThrows(java.io.IOException.class,
+                () -> api.generateContent("bad-model", contents, null));
+    }
+}

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiChatModelReasoningTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiChatModelReasoningTest.java
@@ -14,14 +14,9 @@ package org.conductoross.conductor.ai.providers.gemini;
 
 import java.util.List;
 
+import org.conductoross.conductor.ai.providers.gemini.api.GeminiApi;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.model.ChatResponse;
-
-import com.google.genai.types.Candidate;
-import com.google.genai.types.Content;
-import com.google.genai.types.GenerateContentResponse;
-import com.google.genai.types.GenerateContentResponseUsageMetadata;
-import com.google.genai.types.Part;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -29,57 +24,46 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Unit tests for {@link GeminiChatModel#toSpringChatResponse(GenerateContentResponse, String)} —
+ * Unit tests for {@link GeminiChatModel#toSpringChatResponse(GeminiApi.GenerateContentResponse, String)} —
  * the response-parsing path that lifts Gemini "thought" parts onto {@code
  * ChatResponseMetadata["reasoning"]} and the {@code thoughtsTokenCount} usage field onto {@code
  * ChatResponseMetadata["reasoning_tokens"]}.
  *
- * <p>The Google GenAI {@link com.google.genai.Client} is a concrete class with public field access,
- * so we exercise the response-parsing logic directly via the package-private method rather than
- * mocking the HTTP transport. The conversion is the part that diverges across providers; the SDK
- * call shape is uninteresting.
+ * <p>We exercise the response-parsing logic directly via the package-private method by constructing
+ * {@link GeminiApi.GenerateContentResponse} records directly.
  */
 class GeminiChatModelReasoningTest {
 
     private static GeminiChatModel newChatModel() {
-        // Client is only used inside ``call()`` which we don't exercise here.
-        // Constructor accepts the field as-is; null is safe for these tests.
+        // api is only used inside call() which we don't exercise here.
+        // null is safe for these tests.
         return new GeminiChatModel(null);
     }
 
-    private static Part thoughtPart(String text) {
-        return Part.builder().thought(true).text(text).build();
+    private static GeminiApi.Part thoughtPart(String text) {
+        return new GeminiApi.Part(text, null, null, null, true);
     }
 
-    private static Part textPart(String text) {
-        return Part.builder().text(text).build();
+    private static GeminiApi.Part textPart(String text) {
+        return GeminiApi.Part.text(text);
     }
 
-    private static Content content(Part... parts) {
-        return Content.builder().role("model").parts(List.of(parts)).build();
+    private static GeminiApi.Content content(GeminiApi.Part... parts) {
+        return new GeminiApi.Content("model", List.of(parts));
     }
 
-    private static GenerateContentResponse responseWith(
-            List<Part> parts, Integer thoughtsTokenCount) {
-        Candidate candidate =
-                Candidate.builder().content(content(parts.toArray(new Part[0]))).build();
-        GenerateContentResponseUsageMetadata.Builder usage =
-                GenerateContentResponseUsageMetadata.builder()
-                        .promptTokenCount(8)
-                        .candidatesTokenCount(20);
-        if (thoughtsTokenCount != null) {
-            usage.thoughtsTokenCount(thoughtsTokenCount);
-        }
-        return GenerateContentResponse.builder()
-                .responseId("resp_xyz")
-                .candidates(candidate)
-                .usageMetadata(usage.build())
-                .build();
+    private static GeminiApi.GenerateContentResponse responseWith(
+            List<GeminiApi.Part> parts, Integer thoughtsTokenCount) {
+        GeminiApi.Candidate candidate =
+                new GeminiApi.Candidate(content(parts.toArray(new GeminiApi.Part[0])), "STOP");
+        GeminiApi.UsageMetadata usage =
+                new GeminiApi.UsageMetadata(8, 20, thoughtsTokenCount);
+        return new GeminiApi.GenerateContentResponse(List.of(candidate), usage, "resp_xyz");
     }
 
     @Test
     void thoughtPartsAreConcatenatedIntoReasoningMetadata() {
-        GenerateContentResponse response =
+        GeminiApi.GenerateContentResponse response =
                 responseWith(
                         List.of(
                                 thoughtPart("Consider option A."),
@@ -110,17 +94,17 @@ class GeminiChatModelReasoningTest {
 
     @Test
     void noThoughtParts_metadataOmitsReasoningKey() {
-        GenerateContentResponse response = responseWith(List.of(textPart("Plain answer.")), null);
+        GeminiApi.GenerateContentResponse response = responseWith(List.of(textPart("Plain answer.")), null);
 
         ChatResponse chat = newChatModel().toSpringChatResponse(response, "gemini-2.5-flash");
 
         assertEquals("Plain answer.", chat.getResult().getOutput().getText());
         assertNull(
                 chat.getMetadata().get("reasoning"),
-                "no thought parts ⇒ metadata['reasoning'] must be absent");
+                "no thought parts => metadata['reasoning'] must be absent");
         assertNull(
                 chat.getMetadata().get("reasoning_tokens"),
-                "no thoughtsTokenCount in usage ⇒ metadata['reasoning_tokens'] must be absent");
+                "no thoughtsTokenCount in usage => metadata['reasoning_tokens'] must be absent");
     }
 
     @Test
@@ -128,7 +112,7 @@ class GeminiChatModelReasoningTest {
         // Caller may set ``thinking_budget`` (reasoning under the hood) without
         // asking for summaries. Gemini bills the reasoning tokens regardless,
         // and we want that visible to operators even when no summary text exists.
-        GenerateContentResponse response = responseWith(List.of(textPart("Answer.")), 12);
+        GeminiApi.GenerateContentResponse response = responseWith(List.of(textPart("Answer.")), 12);
 
         ChatResponse chat = newChatModel().toSpringChatResponse(response, "gemini-2.5-flash");
 
@@ -139,7 +123,7 @@ class GeminiChatModelReasoningTest {
 
     @Test
     void blankThoughtTextIsIgnored() {
-        GenerateContentResponse response =
+        GeminiApi.GenerateContentResponse response =
                 responseWith(
                         List.of(thoughtPart("Real thought."), thoughtPart("   "), textPart("Out.")),
                         7);
@@ -159,36 +143,25 @@ class GeminiChatModelReasoningTest {
         // model still gets a single generation in the existing code path because
         // result.text() merges, but reasoning should not be dropped on the floor
         // for non-first candidates.)
-        Candidate c1 =
-                Candidate.builder()
-                        .content(
-                                Content.builder()
-                                        .role("model")
-                                        .parts(
-                                                List.of(
-                                                        thoughtPart("Cand 1 thought."),
-                                                        textPart("A.")))
-                                        .build())
-                        .build();
-        Candidate c2 =
-                Candidate.builder()
-                        .content(
-                                Content.builder()
-                                        .role("model")
-                                        .parts(List.of(thoughtPart("Cand 2 thought.")))
-                                        .build())
-                        .build();
-        GenerateContentResponse response =
-                GenerateContentResponse.builder()
-                        .responseId("resp_multi")
-                        .candidates(c1, c2)
-                        .usageMetadata(
-                                GenerateContentResponseUsageMetadata.builder()
-                                        .promptTokenCount(1)
-                                        .candidatesTokenCount(1)
-                                        .thoughtsTokenCount(3)
-                                        .build())
-                        .build();
+        GeminiApi.Candidate c1 =
+                new GeminiApi.Candidate(
+                        new GeminiApi.Content(
+                                "model",
+                                List.of(
+                                        thoughtPart("Cand 1 thought."),
+                                        textPart("A."))),
+                        "STOP");
+        GeminiApi.Candidate c2 =
+                new GeminiApi.Candidate(
+                        new GeminiApi.Content(
+                                "model",
+                                List.of(thoughtPart("Cand 2 thought."))),
+                        "STOP");
+        GeminiApi.GenerateContentResponse response =
+                new GeminiApi.GenerateContentResponse(
+                        List.of(c1, c2),
+                        new GeminiApi.UsageMetadata(1, 1, 3),
+                        "resp_multi");
 
         ChatResponse chat = newChatModel().toSpringChatResponse(response, "gemini-2.5-pro");
 

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiChatModelReasoningTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiChatModelReasoningTest.java
@@ -24,8 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Unit tests for {@link GeminiChatModel#toSpringChatResponse(GeminiApi.GenerateContentResponse, String)} —
- * the response-parsing path that lifts Gemini "thought" parts onto {@code
+ * Unit tests for {@link GeminiChatModel#toSpringChatResponse(GeminiApi.GenerateContentResponse,
+ * String)} — the response-parsing path that lifts Gemini "thought" parts onto {@code
  * ChatResponseMetadata["reasoning"]} and the {@code thoughtsTokenCount} usage field onto {@code
  * ChatResponseMetadata["reasoning_tokens"]}.
  *
@@ -56,8 +56,7 @@ class GeminiChatModelReasoningTest {
             List<GeminiApi.Part> parts, Integer thoughtsTokenCount) {
         GeminiApi.Candidate candidate =
                 new GeminiApi.Candidate(content(parts.toArray(new GeminiApi.Part[0])), "STOP");
-        GeminiApi.UsageMetadata usage =
-                new GeminiApi.UsageMetadata(8, 20, thoughtsTokenCount);
+        GeminiApi.UsageMetadata usage = new GeminiApi.UsageMetadata(8, 20, thoughtsTokenCount);
         return new GeminiApi.GenerateContentResponse(List.of(candidate), usage, "resp_xyz");
     }
 
@@ -94,7 +93,8 @@ class GeminiChatModelReasoningTest {
 
     @Test
     void noThoughtParts_metadataOmitsReasoningKey() {
-        GeminiApi.GenerateContentResponse response = responseWith(List.of(textPart("Plain answer.")), null);
+        GeminiApi.GenerateContentResponse response =
+                responseWith(List.of(textPart("Plain answer.")), null);
 
         ChatResponse chat = newChatModel().toSpringChatResponse(response, "gemini-2.5-flash");
 
@@ -146,22 +146,15 @@ class GeminiChatModelReasoningTest {
         GeminiApi.Candidate c1 =
                 new GeminiApi.Candidate(
                         new GeminiApi.Content(
-                                "model",
-                                List.of(
-                                        thoughtPart("Cand 1 thought."),
-                                        textPart("A."))),
+                                "model", List.of(thoughtPart("Cand 1 thought."), textPart("A."))),
                         "STOP");
         GeminiApi.Candidate c2 =
                 new GeminiApi.Candidate(
-                        new GeminiApi.Content(
-                                "model",
-                                List.of(thoughtPart("Cand 2 thought."))),
+                        new GeminiApi.Content("model", List.of(thoughtPart("Cand 2 thought."))),
                         "STOP");
         GeminiApi.GenerateContentResponse response =
                 new GeminiApi.GenerateContentResponse(
-                        List.of(c1, c2),
-                        new GeminiApi.UsageMetadata(1, 1, 3),
-                        "resp_multi");
+                        List.of(c1, c2), new GeminiApi.UsageMetadata(1, 1, 3), "resp_multi");
 
         ChatResponse chat = newChatModel().toSpringChatResponse(response, "gemini-2.5-pro");
 

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 
+import okhttp3.OkHttpClient;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class GeminiVertexTest {
@@ -40,7 +42,7 @@ class GeminiVertexTest {
             GeminiVertexConfiguration config = new GeminiVertexConfiguration();
             config.setProjectId("test-project");
             config.setLocation("us-central1");
-            geminiVertex = new GeminiVertex(config);
+            geminiVertex = new GeminiVertex(config, new OkHttpClient());
         }
 
         @Test
@@ -103,7 +105,7 @@ class GeminiVertexTest {
         void testGetChatOptions_withWebSearchFlag_apiKeyPath() {
             GeminiVertexConfiguration apiKeyConfig = new GeminiVertexConfiguration();
             apiKeyConfig.setApiKey("test-api-key");
-            GeminiVertex apiKeyGemini = new GeminiVertex(apiKeyConfig);
+            GeminiVertex apiKeyGemini = new GeminiVertex(apiKeyConfig, new OkHttpClient());
 
             ChatCompletion input = new ChatCompletion();
             input.setModel("gemini-2.5-flash");
@@ -164,7 +166,7 @@ class GeminiVertexTest {
                     System.getenv(ENV_LOCATION) != null
                             ? System.getenv(ENV_LOCATION)
                             : "us-central1");
-            geminiVertex = new GeminiVertex(config);
+            geminiVertex = new GeminiVertex(config, new OkHttpClient());
         }
 
         @Test

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/grok/GrokTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/grok/GrokTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 
+import okhttp3.OkHttpClient;
 import static org.junit.jupiter.api.Assertions.*;
 
 class GrokTest {
@@ -37,7 +38,7 @@ class GrokTest {
         void setUp() {
             GrokAIConfiguration config = new GrokAIConfiguration();
             config.setApiKey("test-api-key");
-            grok = new Grok(config);
+            grok = new Grok(config, new OkHttpClient());
         }
 
         @Test
@@ -84,7 +85,7 @@ class GrokTest {
         void setUp() {
             GrokAIConfiguration config = new GrokAIConfiguration();
             config.setApiKey(System.getenv(ENV_API_KEY));
-            grok = new Grok(config);
+            grok = new Grok(config, new OkHttpClient());
         }
 
         @Test

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/grok/GrokTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/grok/GrokTest.java
@@ -23,6 +23,7 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 
 import okhttp3.OkHttpClient;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class GrokTest {

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFaceApiTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFaceApiTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.huggingface;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HuggingFaceApiTest {
+
+    private MockWebServer server;
+    private HuggingFaceApi api;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        OkHttpClient client = new OkHttpClient.Builder().readTimeout(5, TimeUnit.SECONDS).build();
+        api = new HuggingFaceApi(client, "test-token", server.url("/").toString());
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    void generateCallsApiAndReturnsText() throws Exception {
+        server.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .setBody("[{\"generated_text\":\"Hello world\"}]")
+                        .addHeader("Content-Type", "application/json"));
+
+        String result = api.generate("Say hello");
+
+        assertEquals("Hello world", result);
+        RecordedRequest req = server.takeRequest();
+        assertEquals("POST", req.getMethod());
+        assertTrue(req.getBody().readUtf8().contains("Say hello"));
+        assertEquals("Bearer test-token", req.getHeader("Authorization"));
+    }
+
+    @Test
+    void throwsOnNon200() {
+        server.enqueue(new MockResponse().setResponseCode(503).setBody("unavailable"));
+        assertThrows(java.io.IOException.class, () -> api.generate("test"));
+    }
+}

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFaceConfigurationTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFaceConfigurationTest.java
@@ -14,6 +14,8 @@ package org.conductoross.conductor.ai.providers.huggingface;
 
 import org.junit.jupiter.api.Test;
 
+import okhttp3.OkHttpClient;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class HuggingFaceConfigurationTest {
@@ -36,7 +38,7 @@ class HuggingFaceConfigurationTest {
         HuggingFaceConfiguration config = new HuggingFaceConfiguration();
         config.setApiKey("test-key");
 
-        HuggingFace result = config.get();
+        HuggingFace result = new HuggingFace(config, new OkHttpClient());
 
         assertNotNull(result);
         assertEquals("huggingface", result.getModelProvider());

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFaceTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/huggingface/HuggingFaceTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 
+import okhttp3.OkHttpClient;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class HuggingFaceTest {
@@ -37,7 +39,7 @@ class HuggingFaceTest {
         void setUp() {
             HuggingFaceConfiguration config = new HuggingFaceConfiguration();
             config.setApiKey("test-api-key");
-            huggingFace = new HuggingFace(config);
+            huggingFace = new HuggingFace(config, new OkHttpClient());
         }
 
         @Test
@@ -86,7 +88,7 @@ class HuggingFaceTest {
         void setUp() {
             HuggingFaceConfiguration config = new HuggingFaceConfiguration();
             config.setApiKey(System.getenv(ENV_API_KEY));
-            huggingFace = new HuggingFace(config);
+            huggingFace = new HuggingFace(config, new OkHttpClient());
         }
 
         @Test

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/openai/OpenAIConfigurationTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/openai/OpenAIConfigurationTest.java
@@ -14,6 +14,8 @@ package org.conductoross.conductor.ai.providers.openai;
 
 import org.junit.jupiter.api.Test;
 
+import okhttp3.OkHttpClient;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class OpenAIConfigurationTest {
@@ -43,7 +45,7 @@ class OpenAIConfigurationTest {
         OpenAIConfiguration config = new OpenAIConfiguration();
         config.setApiKey("test-key");
 
-        OpenAI result = config.get();
+        OpenAI result = new OpenAI(config, new OkHttpClient());
 
         assertNotNull(result);
         assertEquals("openai", result.getModelProvider());

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/openai/OpenAITest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/openai/OpenAITest.java
@@ -25,6 +25,7 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 
 import okhttp3.OkHttpClient;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class OpenAITest {

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/openai/OpenAITest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/openai/OpenAITest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 
+import okhttp3.OkHttpClient;
 import static org.junit.jupiter.api.Assertions.*;
 
 class OpenAITest {
@@ -39,7 +40,7 @@ class OpenAITest {
         void setUp() {
             OpenAIConfiguration config = new OpenAIConfiguration();
             config.setApiKey("test-api-key");
-            openAI = new OpenAI(config);
+            openAI = new OpenAI(config, new OkHttpClient());
         }
 
         @Test
@@ -190,7 +191,7 @@ class OpenAITest {
         void setUp() {
             OpenAIConfiguration config = new OpenAIConfiguration();
             config.setApiKey(System.getenv(ENV_API_KEY));
-            openAI = new OpenAI(config);
+            openAI = new OpenAI(config, new OkHttpClient());
         }
 
         @Test

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/perplexity/PerplexityAITest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/perplexity/PerplexityAITest.java
@@ -23,6 +23,7 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 
 import okhttp3.OkHttpClient;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class PerplexityAITest {

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/perplexity/PerplexityAITest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/perplexity/PerplexityAITest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 
+import okhttp3.OkHttpClient;
 import static org.junit.jupiter.api.Assertions.*;
 
 class PerplexityAITest {
@@ -37,7 +38,7 @@ class PerplexityAITest {
         void setUp() {
             PerplexityAIConfiguration config = new PerplexityAIConfiguration();
             config.setApiKey("test-api-key");
-            perplexityAI = new PerplexityAI(config);
+            perplexityAI = new PerplexityAI(config, new OkHttpClient());
         }
 
         @Test
@@ -86,7 +87,7 @@ class PerplexityAITest {
         void setUp() {
             PerplexityAIConfiguration config = new PerplexityAIConfiguration();
             config.setApiKey(System.getenv(ENV_API_KEY));
-            perplexityAI = new PerplexityAI(config);
+            perplexityAI = new PerplexityAI(config, new OkHttpClient());
         }
 
         @Test

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/MongoVectorDBTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/MongoVectorDBTest.java
@@ -86,7 +86,7 @@ public class MongoVectorDBTest {
 
         ObjectMapper objectMapper = new ObjectMapperProvider().getObjectMapper();
         AIModelProvider provider = new AIModelProvider(List.of(), new StandardEnvironment());
-        LLMs llm = new LLMs(null, new JsonSchemaValidator(objectMapper), provider);
+        LLMs llm = new LLMs(null, new JsonSchemaValidator(objectMapper), provider, new okhttp3.OkHttpClient());
 
         MongoDBConfig mongoConfig = new MongoDBConfig();
         mongoConfig.setDatabase(DATABASE_NAME);

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/MongoVectorDBTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/MongoVectorDBTest.java
@@ -86,7 +86,12 @@ public class MongoVectorDBTest {
 
         ObjectMapper objectMapper = new ObjectMapperProvider().getObjectMapper();
         AIModelProvider provider = new AIModelProvider(List.of(), new StandardEnvironment());
-        LLMs llm = new LLMs(null, new JsonSchemaValidator(objectMapper), provider, new okhttp3.OkHttpClient());
+        LLMs llm =
+                new LLMs(
+                        null,
+                        new JsonSchemaValidator(objectMapper),
+                        provider,
+                        new okhttp3.OkHttpClient());
 
         MongoDBConfig mongoConfig = new MongoDBConfig();
         mongoConfig.setDatabase(DATABASE_NAME);


### PR DESCRIPTION
## Summary

- **Shared `OkHttpClient` bean** (`AIHttpClientConfiguration`) with configurable pool, timeouts, and retries injected into every LLM provider — replaces 15+ self-constructed `OkHttpClient` instances
- **`RetryInterceptor`** — transparent retry on `IOException`, HTTP 429 (with `Retry-After` header support), and HTTP 5xx (except 501) using exponential backoff with jitter
- **Spring-AI providers** (Mistral, Ollama, Cohere) migrated to `OkHttp3ClientHttpRequestFactory` — per-provider `timeout` config still honored via `httpClient.newBuilder()`
- **HuggingFace** — replaced Spring AI's `HuggingfaceChatModel` (non-injectable `RestTemplate`) with a thin `HuggingFaceApi` + `HuggingFaceChatModel` backed by OkHttp
- **Gemini** — replaced `google-genai:1.28.0` SDK with a custom `GeminiApi` OkHttp client; supports both AI Studio (API key) and Vertex AI (service account) modes with correct per-mode endpoint verbs (`generateVideos` vs `predictLongRunning`, etc.)
- **Removed dependency**: `com.google.genai:google-genai:1.28.0`; added explicit `com.google.auth:google-auth-library-oauth2-http:1.33.0` (Vertex credentials)

## Configuration

New `conductor.ai.http.*` properties (all optional, defaults shown):

```yaml
conductor:
  ai:
    http:
      connect-timeout: 60s
      read-timeout: 600s
      write-timeout: 60s
      max-idle-connections: 50
      keep-alive: 5m
      max-retries: 3   # set to 0 to disable retry
```

## Test Plan

- [ ] `./gradlew :conductor-ai:build` passes (543 tests; 11 pre-existing live-API failures)
- [ ] `RetryInterceptorTest` — 9 MockWebServer-backed tests covering IOException, 429+Retry-After, 5xx, one-shot body guard
- [ ] `HuggingFaceApiTest` — 2 MockWebServer-backed tests
- [ ] `GeminiApiTest` — 3 MockWebServer-backed tests (generateContent, embedContent, error handling)
- [ ] Verify AI Studio and Vertex AI Gemini paths with live credentials