### PR TITLE
fix(ai): rewrite thinkingTokenLimit to adaptive thinking on Claude Opus 4.7

### DIFF
--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/Anthropic.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/Anthropic.java
@@ -107,6 +107,7 @@ public class Anthropic implements AIModel {
                 .topK(input.getTopK())
                 .stopSequences(input.getStopWords())
                 .thinkingBudgetTokens(thinkingBudget)
+                .reasoningEffort(input.getReasoningEffort())
                 .reasoningSummary(input.getReasoningSummary())
                 .tools(tools.isEmpty() ? null : tools)
                 .build();

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicChatModel.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicChatModel.java
@@ -22,6 +22,7 @@ import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesAp
 import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.Message;
 import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.MessagesRequest;
 import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.MessagesResponse;
+import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.OutputConfig;
 import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.ResponseContentBlock;
 import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.ResponseUsage;
 import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.Thinking;
@@ -113,9 +114,28 @@ public class AnthropicChatModel implements ChatModel {
                     .stopSequences(opts.getStopSequences())
                     .tools(opts.getTools());
 
-            // Thinking mode
-            if (opts.getThinkingBudgetTokens() != null && opts.getThinkingBudgetTokens() > 0) {
-                builder.thinking(Thinking.enabled(opts.getThinkingBudgetTokens()));
+            // Thinking + effort. Claude Opus 4.7 rejects the legacy
+            // ``thinking.type.enabled`` shape with HTTP 400 and requires
+            // ``thinking.type.adaptive`` + ``output_config.effort`` instead. For 4.6 / 4.5 the
+            // legacy shape is still accepted (deprecated on 4.6, primary on 4.5).
+            boolean adaptiveOnly = requiresAdaptiveThinking(opts.getModel());
+            Integer budget = opts.getThinkingBudgetTokens();
+            boolean wantsThinking = budget != null && budget > 0;
+            String effort = opts.getReasoningEffort();
+
+            if (adaptiveOnly) {
+                if (wantsThinking) {
+                    builder.thinking(Thinking.adaptive());
+                    if (effort == null || effort.isBlank()) {
+                        effort = budgetToEffort(budget);
+                    }
+                }
+            } else if (wantsThinking) {
+                builder.thinking(Thinking.enabled(budget));
+            }
+
+            if (effort != null && !effort.isBlank()) {
+                builder.outputConfig(new OutputConfig(effort));
             }
 
             // Check if code_execution tool is present — requires beta header
@@ -286,6 +306,28 @@ public class AnthropicChatModel implements ChatModel {
         }
 
         return new ChatResponse(generations, metaBuilder.build());
+    }
+
+    /**
+     * Returns true for models that reject ``thinking.type.enabled`` and require adaptive thinking
+     * with ``output_config.effort``. Currently Claude Opus 4.7 (any variant — including
+     * ``claude-opus-4-7-20250101`` or future ``-1m``-style suffixes).
+     */
+    static boolean requiresAdaptiveThinking(String model) {
+        return model != null && model.toLowerCase().contains("opus-4-7");
+    }
+
+    /**
+     * Map a legacy ``thinkingTokenLimit`` budget onto an adaptive ``effort`` tier. Used only when a
+     * caller specified a budget for a model that no longer accepts ``budget_tokens`` (Opus 4.7) and
+     * didn't independently set ``reasoningEffort``. Thresholds roughly track Anthropic's published
+     * guidance: bigger budgets → more thorough thinking.
+     */
+    static String budgetToEffort(int budget) {
+        if (budget < 4_000) return "low";
+        if (budget < 16_000) return "medium";
+        if (budget < 32_000) return "high";
+        return "xhigh";
     }
 
     private String mapStopReason(String stopReason) {

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicChatOptions.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicChatOptions.java
@@ -37,6 +37,10 @@ public class AnthropicChatOptions implements ChatOptions {
 
     // Anthropic-specific
     private Integer thinkingBudgetTokens;
+    // One of "low", "medium", "high", "xhigh", "max". Serialized as
+    // ``output_config.effort`` on the request. Required (alongside adaptive thinking) on
+    // Opus 4.7, which rejects ``thinking.type.enabled``. Optional on older models.
+    private String reasoningEffort;
     // Any non-blank value gates surfacing the model's thinking blocks into
     // ChatResponseMetadata["reasoning"]. The thinking budget itself is set
     // via ``thinkingBudgetTokens``; this flag only controls response-side
@@ -64,6 +68,7 @@ public class AnthropicChatOptions implements ChatOptions {
                 .maxTokens(maxTokens)
                 .stopSequences(stopSequences)
                 .thinkingBudgetTokens(thinkingBudgetTokens)
+                .reasoningEffort(reasoningEffort)
                 .reasoningSummary(reasoningSummary)
                 .tools(tools)
                 .build();

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/api/AnthropicMessagesApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/api/AnthropicMessagesApi.java
@@ -122,6 +122,7 @@ public class AnthropicMessagesApi {
             @JsonProperty("stop_sequences") List<String> stopSequences,
             List<Tool> tools,
             Thinking thinking,
+            @JsonProperty("output_config") OutputConfig outputConfig,
             // Not serialized — used to set the anthropic-beta HTTP header
             @JsonIgnoreProperties @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
                     List<String> betaFeatures) {
@@ -143,6 +144,7 @@ public class AnthropicMessagesApi {
                     stopSequences,
                     tools,
                     thinking,
+                    outputConfig,
                     betaFeatures);
         }
 
@@ -157,6 +159,7 @@ public class AnthropicMessagesApi {
             private List<String> stopSequences;
             private List<Tool> tools;
             private Thinking thinking;
+            private OutputConfig outputConfig;
             private List<String> betaFeatures;
 
             public Builder model(String model) {
@@ -209,6 +212,11 @@ public class AnthropicMessagesApi {
                 return this;
             }
 
+            public Builder outputConfig(OutputConfig outputConfig) {
+                this.outputConfig = outputConfig;
+                return this;
+            }
+
             public Builder betaFeatures(List<String> betaFeatures) {
                 this.betaFeatures = betaFeatures;
                 return this;
@@ -226,6 +234,7 @@ public class AnthropicMessagesApi {
                         stopSequences,
                         tools,
                         thinking,
+                        outputConfig,
                         betaFeatures);
             }
         }
@@ -316,16 +325,37 @@ public class AnthropicMessagesApi {
         }
     }
 
-    /** Thinking configuration for extended thinking mode. */
+    /**
+     * Thinking configuration. Two shapes:
+     *
+     * <ul>
+     *   <li>{@code {"type":"enabled","budget_tokens":N}} — manual extended thinking, used by Claude
+     *       Opus 4.5 and earlier. Deprecated on Opus 4.6 / Sonnet 4.6 and rejected with HTTP 400 by
+     *       Opus 4.7.
+     *   <li>{@code {"type":"adaptive"}} — adaptive thinking, where the model picks the budget and
+     *       the caller controls depth via {@link OutputConfig#effort()}. Required on Opus 4.7;
+     *       recommended on Opus/Sonnet 4.6.
+     * </ul>
+     */
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public record Thinking(
-            String type, // "enabled" or "disabled"
-            @JsonProperty("budget_tokens") Integer budgetTokens) {
+    public record Thinking(String type, @JsonProperty("budget_tokens") Integer budgetTokens) {
 
         public static Thinking enabled(int budgetTokens) {
             return new Thinking("enabled", budgetTokens);
         }
+
+        public static Thinking adaptive() {
+            return new Thinking("adaptive", null);
+        }
     }
+
+    /**
+     * Top-level {@code output_config} object. Carries the {@code effort} parameter (one of {@code
+     * low}, {@code medium}, {@code high}, {@code xhigh}, {@code max}) — the recommended way to
+     * control thinking depth and overall token spend on Claude Opus 4.6+ and Sonnet 4.6+.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record OutputConfig(String effort) {}
 
     // -- Response DTOs --
 

--- a/ai/src/test/java/org/conductoross/conductor/ai/LLMHelperChatCompleteTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/LLMHelperChatCompleteTest.java
@@ -1,0 +1,615 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.conductoross.conductor.ai.models.ChatCompletion;
+import org.conductoross.conductor.ai.models.ChatMessage;
+import org.conductoross.conductor.ai.models.EmbeddingGenRequest;
+import org.conductoross.conductor.ai.models.LLMResponse;
+import org.conductoross.conductor.ai.models.ToolCall;
+import org.conductoross.conductor.ai.models.ToolSpec;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.metadata.ChatGenerationMetadata;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.DefaultUsage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.image.ImageModel;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end coverage of {@link LLMHelper#chatComplete(Task, AIModel, ChatCompletion, String,
+ * java.util.function.Consumer)} using an in-process fake {@link AIModel} / {@link ChatModel}. The
+ * existing {@link LLMHelperTest} pins the small pure helpers ({@code parseNestedJsonStrings},
+ * {@code isJsonString}, {@code extractMethodFromInputParameters}, {@code
+ * ensureLastMessageIsFromUser}); this file covers the larger code path around the chat round-trip —
+ * reasoning / responseId extraction, tool-call assembly, finishReason mapping, JSON output parsing,
+ * single-vs-multi generation reduction, and token-usage logging — without needing a live LLM.
+ */
+public class LLMHelperChatCompleteTest {
+
+    private LLMHelper helper;
+
+    @BeforeEach
+    void setUp() {
+        // ``storeMedia`` iterates over ``documentLoaders`` unconditionally, so a null list
+        // would NPE before checking the location. An empty list is the right "no-op" wiring
+        // for the unit-test path that never expects media to be stored.
+        helper = new LLMHelper(null, new ArrayList<>());
+    }
+
+    private static Task task(String id) {
+        Task t = new Task();
+        t.setTaskId(id);
+        return t;
+    }
+
+    /**
+     * Most fake {@link AIModel}s in these tests only override {@link #getChatModel()}. Anything
+     * that depends on provider-specific options ({@code getChatOptions}) falls back to the
+     * interface default, which returns a {@code ToolCallingChatOptions} — exactly what production
+     * adapters do for the generic path. That keeps each test focused on the helper logic rather
+     * than provider plumbing.
+     */
+    static class FakeAIModel implements AIModel {
+        private final ChatModel chatModel;
+
+        FakeAIModel(ChatModel chatModel) {
+            this.chatModel = chatModel;
+        }
+
+        @Override
+        public String getModelProvider() {
+            return "fake";
+        }
+
+        @Override
+        public List<Float> generateEmbeddings(EmbeddingGenRequest req) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChatModel getChatModel() {
+            return chatModel;
+        }
+
+        @Override
+        public ImageModel getImageModel() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /**
+     * Minimal {@link ChatModel} that returns a {@link ChatResponse} the test pre-stages. Optional
+     * {@link #lastPrompt} capture lets assertions reach into the messages the helper actually built
+     * — important for verifying instruction injection + {@code ensureLastMessageIsFromUser}.
+     */
+    static class StagedChatModel implements ChatModel {
+        private ChatResponse staged;
+        Prompt lastPrompt;
+
+        void stage(ChatResponse response) {
+            this.staged = response;
+        }
+
+        @Override
+        public ChatResponse call(Prompt prompt) {
+            this.lastPrompt = prompt;
+            return staged;
+        }
+    }
+
+    private static ChatResponse responseOf(
+            AssistantMessage assistantMessage, String finishReason, ChatResponseMetadata metadata) {
+        Generation g =
+                new Generation(
+                        assistantMessage,
+                        ChatGenerationMetadata.builder().finishReason(finishReason).build());
+        return new ChatResponse(List.of(g), metadata);
+    }
+
+    private static ChatResponseMetadata metaWithUsage(int prompt, int completion, int total) {
+        return ChatResponseMetadata.builder()
+                .usage(new DefaultUsage(prompt, completion, total))
+                .build();
+    }
+
+    // =================================================================
+    // chatComplete — happy path: single text result, no tools / reasoning
+    // =================================================================
+
+    @Test
+    void chatComplete_singleTextResult_setsResultAndUsage_andLogsTokens() {
+        StagedChatModel model = new StagedChatModel();
+        model.stage(responseOf(new AssistantMessage("Paris"), "stop", metaWithUsage(11, 22, 33)));
+
+        ChatCompletion in = new ChatCompletion();
+        in.setLlmProvider("fake");
+        in.setModel("fake-1");
+        in.setInstructions("You are concise.");
+        in.getMessages().add(new ChatMessage(ChatMessage.Role.user, "Capital of France?"));
+
+        AtomicReference<TokenUsageLog> logged = new AtomicReference<>();
+
+        LLMResponse out =
+                helper.chatComplete(task("t1"), new FakeAIModel(model), in, null, logged::set);
+
+        assertEquals("Paris", out.getResult(), "single response must be unwrapped to scalar");
+        assertEquals("STOP", out.getFinishReason(), "finishReason 'stop' must uppercase to STOP");
+        assertEquals(33, out.getTokenUsed());
+        assertEquals(22, out.getCompletionTokens());
+        assertEquals(11, out.getPromptTokens());
+        assertNull(out.getReasoning());
+        assertNull(out.getReasoningTokens());
+        assertNull(out.getResponseId());
+        assertNull(out.getToolCalls());
+
+        // Token-usage logger callback must fire with the same accounting.
+        TokenUsageLog log = logged.get();
+        assertNotNull(log, "tokenUsageLogger consumer must be invoked");
+        assertEquals("t1", log.getTaskId());
+        assertEquals("fake-1", log.getApi());
+        assertEquals("fake", log.getIntegrationName());
+        assertEquals(33, log.getTotalTokens());
+
+        // The helper prepended a system instruction; verify it survived to the chat model.
+        Prompt sent = model.lastPrompt;
+        assertNotNull(sent);
+        List<Message> sentMessages = sent.getInstructions();
+        assertTrue(
+                sentMessages.stream().anyMatch(m -> "You are concise.".equals(m.getText())),
+                "system instruction must reach the chat model");
+    }
+
+    // =================================================================
+    // chatComplete — finishReason mapping for known synonyms
+    // =================================================================
+
+    @Test
+    void chatComplete_finishReasonMap_endTurn_translatesToSTOP() {
+        StagedChatModel model = new StagedChatModel();
+        model.stage(responseOf(new AssistantMessage("done"), "end_turn", metaWithUsage(1, 1, 2)));
+
+        ChatCompletion in = new ChatCompletion();
+        in.setLlmProvider("fake");
+        in.setModel("fake-1");
+        in.getMessages().add(new ChatMessage(ChatMessage.Role.user, "ping"));
+
+        LLMResponse out =
+                helper.chatComplete(task("t2"), new FakeAIModel(model), in, null, x -> {});
+        assertEquals("STOP", out.getFinishReason(), "Anthropic 'end_turn' must map to STOP");
+    }
+
+    @Test
+    void chatComplete_finishReasonMap_refusal_translatesToCONTENT_FILTER() {
+        StagedChatModel model = new StagedChatModel();
+        model.stage(responseOf(new AssistantMessage(""), "refusal", metaWithUsage(1, 0, 1)));
+
+        ChatCompletion in = new ChatCompletion();
+        in.setLlmProvider("fake");
+        in.setModel("fake-1");
+        in.getMessages().add(new ChatMessage(ChatMessage.Role.user, "..."));
+
+        LLMResponse out =
+                helper.chatComplete(task("t3"), new FakeAIModel(model), in, null, x -> {});
+        assertEquals(
+                "CONTENT_FILTER",
+                out.getFinishReason(),
+                "'refusal' must map onto OpenAI-style CONTENT_FILTER");
+    }
+
+    // =================================================================
+    // chatComplete — reasoning + responseId surfaced from metadata
+    // =================================================================
+
+    @Test
+    void chatComplete_extractsReasoningAndResponseIdFromMetadata() {
+        ChatResponseMetadata meta =
+                ChatResponseMetadata.builder()
+                        .usage(new DefaultUsage(5, 10, 15))
+                        .keyValue("response_id", "resp_abc")
+                        .keyValue("reasoning", "Think hard, answer plainly.")
+                        .keyValue("reasoning_tokens", 42)
+                        .build();
+        StagedChatModel model = new StagedChatModel();
+        model.stage(responseOf(new AssistantMessage("answer"), "stop", meta));
+
+        ChatCompletion in = new ChatCompletion();
+        in.setLlmProvider("fake");
+        in.setModel("fake-reasoning");
+        in.getMessages().add(new ChatMessage(ChatMessage.Role.user, "go"));
+
+        LLMResponse out =
+                helper.chatComplete(task("t4"), new FakeAIModel(model), in, null, x -> {});
+
+        assertEquals("resp_abc", out.getResponseId());
+        assertEquals("Think hard, answer plainly.", out.getReasoning());
+        assertEquals(42, out.getReasoningTokens());
+    }
+
+    @Test
+    void chatComplete_blankReasoning_isNormalizedToNull() {
+        // The helper must treat blank/empty reasoning strings as absent — surfacing them onto
+        // metadata["reasoning"] would lie to downstream code that uses non-null as the
+        // "model returned a summary" signal.
+        ChatResponseMetadata meta =
+                ChatResponseMetadata.builder()
+                        .usage(new DefaultUsage(1, 1, 2))
+                        .keyValue("reasoning", "   ")
+                        .build();
+        StagedChatModel model = new StagedChatModel();
+        model.stage(responseOf(new AssistantMessage("x"), "stop", meta));
+
+        ChatCompletion in = new ChatCompletion();
+        in.setLlmProvider("fake");
+        in.setModel("fake-1");
+        in.getMessages().add(new ChatMessage(ChatMessage.Role.user, "go"));
+
+        LLMResponse out =
+                helper.chatComplete(task("t5"), new FakeAIModel(model), in, null, x -> {});
+        assertNull(out.getReasoning(), "blank reasoning must collapse to null");
+    }
+
+    @Test
+    void chatComplete_reasoningTokensAcceptsLongFromMetadataRoundtrip() {
+        // ChatResponseMetadata stores arbitrary values; Jackson round-trips can land an int as
+        // a Long. The helper must accept any Number, not just Integer.
+        ChatResponseMetadata meta =
+                ChatResponseMetadata.builder()
+                        .usage(new DefaultUsage(1, 1, 2))
+                        .keyValue("reasoning_tokens", 99L)
+                        .build();
+        StagedChatModel model = new StagedChatModel();
+        model.stage(responseOf(new AssistantMessage("x"), "stop", meta));
+
+        ChatCompletion in = new ChatCompletion();
+        in.setLlmProvider("fake");
+        in.setModel("fake-1");
+        in.getMessages().add(new ChatMessage(ChatMessage.Role.user, "go"));
+
+        LLMResponse out =
+                helper.chatComplete(task("t6"), new FakeAIModel(model), in, null, x -> {});
+        assertEquals(99, out.getReasoningTokens());
+    }
+
+    // =================================================================
+    // chatComplete — tool_use round-trip
+    // =================================================================
+
+    @Test
+    void chatComplete_toolUseResponse_producesToolCallsAndMapsFinishReason() {
+        // Model returns an assistant message with a tool call instead of text. The helper
+        // must surface ``toolCalls`` on the LLMResponse, parse JSON arguments, attach a
+        // "method" key, look up the ToolSpec by name (to pick up integrationNames + type),
+        // and translate finishReason ``tool_use`` to TOOL_CALLS.
+        AssistantMessage.ToolCall call =
+                new AssistantMessage.ToolCall(
+                        "call_1", "function", "get_weather", "{\"city\":\"Tokyo\"}");
+        AssistantMessage assistant =
+                AssistantMessage.builder().content("").toolCalls(List.of(call)).build();
+        StagedChatModel model = new StagedChatModel();
+        model.stage(responseOf(assistant, "tool_use", metaWithUsage(5, 5, 10)));
+
+        ChatCompletion in = new ChatCompletion();
+        in.setLlmProvider("fake");
+        in.setModel("fake-1");
+        in.getMessages().add(new ChatMessage(ChatMessage.Role.user, "weather?"));
+        ToolSpec spec = new ToolSpec();
+        spec.setName("get_weather");
+        spec.setType("HTTP");
+        spec.setIntegrationNames(Map.of("weather_api", "openweathermap"));
+        in.setTools(List.of(spec));
+
+        LLMResponse out =
+                helper.chatComplete(task("t7"), new FakeAIModel(model), in, null, x -> {});
+
+        assertEquals("TOOL_CALLS", out.getFinishReason());
+        assertNotNull(out.getToolCalls(), "tool calls must be surfaced");
+        assertEquals(1, out.getToolCalls().size());
+        ToolCall tc = out.getToolCalls().getFirst();
+        assertEquals("get_weather", tc.getName());
+        assertEquals("call_1", tc.getTaskReferenceName(), "ToolCall id must propagate");
+        assertEquals("HTTP", tc.getType(), "type must come from the matching ToolSpec");
+        assertEquals("Tokyo", tc.getInputParameters().get("city"));
+        assertEquals(
+                "get_weather",
+                tc.getInputParameters().get("method"),
+                "helper must inject the method name into the tool args");
+        assertEquals(
+                "openweathermap",
+                tc.getIntegrationNames().get("weather_api"),
+                "ToolSpec.integrationNames must be propagated");
+    }
+
+    @Test
+    void chatComplete_toolUseWithBlankId_generatesUuidTaskReferenceName() {
+        AssistantMessage.ToolCall call =
+                new AssistantMessage.ToolCall("", "function", "noop", "{}");
+        AssistantMessage assistant =
+                AssistantMessage.builder().content("").toolCalls(List.of(call)).build();
+        StagedChatModel model = new StagedChatModel();
+        model.stage(responseOf(assistant, "tool_use", metaWithUsage(1, 1, 2)));
+
+        ChatCompletion in = new ChatCompletion();
+        in.setLlmProvider("fake");
+        in.setModel("fake-1");
+        in.getMessages().add(new ChatMessage(ChatMessage.Role.user, "do nothing"));
+
+        LLMResponse out =
+                helper.chatComplete(task("t8"), new FakeAIModel(model), in, null, x -> {});
+        assertNotNull(out.getToolCalls());
+        String ref = out.getToolCalls().getFirst().getTaskReferenceName();
+        assertNotNull(ref);
+        // UUID.toString() form is 36 chars including 4 dashes.
+        assertEquals(36, ref.length(), "blank tool-call id must be replaced by a UUID");
+    }
+
+    @Test
+    void chatComplete_toolUseWithMalformedArgsJson_yieldsArgsWithOnlyMethodKey() {
+        // Helper parses tool args via Jackson; a parse failure must be swallowed and the
+        // args reduced to just the synthetic ``method`` entry rather than blowing up the
+        // whole task.
+        AssistantMessage.ToolCall call =
+                new AssistantMessage.ToolCall("c1", "function", "noop", "not-json");
+        AssistantMessage assistant =
+                AssistantMessage.builder().content("").toolCalls(List.of(call)).build();
+        StagedChatModel model = new StagedChatModel();
+        model.stage(responseOf(assistant, "tool_use", metaWithUsage(1, 1, 2)));
+
+        ChatCompletion in = new ChatCompletion();
+        in.setLlmProvider("fake");
+        in.setModel("fake-1");
+        in.getMessages().add(new ChatMessage(ChatMessage.Role.user, "noop"));
+
+        LLMResponse out =
+                helper.chatComplete(task("t9"), new FakeAIModel(model), in, null, x -> {});
+        Map<String, Object> args = out.getToolCalls().getFirst().getInputParameters();
+        assertEquals(1, args.size());
+        assertEquals("noop", args.get("method"));
+    }
+
+    // =================================================================
+    // chatComplete — JSON output path
+    // =================================================================
+
+    @Test
+    void chatComplete_jsonOutputTrueAndModelReturnsJson_parsesIntoMap() {
+        // jsonOutput=true is a hint to the LLM that drives extractResponse to parse text into
+        // a Map. The helper must surface the parsed map as ``result`` (single response is
+        // unwrapped to a single value).
+        StagedChatModel model = new StagedChatModel();
+        model.stage(
+                responseOf(
+                        new AssistantMessage("{\"name\":\"Conductor\",\"value\":42}"),
+                        "stop",
+                        metaWithUsage(1, 5, 6)));
+
+        ChatCompletion in = new ChatCompletion();
+        in.setLlmProvider("fake");
+        in.setModel("fake-1");
+        in.setJsonOutput(true);
+        in.getMessages().add(new ChatMessage(ChatMessage.Role.user, "Return JSON."));
+
+        LLMResponse out =
+                helper.chatComplete(task("t10"), new FakeAIModel(model), in, null, x -> {});
+        Object result = out.getResult();
+        assertTrue(result instanceof Map, "json result must be parsed into a Map; was " + result);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> asMap = (Map<String, Object>) result;
+        assertEquals("Conductor", asMap.get("name"));
+        assertEquals(42, asMap.get("value"));
+    }
+
+    @Test
+    void chatComplete_jsonFenced_codeFence_isStripped() {
+        // Models often wrap JSON in ```json …``` fences. The helper must strip those before
+        // parsing — otherwise downstream code receives the raw fenced string.
+        StagedChatModel model = new StagedChatModel();
+        model.stage(
+                responseOf(
+                        new AssistantMessage("```json\n{\"k\":1}\n```"),
+                        "stop",
+                        metaWithUsage(1, 5, 6)));
+
+        ChatCompletion in = new ChatCompletion();
+        in.setLlmProvider("fake");
+        in.setModel("fake-1");
+        in.setJsonOutput(true);
+        in.getMessages().add(new ChatMessage(ChatMessage.Role.user, "Return JSON in a fence."));
+
+        LLMResponse out =
+                helper.chatComplete(task("t11"), new FakeAIModel(model), in, null, x -> {});
+        assertTrue(
+                out.getResult() instanceof Map,
+                "fenced JSON must still parse cleanly; result was: " + out.getResult());
+        assertEquals(1, ((Map<?, ?>) out.getResult()).get("k"));
+    }
+
+    @Test
+    void chatComplete_jsonOutputFalse_nonJsonText_isReturnedVerbatim() {
+        StagedChatModel model = new StagedChatModel();
+        model.stage(
+                responseOf(new AssistantMessage("hello, world"), "stop", metaWithUsage(1, 5, 6)));
+
+        ChatCompletion in = new ChatCompletion();
+        in.setLlmProvider("fake");
+        in.setModel("fake-1");
+        in.getMessages().add(new ChatMessage(ChatMessage.Role.user, "Say hi."));
+
+        LLMResponse out =
+                helper.chatComplete(task("t12"), new FakeAIModel(model), in, null, x -> {});
+        assertEquals("hello, world", out.getResult());
+    }
+
+    // =================================================================
+    // chatComplete — message construction edge case (tool_call role)
+    // =================================================================
+
+    @Test
+    void chatComplete_priorToolCallMessageInHistory_isForwardedAsAssistantWithToolCalls() {
+        // Conductor's loop-history injection sometimes attaches a prior iteration's tool_call
+        // frame followed by a user turn back into the next request. The helper must convert
+        // that ChatMessage into a Spring AI AssistantMessage with toolCalls populated (rather
+        // than dropping it or treating it as a user turn).
+        //
+        // Note we place a real user message *after* the tool_call frame so the assistant
+        // frame isn't the last message — otherwise ``ensureLastMessageIsFromUser`` would
+        // strip it (a behavior we cover separately in LLMHelperTest).
+        StagedChatModel model = new StagedChatModel();
+        model.stage(responseOf(new AssistantMessage("ok"), "stop", metaWithUsage(1, 1, 2)));
+
+        ToolCall priorCall =
+                ToolCall.builder()
+                        .taskReferenceName("call_99")
+                        .name("get_weather")
+                        .inputParameters(
+                                new HashMap<>(Map.of("city", "Tokyo", "method", "get_weather")))
+                        .build();
+        ChatMessage toolCallMsg = new ChatMessage(ChatMessage.Role.tool_call, priorCall);
+
+        ChatCompletion in = new ChatCompletion();
+        in.setLlmProvider("fake");
+        in.setModel("fake-1");
+        in.setMessages(
+                new ArrayList<>(
+                        List.of(
+                                new ChatMessage(ChatMessage.Role.user, "What's the weather?"),
+                                toolCallMsg,
+                                new ChatMessage(ChatMessage.Role.user, "Anything else?"))));
+
+        // Calling the helper drives constructMessage(tool_call) via the public chatComplete.
+        LLMResponse out =
+                helper.chatComplete(task("t13"), new FakeAIModel(model), in, null, x -> {});
+        assertNotNull(out);
+
+        // Pick the assistant frame out of the sent prompt and verify the conversion worked.
+        List<Message> sent = model.lastPrompt.getInstructions();
+        AssistantMessage asst =
+                sent.stream()
+                        .filter(m -> m instanceof AssistantMessage)
+                        .map(m -> (AssistantMessage) m)
+                        .findFirst()
+                        .orElseThrow(
+                                () ->
+                                        new AssertionError(
+                                                "expected at least one AssistantMessage in sent"
+                                                        + " prompt; was: "
+                                                        + sent));
+        assertTrue(
+                asst.hasToolCalls(),
+                "tool_call role must be converted into an AssistantMessage with toolCalls;"
+                        + " got: "
+                        + asst);
+        AssistantMessage.ToolCall converted = asst.getToolCalls().getFirst();
+        assertEquals("call_99", converted.id(), "ToolCall.taskReferenceName must become id");
+        assertEquals(
+                "get_weather",
+                converted.name(),
+                "tool name must surface either from the 'method' key or the ToolCall.name");
+    }
+
+    // =================================================================
+    // chatComplete — empty response result-set
+    // =================================================================
+
+    @Test
+    void chatComplete_emptyGenerationList_returnsSerializedResponseAsResult() {
+        // Spring AI may emit a ChatResponse with zero generations (e.g. content-filter
+        // refusal). The helper must not NPE on getFirst(); it should serialize the
+        // ChatResponse JSON and surface that as a string ``result`` plus usage.
+        StagedChatModel model = new StagedChatModel();
+        ChatResponse empty = new ChatResponse(List.of(), metaWithUsage(2, 0, 2));
+        model.stage(empty);
+
+        ChatCompletion in = new ChatCompletion();
+        in.setLlmProvider("fake");
+        in.setModel("fake-1");
+        in.getMessages().add(new ChatMessage(ChatMessage.Role.user, "go"));
+
+        AtomicReference<TokenUsageLog> logged = new AtomicReference<>();
+        LLMResponse out =
+                helper.chatComplete(task("t14"), new FakeAIModel(model), in, null, logged::set);
+        assertNotNull(out.getResult());
+        assertEquals(2, out.getTokenUsed());
+        assertNotNull(logged.get(), "token-usage logger must still fire on empty-result path");
+    }
+
+    // =================================================================
+    // chatComplete — null ChatResponse path
+    // =================================================================
+
+    @Test
+    void chatComplete_chatClientReturnsNull_propagatesAsRuntimeException() {
+        // Defensive contract: if the underlying ChatClient returns no response object at all,
+        // the helper must raise a clear RuntimeException rather than silently producing an
+        // LLMResponse with an empty/null result.
+        StagedChatModel model = new StagedChatModel();
+        model.stage(null);
+
+        ChatCompletion in = new ChatCompletion();
+        in.setLlmProvider("fake");
+        in.setModel("fake-1");
+        in.getMessages().add(new ChatMessage(ChatMessage.Role.user, "ping"));
+
+        RuntimeException thrown =
+                org.junit.jupiter.api.Assertions.assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                helper.chatComplete(
+                                        task("t15"), new FakeAIModel(model), in, null, x -> {}));
+        assertTrue(
+                thrown.getMessage().contains("No response generated"),
+                "expected the 'No response generated' guard; got: " + thrown.getMessage());
+    }
+
+    // =================================================================
+    // generateEmbeddings — passthrough to the underlying AIModel
+    // =================================================================
+
+    @Test
+    void generateEmbeddings_delegatesToAIModel() {
+        // Helper is a thin shell around AIModel.generateEmbeddings — but the wrapper is still
+        // worth pinning so a future refactor that adds caching / batching has a baseline
+        // contract to compare against.
+        List<Float> staged = List.of(0.1f, 0.2f, 0.3f);
+        AIModel fake =
+                new FakeAIModel(new StagedChatModel()) {
+                    @Override
+                    public List<Float> generateEmbeddings(EmbeddingGenRequest req) {
+                        return staged;
+                    }
+                };
+        EmbeddingGenRequest req = new EmbeddingGenRequest();
+        req.setText("hello");
+        List<Float> got = helper.generateEmbeddings(task("t16"), fake, req, x -> {});
+        assertSame(staged, got);
+    }
+}

--- a/ai/src/test/java/org/conductoross/conductor/ai/integration/AIModelIntegrationTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/integration/AIModelIntegrationTest.java
@@ -634,7 +634,7 @@ public class AIModelIntegrationTest {
             ChatModel chatModel = anthropic.getChatModel();
 
             ChatCompletion input = new ChatCompletion();
-            input.setModel("claude-sonnet-4-5"); // Sonnet 4.5 supports thinking
+            input.setModel("claude-sonnet-4-6"); // Sonnet 4.6 supports legacy thinking
             input.setMaxTokens(16000); // Thinking requires larger token limit
             input.setThinkingTokenLimit(8000); // Enable thinking mode
             // Note: Temperature is forced to 1.0 when thinking is enabled
@@ -649,6 +649,67 @@ public class AIModelIntegrationTest {
             String text = response.getResult().getOutput().getText();
             assertNotNull(text);
             assertTrue(text.contains("345"), "Expected 345 in response, got: " + text);
+        }
+
+        @Test
+        @DisplayName(
+                "Opus 4.7 + thinkingTokenLimit must be rewritten to adaptive thinking (regression)")
+        void testOpus47ThinkingBudget_routesThroughAdaptive() {
+            // Regression for the production HTTP 400:
+            //   "thinking.type.enabled" is not supported for this model.
+            //   Use "thinking.type.adaptive" and "output_config.effort" ...
+            //
+            // The adapter must translate ``thinkingTokenLimit`` into
+            // ``thinking.type=adaptive`` + ``output_config.effort`` whenever the
+            // model id targets Opus 4.7 (Opus 4.6 / Sonnet 4.6 still accept the
+            // legacy ``enabled`` + ``budget_tokens`` shape and are exercised by
+            // ``testThinkingMode`` above). If that translation regresses, this
+            // call returns HTTP 400 with the exact message quoted above.
+            ChatModel chatModel = anthropic.getChatModel();
+
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("claude-opus-4-7");
+            input.setMaxTokens(16000);
+            input.setThinkingTokenLimit(10000);
+
+            var chatOptions = anthropic.getChatOptions(input);
+            Prompt prompt = new Prompt("What is 2 + 2? Think step by step.", chatOptions);
+
+            ChatResponse response = chatModel.call(prompt);
+
+            assertNotNull(response);
+            assertNotNull(response.getResult());
+            String text = response.getResult().getOutput().getText();
+            assertNotNull(text);
+            assertFalse(text.isEmpty());
+            assertTrue(
+                    text.contains("4"), "Expected the model to reach the answer '4'; got: " + text);
+        }
+
+        @Test
+        @DisplayName("Opus 4.7 + reasoningEffort only (no thinkingTokenLimit) is accepted")
+        void testOpus47ReasoningEffortOnly() {
+            // Opus 4.7 also accepts ``output_config.effort`` without an
+            // accompanying ``thinking`` block. The adapter must forward
+            // ``reasoningEffort`` straight through without attaching any
+            // thinking configuration.
+            ChatModel chatModel = anthropic.getChatModel();
+
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("claude-opus-4-7");
+            input.setMaxTokens(1024);
+            input.setReasoningEffort("low");
+
+            var chatOptions = anthropic.getChatOptions(input);
+            Prompt prompt = new Prompt("Say hi.", chatOptions);
+
+            ChatResponse response = chatModel.call(prompt);
+
+            assertNotNull(response);
+            assertNotNull(response.getResult());
+            String text = response.getResult().getOutput().getText();
+            assertNotNull(text);
+            assertFalse(text.isEmpty());
         }
 
         @Test

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicTest.java
@@ -230,8 +230,13 @@ class AnthropicTest {
 
         @Test
         void testChatCompletion_withThinking() {
+            // Lightweight smoke check for the legacy ``thinking.type=enabled`` shape on a model
+            // that still accepts it. Coverage for the Opus 4.7 adaptive-thinking translation
+            // (the production fix that motivates the regression suite) lives in
+            // ``AIModelIntegrationTest.AnthropicTests`` so it sits alongside the other live
+            // provider tests.
             ChatCompletion input = new ChatCompletion();
-            input.setModel("claude-sonnet-4-5");
+            input.setModel("claude-sonnet-4-6");
             input.setMaxTokens(16000);
             input.setThinkingTokenLimit(10000);
 

--- a/ai/src/test/java/org/conductoross/conductor/ai/tasks/worker/LLMWorkersTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/tasks/worker/LLMWorkersTest.java
@@ -1,0 +1,413 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.tasks.worker;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.conductoross.conductor.ai.LLMs;
+import org.conductoross.conductor.ai.models.AudioGenRequest;
+import org.conductoross.conductor.ai.models.ChatCompletion;
+import org.conductoross.conductor.ai.models.EmbeddingGenRequest;
+import org.conductoross.conductor.ai.models.ImageGenRequest;
+import org.conductoross.conductor.ai.models.LLMResponse;
+import org.conductoross.conductor.ai.models.TextCompletion;
+import org.conductoross.conductor.ai.models.VideoGenRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.TaskResult;
+import com.netflix.conductor.sdk.workflow.executor.task.NonRetryableException;
+import com.netflix.conductor.sdk.workflow.executor.task.TaskContext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Drives every {@code @WorkerTask} method on {@link LLMWorkers} with a stubbed {@link LLMs} so the
+ * pure plumbing (input mapping, task-context wiring, video state machine, embeddings validation) is
+ * covered without a live provider. Production already exercises this code via {@code
+ * AIReasoningEndToEndTest} end-to-end; this file pins the fast-path unit behavior.
+ */
+public class LLMWorkersTest {
+
+    private RecordingLLMs llms;
+    private LLMWorkers workers;
+    private Task task;
+
+    @BeforeEach
+    void setUp() {
+        llms = new RecordingLLMs();
+        workers = new LLMWorkers(llms);
+        task = new Task();
+        task.setTaskId("task-" + System.nanoTime());
+        task.setWorkflowInstanceId("wf-" + System.nanoTime());
+        // TaskContext.set() builds a TaskResult from the task — the TaskResult ctor reads
+        // task.getStatus().ordinal(), so the status must be set before we publish.
+        task.setStatus(Task.Status.IN_PROGRESS);
+        // LLMWorkers reads ``TaskContext.get().getTask()`` inside each handler — the
+        // SystemTaskWorker normally seeds this before invoking @WorkerTask methods. In a
+        // unit test we have to do that ourselves.
+        TaskContext.set(task);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TaskContext.clear();
+    }
+
+    // =================================================================
+    // LLM_CHAT_COMPLETE
+    // =================================================================
+
+    @Test
+    void chatCompletion_passesInputToLLMsAndReturnsResponse() {
+        // The worker is a thin shell — its job is to forward the ChatCompletion (and the
+        // ThreadLocal-bound Task) into LLMs.chatComplete. Verify both ends of that contract.
+        LLMResponse canned = LLMResponse.builder().result("hello").completionTokens(7).build();
+        llms.stagedChatResponse = canned;
+
+        ChatCompletion in = new ChatCompletion();
+        in.setLlmProvider("fake");
+        in.setModel("fake-1");
+
+        LLMResponse out = workers.chatCompletion(in);
+
+        assertSame(canned, out, "worker must return whatever LLMs.chatComplete produced");
+        assertSame(task, llms.lastChatTask, "worker must forward the TaskContext-bound task");
+        assertSame(in, llms.lastChatCompletion, "worker must pass through the ChatCompletion");
+    }
+
+    // =================================================================
+    // LLM_TEXT_COMPLETE — maps TextCompletion → ChatCompletion
+    // =================================================================
+
+    @Test
+    void textCompletion_mapsAllFieldsOntoChatCompletionAndAddsBootstrapUserMessage() {
+        // textCompletion is the only worker that synthesizes its own messages array — and
+        // it has a non-trivial promptName-vs-prompt selector. The mapping has historically
+        // been a source of bugs (field added on TextCompletion but missed here), so pin
+        // each translation point explicitly.
+        TextCompletion in = new TextCompletion();
+        in.setLlmProvider("fake");
+        in.setModel("fake-1");
+        in.setTemperature(0.4);
+        in.setMaxResults(2);
+        in.setMaxTokens(123);
+        in.setTopP(0.8);
+        in.setStopWords(List.of("STOP"));
+        in.setJsonOutput(true);
+        in.setPrompt("ignored when promptName is set");
+        in.setPromptName("greeting_v1");
+        in.setPromptVersion(5);
+        in.setPromptVariables(Map.of("name", "Conductor"));
+
+        llms.stagedChatResponse = LLMResponse.builder().result("hi").build();
+        LLMResponse out = workers.textCompletion(in);
+        assertNotNull(out);
+
+        ChatCompletion mapped = llms.lastChatCompletion;
+        assertNotNull(mapped, "textCompletion must invoke LLMs.chatComplete");
+
+        assertEquals("fake", mapped.getLlmProvider());
+        assertEquals("fake-1", mapped.getModel());
+        assertEquals(0.4, mapped.getTemperature());
+        assertEquals(2, mapped.getMaxResults());
+        assertEquals(123, mapped.getMaxTokens());
+        assertEquals(0.8, mapped.getTopP());
+        assertEquals(List.of("STOP"), mapped.getStopWords());
+        assertTrue(mapped.isJsonOutput());
+        assertEquals(
+                "greeting_v1",
+                mapped.getInstructions(),
+                "promptName must win over prompt when both are set");
+        assertEquals(5, mapped.getPromptVersion());
+        assertEquals(Map.of("name", "Conductor"), mapped.getPromptVariables());
+
+        // The bootstrap user turn is non-obvious — without it, providers see an
+        // instructions-only payload and refuse to respond. Lock it in.
+        assertEquals(
+                1,
+                mapped.getMessages().size(),
+                "textCompletion must add a single bootstrap user message");
+        assertEquals(
+                "user",
+                mapped.getMessages().getFirst().getRole().name(),
+                "bootstrap message role must be ``user``");
+        assertTrue(
+                mapped.getMessages().getFirst().getMessage().toLowerCase().contains("instructions"),
+                "bootstrap message must reference the instructions: "
+                        + mapped.getMessages().getFirst().getMessage());
+    }
+
+    @Test
+    void textCompletion_promptNameNull_fallsBackToPrompt() {
+        // The ?: in textCompletion uses promptName when non-null, else prompt. Pin the
+        // fallback branch directly.
+        TextCompletion in = new TextCompletion();
+        in.setLlmProvider("fake");
+        in.setModel("fake-1");
+        in.setPrompt("write me a haiku");
+        in.setPromptName(null);
+
+        llms.stagedChatResponse = LLMResponse.builder().result("done").build();
+        workers.textCompletion(in);
+
+        assertEquals(
+                "write me a haiku",
+                llms.lastChatCompletion.getInstructions(),
+                "with promptName=null, the prompt field must populate ChatCompletion.instructions");
+    }
+
+    // =================================================================
+    // GENERATE_IMAGE / GENERATE_AUDIO — pure delegations
+    // =================================================================
+
+    @Test
+    void generateImage_forwardsToLLMs() {
+        ImageGenRequest req = new ImageGenRequest();
+        req.setLlmProvider("fake");
+        req.setModel("fake-image");
+        llms.stagedImageResponse = LLMResponse.builder().result("img").build();
+
+        LLMResponse out = workers.generateImage(req);
+        assertSame(llms.stagedImageResponse, out);
+        assertSame(req, llms.lastImageReq);
+        assertSame(task, llms.lastImageTask);
+    }
+
+    @Test
+    void generateAudio_forwardsToLLMs() {
+        AudioGenRequest req = AudioGenRequest.builder().text("hello").voice("alloy").build();
+        req.setLlmProvider("fake");
+        req.setModel("tts-1");
+        llms.stagedAudioResponse = LLMResponse.builder().result("audio").build();
+
+        LLMResponse out = workers.generateAudio(req);
+        assertSame(llms.stagedAudioResponse, out);
+        assertSame(req, llms.lastAudioReq);
+        assertSame(task, llms.lastAudioTask);
+    }
+
+    // =================================================================
+    // GENERATE_VIDEO — state machine
+    // =================================================================
+
+    @Test
+    void generateVideo_initialCall_startsJobAndReturnsInProgress() {
+        // First invocation has no jobId on the task output, so LLMWorkers must call
+        // LLMs.generateVideo(...) (the "start" half) and emit IN_PROGRESS with a 5s
+        // callback delay.
+        llms.stagedVideoResponse =
+                LLMResponse.builder().jobId("job-1").finishReason("RUNNING").build();
+
+        VideoGenRequest req = new VideoGenRequest();
+        req.setLlmProvider("fake");
+        req.setModel("fake-video");
+
+        TaskResult result = workers.generateVideo(req);
+
+        assertEquals(TaskResult.Status.IN_PROGRESS, result.getStatus());
+        assertEquals(5L, result.getCallbackAfterSeconds());
+        assertEquals("job-1", result.getOutputData().get("jobId"));
+        assertNotNull(llms.lastVideoStartTask, "first invocation must hit generateVideo");
+        // The "checkVideoStatus" path must NOT have run yet — that's what differentiates
+        // the start half from the poll half.
+        assertSame(null, llms.lastVideoStatusReq);
+    }
+
+    @Test
+    void generateVideo_pollWithJobIdAndStatusRunning_keepsInProgress() {
+        // After the start call the worker writes ``jobId`` onto Task.outputData. On the
+        // poll iteration the worker reads that back and invokes checkVideoStatus instead.
+        task.getOutputData().put("jobId", "job-1");
+        llms.stagedVideoStatusResponse =
+                LLMResponse.builder().jobId("job-1").finishReason("RUNNING").build();
+
+        VideoGenRequest req = new VideoGenRequest();
+        req.setLlmProvider("fake");
+        req.setModel("fake-video");
+
+        TaskResult result = workers.generateVideo(req);
+
+        // ``RUNNING`` is neither COMPLETED nor FAILED — worker must leave the status as
+        // the default IN_PROGRESS so the next poll fires.
+        assertEquals(TaskResult.Status.IN_PROGRESS, result.getStatus());
+        assertEquals(5L, result.getCallbackAfterSeconds());
+        assertNotNull(llms.lastVideoStatusReq, "poll iteration must hit checkVideoStatus");
+        assertEquals(
+                "job-1",
+                llms.lastVideoStatusReq.getJobId(),
+                "worker must thread the persisted jobId back into the status request");
+    }
+
+    @Test
+    void generateVideo_pollWithStatusCompleted_marksTaskCompleted() {
+        task.getOutputData().put("jobId", "job-1");
+        llms.stagedVideoStatusResponse =
+                LLMResponse.builder().jobId("job-1").finishReason("COMPLETED").build();
+
+        VideoGenRequest req = new VideoGenRequest();
+        TaskResult result = workers.generateVideo(req);
+
+        assertEquals(TaskResult.Status.COMPLETED, result.getStatus());
+    }
+
+    @Test
+    void generateVideo_pollWithStatusFailed_marksTaskFailed() {
+        task.getOutputData().put("jobId", "job-1");
+        llms.stagedVideoStatusResponse =
+                LLMResponse.builder().jobId("job-1").finishReason("FAILED").build();
+
+        VideoGenRequest req = new VideoGenRequest();
+        TaskResult result = workers.generateVideo(req);
+
+        assertEquals(TaskResult.Status.FAILED, result.getStatus());
+    }
+
+    // =================================================================
+    // LLM_GENERATE_EMBEDDINGS — pre-flight validation + delegation
+    // =================================================================
+
+    @Test
+    void generateEmbeddings_blankText_throwsNonRetryable() {
+        EmbeddingGenRequest req = new EmbeddingGenRequest();
+        req.setLlmProvider("fake");
+        req.setModel("fake-embed");
+        req.setText("   "); // blank should be treated the same as empty/null
+
+        NonRetryableException thrown =
+                assertThrows(NonRetryableException.class, () -> workers.generateEmbeddings(req));
+        assertTrue(
+                thrown.getMessage().toLowerCase().contains("no input text"),
+                "expected the 'No input text' guard; got: " + thrown.getMessage());
+        // Validation must run BEFORE any provider call; nothing should land on the stub.
+        assertFalse(llms.embeddingsCalled, "blank text must not reach LLMs.generateEmbeddings");
+    }
+
+    @Test
+    void generateEmbeddings_validInput_delegatesAndReturnsList() {
+        List<Float> staged = List.of(0.1f, 0.2f, 0.3f, 0.4f);
+        llms.stagedEmbeddings = staged;
+
+        EmbeddingGenRequest req = new EmbeddingGenRequest();
+        req.setLlmProvider("fake");
+        req.setModel("fake-embed");
+        req.setText("hello");
+        req.setDimensions(4);
+
+        List<Float> got = workers.generateEmbeddings(req);
+        assertSame(staged, got);
+        assertTrue(llms.embeddingsCalled);
+        // Worker rebuilds an EmbeddingGenRequest internally; verify the rebuild
+        // preserved the model, text, dimensions, and provider.
+        assertNotNull(llms.lastEmbeddingsReq);
+        assertEquals("fake-embed", llms.lastEmbeddingsReq.getModel());
+        assertEquals("hello", llms.lastEmbeddingsReq.getText());
+        assertEquals(4, llms.lastEmbeddingsReq.getDimensions());
+        assertEquals("fake", llms.lastEmbeddingsReq.getLlmProvider());
+    }
+
+    // =================================================================
+    // Test double — records calls into an LLMs-shaped surface
+    // =================================================================
+
+    /**
+     * Stub {@link LLMs} that lets each test stage canned return values and inspect the inputs the
+     * worker forwarded. We construct {@link LLMs} with null collaborators because every public
+     * method that LLMWorkers calls is overridden here — the parent constructor never dereferences
+     * the dependencies.
+     */
+    static class RecordingLLMs extends LLMs {
+
+        LLMResponse stagedChatResponse;
+        LLMResponse stagedImageResponse;
+        LLMResponse stagedAudioResponse;
+        LLMResponse stagedVideoResponse;
+        LLMResponse stagedVideoStatusResponse;
+        List<Float> stagedEmbeddings = new ArrayList<>();
+
+        Task lastChatTask;
+        ChatCompletion lastChatCompletion;
+        Task lastImageTask;
+        ImageGenRequest lastImageReq;
+        Task lastAudioTask;
+        AudioGenRequest lastAudioReq;
+        Task lastVideoStartTask;
+        VideoGenRequest lastVideoStartReq;
+        VideoGenRequest lastVideoStatusReq;
+        EmbeddingGenRequest lastEmbeddingsReq;
+        boolean embeddingsCalled;
+
+        RecordingLLMs() {
+            // The parent constructor walks the modelConfigurations list — passing an empty
+            // list makes that loop a no-op, so ``Environment`` is never dereferenced and
+            // ``payloadStoreLocation`` stays null. Every method LLMWorkers actually calls on
+            // ``LLMs`` is overridden below, so none of those dependencies are touched at
+            // runtime.
+            super(new ArrayList<>(), null, emptyProvider(), null);
+        }
+
+        private static org.conductoross.conductor.ai.AIModelProvider emptyProvider() {
+            return new org.conductoross.conductor.ai.AIModelProvider(new ArrayList<>(), null);
+        }
+
+        @Override
+        public LLMResponse chatComplete(Task task, ChatCompletion chatCompletion) {
+            lastChatTask = task;
+            lastChatCompletion = chatCompletion;
+            return stagedChatResponse;
+        }
+
+        @Override
+        public LLMResponse generateImage(Task task, ImageGenRequest req) {
+            lastImageTask = task;
+            lastImageReq = req;
+            return stagedImageResponse;
+        }
+
+        @Override
+        public LLMResponse generateAudio(Task task, AudioGenRequest req) {
+            lastAudioTask = task;
+            lastAudioReq = req;
+            return stagedAudioResponse;
+        }
+
+        @Override
+        public LLMResponse generateVideo(Task task, VideoGenRequest req) {
+            lastVideoStartTask = task;
+            lastVideoStartReq = req;
+            return stagedVideoResponse;
+        }
+
+        @Override
+        public LLMResponse checkVideoStatus(Task task, VideoGenRequest req) {
+            lastVideoStatusReq = req;
+            return stagedVideoStatusResponse;
+        }
+
+        @Override
+        public List<Float> generateEmbeddings(Task task, EmbeddingGenRequest req) {
+            embeddingsCalled = true;
+            lastEmbeddingsReq = req;
+            return stagedEmbeddings;
+        }
+    }
+}

--- a/docker/docker-compose-postgres-e2e.yaml
+++ b/docker/docker-compose-postgres-e2e.yaml
@@ -2,6 +2,10 @@ services:
   conductor-server:
     environment:
       - CONFIG_PROP=config-postgres.properties
+      # Forwarded from the host shell when set. Empty/absent ⇒ the matching AI provider
+      # stays unconfigured and the LLM e2e tests that depend on it self-skip.
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
     image: conductor:server
     container_name: conductor-server-e2e
     networks:

--- a/docker/docker-compose-postgres.yaml
+++ b/docker/docker-compose-postgres.yaml
@@ -4,6 +4,10 @@ services:
   conductor-server:
     environment:
       - CONFIG_PROP=config-postgres.properties
+      # Forwarded from the host shell when set. Empty/absent ⇒ the matching AI provider
+      # stays unconfigured and the LLM e2e tests that depend on it self-skip.
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
     image: conductor:server
     container_name: conductor-server
     build:

--- a/e2e/src/test/java/io/conductor/e2e/task/LLMChatCompleteTests.java
+++ b/e2e/src/test/java/io/conductor/e2e/task/LLMChatCompleteTests.java
@@ -1,0 +1,1123 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.conductor.e2e.task;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import com.netflix.conductor.client.http.MetadataClient;
+import com.netflix.conductor.client.http.WorkflowClient;
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.common.metadata.tasks.TaskType;
+import com.netflix.conductor.common.metadata.workflow.StartWorkflowRequest;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.common.run.Workflow;
+
+import io.conductor.e2e.util.ApiUtil;
+import lombok.extern.slf4j.Slf4j;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Server-side end-to-end coverage for {@code LLM_CHAT_COMPLETE} against live providers.
+ *
+ * <p>Each {@code @Test} method is independently gated on the provider's API key being present on
+ * the host shell. The {@code docker-compose-postgres.yaml} / {@code
+ * docker-compose-postgres-e2e.yaml} files forward those variables through to the conductor-server
+ * container, where Spring binds them onto {@code conductor.ai.<provider>.api-key}. If a key isn't
+ * set, the dependent tests self-skip via {@link EnabledIfEnvironmentVariable}.
+ *
+ * <h2>Model selection</h2>
+ *
+ * Models are pinned to the current generally-available lineup published by each provider:
+ *
+ * <ul>
+ *   <li><b>Anthropic</b> (from <a
+ *       href="https://platform.claude.com/docs/en/about-claude/models/overview">claude.com/docs/models/overview</a>):
+ *       <ul>
+ *         <li>{@link #ANTHROPIC_HAIKU_MODEL} — non-thinking baseline.
+ *         <li>{@link #ANTHROPIC_SONNET_THINKING_MODEL} — extended-thinking-capable (legacy {@code
+ *             thinking.type=enabled} + {@code budget_tokens} still accepted).
+ *         <li>{@link #ANTHROPIC_OPUS_THINKING_MODEL} — adaptive-thinking only; rejects the legacy
+ *             shape, the adapter must rewrite {@code thinkingTokenLimit} into {@code
+ *             thinking.type=adaptive} + {@code output_config.effort}.
+ *       </ul>
+ *   <li><b>OpenAI</b> (from <a
+ *       href="https://developers.openai.com/api/docs/models/all">developers.openai.com/api/docs/models/all</a>):
+ *       <ul>
+ *         <li>{@link #OPENAI_CHAT_MODEL} — general-purpose, non-reasoning chat.
+ *         <li>{@link #OPENAI_REASONING_MODEL} — reasoning model that honors {@code reasoningEffort}
+ *             / {@code reasoningSummary} via the Responses API.
+ *       </ul>
+ * </ul>
+ *
+ * <h2>Matrix</h2>
+ *
+ * <table>
+ *   <tr><th>Scenario</th><th>Anthropic non-thinking</th><th>Anthropic Sonnet thinking</th>
+ *       <th>Anthropic Opus thinking (adaptive)</th><th>OpenAI non-thinking</th>
+ *       <th>OpenAI reasoning</th></tr>
+ *   <tr><td>Single chat</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+ *   <tr><td>Multi-turn history (`messages`)</td><td>✓</td><td></td><td></td><td>✓</td><td></td></tr>
+ *   <tr><td>Function tool calling</td><td>✓</td><td></td><td></td><td>✓</td><td></td></tr>
+ *   <tr><td>JSON output</td><td></td><td></td><td></td><td>✓</td><td></td></tr>
+ *   <tr><td>Response chaining (previousResponseId)</td><td></td><td></td><td></td>
+ *       <td>✓</td><td></td></tr>
+ *   <tr><td>LLM in DO_WHILE loop</td><td></td><td></td><td>✓ (regression)</td><td></td><td></td></tr>
+ *   <tr><td>Response chaining inside DO_WHILE</td><td></td><td></td><td></td>
+ *       <td>✓</td><td></td></tr>
+ *   <tr><td>Agentic DO_WHILE (workingState hand-off)</td><td></td><td></td>
+ *       <td>✓</td><td></td><td></td></tr>
+ * </table>
+ *
+ * <p>The headline test {@link #anthropic_opus_thinking_inDoWhileLoop_completesAcrossIterations} is
+ * the regression lock for the production HTTP 400: pre-fix, Opus 4.7 + {@code thinkingTokenLimit}
+ * sent {@code thinking.type=enabled} which Opus 4.7 rejects ({@code "thinking.type.enabled" is not
+ * supported for this model. Use "thinking.type.adaptive" and "output_config.effort" ...}); the
+ * loop's first iteration failed and the workflow landed in FAILED. Post-fix the adapter rewrites
+ * the budget into {@code thinking.type=adaptive} + {@code output_config.effort}, so the loop
+ * completes both iterations.
+ */
+@Slf4j
+public class LLMChatCompleteTests {
+
+    // ----------------------------------------------------------------
+    // Pinned model IDs (update when migrating to a newer generation)
+    // ----------------------------------------------------------------
+
+    /** Fastest non-thinking Claude. Source: claude.com/docs/models/overview "latest". */
+    private static final String ANTHROPIC_HAIKU_MODEL = "claude-haiku-4-5";
+
+    /**
+     * Sonnet 4.6. Supports both extended thinking (legacy ``thinking.type=enabled`` +
+     * ``budget_tokens``, deprecated but still accepted) and adaptive thinking. We use it to cover
+     * the legacy-shape path against a current model so this test catches regressions in the older
+     * code path even after Opus 4.7 ages out.
+     */
+    private static final String ANTHROPIC_SONNET_THINKING_MODEL = "claude-sonnet-4-6";
+
+    /**
+     * Opus 4.7. Adaptive thinking only — the legacy ``thinking.type=enabled`` shape returns HTTP
+     * 400. This is the model that motivated the adapter rewrite under test.
+     */
+    private static final String ANTHROPIC_OPUS_THINKING_MODEL = "claude-opus-4-7";
+
+    /**
+     * General-purpose non-reasoning OpenAI chat model. Source: developers.openai.com
+     * "general-purpose chat models" list. Pinned to the latest 4.x mini for cost + parity with the
+     * in-repo {@code AIModelIntegrationTest} suite.
+     */
+    private static final String OPENAI_CHAT_MODEL = "gpt-4.1-mini";
+
+    /**
+     * OpenAI reasoning model (Responses API path that nests ``reasoning.effort``). gpt-5-mini is
+     * the smallest gpt-5 reasoning variant and matches what the AI module's live integration tests
+     * use today.
+     */
+    private static final String OPENAI_REASONING_MODEL = "gpt-5-mini";
+
+    private final WorkflowClient workflowClient = ApiUtil.WORKFLOW_CLIENT;
+    private final MetadataClient metadataClient = ApiUtil.METADATA_CLIENT;
+
+    // ====================================================================
+    // Anthropic — non-thinking model (Claude Haiku 4.5)
+    // ====================================================================
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
+    public void anthropic_haiku_singleChat_completes() {
+        // Sanity check for the simplest LLM_CHAT_COMPLETE input on a non-thinking model.
+        // Haiku 4.5 does not engage thinking; the request omits both thinkingTokenLimit
+        // and reasoningEffort, exercising the adapter's bare-minimum chat path.
+        String wfName = "ai_e2e_anthropic_haiku_single";
+        registerSingleTaskWorkflow(wfName);
+
+        Workflow wf =
+                runAndWait(
+                        wfName,
+                        Map.of(
+                                "llmProvider", "anthropic",
+                                "model", ANTHROPIC_HAIKU_MODEL,
+                                "instructions", "You are a helpful math assistant. Be concise.",
+                                "userInput", "What is 2 + 2? Reply with just the number."),
+                        60);
+        assertChatCompletedWithAnswer(wf, "4");
+    }
+
+    // ====================================================================
+    // Anthropic — Sonnet 4.6 + thinking (legacy ``thinking.type=enabled`` shape)
+    // ====================================================================
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
+    public void anthropic_sonnet_thinking_singleChat_completes() {
+        // Sonnet 4.6 still accepts the legacy ``thinking.type=enabled`` + ``budget_tokens``
+        // shape (the adaptive path is recommended but the deprecated path remains
+        // functional). This test guards against the adapter accidentally over-routing every
+        // thinking-capable model through adaptive — which would suppress the legacy code
+        // path entirely.
+        String wfName = "ai_e2e_anthropic_sonnet_thinking_single";
+        registerSingleTaskWorkflow(wfName);
+
+        Workflow wf =
+                runAndWait(
+                        wfName,
+                        Map.of(
+                                "llmProvider", "anthropic",
+                                "model", ANTHROPIC_SONNET_THINKING_MODEL,
+                                "thinkingTokenLimit", 4000,
+                                "instructions", "You are a helpful math assistant. Be concise.",
+                                "userInput", "What is 5 + 6? Reply with just the number."),
+                        90);
+        assertChatCompletedWithAnswer(wf, "11");
+    }
+
+    // ====================================================================
+    // Anthropic — Opus 4.7 + thinking (adaptive-only) — regression for the HTTP 400
+    // ====================================================================
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
+    public void anthropic_opus_thinking_singleChat_completes() {
+        // Single-chat companion to the loop regression below. Locks in that Opus 4.7 +
+        // thinkingTokenLimit round-trips through the Conductor task pipeline (mapper →
+        // worker → adapter → live API → LLMResponse) when the adaptive-thinking rewrite
+        // is in place.
+        String wfName = "ai_e2e_anthropic_opus_thinking_single";
+        registerSingleTaskWorkflow(wfName);
+
+        Workflow wf =
+                runAndWait(
+                        wfName,
+                        Map.of(
+                                "llmProvider", "anthropic",
+                                "model", ANTHROPIC_OPUS_THINKING_MODEL,
+                                "thinkingTokenLimit", 4000,
+                                "instructions", "You are a helpful math assistant. Be concise.",
+                                "userInput", "What is 3 + 4? Reply with just the number."),
+                        90);
+        assertChatCompletedWithAnswer(wf, "7");
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
+    public void anthropic_opus_thinking_inDoWhileLoop_completesAcrossIterations() {
+        // The headline regression. Two iterations × LLM_CHAT_COMPLETE × Opus 4.7 ×
+        // thinkingTokenLimit. Pre-fix iteration 1 hits HTTP 400 and the workflow lands in
+        // FAILED; post-fix both iterations COMPLETE and the workflow reaches COMPLETED.
+        String wfName = "ai_e2e_anthropic_opus_thinking_loop";
+        registerLoopWorkflow(wfName, 2);
+
+        Workflow wf =
+                runAndWait(
+                        wfName,
+                        Map.of(
+                                "llmProvider", "anthropic",
+                                "model", ANTHROPIC_OPUS_THINKING_MODEL,
+                                "thinkingTokenLimit", 4000,
+                                "instructions", "You are a helpful math assistant. Be concise.",
+                                "userInput", "What is 2 + 2? Reply with just the number."),
+                        120);
+
+        List<Task> chatTasks = chatTasks(wf);
+        assertEquals(
+                2,
+                chatTasks.size(),
+                "expected one LLM_CHAT_COMPLETE per loop iteration (×2); saw: " + chatTasks);
+        for (Task t : chatTasks) {
+            assertEquals(
+                    Task.Status.COMPLETED,
+                    t.getStatus(),
+                    "iteration "
+                            + t.getIteration()
+                            + " must complete; reason: "
+                            + t.getReasonForIncompletion());
+            assertTrue(
+                    String.valueOf(t.getOutputData().get("result")).contains("4"),
+                    "iteration "
+                            + t.getIteration()
+                            + " must reach the model's answer '4'; got: "
+                            + t.getOutputData().get("result"));
+        }
+    }
+
+    // ====================================================================
+    // Anthropic — multi-turn history via ``messages`` array
+    // ====================================================================
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
+    public void anthropic_haiku_multiTurnHistory_recallsPriorTurn() {
+        // Verifies the mapper passes an explicit ``messages`` array (system + user +
+        // assistant + user) through to the provider untouched, so the model can answer
+        // questions about earlier turns. A failure here typically means either the
+        // mapper dropped the history, or the provider adapter mangled the role mapping.
+        String wfName = "ai_e2e_anthropic_haiku_history";
+        registerHistoryWorkflow(wfName);
+
+        Workflow wf =
+                runAndWait(
+                        wfName,
+                        Map.of("llmProvider", "anthropic", "model", ANTHROPIC_HAIKU_MODEL),
+                        60);
+
+        Object result = wf.getTasks().getFirst().getOutputData().get("result");
+        assertNotNull(result);
+        assertTrue(
+                result.toString().toLowerCase().contains("conductor"),
+                "model must recall the name 'Conductor' from the prior assistant turn; got: "
+                        + result);
+    }
+
+    // ====================================================================
+    // Anthropic — function tool calling (model returns tool_use, not result)
+    // ====================================================================
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
+    public void anthropic_haiku_functionTool_returnsToolCall() {
+        // The mapper must surface ``tools`` from the input parameters and the adapter
+        // must convert each ToolSpec into a custom Anthropic tool. The model's chosen
+        // tool_use response then has to round-trip back through the worker into
+        // ``toolCalls`` on the task output.
+        String wfName = "ai_e2e_anthropic_haiku_tools";
+        registerSingleTaskWorkflow(wfName);
+
+        Workflow wf =
+                runAndWait(
+                        wfName,
+                        Map.of(
+                                "llmProvider", "anthropic",
+                                "model", ANTHROPIC_HAIKU_MODEL,
+                                "instructions", "Use tools to answer the user's question.",
+                                "userInput", "What is the weather in Tokyo?",
+                                "tools", List.of(weatherTool())),
+                        60);
+
+        Task chat = wf.getTasks().getFirst();
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> toolCalls =
+                (List<Map<String, Object>>) chat.getOutputData().get("toolCalls");
+        assertNotNull(toolCalls, "expected toolCalls on the task output");
+        assertFalse(toolCalls.isEmpty(), "expected at least one tool call");
+        Map<String, Object> first = toolCalls.getFirst();
+        assertEquals("get_weather", first.get("name"));
+        // Conductor's ToolCall record exposes parsed args under ``inputParameters`` — the
+        // adapter has already JSON-decoded whatever the provider returned, so this is a
+        // Map<String,Object> on the task output. Fall back to alternate keys if the
+        // serialization shape ever shifts under us.
+        Object args =
+                first.getOrDefault(
+                        "inputParameters", first.getOrDefault("arguments", first.get("input")));
+        assertNotNull(args, "expected parsed tool arguments on task output; got: " + first);
+        String argsText = args.toString();
+        assertTrue(
+                argsText.toLowerCase().contains("tokyo"),
+                "expected 'tokyo' in tool arguments; got: " + argsText);
+    }
+
+    // ====================================================================
+    // OpenAI — general-purpose non-reasoning chat (gpt-4.1-mini)
+    // ====================================================================
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+    public void openai_chat_singleChat_completes() {
+        String wfName = "ai_e2e_openai_chat_single";
+        registerSingleTaskWorkflow(wfName);
+
+        Workflow wf =
+                runAndWait(
+                        wfName,
+                        Map.of(
+                                "llmProvider", "openai",
+                                "model", OPENAI_CHAT_MODEL,
+                                "instructions", "You are a helpful math assistant. Be concise.",
+                                "userInput", "What is 2 + 2? Reply with just the number."),
+                        60);
+        assertChatCompletedWithAnswer(wf, "4");
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+    public void openai_chat_jsonOutput_returnsJson() {
+        // Locks in the ``jsonOutput=true`` path on a non-thinking OpenAI model.
+        // The prompt must mention JSON for the model to honor response_format.
+        String wfName = "ai_e2e_openai_chat_json";
+        registerSingleTaskWorkflow(wfName);
+
+        Workflow wf =
+                runAndWait(
+                        wfName,
+                        Map.of(
+                                "llmProvider", "openai",
+                                "model", OPENAI_CHAT_MODEL,
+                                "jsonOutput", true,
+                                "instructions",
+                                        "Return a JSON object with keys 'name' and 'value'. JSON only.",
+                                "userInput",
+                                        "Reply with name='test' and value=42 as a JSON object."),
+                        60);
+
+        Object result = wf.getTasks().getFirst().getOutputData().get("result");
+        assertNotNull(result);
+        String text = result.toString();
+        assertTrue(text.contains("42"), "expected value 42 in JSON; got: " + text);
+        assertTrue(text.contains("name"), "expected key 'name' in JSON; got: " + text);
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+    public void openai_chat_multiTurnHistory_recallsPriorTurn() {
+        String wfName = "ai_e2e_openai_chat_history";
+        registerHistoryWorkflow(wfName);
+
+        Workflow wf =
+                runAndWait(wfName, Map.of("llmProvider", "openai", "model", OPENAI_CHAT_MODEL), 60);
+
+        Object result = wf.getTasks().getFirst().getOutputData().get("result");
+        assertNotNull(result);
+        assertTrue(
+                result.toString().toLowerCase().contains("conductor"),
+                "model must recall the name 'Conductor' from the prior assistant turn; got: "
+                        + result);
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+    public void openai_chat_functionTool_returnsToolCall() {
+        String wfName = "ai_e2e_openai_chat_tools";
+        registerSingleTaskWorkflow(wfName);
+
+        Workflow wf =
+                runAndWait(
+                        wfName,
+                        Map.of(
+                                "llmProvider", "openai",
+                                "model", OPENAI_CHAT_MODEL,
+                                "instructions", "Use tools to answer the user's question.",
+                                "userInput", "What is the weather in Tokyo?",
+                                "tools", List.of(weatherTool())),
+                        60);
+
+        Task chat = wf.getTasks().getFirst();
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> toolCalls =
+                (List<Map<String, Object>>) chat.getOutputData().get("toolCalls");
+        assertNotNull(toolCalls, "expected toolCalls on the task output");
+        assertFalse(toolCalls.isEmpty(), "expected at least one tool call");
+        Map<String, Object> first = toolCalls.getFirst();
+        assertEquals("get_weather", first.get("name"));
+        Object args =
+                first.getOrDefault(
+                        "inputParameters", first.getOrDefault("arguments", first.get("input")));
+        assertNotNull(args, "expected parsed tool arguments on task output; got: " + first);
+        String argsText = args.toString();
+        assertTrue(
+                argsText.toLowerCase().contains("tokyo"),
+                "expected 'tokyo' in tool arguments; got: " + argsText);
+    }
+
+    // ====================================================================
+    // OpenAI — reasoning model (gpt-5-mini, Responses API)
+    // ====================================================================
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+    public void openai_reasoning_singleChat_completesAndSurfacesReasoningTokens() {
+        // OpenAI reasoning models go through the Responses API path that nests effort
+        // under ``reasoning.effort``. The adapter must forward both reasoningEffort
+        // and reasoningSummary; the worker must surface ``reasoningTokens`` (and, when
+        // the model emits a summary, ``reasoning``) onto the task output.
+        String wfName = "ai_e2e_openai_reasoning_single";
+        registerSingleTaskWorkflow(wfName);
+
+        Workflow wf =
+                runAndWait(
+                        wfName,
+                        Map.of(
+                                "llmProvider", "openai",
+                                "model", OPENAI_REASONING_MODEL,
+                                "reasoningEffort", "medium",
+                                "reasoningSummary", "auto",
+                                "instructions", "Solve carefully and show your reasoning.",
+                                "userInput",
+                                        "If a train leaves at 3pm and travels 60mph for 2.5 hours,"
+                                                + " how far has it gone? Reply with just the number"
+                                                + " of miles."),
+                        120);
+
+        Task chat = wf.getTasks().getFirst();
+        Object result = chat.getOutputData().get("result");
+        assertNotNull(result);
+        assertTrue(
+                result.toString().contains("150"),
+                "expected the reasoning model to reach 150 miles; got: " + result);
+        // ``reasoningTokens`` is the part the AI module is responsible for plumbing;
+        // its presence proves the reasoning request shape reached OpenAI intact (a
+        // value of 0 is the model's prerogative, but the key must exist).
+        Object reasoningTokens = chat.getOutputData().get("reasoningTokens");
+        assertNotNull(
+                reasoningTokens,
+                "expected reasoningTokens on a "
+                        + OPENAI_REASONING_MODEL
+                        + " response — request shape must be carrying the reasoning block");
+    }
+
+    // ====================================================================
+    // OpenAI — response chaining via previousResponseId (Responses API)
+    // ====================================================================
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+    public void openai_chat_previousResponseId_chainsAcrossTasks() {
+        // Two LLM_CHAT_COMPLETE tasks in one workflow. Task 1 establishes context ("My
+        // name is Conductor"); task 2 references task 1's responseId and asks a follow-up.
+        // No ``messages`` array is sent on task 2 — the only way the model can answer
+        // correctly is if the OpenAI Responses-API server-side store recalls turn 1 from
+        // its ``previousResponseId``. This proves the full chain:
+        //
+        //   task 1 output.responseId  →  ${task1.output.responseId} parameter binding
+        //   →  ChatCompletion.previousResponseId  →  OpenAIResponsesChatOptions
+        //   →  Responses API ``previous_response_id``  →  server-side context recall.
+        //
+        // Mapper-side unit coverage lives in AIModelTaskMapperPreviousResponseIdTest;
+        // this asserts the same chain works end-to-end against the live API.
+        String wfName = "ai_e2e_openai_chat_prev_response_id_chain";
+        registerChainedWorkflow(wfName);
+
+        Workflow wf =
+                runAndWait(wfName, Map.of("llmProvider", "openai", "model", OPENAI_CHAT_MODEL), 90);
+
+        // The workflow holds two LLM_CHAT_COMPLETE tasks. Task 1 must surface a non-blank
+        // responseId — without it, task 2 has nothing to chain to and the test below would
+        // be vacuously green.
+        List<Task> chatTasks = chatTasks(wf);
+        assertEquals(
+                2,
+                chatTasks.size(),
+                "expected two LLM_CHAT_COMPLETE tasks (turn 1 + turn 2); saw: " + chatTasks);
+
+        Task turn1 = chatTasks.get(0);
+        Task turn2 = chatTasks.get(1);
+
+        Object turn1ResponseId = turn1.getOutputData().get("responseId");
+        assertNotNull(
+                turn1ResponseId,
+                "turn 1 must emit a ``responseId`` for chaining; if absent, the OpenAI"
+                        + " Responses API path didn't populate it");
+        assertFalse(
+                turn1ResponseId.toString().isBlank(), "turn 1 ``responseId`` must not be blank");
+
+        // The actual proof: task 2 recalls the name from turn 1's context. Turn 2's only
+        // input is the bare question ``What is my name?``; no history is sent locally.
+        Object turn2Result = turn2.getOutputData().get("result");
+        assertNotNull(turn2Result);
+        assertTrue(
+                turn2Result.toString().toLowerCase().contains("conductor"),
+                "turn 2 must recall the name 'Conductor' from the server-side context"
+                        + " keyed by previousResponseId; got: "
+                        + turn2Result);
+
+        // Sanity: turn 2 should also have its own responseId so a longer chain is
+        // possible (turn 3 → turn 2's id, etc.). Tested at the unit layer too, but
+        // surfacing here as well is cheap.
+        Object turn2ResponseId = turn2.getOutputData().get("responseId");
+        assertNotNull(turn2ResponseId, "turn 2 must also emit a ``responseId``");
+    }
+
+    // ====================================================================
+    // OpenAI — previousResponseId chained across DO_WHILE iterations
+    // ====================================================================
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+    public void openai_chat_previousResponseId_chain_inDoWhileLoop_recallsAcrossIterations() {
+        // Variant of openai_chat_previousResponseId_chainsAcrossTasks that lives *inside*
+        // a DO_WHILE. The loop body has two tasks per iteration:
+        //
+        //   1. chat (LLM_CHAT_COMPLETE)  — previousResponseId=${workflow.variables.lastResponseId}
+        //   2. update_state (SET_VARIABLE) — lastResponseId=${chat.output.responseId}
+        //
+        // Iteration N's chat resumes from iteration N-1's server-side context via the
+        // workflow-variable thread (the variable is reset between iterations by the
+        // sibling set_variable task). Auto loop-history injection is irrelevant here —
+        // no ``messages`` array is sent on any iteration; the model only "remembers"
+        // because the Responses-API server-side context store is being keyed by the
+        // chained responseId.
+        //
+        // Iteration script:
+        //   iter 1: "Remember the number 42." (no chain — bootstraps a new server context)
+        //   iter 2: "Remember the color blue."  (chains from iter 1)
+        //   iter 3: "What number and color did I tell you?" (chains from iter 2)
+        //
+        // The final iteration's result must mention both ``42`` and ``blue`` — proof
+        // that the chained context survived two hops through the workflow-variable
+        // thread + the OpenAI server-side store.
+        String wfName = "ai_e2e_openai_chat_prev_response_id_loop";
+        registerChainedLoopWorkflow(wfName);
+
+        Workflow wf =
+                runAndWait(
+                        wfName,
+                        Map.of(
+                                "llmProvider", "openai",
+                                "model", OPENAI_CHAT_MODEL,
+                                "prompts", CHAINED_LOOP_PROMPTS),
+                        180);
+
+        List<Task> chatTasks = chatTasks(wf);
+        assertEquals(
+                3,
+                chatTasks.size(),
+                "expected three LLM_CHAT_COMPLETE tasks (one per iteration); saw: "
+                        + chatTasks.size());
+
+        // Every iteration must surface its own responseId. If any are blank the
+        // chain breaks downstream.
+        for (Task t : chatTasks) {
+            Object rid = t.getOutputData().get("responseId");
+            assertNotNull(
+                    rid, "iteration " + t.getIteration() + " must emit a ``responseId``; got null");
+            assertFalse(
+                    rid.toString().isBlank(),
+                    "iteration " + t.getIteration() + " ``responseId`` must not be blank");
+        }
+
+        // Iterations 2+ must have received the prior iteration's responseId on their
+        // own previousResponseId input. Iteration 1 is the bootstrap and is allowed to
+        // be unchained (empty string is fine).
+        for (int i = 1; i < chatTasks.size(); i++) {
+            Task prior = chatTasks.get(i - 1);
+            Task current = chatTasks.get(i);
+            String priorResponseId = String.valueOf(prior.getOutputData().get("responseId"));
+            Object currentPrev = current.getInputData().get("previousResponseId");
+            assertEquals(
+                    priorResponseId,
+                    String.valueOf(currentPrev),
+                    "iteration "
+                            + current.getIteration()
+                            + " previousResponseId must equal iteration "
+                            + prior.getIteration()
+                            + "'s responseId; saw "
+                            + currentPrev);
+        }
+
+        // The headline assertion: iteration 3's answer must include both prior facts.
+        Task finalTurn = chatTasks.get(chatTasks.size() - 1);
+        String finalText = String.valueOf(finalTurn.getOutputData().get("result")).toLowerCase();
+        assertTrue(
+                finalText.contains("42"),
+                "iteration 3 must recall the number 42 from iter 1's context; got: " + finalText);
+        assertTrue(
+                finalText.contains("blue"),
+                "iteration 3 must recall the color blue from iter 2's context; got: " + finalText);
+    }
+
+    // ====================================================================
+    // Anthropic — Opus 4.7 + thinking in an agentic DO_WHILE
+    // ====================================================================
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+")
+    public void anthropic_opus_thinking_agentLoop_threadsWorkingStateAcrossIterations() {
+        // "Agent" pattern on top of Opus 4.7 + thinking. Anthropic providers declare
+        // supportsAssistantPrefill=false, so Conductor's auto loop-history injection
+        // is suppressed — each iteration's chat would otherwise see *only* its own
+        // messages and lose any context from prior iterations.
+        //
+        // To work around that, the loop body manually threads agent state through a
+        // workflow variable:
+        //
+        //   1. chat (LLM_CHAT_COMPLETE, Opus 4.7 + thinking, instructions reference
+        //      ${workflow.variables.workingState})
+        //   2. update_state (SET_VARIABLE) — workingState=${chat.output.result}
+        //
+        // The agent is given a multi-step calculation and asked to do ONE step per
+        // iteration, returning the running total. With workingState carrying the
+        // prior iteration's result forward, iteration 2 can pick up where iteration 1
+        // left off — proving the agent loop pattern works end-to-end with thinking
+        // enabled on an adaptive-only model.
+        //
+        // Problem: compute (3 + 4) × 2.
+        //   iter 1: 3 + 4 = 7   → workingState="7"
+        //   iter 2: 7 × 2 = 14  → workingState="14"
+        String wfName = "ai_e2e_anthropic_opus_thinking_agent_loop";
+        registerAgentLoopWorkflow(wfName, 2);
+
+        Workflow wf =
+                runAndWait(
+                        wfName,
+                        Map.of(
+                                "llmProvider",
+                                "anthropic",
+                                "model",
+                                ANTHROPIC_OPUS_THINKING_MODEL,
+                                "thinkingTokenLimit",
+                                4000),
+                        180);
+
+        List<Task> chatTasks = chatTasks(wf);
+        assertEquals(
+                2,
+                chatTasks.size(),
+                "expected two LLM_CHAT_COMPLETE tasks (one per iteration); saw: "
+                        + chatTasks.size());
+        for (Task t : chatTasks) {
+            assertEquals(
+                    Task.Status.COMPLETED,
+                    t.getStatus(),
+                    "iteration "
+                            + t.getIteration()
+                            + " must complete; reason: "
+                            + t.getReasonForIncompletion());
+        }
+
+        // Iteration 2 must have received iteration 1's result on its workingState
+        // input — this is the thread that makes the agent "remember" without
+        // relying on assistant-prefill auto-injection.
+        Task iter1 = chatTasks.get(0);
+        Task iter2 = chatTasks.get(1);
+        String iter1Result = String.valueOf(iter1.getOutputData().get("result"));
+        Object iter2WorkingState = iter2.getInputData().get("workingState");
+        assertEquals(
+                iter1Result,
+                String.valueOf(iter2WorkingState),
+                "iteration 2's ``workingState`` must equal iteration 1's chat result —"
+                        + " that's the agent state hand-off the test is asserting on");
+
+        // The headline: iteration 2's reply must reach the multi-step answer 14.
+        // Models do drift on phrasing; we don't pin "= 14" exactly, only that the
+        // number appears.
+        String iter2Result = String.valueOf(iter2.getOutputData().get("result"));
+        assertTrue(
+                iter2Result.contains("14"),
+                "iteration 2 must reach the multi-step answer 14 by acting on iter 1's"
+                        + " workingState; got: "
+                        + iter2Result);
+    }
+
+    // ====================================================================
+    // Workflow-def helpers
+    // ====================================================================
+
+    private void registerSingleTaskWorkflow(String name) {
+        ensureLLMChatCompleteTaskDef();
+        WorkflowTask chat = passThroughChatTask("chat");
+        WorkflowDef def = new WorkflowDef();
+        def.setName(name);
+        def.setVersion(1);
+        def.setOwnerEmail("ai-e2e@conductor.test");
+        def.setTasks(List.of(chat));
+        metadataClient.updateWorkflowDefs(List.of(def));
+    }
+
+    private void registerLoopWorkflow(String name, int iterations) {
+        ensureLLMChatCompleteTaskDef();
+        WorkflowTask chat = passThroughChatTask("chat");
+
+        WorkflowTask loop = new WorkflowTask();
+        loop.setName("loop");
+        loop.setTaskReferenceName("loop");
+        loop.setType(TaskType.DO_WHILE.name());
+        loop.setLoopCondition(
+                "if ( $.loop['iteration'] < " + iterations + " ) { true; } else { false; }");
+        loop.setLoopOver(List.of(chat));
+
+        WorkflowDef def = new WorkflowDef();
+        def.setName(name);
+        def.setVersion(1);
+        def.setOwnerEmail("ai-e2e@conductor.test");
+        def.setTasks(List.of(loop));
+        metadataClient.updateWorkflowDefs(List.of(def));
+    }
+
+    /**
+     * Workflow with a chat task whose {@code messages} input is wired to a fixed multi-turn
+     * conversation: system + user + assistant ("My name is Conductor") + user ("What's my name?").
+     * The model must recall the name from the assistant turn, which is the wire-level proof that
+     * the history array survived the mapper round-trip.
+     */
+    private void registerHistoryWorkflow(String name) {
+        ensureLLMChatCompleteTaskDef();
+
+        WorkflowTask chat = new WorkflowTask();
+        chat.setName("LLM_CHAT_COMPLETE");
+        chat.setTaskReferenceName("chat");
+        chat.setType("LLM_CHAT_COMPLETE");
+
+        List<Map<String, Object>> messages = new ArrayList<>();
+        messages.add(
+                Map.of("role", "system", "message", "You are a helpful and concise assistant."));
+        messages.add(Map.of("role", "user", "message", "My name is Conductor. Remember that."));
+        messages.add(
+                Map.of(
+                        "role",
+                        "assistant",
+                        "message",
+                        "Got it — I'll remember your name is Conductor."));
+        messages.add(Map.of("role", "user", "message", "What is my name?"));
+
+        Map<String, Object> inputParameters = new HashMap<>();
+        inputParameters.put("llmProvider", "${workflow.input.llmProvider}");
+        inputParameters.put("model", "${workflow.input.model}");
+        inputParameters.put("messages", messages);
+        chat.setInputParameters(inputParameters);
+
+        WorkflowDef def = new WorkflowDef();
+        def.setName(name);
+        def.setVersion(1);
+        def.setOwnerEmail("ai-e2e@conductor.test");
+        def.setTasks(List.of(chat));
+        metadataClient.updateWorkflowDefs(List.of(def));
+    }
+
+    /**
+     * Per-iteration prompts used by the chained-DO_WHILE test. Iteration 1 + 2 plant facts, and
+     * iteration 3 asks the model to recall them. The list length (3) determines the loop count
+     * because the workflow uses Conductor's list-iteration mode ({@code WorkflowTask.setItems}).
+     */
+    private static final List<String> CHAINED_LOOP_PROMPTS =
+            List.of(
+                    "Please remember the number 42. Just acknowledge.",
+                    "Please remember the color blue. Just acknowledge.",
+                    "What number and color did I tell you? Reply with both, no extra prose.");
+
+    /**
+     * DO_WHILE that threads {@code previousResponseId} across iterations via a workflow variable.
+     * Loop body per iteration:
+     *
+     * <ol>
+     *   <li>{@code chat} — reads {@code previousResponseId=${workflow.variables.lastResponseId}}
+     *       and {@code userInput=${loop.output.loopItem}} (the current prompt for this turn).
+     *   <li>{@code update_state} ({@code SET_VARIABLE}) — overwrites {@code lastResponseId} with
+     *       {@code ${chat.output.responseId}} so the next iteration's chat picks it up.
+     * </ol>
+     *
+     * <p>The DO_WHILE uses Conductor's list-iteration mode ({@code setItems}). The loop runs once
+     * per element in {@code ${workflow.input.prompts}}, and {@code DoWhile.injectLoopVariables}
+     * binds the current element to {@code loop.output.loopItem} on every iteration's scheduling
+     * pass — which is the clean way to vary the per-iteration prompt without arithmetic inside
+     * {@code ${...}} expressions.
+     *
+     * <p>{@code lastResponseId} is pre-seeded to "" so iteration 1 sees an unchained start rather
+     * than an unresolved placeholder.
+     */
+    private void registerChainedLoopWorkflow(String name) {
+        ensureLLMChatCompleteTaskDef();
+
+        // Pre-loop: seed workflow.variables.lastResponseId so iteration 1's chat sees an
+        // empty string (unchained start) rather than an unresolved ${...} placeholder.
+        WorkflowTask initVars = new WorkflowTask();
+        initVars.setName("set_variable");
+        initVars.setTaskReferenceName("init_vars");
+        initVars.setWorkflowTaskType(TaskType.SET_VARIABLE);
+        initVars.setInputParameters(Map.of("lastResponseId", ""));
+
+        WorkflowTask chat = new WorkflowTask();
+        chat.setName("LLM_CHAT_COMPLETE");
+        chat.setTaskReferenceName("chat");
+        chat.setType("LLM_CHAT_COMPLETE");
+        Map<String, Object> chatIn = new HashMap<>();
+        chatIn.put("llmProvider", "${workflow.input.llmProvider}");
+        chatIn.put("model", "${workflow.input.model}");
+        chatIn.put(
+                "instructions",
+                "You are a careful note-taker. Reply concisely. Do not invent details that"
+                        + " were not stated.");
+        // ``loop.output.loopItem`` is the current item from the items list — injected by
+        // DoWhile.injectLoopVariables on every iteration's scheduling pass.
+        chatIn.put("userInput", "${loop.output.loopItem}");
+        chatIn.put("previousResponseId", "${workflow.variables.lastResponseId}");
+        chat.setInputParameters(chatIn);
+
+        WorkflowTask updateState = new WorkflowTask();
+        updateState.setName("set_variable");
+        updateState.setTaskReferenceName("update_state");
+        updateState.setWorkflowTaskType(TaskType.SET_VARIABLE);
+        updateState.setInputParameters(Map.of("lastResponseId", "${chat.output.responseId}"));
+
+        WorkflowTask loop = new WorkflowTask();
+        loop.setName("loop");
+        loop.setTaskReferenceName("loop");
+        loop.setType(TaskType.DO_WHILE.name());
+        // List iteration via the Orkes-compatible ``_items`` inputParameter — the same
+        // ``DoWhile.isListIteration`` accepts either ``setItems(...)`` (newer OSS API) or
+        // ``inputParameters._items`` (legacy). We go through the latter because the e2e
+        // module depends on the published ``conductor-client:5.0.1`` JAR, which predates
+        // ``WorkflowTask.setItems``. The server resolves this at scheduling time.
+        loop.setInputParameters(Map.of("_items", "${workflow.input.prompts}"));
+        // The workflow-def validator requires a non-blank loopCondition on every DO_WHILE.
+        // List-iteration termination logic combines this with ``hasMoreItems`` (see
+        // ``DoWhile.evaluateCondition`` under ``isListIteration``) — a permissive ``true``
+        // here defers all stopping to the items list being consumed.
+        loop.setLoopCondition("true");
+        loop.setLoopOver(List.of(chat, updateState));
+
+        WorkflowDef def = new WorkflowDef();
+        def.setName(name);
+        def.setVersion(1);
+        def.setOwnerEmail("ai-e2e@conductor.test");
+        def.setTasks(List.of(initVars, loop));
+        metadataClient.updateWorkflowDefs(List.of(def));
+    }
+
+    /**
+     * Agentic DO_WHILE that hands a piece of "working state" forward across iterations using a
+     * sibling {@code SET_VARIABLE} task. Each iteration:
+     *
+     * <ol>
+     *   <li>{@code chat} — Opus 4.7 + thinking. The {@code instructions} field embeds {@code
+     *       ${workflow.variables.workingState}} so the model can see what the prior turn produced.
+     *   <li>{@code update_state} ({@code SET_VARIABLE}) — overwrites {@code workingState} with
+     *       {@code ${chat.output.result}}.
+     * </ol>
+     *
+     * <p>This is the manual-threading pattern documented in {@code AIReasoningEndToEndTest}'s
+     * loop-history javadoc: providers that reject assistant prefill (Anthropic 4.6+) must receive
+     * prior-iteration context through user-message templating, not via auto-injection.
+     */
+    private void registerAgentLoopWorkflow(String name, int iterations) {
+        ensureLLMChatCompleteTaskDef();
+
+        WorkflowTask initVars = new WorkflowTask();
+        initVars.setName("set_variable");
+        initVars.setTaskReferenceName("init_vars");
+        initVars.setWorkflowTaskType(TaskType.SET_VARIABLE);
+        initVars.setInputParameters(Map.of("workingState", ""));
+
+        WorkflowTask chat = new WorkflowTask();
+        chat.setName("LLM_CHAT_COMPLETE");
+        chat.setTaskReferenceName("chat");
+        chat.setType("LLM_CHAT_COMPLETE");
+        Map<String, Object> chatIn = new HashMap<>();
+        chatIn.put("llmProvider", "${workflow.input.llmProvider}");
+        chatIn.put("model", "${workflow.input.model}");
+        chatIn.put("thinkingTokenLimit", "${workflow.input.thinkingTokenLimit}");
+        chatIn.put(
+                "instructions",
+                "You are a step-by-step math agent. You will be asked to do ONE step of a"
+                        + " calculation each turn. On the first turn ``workingState`` is empty;"
+                        + " on later turns it carries the running total from the previous turn."
+                        + " Reply with just the new running total — a single number, no prose.");
+        chatIn.put(
+                "userInput",
+                "Compute (3 + 4) * 2 step by step. On turn 1 evaluate ``3 + 4``. On turn 2,"
+                        + " take the running total in workingState and multiply by 2.\nworkingState:"
+                        + " ${workflow.variables.workingState}");
+        // Also surface workingState as a top-level input so the test can read it back
+        // out of the task input for hand-off assertions.
+        chatIn.put("workingState", "${workflow.variables.workingState}");
+        chat.setInputParameters(chatIn);
+
+        WorkflowTask updateState = new WorkflowTask();
+        updateState.setName("set_variable");
+        updateState.setTaskReferenceName("update_state");
+        updateState.setWorkflowTaskType(TaskType.SET_VARIABLE);
+        updateState.setInputParameters(Map.of("workingState", "${chat.output.result}"));
+
+        WorkflowTask loop = new WorkflowTask();
+        loop.setName("loop");
+        loop.setTaskReferenceName("loop");
+        loop.setType(TaskType.DO_WHILE.name());
+        loop.setLoopCondition(
+                "if ( $.loop['iteration'] < " + iterations + " ) { true; } else { false; }");
+        loop.setLoopOver(List.of(chat, updateState));
+
+        WorkflowDef def = new WorkflowDef();
+        def.setName(name);
+        def.setVersion(1);
+        def.setOwnerEmail("ai-e2e@conductor.test");
+        def.setTasks(List.of(initVars, loop));
+        metadataClient.updateWorkflowDefs(List.of(def));
+    }
+
+    /**
+     * Two-task workflow that exercises OpenAI's Responses-API server-side context store. Task 1
+     * establishes context ("My name is Conductor"); task 2 references {@code
+     * ${turn1.output.responseId}} via {@code previousResponseId} so OpenAI looks up turn 1
+     * server-side rather than relying on a re-sent {@code messages} array.
+     *
+     * <p>Both tasks pull {@code llmProvider} + {@code model} from {@code workflow.input}, so the
+     * same definition can be flipped to another OpenAI model without re-registering.
+     */
+    private void registerChainedWorkflow(String name) {
+        ensureLLMChatCompleteTaskDef();
+
+        WorkflowTask turn1 = new WorkflowTask();
+        turn1.setName("LLM_CHAT_COMPLETE");
+        turn1.setTaskReferenceName("turn1");
+        turn1.setType("LLM_CHAT_COMPLETE");
+        Map<String, Object> turn1In = new HashMap<>();
+        turn1In.put("llmProvider", "${workflow.input.llmProvider}");
+        turn1In.put("model", "${workflow.input.model}");
+        turn1In.put("instructions", "You are a helpful assistant. Keep replies very short.");
+        turn1In.put(
+                "userInput",
+                "Please remember the following for the rest of this conversation: my name is"
+                        + " Conductor.");
+        turn1.setInputParameters(turn1In);
+
+        WorkflowTask turn2 = new WorkflowTask();
+        turn2.setName("LLM_CHAT_COMPLETE");
+        turn2.setTaskReferenceName("turn2");
+        turn2.setType("LLM_CHAT_COMPLETE");
+        Map<String, Object> turn2In = new HashMap<>();
+        turn2In.put("llmProvider", "${workflow.input.llmProvider}");
+        turn2In.put("model", "${workflow.input.model}");
+        turn2In.put("instructions", "You are a helpful assistant. Keep replies very short.");
+        // No local history. The follow-up question only resolves if the server-side
+        // Responses-API context store recalls turn 1 via previousResponseId.
+        turn2In.put("userInput", "What is my name?");
+        turn2In.put("previousResponseId", "${turn1.output.responseId}");
+        turn2.setInputParameters(turn2In);
+
+        WorkflowDef def = new WorkflowDef();
+        def.setName(name);
+        def.setVersion(1);
+        def.setOwnerEmail("ai-e2e@conductor.test");
+        def.setTasks(List.of(turn1, turn2));
+        metadataClient.updateWorkflowDefs(List.of(def));
+    }
+
+    /**
+     * Chat task that pulls every field from {@code workflow.input.*}. This lets each test reuse the
+     * same registration helper and vary inputs purely by what the {@link StartWorkflowRequest}
+     * carries — including optional ones like {@code thinkingTokenLimit}, {@code reasoningEffort},
+     * {@code reasoningSummary}, {@code jsonOutput}, and {@code tools}. Conductor's parameter
+     * binding leaves unresolved ${...} placeholders as null/false/empty when the input field is
+     * absent, so the inputs schema stays additive instead of combinatorial.
+     */
+    private WorkflowTask passThroughChatTask(String refName) {
+        WorkflowTask chat = new WorkflowTask();
+        chat.setName("LLM_CHAT_COMPLETE");
+        chat.setTaskReferenceName(refName);
+        chat.setType("LLM_CHAT_COMPLETE");
+
+        Map<String, Object> in = new HashMap<>();
+        in.put("llmProvider", "${workflow.input.llmProvider}");
+        in.put("model", "${workflow.input.model}");
+        in.put("instructions", "${workflow.input.instructions}");
+        in.put("userInput", "${workflow.input.userInput}");
+        in.put("thinkingTokenLimit", "${workflow.input.thinkingTokenLimit}");
+        in.put("reasoningEffort", "${workflow.input.reasoningEffort}");
+        in.put("reasoningSummary", "${workflow.input.reasoningSummary}");
+        in.put("jsonOutput", "${workflow.input.jsonOutput}");
+        in.put("tools", "${workflow.input.tools}");
+        chat.setInputParameters(in);
+        return chat;
+    }
+
+    private void ensureLLMChatCompleteTaskDef() {
+        TaskDef def = new TaskDef();
+        def.setName("LLM_CHAT_COMPLETE");
+        def.setRetryCount(0);
+        def.setTimeoutSeconds(180);
+        def.setOwnerEmail("ai-e2e@conductor.test");
+        try {
+            metadataClient.registerTaskDefs(List.of(def));
+        } catch (Exception ignore) {
+            // already registered from a prior run / parallel fork
+        }
+    }
+
+    // ====================================================================
+    // Tool spec helper
+    // ====================================================================
+
+    /**
+     * Standard weather tool used by both the Anthropic and OpenAI tool-calling tests so the
+     * comparison is apples-to-apples. The schema matches the shape both providers' adapters convert
+     * into their native tool definitions.
+     */
+    private static Map<String, Object> weatherTool() {
+        return Map.of(
+                "name", "get_weather",
+                "description", "Get the current weather for a location",
+                "inputSchema",
+                        Map.of(
+                                "type", "object",
+                                "properties",
+                                        Map.of(
+                                                "location",
+                                                Map.of(
+                                                        "type", "string",
+                                                        "description", "City name")),
+                                "required", List.of("location")));
+    }
+
+    // ====================================================================
+    // Workflow execution + assertion helpers
+    // ====================================================================
+
+    private Workflow runAndWait(String wfName, Map<String, Object> input, int maxSeconds) {
+        StartWorkflowRequest req = new StartWorkflowRequest();
+        req.setName(wfName);
+        req.setVersion(1);
+        req.setInput(input);
+        String workflowId = workflowClient.startWorkflow(req);
+        log.info("Started workflow name={} id={}", wfName, workflowId);
+
+        await().pollInterval(2, TimeUnit.SECONDS)
+                .atMost(maxSeconds, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            Workflow wf = workflowClient.getWorkflow(workflowId, true);
+                            assertNotNull(wf);
+                            assertNotNull(wf.getStatus());
+                            assertTrue(
+                                    wf.getStatus().isTerminal(),
+                                    "workflow not terminal yet: " + wf.getStatus());
+                        });
+
+        Workflow finished = workflowClient.getWorkflow(workflowId, true);
+        assertEquals(
+                Workflow.WorkflowStatus.COMPLETED,
+                finished.getStatus(),
+                "workflow must complete; tasks: " + finished.getTasks());
+        return finished;
+    }
+
+    private static void assertChatCompletedWithAnswer(Workflow wf, String expectedSubstring) {
+        Task chat =
+                wf.getTasks().stream()
+                        .filter(t -> "LLM_CHAT_COMPLETE".equals(t.getTaskType()))
+                        .findFirst()
+                        .orElseThrow(
+                                () -> new AssertionError("no LLM_CHAT_COMPLETE task in " + wf));
+        assertEquals(Task.Status.COMPLETED, chat.getStatus(), "chat task must complete");
+        Object result = chat.getOutputData().get("result");
+        assertNotNull(result, "expected `result` on task output");
+        assertTrue(
+                result.toString().contains(expectedSubstring),
+                "expected model output to contain '" + expectedSubstring + "'; got: " + result);
+    }
+
+    private static List<Task> chatTasks(Workflow wf) {
+        return wf.getTasks().stream()
+                .filter(t -> "LLM_CHAT_COMPLETE".equals(t.getTaskType()))
+                .toList();
+    }
+}


### PR DESCRIPTION
## Summary

- Claude Opus 4.7 rejects the legacy `thinking.type=enabled` + `budget_tokens` request shape with HTTP 400. The Anthropic adapter now rewrites `thinkingTokenLimit` into `thinking.type=adaptive` + `output_config.effort` whenever the target model is Opus 4.7; Sonnet/Opus 4.6 and earlier keep the legacy shape.
- `reasoningEffort` from `ChatCompletion` is now forwarded into `output_config.effort` on every Anthropic model — callers can tune token spend without engaging thinking.
- Adds 27 new AI-module unit tests (LLMHelper / LLMWorkers) lifting `ai` package line coverage 16→45 % and `tasks.worker` 15→40 % (module overall 45→49 %).
- Adds a 14-test live e2e matrix (`e2e/.../LLMChatCompleteTests`) against the in-tree server: single chat / multi-turn history / tools / JSON output / reasoning model / `previousResponseId` chaining (incl. inside `DO_WHILE`) / Opus 4.7 + thinking LLM-in-loop regression / agentic Opus 4.7 + thinking `DO_WHILE` that threads working state via `SET_VARIABLE`.
- `docker-compose-postgres(-e2e).yaml` forwards `ANTHROPIC_API_KEY` + `OPENAI_API_KEY` into the conductor-server container so the e2e tests run consistently when keys are set on the host. Tests self-skip via `@EnabledIfEnvironmentVariable` when their key isn't set.

## Production failure this fixes

```
Task execution failed: Anthropic Messages API call failed with status 400:
{
  "type": "error",
  "error": {
    "type": "invalid_request_error",
    "message": "\"thinking.type.enabled\" is not supported for this model. Use \"thinking.type.adaptive\" and \"output_config.effort\" to control thinking behavior."
  }
}
```

The fix is minimal and version-bracketed: `AnthropicChatModel.requiresAdaptiveThinking(modelId)` gates the rewrite to `claude-opus-4-7` (and any future variant whose id contains that substring). Older models keep their existing code path bit-for-bit.

## Test plan

- [x] `:conductor-ai:test` — 562 / 564 passing (the two `MongoVectorDBTest` / `JDBCEndToEndTest` failures need a running Docker daemon and fail identically on `main`).
- [x] Live Anthropic integration tests (`AIModelIntegrationTest.AnthropicTests` + `AnthropicTest`) pass against the real API with `ANTHROPIC_API_KEY` set, including the Opus 4.7 regression cases.
- [x] e2e suite `LLMChatCompleteTests` — 14 / 14 passing against the in-tree `:conductor-server:bootRun` with both `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` set.
- [x] Spotless + compile clean on `:conductor-ai`, `:conductor-server`, `:conductor-e2e`.
- [ ] Reviewer: run `ANTHROPIC_API_KEY=... ./gradlew :conductor-ai:test --tests "*AIModelIntegrationTest*AnthropicTests*"` to reproduce locally.
- [ ] Reviewer: run the full e2e suite via `./e2e/run_tests-postgres.sh` (with both keys in the host shell) to exercise the docker-compose pass-through and the server-side path.