### PR TITLE
test(e2e): raise nested rerun await to 30s for sub-workflow propagation

### DIFF
--- a/e2e/src/test/java/io/conductor/e2e/workflow/WorkflowRerunTests.java
+++ b/e2e/src/test/java/io/conductor/e2e/workflow/WorkflowRerunTests.java
@@ -1591,7 +1591,10 @@ public class WorkflowRerunTests {
             Workflow newSubWf2 = workflowClient.getWorkflow(newSubWfId2, true);
             completeTask(newSubWf2.getTasks().get(0), TaskResult.Status.COMPLETED);
 
-            await().atMost(10, TimeUnit.SECONDS)
+            // Wait must cover a multi-hop propagation: inner SIMPLE COMPLETED -> sub_wf_fork2
+            // sub-workflow completion (driven by sweeper) -> JOIN evaluation -> parent schedules
+            // simpleTaskAfter. Under parallel e2e load this can exceed 10s.
+            await().atMost(30, TimeUnit.SECONDS)
                     .untilAsserted(
                             () -> {
                                 Workflow wf = workflowClient.getWorkflow(workflowId, true);


### PR DESCRIPTION
## Summary

- Single-line timeout bump in `WorkflowRerunTests > Rerun from inner task of SUB_WORKFLOW in FORK branch` to fix consistent CI flakiness ([example failed run](https://github.com/conductor-oss/conductor/actions/runs/26265452701)).
- The assertion at `WorkflowRerunTests.java:1598` waits for `simpleTaskAfter` to be scheduled after completing the inner task of `sub_wf_fork2`. That requires a multi-hop cascade — inner SIMPLE COMPLETED → `sub_wf_fork2` sub-workflow status update (driven by the sub-workflow sweeper) → JOIN evaluation → parent decider schedules `simpleTaskAfter` — which routinely exceeds 10 s when the e2e suite runs with several Gradle test executors in parallel hitting the same server. The test passes on re-run because the second run hits a less-contended scheduler.
- Bumping just the affected await to 30 s; not touching the other 10 s awaits in this test since they're not the ones timing out.

## Test plan

- [ ] CI `e2e (redis-es8)` passes on this PR
- [ ] Re-running CI also passes (no regression in the happy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)