### PR TITLE
fix(ai): gate loop assistant-prefill injection on provider capability

### DIFF
--- a/ai/src/main/java/org/conductoross/conductor/ai/AIModel.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/AIModel.java
@@ -68,6 +68,27 @@ public interface AIModel {
     }
 
     /**
+     * Whether this provider accepts a chat-completion request whose last message has the {@code
+     * assistant} role — i.e. assistant-message prefill, used to nudge the model's response to start
+     * a certain way (and, in this codebase, the format in which {@link
+     * org.conductoross.conductor.ai.tasks.mapper.ChatCompleteTaskMapper}'s loop-history injection
+     * carries prior DO_WHILE iteration outputs back into the next iteration).
+     *
+     * <p>When this returns {@code false}, the mapper suppresses the same-refName loop-iteration
+     * assistant injection: those auto-attached assistant messages would either be rejected outright
+     * by the provider's API (e.g. Anthropic Claude Sonnet 4.6+ returns {@code 400 "This model does
+     * not support assistant message prefill. The conversation must end with a user message."}) or
+     * be silently mis-handled. Participants, tool calls, and sub-workflow context are unaffected by
+     * this flag.
+     *
+     * <p>Default is {@code true} to preserve historical behavior for providers (OpenAI Responses
+     * API with {@code previousResponseId}, Gemini, etc.) that accept trailing assistant messages.
+     */
+    default boolean supportsAssistantPrefill() {
+        return true;
+    }
+
+    /**
      * Embedding generation
      *
      * @param embeddingGenRequest request

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/Anthropic.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/Anthropic.java
@@ -57,6 +57,22 @@ public class Anthropic implements AIModel {
         return NAME;
     }
 
+    /**
+     * Anthropic Claude Sonnet 4.6+ rejects requests whose final message has the {@code assistant}
+     * role with {@code 400 "This model does not support assistant message prefill. The conversation
+     * must end with a user message."} Earlier Claude models (Sonnet 4.5 and below) silently
+     * accepted prefill, which is the only reason {@link
+     * org.conductoross.conductor.ai.tasks.mapper.ChatCompleteTaskMapper}'s loop-history
+     * auto-injection ever worked on Anthropic — the injected messages arrived as accidental
+     * prefill. We declare {@code false} here so the mapper suppresses that injection across all
+     * Anthropic models; workflows that need prior-iteration state on an Anthropic loop should
+     * template it into the user message via {@code ${...output.result}}.
+     */
+    @Override
+    public boolean supportsAssistantPrefill() {
+        return false;
+    }
+
     @Override
     public List<Float> generateEmbeddings(EmbeddingGenRequest embeddingGenRequest) {
         throw new UnsupportedOperationException("Not supported");

--- a/ai/src/main/java/org/conductoross/conductor/ai/tasks/mapper/ChatCompleteTaskMapper.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/tasks/mapper/ChatCompleteTaskMapper.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.conductoross.conductor.ai.AIModel;
+import org.conductoross.conductor.ai.AIModelProvider;
 import org.conductoross.conductor.ai.models.ChatCompletion;
 import org.conductoross.conductor.ai.models.ChatMessage;
 import org.conductoross.conductor.ai.models.LLMResponse;
@@ -26,7 +28,9 @@ import org.conductoross.conductor.ai.models.Media;
 import org.conductoross.conductor.ai.models.ToolCall;
 import org.conductoross.conductor.common.utils.StringTemplate;
 import org.conductoross.conductor.config.AIIntegrationEnabledCondition;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
@@ -50,8 +54,22 @@ public class ChatCompleteTaskMapper extends AIModelTaskMapper<ChatCompletion> {
     private static final Set<String> toolTaskTypes =
             Set.of(TASK_TYPE_HTTP, TASK_TYPE_SIMPLE, "MCP", "CALL_MCP_TOOL");
 
+    /**
+     * Nullable: present at runtime under Spring (auto-wired via the AI integration condition);
+     * nullable in unit tests that instantiate the mapper directly. When null, the mapper falls back
+     * to the historical "every provider supports prefill" assumption — same behavior as before this
+     * dependency was introduced.
+     */
+    @Nullable private final AIModelProvider aiModelProvider;
+
     public ChatCompleteTaskMapper() {
+        this(null);
+    }
+
+    @Autowired
+    public ChatCompleteTaskMapper(@Nullable AIModelProvider aiModelProvider) {
         super(ChatCompletion.NAME);
+        this.aiModelProvider = aiModelProvider;
     }
 
     @Override
@@ -68,12 +86,12 @@ public class ChatCompleteTaskMapper extends AIModelTaskMapper<ChatCompletion> {
                 history.add(new ChatMessage(ChatMessage.Role.user, chatCompletion.getUserInput()));
             }
             // getHistory() internally skips prior loop-iteration assistant messages
-            // for this same task refName when previousResponseId is in play —
-            // OpenAI's Responses API already has those server-side, and the local
-            // history injection drops the matching user prompts which would leave
-            // the model staring at orphaned replies. Participants, tool calls, and
-            // sub-workflow context are still preserved since the server has never
-            // seen those.
+            // for this same task refName when (a) previousResponseId is in play
+            // (OpenAI Responses API server-side store owns the prior turns) or
+            // (b) the provider declares it doesn't accept assistant-message
+            // prefill (AIModel.supportsAssistantPrefill — e.g. Anthropic, where
+            // Claude Sonnet 4.6+ rejects prefill outright). Participants, tool
+            // calls, and sub-workflow context are still preserved in both cases.
             getHistory(workflowModel, taskModel, chatCompletion);
             updateTaskModel(chatCompletion, taskModel);
 
@@ -111,6 +129,28 @@ public class ChatCompleteTaskMapper extends AIModelTaskMapper<ChatCompletion> {
         simpleTask.getInputData().put("tools", chatCompletion.getTools());
     }
 
+    /**
+     * Resolves the configured {@link AIModel} for this chat completion and asks it whether it
+     * accepts assistant-message prefill. Returns {@code true} (the historical default) if no
+     * provider registry is wired in (unit tests), if the request specifies no provider, or if the
+     * provider name doesn't match a registered model — those cases preserve the pre-capability
+     * behavior so we don't silently change history-injection semantics for unrelated callers.
+     */
+    private boolean providerSupportsAssistantPrefill(ChatCompletion chatCompletion) {
+        if (aiModelProvider == null || chatCompletion.getLlmProvider() == null) {
+            return true;
+        }
+        try {
+            AIModel model = aiModelProvider.getModel(chatCompletion);
+            return model.supportsAssistantPrefill();
+        } catch (RuntimeException unknownProvider) {
+            log.debug(
+                    "Provider '{}' not registered; defaulting supportsAssistantPrefill=true",
+                    chatCompletion.getLlmProvider());
+            return true;
+        }
+    }
+
     private void getHistory(
             WorkflowModel workflow, TaskModel chatCompleteTask, ChatCompletion chatCompletion) {
         Map<String, List<TaskModel>> refNameToTask = new HashMap<>();
@@ -132,14 +172,27 @@ public class ChatCompleteTaskMapper extends AIModelTaskMapper<ChatCompletion> {
         if (chatCompleteTask.getParentTaskReferenceName() != null) {
             historyContextTaskRefName = chatCompleteTask.getParentTaskReferenceName();
         }
-        // When previousResponseId is in play, the OpenAI Responses API server-side
-        // conversation store already has every prior turn for this loop. Re-injecting
-        // those prior assistant messages here would duplicate context and — because
-        // we only emit the assistant side, not the user prompt — leave the model
-        // looking at orphaned replies. We still want participants, tool calls, and
-        // sub-workflow context, which the server has never seen.
+        // Suppress the same-refName loop-iteration assistant injection when either:
+        //   (a) previousResponseId is set — OpenAI's Responses API server-side store
+        //       already has every prior turn for this loop; re-injecting them
+        //       duplicates context and, because we only emit the assistant side
+        //       (not the matching user prompt), leaves the model staring at
+        //       orphaned replies.
+        //   (b) the provider declares it doesn't accept assistant-message prefill
+        //       (see AIModel.supportsAssistantPrefill). The loop-iteration messages
+        //       arrive as a trailing assistant turn on the next call — if the
+        //       provider's API rejects that shape (e.g. Anthropic Sonnet 4.6+:
+        //       400 "This model does not support assistant message prefill. The
+        //       conversation must end with a user message."), the whole turn
+        //       fails. Workflow authors who need prior-iteration state should
+        //       template it into the user message via ${...output.result}.
+        // Participants, tool calls, and sub-workflow context are not suppressed
+        // in either case — those are legitimate conversation turns the server
+        // (or model) has never seen.
         String prevRespId = chatCompletion.getPreviousResponseId();
-        boolean suppressLoopAssistantHistory = prevRespId != null && !prevRespId.isBlank();
+        boolean suppressLoopAssistantHistory =
+                (prevRespId != null && !prevRespId.isBlank())
+                        || !providerSupportsAssistantPrefill(chatCompletion);
         List<ChatMessage> history = new ArrayList<>();
         for (TaskModel task : workflow.getTasks()) {
             if (!task.getStatus().isTerminal()) {

--- a/ai/src/test/java/org/conductoross/conductor/ai/integration/AIModelIntegrationTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/integration/AIModelIntegrationTest.java
@@ -12,6 +12,7 @@
  */
 package org.conductoross.conductor.ai.integration;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
@@ -76,6 +77,21 @@ public class AIModelIntegrationTest {
     private static final String EMBEDDING_TEXT =
             "Hello, world! This is a test sentence for embeddings.";
     private static final String AUDIO_TEXT = "Hello, this is a test of text to speech.";
+
+    /**
+     * Builds an OkHttp client whose timeouts match the production {@code conductorAiHttpClient}
+     * Spring bean ({@code AIHttpClientProperties}). The default {@code new OkHttpClient()} ships
+     * with a 10s read timeout that's too short for slow provider operations — notably {@code
+     * gpt-image-1} image generation at 1024×1024, which regularly takes 30–60s and was failing this
+     * suite as a result.
+     */
+    private static OkHttpClient testHttpClient() {
+        return new OkHttpClient.Builder()
+                .connectTimeout(Duration.ofSeconds(60))
+                .readTimeout(Duration.ofSeconds(600))
+                .writeTimeout(Duration.ofSeconds(60))
+                .build();
+    }
 
     // ========================================================================
     // Environment variable helpers
@@ -165,7 +181,7 @@ public class AIModelIntegrationTest {
             OpenAIConfiguration config = new OpenAIConfiguration();
             config.setApiKey(System.getenv("OPENAI_API_KEY"));
             config.setBaseURL(System.getenv("OPENAI_BASE_URL"));
-            openAI = new OpenAI(config, new OkHttpClient());
+            openAI = new OpenAI(config, testHttpClient());
         }
 
         @Test
@@ -562,7 +578,7 @@ public class AIModelIntegrationTest {
             AnthropicConfiguration config = new AnthropicConfiguration();
             config.setApiKey(System.getenv("ANTHROPIC_API_KEY"));
             config.setBaseURL(System.getenv("ANTHROPIC_BASE_URL"));
-            anthropic = new Anthropic(config, new OkHttpClient());
+            anthropic = new Anthropic(config, testHttpClient());
         }
 
         @Test
@@ -1136,7 +1152,7 @@ public class AIModelIntegrationTest {
             GrokAIConfiguration config = new GrokAIConfiguration();
             config.setApiKey(System.getenv("GROK_API_KEY"));
             config.setBaseURL(System.getenv("GROK_BASE_URL"));
-            grok = new Grok(config, new OkHttpClient());
+            grok = new Grok(config, testHttpClient());
         }
 
         @Test
@@ -1299,7 +1315,7 @@ public class AIModelIntegrationTest {
             AzureOpenAIConfiguration config = new AzureOpenAIConfiguration();
             config.setApiKey(System.getenv("AZURE_OPENAI_API_KEY"));
             config.setBaseURL(System.getenv("AZURE_OPENAI_ENDPOINT"));
-            azureOpenAI = new AzureOpenAI(config, new OkHttpClient());
+            azureOpenAI = new AzureOpenAI(config, testHttpClient());
         }
 
         @Test
@@ -1438,7 +1454,7 @@ public class AIModelIntegrationTest {
             PerplexityAIConfiguration config = new PerplexityAIConfiguration();
             config.setApiKey(System.getenv("PERPLEXITY_API_KEY"));
             config.setBaseURL(System.getenv("PERPLEXITY_BASE_URL"));
-            perplexity = new PerplexityAI(config, new OkHttpClient());
+            perplexity = new PerplexityAI(config, testHttpClient());
         }
 
         @Test

--- a/ai/src/test/java/org/conductoross/conductor/ai/mapper/AIModelTaskMapperPreviousResponseIdTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/mapper/AIModelTaskMapperPreviousResponseIdTest.java
@@ -17,6 +17,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.conductoross.conductor.ai.AIModel;
+import org.conductoross.conductor.ai.AIModelProvider;
+import org.conductoross.conductor.ai.models.LLMWorkerInput;
 import org.conductoross.conductor.ai.tasks.mapper.ChatCompleteTaskMapper;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -31,6 +34,9 @@ import com.netflix.conductor.model.WorkflowModel;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@code AIModelTaskMapper.threadPreviousResponseId()} — the auto-injection of
@@ -237,6 +243,132 @@ class AIModelTaskMapperPreviousResponseIdTest {
     }
 
     @Test
+    void localHistoryInjectionIsSkippedWhenProviderRejectsPrefill() {
+        // Provider-agnostic check: the mapper asks the resolved AIModel
+        // whether it accepts assistant-message prefill, and suppresses the
+        // same-refName loop-iteration injection when the provider says no.
+        // Anthropic Claude Sonnet 4.6+ is the original motivating case (it
+        // returns 400 "This model does not support assistant message prefill.
+        // The conversation must end with a user message"), but the suppression
+        // path itself is keyed off the capability flag — not a hardcoded
+        // provider name — so any future provider that declares the same
+        // capability is covered automatically.
+        WorkflowModel workflow = newWorkflowWithLoop();
+        TaskModel prior = completedIteration("ignored_resp");
+        prior.getOutputData().put("result", "Loop-iteration assistant.");
+        prior.setIteration(1); // makes isLoopOverTask() true
+        workflow.getTasks().add(prior);
+
+        Map<String, Object> input = chatInput();
+        input.put("llmProvider", "anthropic");
+        input.put("model", "claude-sonnet-4-6");
+        input.put("messages", new ArrayList<Map<String, Object>>());
+        TaskMapperContext ctx = newContext(workflow, llmTask(), input);
+
+        ChatCompleteTaskMapper mapper = new ChatCompleteTaskMapper(providerFor("anthropic", false));
+        List<TaskModel> mapped = mapper.getMappedTasks(ctx);
+
+        @SuppressWarnings("unchecked")
+        List<org.conductoross.conductor.ai.models.ChatMessage> messages =
+                (List<org.conductoross.conductor.ai.models.ChatMessage>)
+                        mapped.get(0).getInputData().get("messages");
+        assertTrue(
+                messages == null || messages.isEmpty(),
+                "providers that reject prefill must not auto-inject loop assistant history; saw "
+                        + messages);
+    }
+
+    @Test
+    void localHistoryInjectionStillRunsWhenProviderAcceptsPrefill() {
+        // Regression safety: the capability check must not over-suppress.
+        // A provider that accepts prefill (the historical default) should
+        // still receive the auto-injected loop-iteration assistant history,
+        // matching pre-capability behavior for OpenAI without previousResponseId,
+        // Gemini, and similar.
+        WorkflowModel workflow = newWorkflowWithLoop();
+        TaskModel prior = completedIteration("ignored_resp");
+        prior.getOutputData().put("result", "Loop-iteration assistant.");
+        prior.setIteration(1);
+        workflow.getTasks().add(prior);
+
+        Map<String, Object> input = chatInput();
+        input.put("messages", new ArrayList<Map<String, Object>>());
+        TaskMapperContext ctx = newContext(workflow, llmTask(), input);
+
+        ChatCompleteTaskMapper mapper = new ChatCompleteTaskMapper(providerFor("openai", true));
+        List<TaskModel> mapped = mapper.getMappedTasks(ctx);
+
+        @SuppressWarnings("unchecked")
+        List<org.conductoross.conductor.ai.models.ChatMessage> messages =
+                (List<org.conductoross.conductor.ai.models.ChatMessage>)
+                        mapped.get(0).getInputData().get("messages");
+        boolean sawAssistantLoopIteration =
+                messages != null
+                        && messages.stream()
+                                .anyMatch(m -> "Loop-iteration assistant.".equals(m.getMessage()));
+        assertTrue(
+                sawAssistantLoopIteration,
+                "providers that accept prefill must still receive loop-iteration history; saw "
+                        + messages);
+    }
+
+    @Test
+    void participantHistoryIsPreservedWhenProviderRejectsPrefill() {
+        // Regression safety against an over-broad suppression. The capability
+        // gate must scope to the same-refName loop-iteration assistant branch
+        // only — participants (a different refName, registered in participants
+        // map) are legitimate conversation turns and must still flow through.
+        WorkflowModel workflow = newWorkflowWithLoop();
+
+        TaskModel priorChat = completedIteration("ignored_resp");
+        priorChat.getOutputData().put("result", "Loop-iteration assistant.");
+        priorChat.setIteration(1);
+        workflow.getTasks().add(priorChat);
+
+        TaskModel participant = new TaskModel();
+        participant.setStatus(TaskModel.Status.COMPLETED);
+        participant.setTaskType("HUMAN");
+        WorkflowTask participantTask = new WorkflowTask();
+        participantTask.setName("user_proxy");
+        participantTask.setTaskReferenceName("user_proxy_ref");
+        participantTask.setType("HUMAN");
+        participant.setWorkflowTask(participantTask);
+        Map<String, Object> participantOutput = new HashMap<>();
+        participantOutput.put("result", "User says: continue.");
+        participant.setOutputData(participantOutput);
+        workflow.getTasks().add(participant);
+
+        Map<String, Object> input = chatInput();
+        input.put("llmProvider", "anthropic");
+        input.put("model", "claude-sonnet-4-6");
+        input.put("messages", new ArrayList<Map<String, Object>>());
+        Map<String, String> participants = new HashMap<>();
+        participants.put("user_proxy_ref", "user");
+        input.put("participants", participants);
+        TaskMapperContext ctx = newContext(workflow, llmTask(), input);
+
+        ChatCompleteTaskMapper mapper = new ChatCompleteTaskMapper(providerFor("anthropic", false));
+        List<TaskModel> mapped = mapper.getMappedTasks(ctx);
+
+        @SuppressWarnings("unchecked")
+        List<org.conductoross.conductor.ai.models.ChatMessage> messages =
+                (List<org.conductoross.conductor.ai.models.ChatMessage>)
+                        mapped.get(0).getInputData().get("messages");
+        assertTrue(
+                messages != null && !messages.isEmpty(),
+                "participant message must be preserved when provider rejects prefill");
+        boolean sawParticipant =
+                messages.stream().anyMatch(m -> "User says: continue.".equals(m.getMessage()));
+        boolean sawAssistantLoopIteration =
+                messages.stream().anyMatch(m -> "Loop-iteration assistant.".equals(m.getMessage()));
+        assertTrue(sawParticipant, "participant 'user' message must flow through: " + messages);
+        assertTrue(
+                !sawAssistantLoopIteration,
+                "same-refName loop-iteration assistant must NOT flow when provider rejects prefill: "
+                        + messages);
+    }
+
+    @Test
     void inProgressPriorTaskIsSkippedEvenIfItAlreadyHasAResponseId() {
         // A task is only considered if its status is terminal. An in-flight
         // task with a (partial) responseId on its output must not be threaded.
@@ -300,5 +432,20 @@ class AIModelTaskMapperPreviousResponseIdTest {
                 .withRetryCount(0)
                 .withTaskId("task-" + System.nanoTime())
                 .build();
+    }
+
+    /**
+     * Stubs an {@link AIModelProvider} that returns a single {@link AIModel} for the given provider
+     * name, with {@link AIModel#supportsAssistantPrefill()} configured per the second argument. The
+     * model's other abstract methods are never invoked by the mapper code under test, so Mockito's
+     * default returns are fine.
+     */
+    private static AIModelProvider providerFor(String providerName, boolean supportsPrefill) {
+        AIModel model = mock(AIModel.class);
+        when(model.getModelProvider()).thenReturn(providerName);
+        when(model.supportsAssistantPrefill()).thenReturn(supportsPrefill);
+        AIModelProvider provider = mock(AIModelProvider.class);
+        when(provider.getModel(any(LLMWorkerInput.class))).thenReturn(model);
+        return provider;
     }
 }

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/ai/AIReasoningEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/ai/AIReasoningEndToEndTest.java
@@ -128,6 +128,7 @@ class AIReasoningEndToEndTest {
     @Autowired private ExecutionService executionService;
     @Autowired private AIModelProvider aiModelProvider;
     @Autowired private FakeChatModel fakeChatModel;
+    @Autowired private FakeAIModel fakeAIModel;
     @Autowired private QueueDAO queueDAO;
     @Autowired private AsyncSystemTaskExecutor asyncSystemTaskExecutor;
 
@@ -143,6 +144,7 @@ class AIReasoningEndToEndTest {
     @BeforeEach
     void resetFakeBetweenRuns() {
         fakeChatModel.reset();
+        fakeAIModel.setSupportsAssistantPrefill(true);
     }
 
     @Test
@@ -275,6 +277,190 @@ class AIReasoningEndToEndTest {
                 "loop iterations must NOT auto-thread previousResponseId — re-enable only after the history rebuild emits a strict delta");
     }
 
+    @Test
+    void loopHistoryInjectionIsSuppressedWhenProviderRejectsPrefill() {
+        // Reproduces the original Anthropic Sonnet 4.6 production failure path
+        // end-to-end. The fake provider declares supportsAssistantPrefill=false;
+        // a 2-iteration DO_WHILE runs the chat task twice; iteration 2's
+        // resolved messages array must NOT contain a trailing assistant message
+        // from iteration 1. Before this fix, ChatCompleteTaskMapper.getHistory()
+        // appended the prior iteration's output as an assistant turn, which
+        // Anthropic 4.6+ rejects with HTTP 400 "This model does not support
+        // assistant message prefill."
+        fakeAIModel.setSupportsAssistantPrefill(false);
+        fakeChatModel.stageResponse("Turn one.", null, null, "resp_t1");
+        fakeChatModel.stageResponse("Turn two.", null, null, "resp_t2");
+
+        String wfName = "ai_loop_prefill_off_e2e_" + UUID.randomUUID();
+        registerLoopWorkflow(wfName);
+
+        Workflow completed = runLoopWorkflow(wfName);
+        assertEquals(Workflow.WorkflowStatus.COMPLETED, completed.getStatus());
+
+        List<Map<String, Object>> iter2Messages = messagesForLoopIteration(completed, "chat", 2);
+        assertTrue(
+                iter2Messages.stream().noneMatch(m -> "assistant".equals(m.get("role"))),
+                "iteration 2 must NOT carry a trailing assistant message when the provider "
+                        + "rejects prefill; saw "
+                        + iter2Messages);
+        // Sanity-check: iteration 2 still has the user turn so the model has a
+        // prompt to answer — the suppression isn't accidentally dropping
+        // everything.
+        assertTrue(
+                iter2Messages.stream().anyMatch(m -> "user".equals(m.get("role"))),
+                "iteration 2 must retain its user message; saw " + iter2Messages);
+    }
+
+    @Test
+    void loopHistoryInjectionStillRunsWhenProviderAcceptsPrefill() {
+        // Regression safety: the capability gate must not over-suppress.
+        // Providers that accept assistant prefill (OpenAI without
+        // previousResponseId, Gemini, etc.) should still receive the
+        // auto-injected prior iteration assistant message — that's the
+        // historical agentic-flow behavior the loop-history injection was
+        // designed for. Iteration 2 here MUST carry an assistant turn whose
+        // content matches iteration 1's output.
+        fakeAIModel.setSupportsAssistantPrefill(true);
+        fakeChatModel.stageResponse("Turn one.", null, null, "resp_t1");
+        fakeChatModel.stageResponse("Turn two.", null, null, "resp_t2");
+
+        String wfName = "ai_loop_prefill_on_e2e_" + UUID.randomUUID();
+        registerLoopWorkflow(wfName);
+
+        Workflow completed = runLoopWorkflow(wfName);
+        assertEquals(Workflow.WorkflowStatus.COMPLETED, completed.getStatus());
+
+        List<Map<String, Object>> iter2Messages = messagesForLoopIteration(completed, "chat", 2);
+        boolean sawTurnOneAssistant =
+                iter2Messages.stream()
+                        .anyMatch(
+                                m ->
+                                        "assistant".equals(m.get("role"))
+                                                && String.valueOf(m.get("message"))
+                                                        .contains("Turn one."));
+        assertTrue(
+                sawTurnOneAssistant,
+                "iteration 2 must carry iter 1's assistant output when the provider accepts "
+                        + "prefill; saw "
+                        + iter2Messages);
+    }
+
+    @Test
+    void explicitPreviousResponseIdPropagatesToProvider() {
+        // Auto-threading is intentionally OFF (see
+        // doWhileLoopDoesNotAutoThreadPreviousResponseId), but an EXPLICIT
+        // previousResponseId set on the chat task's input must still reach
+        // the provider — that's how callers thread multi-turn conversations
+        // through the OpenAI Responses API today.
+        fakeChatModel.stageResponse("Reply.", null, null, "resp_explicit");
+        AtomicReference<String> seenPreviousId = new AtomicReference<>();
+        fakeChatModel.onCall(
+                (callIndex, opts) -> {
+                    if (opts instanceof FakeChatOptions f) {
+                        seenPreviousId.set(f.previousResponseId);
+                    }
+                });
+
+        String wfName = "ai_explicit_prev_resp_id_e2e_" + UUID.randomUUID();
+        registerWorkflowWithPreviousResponseId(wfName);
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("llmProvider", FAKE_PROVIDER);
+        input.put("model", "fake-explicit");
+        input.put("instructions", "Continue.");
+        input.put("userInput", "Continue.");
+        input.put("previousResponseId", "resp_caller_supplied_xyz");
+
+        StartWorkflowInput swi = new StartWorkflowInput();
+        swi.setName(wfName);
+        swi.setVersion(1);
+        swi.setWorkflowInput(input);
+        String workflowId = workflowExecutor.startWorkflow(swi);
+
+        Workflow completed = awaitWorkflow(workflowId);
+        assertEquals(Workflow.WorkflowStatus.COMPLETED, completed.getStatus());
+        assertEquals(
+                "resp_caller_supplied_xyz",
+                seenPreviousId.get(),
+                "an explicit previousResponseId on workflow input must propagate end-to-end "
+                        + "through the mapper to the provider's ChatOptions");
+    }
+
+    @Test
+    void explicitPreviousResponseIdSuppressesLoopHistoryInjection() {
+        // Two independent suppression triggers exist — this one was here before
+        // the supportsAssistantPrefill capability was added: when
+        // previousResponseId is set, the OpenAI Responses API server-side store
+        // owns prior turns, so the mapper must not also inject them locally.
+        // Verify end-to-end that even with a prefill-accepting provider,
+        // setting previousResponseId on the loop body's chat input keeps the
+        // mapper from adding the iter-1 assistant message into iter 2's
+        // messages array.
+        fakeAIModel.setSupportsAssistantPrefill(true);
+        fakeChatModel.stageResponse("Turn one.", null, null, "resp_t1");
+        fakeChatModel.stageResponse("Turn two.", null, null, "resp_t2");
+
+        String wfName = "ai_loop_explicit_prev_resp_id_e2e_" + UUID.randomUUID();
+        registerLoopWorkflowWithPreviousResponseId(wfName);
+
+        Workflow completed = runLoopWorkflow(wfName);
+        assertEquals(Workflow.WorkflowStatus.COMPLETED, completed.getStatus());
+
+        List<Map<String, Object>> iter2Messages = messagesForLoopIteration(completed, "chat", 2);
+        assertTrue(
+                iter2Messages.stream().noneMatch(m -> "assistant".equals(m.get("role"))),
+                "iteration 2 must NOT carry a trailing assistant message when "
+                        + "previousResponseId is set, regardless of provider prefill support; "
+                        + "saw "
+                        + iter2Messages);
+    }
+
+    private Workflow runLoopWorkflow(String wfName) {
+        Map<String, Object> input = new HashMap<>();
+        input.put("llmProvider", FAKE_PROVIDER);
+        input.put("model", "fake-loop");
+        input.put("instructions", "Iterate.");
+        input.put("userInput", "Iterate.");
+
+        StartWorkflowInput swi = new StartWorkflowInput();
+        swi.setName(wfName);
+        swi.setVersion(1);
+        swi.setWorkflowInput(input);
+        String workflowId = workflowExecutor.startWorkflow(swi);
+        return awaitWorkflow(workflowId);
+    }
+
+    /**
+     * Walks {@link Workflow#getTasks()} to find the LLM_CHAT_COMPLETE task that ran as the given
+     * iteration of the named loop body, then returns its mapper-resolved {@code messages} input —
+     * i.e. exactly what {@link ChatCompleteTaskMapper} produced before the worker called the
+     * provider. Reading at this layer rather than the post-LLMHelper sanitized prompt lets the
+     * assertions speak to mapper behavior directly, independent of downstream message normalization
+     * in {@code LLMHelper.ensureLastMessageIsFromUser}.
+     */
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> messagesForLoopIteration(
+            Workflow workflow, String loopBodyRef, int iteration) {
+        return workflow.getTasks().stream()
+                .filter(t -> "LLM_CHAT_COMPLETE".equals(t.getTaskType()))
+                .filter(t -> t.getIteration() == iteration)
+                .filter(
+                        t ->
+                                t.getReferenceTaskName() != null
+                                        && t.getReferenceTaskName().startsWith(loopBodyRef))
+                .findFirst()
+                .map(t -> (List<Map<String, Object>>) t.getInputData().get("messages"))
+                .orElseThrow(
+                        () ->
+                                new IllegalStateException(
+                                        "no LLM_CHAT_COMPLETE task found for ref '"
+                                                + loopBodyRef
+                                                + "' iteration "
+                                                + iteration
+                                                + "; tasks: "
+                                                + workflow.getTasks()));
+    }
+
     // -- workflow registration helpers --
 
     private void registerWorkflow(String name) {
@@ -352,6 +538,84 @@ class AIReasoningEndToEndTest {
         metadataService.updateWorkflowDef(List.of(def));
     }
 
+    private void registerWorkflowWithPreviousResponseId(String name) {
+        TaskDef taskDef = new TaskDef();
+        taskDef.setName("LLM_CHAT_COMPLETE");
+        taskDef.setRetryCount(0);
+        taskDef.setTimeoutSeconds(60);
+        try {
+            metadataService.registerTaskDef(List.of(taskDef));
+        } catch (Exception ignore) {
+        }
+
+        WorkflowTask task = new WorkflowTask();
+        task.setName("LLM_CHAT_COMPLETE");
+        task.setTaskReferenceName("chat");
+        task.setType("LLM_CHAT_COMPLETE");
+        Map<String, Object> taskInput = new HashMap<>();
+        taskInput.put("llmProvider", "${workflow.input.llmProvider}");
+        taskInput.put("model", "${workflow.input.model}");
+        taskInput.put("instructions", "${workflow.input.instructions}");
+        taskInput.put("userInput", "${workflow.input.userInput}");
+        // Explicit previousResponseId from workflow input — proves the caller-set
+        // value flows through to the provider's ChatOptions.
+        taskInput.put("previousResponseId", "${workflow.input.previousResponseId}");
+        task.setInputParameters(taskInput);
+
+        WorkflowDef def = new WorkflowDef();
+        def.setName(name);
+        def.setVersion(1);
+        def.setOwnerEmail("ai-e2e@conductor.test");
+        def.setTasks(List.of(task));
+        metadataService.updateWorkflowDef(List.of(def));
+    }
+
+    private void registerLoopWorkflowWithPreviousResponseId(String name) {
+        TaskDef taskDef = new TaskDef();
+        taskDef.setName("LLM_CHAT_COMPLETE");
+        taskDef.setRetryCount(0);
+        taskDef.setTimeoutSeconds(60);
+        try {
+            metadataService.registerTaskDef(List.of(taskDef));
+        } catch (Exception ignore) {
+        }
+        TaskDef loopDef = new TaskDef();
+        loopDef.setName("DO_WHILE");
+        loopDef.setRetryCount(0);
+        try {
+            metadataService.registerTaskDef(List.of(loopDef));
+        } catch (Exception ignore) {
+        }
+
+        WorkflowTask chat = new WorkflowTask();
+        chat.setName("LLM_CHAT_COMPLETE");
+        chat.setTaskReferenceName("chat");
+        chat.setType("LLM_CHAT_COMPLETE");
+        Map<String, Object> taskInput = new HashMap<>();
+        taskInput.put("llmProvider", "${workflow.input.llmProvider}");
+        taskInput.put("model", "${workflow.input.model}");
+        taskInput.put("instructions", "${workflow.input.instructions}");
+        taskInput.put("userInput", "${workflow.input.userInput}");
+        // Constant on every iteration — what matters for this test is that
+        // *any* non-blank previousResponseId triggers the suppression branch.
+        taskInput.put("previousResponseId", "resp_loop_explicit_threading");
+        chat.setInputParameters(taskInput);
+
+        WorkflowTask loop = new WorkflowTask();
+        loop.setName("loop");
+        loop.setTaskReferenceName("loop");
+        loop.setType(TaskType.DO_WHILE.name());
+        loop.setLoopCondition("if ( $.loop['iteration'] < 2 ) { true; } else { false; }");
+        loop.setLoopOver(List.of(chat));
+
+        WorkflowDef def = new WorkflowDef();
+        def.setName(name);
+        def.setVersion(1);
+        def.setOwnerEmail("ai-e2e@conductor.test");
+        def.setTasks(List.of(loop));
+        metadataService.updateWorkflowDef(List.of(def));
+    }
+
     private Workflow awaitWorkflow(String workflowId) {
         AtomicReference<Workflow> latest = new AtomicReference<>();
         Awaitility.await()
@@ -405,8 +669,13 @@ class AIReasoningEndToEndTest {
         }
 
         @Bean
-        ModelConfiguration<FakeAIModel> fakeAIModelConfiguration(FakeChatModel fakeChatModel) {
-            return () -> new FakeAIModel(fakeChatModel);
+        FakeAIModel fakeAIModel(FakeChatModel fakeChatModel) {
+            return new FakeAIModel(fakeChatModel);
+        }
+
+        @Bean
+        ModelConfiguration<FakeAIModel> fakeAIModelConfiguration(FakeAIModel fakeAIModel) {
+            return () -> fakeAIModel;
         }
     }
 
@@ -417,13 +686,30 @@ class AIReasoningEndToEndTest {
 
         private final FakeChatModel chatModel;
 
+        /**
+         * Mutable per-test so a single {@link FakeAIModel} bean can simulate both an
+         * Anthropic-Sonnet-4.6-like provider (rejects prefill) and an OpenAI-like provider (accepts
+         * prefill) without re-wiring the Spring context between tests. Reset to {@code true} in
+         * {@link #resetFakeBetweenRuns}.
+         */
+        private volatile boolean supportsAssistantPrefill = true;
+
         FakeAIModel(FakeChatModel chatModel) {
             this.chatModel = chatModel;
+        }
+
+        void setSupportsAssistantPrefill(boolean value) {
+            this.supportsAssistantPrefill = value;
         }
 
         @Override
         public String getModelProvider() {
             return FAKE_PROVIDER;
+        }
+
+        @Override
+        public boolean supportsAssistantPrefill() {
+            return supportsAssistantPrefill;
         }
 
         @Override


### PR DESCRIPTION
## Summary

- Anthropic Claude Sonnet 4.6+ rejects multi-iteration LLM_CHAT_COMPLETE DO_WHILE loops with HTTP 400 \"This model does not support assistant message prefill.\" The mapper was auto-injecting prior loop-iteration output as a trailing assistant message; 4.5 silently accepted prefill, 4.6 doesn't.
- Introduce `AIModel.supportsAssistantPrefill()` (default `true`); Anthropic overrides to `false`; `ChatCompleteTaskMapper` resolves the provider via `AIModelProvider` and suppresses the same-refName loop-iteration assistant branch when the capability is off — same suppression path the OpenAI Responses API `previousResponseId` case already used. No hardcoded provider strings in the mapper.
- Drive-by: `AIModelIntegrationTest` was instantiating `new OkHttpClient()` (OkHttp's 10s default read timeout) so `gpt-image-1` at 1024×1024 timed out. Added a `testHttpClient()` helper matching the production `conductorAiHttpClient` bean (60/600/60s connect/read/write).

## Root cause

`ChatCompleteTaskMapper.getHistory()` walks `workflow.getTasks()` looking for prior loop iterations of the same task ref name; for each match it appends the prior output as a `ChatMessage.Role.assistant` in the next iteration's `messages`. Before this PR, the only suppression was `previousResponseId != null && !previousResponseId.isBlank()` — OpenAI-specific. For every other provider, including all Anthropic models, the injection ran unconditionally. Sonnet 4.6's API change made the latent design issue user-visible.

## What changed

| File | Change |
|---|---|
| `ai/.../AIModel.java` | Add `default boolean supportsAssistantPrefill() { return true; }` with javadoc |
| `ai/.../providers/anthropic/Anthropic.java` | Override to `return false` with failure-mode comment |
| `ai/.../tasks/mapper/ChatCompleteTaskMapper.java` | Optional `AIModelProvider` constructor injection (nullable for unit tests); consult `model.supportsAssistantPrefill()` in the suppression check; unknown-provider lookup defaults to `true` to preserve historical behavior |
| `ai/.../mapper/AIModelTaskMapperPreviousResponseIdTest.java` | 3 new unit tests: suppression-when-rejects, still-injects-when-accepts, participants-preserved-when-rejects. Mockito stub helper `providerFor(name, supportsPrefill)` |
| `ai/.../integration/AIModelIntegrationTest.java` | `testHttpClient()` helper (60/600/60s); replaced 5 raw `new OkHttpClient()` sites |
| `test-harness/.../ai/AIReasoningEndToEndTest.java` | 4 new e2e tests (full Spring Boot Conductor + Redis testcontainer + fake provider): `loopHistoryInjectionIsSuppressedWhenProviderRejectsPrefill`, `loopHistoryInjectionStillRunsWhenProviderAcceptsPrefill`, `explicitPreviousResponseIdPropagatesToProvider`, `explicitPreviousResponseIdSuppressesLoopHistoryInjection`. `FakeAIModel` gains mutable `supportsAssistantPrefill` so a single bean covers both Anthropic-like and OpenAI-like behavior; exposed as a Spring `@Bean` so tests can `@Autowired` it |

## Test plan

- [x] `./gradlew :conductor-ai:test --tests 'AIModelTaskMapperPreviousResponseIdTest'` — 10 tests, 1 pre-existing `@Disabled`, 0 failures
- [x] `./gradlew :conductor-test-harness:test --tests 'AIReasoningEndToEndTest'` — 7 tests (3 existing + 4 new), 0 failures
- [x] `./gradlew :conductor-ai:test --tests 'AIModelIntegrationTest\$OpenAITests'` — 12 tests, 0 failures (image-gen now 13.6s, within budget)
- [x] `./gradlew :conductor-ai:spotlessApply` — clean
- [ ] CI green

## Out of scope

- `MistralAITest$IntegrationTests` / `AIModelIntegrationTest$MistralTests` failing with 401 — stale `MISTRAL_API_KEY` in the dev env; will follow up by either tightening the env-var gate or rotating the key.
- `BedrockTest$IntegrationTests` 404 — `amazon.titan-embed-text-v2:0` was marked Legacy by AWS; follow-up to update the test to a current model.

## Notes for reviewers

- `LLMHelper.ensureLastMessageIsFromUser` (added in #943) already rewrites a trailing assistant message to a \"You were saying:\" user turn at the worker layer. This PR fixes the issue at the mapper layer where it originates — the runtime sanitizer was a band-aid that also changed prompt semantics (\"continue what you started\" vs \"author from scratch\"); workflows like the original gtm_mavericks_v1 explicitly state they want stateless re-authoring.
- The auto-threading of `previousResponseId` between same-refName loop iterations remains intentionally OFF (`AIModelTaskMapper.threadPreviousResponseId` javadoc has the OpenAI token billing reasoning); explicit `previousResponseId` set by the caller still propagates — covered by new test `explicitPreviousResponseIdPropagatesToProvider`.