### PR TITLE
feat: add scheduled workflow history cleaner

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/SchedulerConfiguration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/SchedulerConfiguration.java
@@ -67,7 +67,7 @@ public class SchedulerConfiguration implements SchedulingConfigurer {
     @Override
     public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
         ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
-        threadPoolTaskScheduler.setPoolSize(3); // equal to the number of scheduled jobs
+        threadPoolTaskScheduler.setPoolSize(4); // equal to the number of scheduled jobs
         threadPoolTaskScheduler.setThreadNamePrefix("scheduled-task-pool-");
         threadPoolTaskScheduler.initialize();
         taskRegistrar.setTaskScheduler(threadPoolTaskScheduler);

--- a/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowHistoryCleaner.java
+++ b/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowHistoryCleaner.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.reconciliation;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.core.env.Environment;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.netflix.conductor.core.LifecycleAwareComponent;
+import com.netflix.conductor.core.dal.ExecutionDAOFacade;
+import com.netflix.conductor.core.sync.Lock;
+import com.netflix.conductor.dao.IndexDAO;
+import com.netflix.conductor.metrics.Monitors;
+
+/**
+ * Periodically removes terminal workflows (and their tasks) that are older than the configured
+ * retention window.
+ *
+ * <p>The batch is intentionally thin: it pages over candidate ids using {@link
+ * IndexDAO#searchArchivableWorkflows(String, long)} and delegates the actual removal to {@link
+ * ExecutionDAOFacade#removeWorkflow(String, boolean)}, which already coordinates the execution
+ * store and the search index in the right order.
+ *
+ * <p>Distributed safety is provided by the pluggable {@link Lock} abstraction so only one instance
+ * runs per scheduling tick — failed acquisitions back off immediately rather than queueing. The
+ * batch implements {@link LifecycleAwareComponent} so an in-flight run aborts cooperatively when
+ * the Spring context begins to stop.
+ *
+ * <p>Rolling indices such as {@code conductor_task_log_*}, {@code conductor_event_*} and {@code
+ * conductor_message_*} are out of scope; manage their retention through index-level lifecycle
+ * policies (e.g. OpenSearch ISM) instead.
+ *
+ * <p>The component is disabled unless {@code conductor.workflow-history-cleanup.enabled=true}.
+ */
+@Component
+@EnableConfigurationProperties(WorkflowHistoryCleanupProperties.class)
+@ConditionalOnProperty(name = "conductor.workflow-history-cleanup.enabled", havingValue = "true")
+public class WorkflowHistoryCleaner extends LifecycleAwareComponent {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WorkflowHistoryCleaner.class);
+
+    private final ExecutionDAOFacade executionDAOFacade;
+    private final IndexDAO indexDAO;
+    private final Lock lock;
+    private final WorkflowHistoryCleanupProperties properties;
+    private final String workflowIndexName;
+
+    public WorkflowHistoryCleaner(
+            ExecutionDAOFacade executionDAOFacade,
+            IndexDAO indexDAO,
+            Lock lock,
+            WorkflowHistoryCleanupProperties properties,
+            Environment environment) {
+        this.executionDAOFacade = executionDAOFacade;
+        this.indexDAO = indexDAO;
+        this.lock = lock;
+        this.properties = properties;
+        this.workflowIndexName = resolveWorkflowIndexName(properties, environment);
+        LOGGER.info(
+                "WorkflowHistoryCleaner initialized. retentionDays={}, catchUpDays={}, cron='{} ({})', indexName={}",
+                properties.getRetentionDays(),
+                properties.getCatchUpDays(),
+                properties.getCron(),
+                properties.getZone(),
+                workflowIndexName);
+    }
+
+    @Scheduled(
+            cron = "${conductor.workflow-history-cleanup.cron:0 0 * * * *}",
+            zone = "${conductor.workflow-history-cleanup.zone:UTC}")
+    public void cleanup() {
+        // The trigger can still fire just after the ApplicationContext signals stop(); bail out
+        // before touching the lock so a shutting-down node never extends its workload.
+        if (!isRunning()) {
+            LOGGER.debug("Component stopped, skip workflow history cleanup");
+            return;
+        }
+        // Even if every instance fires at the same time, a single winner is enough. Losers exit
+        // immediately rather than queueing on the lock.
+        if (!tryLock()) {
+            LOGGER.info("Another instance holds the cleanup lock; skipping this run.");
+            return;
+        }
+        long started = System.currentTimeMillis();
+        int totalDeleted = 0;
+        int totalFailed = 0;
+        try {
+            int retentionDays = properties.getRetentionDays();
+            int catchUpDays = Math.max(1, properties.getCatchUpDays());
+
+            for (int offset = 0; offset < catchUpDays; offset++) {
+                if (!isRunning()) {
+                    LOGGER.info(
+                            "Component stopping mid-run; aborting after processing {} day(s)",
+                            offset);
+                    break;
+                }
+                long ttlDays = (long) retentionDays + offset;
+                DayResult r = cleanupOneDay(ttlDays);
+                totalDeleted += r.deleted;
+                totalFailed += r.failed;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.warn("Cleanup interrupted.");
+        } catch (Exception e) {
+            LOGGER.error("Unexpected error during workflow history cleanup", e);
+            Monitors.error(WorkflowHistoryCleaner.class.getSimpleName(), "cleanup");
+        } finally {
+            try {
+                lock.releaseLock(properties.getLockId());
+            } catch (Exception e) {
+                LOGGER.warn("Failed to release cleanup lock", e);
+            }
+            LOGGER.info(
+                    "Workflow history cleanup finished in {}ms. deleted={}, failed={}",
+                    System.currentTimeMillis() - started,
+                    totalDeleted,
+                    totalFailed);
+        }
+    }
+
+    private DayResult cleanupOneDay(long ttlDays) throws InterruptedException {
+        DayResult result = new DayResult();
+        RecentIdCache processed = new RecentIdCache(properties.getProcessedCacheSize());
+        int noProgress = 0;
+        long batchPauseMillis = properties.getBatchPause().toMillis();
+        long refreshWaitMillis = properties.getIndexRefreshWait().toMillis();
+        int maxIterations = Math.max(1, properties.getMaxIterationsPerDay());
+
+        for (int iteration = 0; iteration < maxIterations; iteration++) {
+            if (!isRunning()) {
+                break;
+            }
+            List<String> candidates =
+                    indexDAO.searchArchivableWorkflows(workflowIndexName, ttlDays);
+            if (candidates == null || candidates.isEmpty()) {
+                break;
+            }
+
+            List<String> toProcess = new ArrayList<>(candidates.size());
+            for (String id : candidates) {
+                if (!processed.contains(id)) {
+                    toProcess.add(id);
+                }
+            }
+
+            if (toProcess.isEmpty()) {
+                // Same ids came back — the asynchronous index delete has not landed yet. Sleep
+                // once and retry, but bail after a few consecutive no-progress passes to avoid
+                // burning the iteration budget on a stuck cluster.
+                noProgress++;
+                if (noProgress >= 3) {
+                    LOGGER.debug(
+                            "Stopping day ttlDays={} after {} no-progress iterations",
+                            ttlDays,
+                            noProgress);
+                    break;
+                }
+                Thread.sleep(refreshWaitMillis);
+                continue;
+            }
+            noProgress = 0;
+
+            for (String id : toProcess) {
+                if (!isRunning()) {
+                    break;
+                }
+                try {
+                    executionDAOFacade.removeWorkflow(id, false);
+                    result.deleted++;
+                } catch (Exception e) {
+                    result.failed++;
+                    LOGGER.warn(
+                            "Failed to remove workflow {} during history cleanup: {}",
+                            id,
+                            e.getMessage());
+                    Monitors.error(WorkflowHistoryCleaner.class.getSimpleName(), "removeWorkflow");
+                }
+                // Mark even failures as processed so a transient error does not pin the batch.
+                processed.add(id);
+            }
+
+            if (batchPauseMillis > 0) {
+                Thread.sleep(batchPauseMillis);
+            }
+        }
+
+        if (result.deleted > 0 || result.failed > 0) {
+            LOGGER.info(
+                    "Cleanup day ttlDays={} -> deleted={}, failed={}",
+                    ttlDays,
+                    result.deleted,
+                    result.failed);
+        }
+        return result;
+    }
+
+    /**
+     * Non-blocking lock acquisition: {@code timeToTry=0} so the call returns immediately on
+     * contention. Lock implementations that ignore {@code leaseTime} (for example, those backed by
+     * Redis registries with a fixed TTL) still get the configured value passed for clarity.
+     */
+    private boolean tryLock() {
+        try {
+            boolean acquired =
+                    lock.acquireLock(
+                            properties.getLockId(),
+                            0L,
+                            properties.getLockLeaseTime().toMillis(),
+                            TimeUnit.MILLISECONDS);
+            if (!acquired) {
+                Monitors.recordAcquireLockUnsuccessful();
+            }
+            return acquired;
+        } catch (Exception e) {
+            Monitors.recordAcquireLockFailure(e.getClass().getName());
+            LOGGER.warn("Failed to acquire cleanup lock", e);
+            return false;
+        }
+    }
+
+    private static String resolveWorkflowIndexName(
+            WorkflowHistoryCleanupProperties props, Environment env) {
+        if (StringUtils.isNotBlank(props.getWorkflowIndexName())) {
+            return props.getWorkflowIndexName();
+        }
+        String prefix =
+                env.getProperty("conductor.elasticsearch.index-prefix", String.class, "conductor");
+        return prefix + "_workflow";
+    }
+
+    private static final class DayResult {
+        int deleted;
+        int failed;
+    }
+
+    /**
+     * Fixed-size LRU keyed by workflow id. Insertion-order eviction keeps memory bounded even when
+     * a backlog of millions of workflows needs to drain.
+     */
+    private static final class RecentIdCache {
+
+        private final LinkedHashMap<String, Boolean> map;
+
+        RecentIdCache(int maxSize) {
+            final int capacity = Math.max(1, maxSize);
+            this.map =
+                    new LinkedHashMap<>(Math.min(16, capacity), 0.75f, false) {
+                        @Override
+                        protected boolean removeEldestEntry(Map.Entry<String, Boolean> eldest) {
+                            return size() > capacity;
+                        }
+                    };
+        }
+
+        boolean contains(String id) {
+            return map.containsKey(id);
+        }
+
+        void add(String id) {
+            map.put(id, Boolean.TRUE);
+        }
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowHistoryCleanupProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowHistoryCleanupProperties.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.reconciliation;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationUnit;
+
+@ConfigurationProperties("conductor.workflow-history-cleanup")
+public class WorkflowHistoryCleanupProperties {
+
+    /** Master switch for the cleanup batch. Disabled by default. */
+    private boolean enabled = false;
+
+    /** Cron expression that drives the cleanup batch. Defaults to top-of-the-hour. */
+    private String cron = "0 0 * * * *";
+
+    /** Time zone used to interpret the cron expression. */
+    private String zone = "UTC";
+
+    /**
+     * Retention window (in days). Terminal workflows whose endTime is older than this threshold are
+     * eligible for deletion. {@link
+     * com.netflix.conductor.dao.IndexDAO#searchArchivableWorkflows(String, long)} returns a one-day
+     * window per call, so this value is treated as the lower bound of the iteration loop.
+     */
+    private int retentionDays = 30;
+
+    /**
+     * Number of additional days to catch up on, starting from {@code retentionDays}. Because the
+     * underlying index query is bucketed by day, the batch walks the range {@code [retentionDays,
+     * retentionDays + catchUpDays - 1]}. This lets a single run recover from missed schedules. To
+     * do a one-time backfill of historical data, temporarily set this to a large value (e.g. 3650)
+     * and then restore the default after the initial drain.
+     */
+    private int catchUpDays = 7;
+
+    /**
+     * Hard cap on iterations per day to prevent infinite loops. Each iteration removes at most
+     * ~1000 rows.
+     */
+    private int maxIterationsPerDay = 200;
+
+    /**
+     * Size of the LRU cache that tracks recently-processed workflow ids. The index query typically
+     * returns the same page until the asynchronous index delete catches up; the cache prevents
+     * redundant delete attempts in that window. Sized for the page size (~1000) with headroom.
+     */
+    private int processedCacheSize = 5_000;
+
+    /** Pause between iterations to spread DB / index load. */
+    @DurationUnit(ChronoUnit.MILLIS)
+    private Duration batchPause = Duration.ofMillis(500);
+
+    /**
+     * Wait inserted when the same ids keep coming back, to give the asynchronous index removal a
+     * chance to land. Bounded by {@code maxIterationsPerDay}.
+     */
+    @DurationUnit(ChronoUnit.MILLIS)
+    private Duration indexRefreshWait = Duration.ofSeconds(2);
+
+    /**
+     * Identifier passed to {@link com.netflix.conductor.core.sync.Lock} when acquiring the cleanup
+     * lock.
+     */
+    private String lockId = "workflow-history-cleanup";
+
+    /**
+     * Upper bound on lock holding time. If the batch ever exceeds this, another instance may take
+     * over, so give it some headroom over the expected runtime.
+     */
+    private Duration lockLeaseTime = Duration.ofHours(2);
+
+    /**
+     * Name of the OpenSearch / Elasticsearch index that holds workflow documents. Leave blank to
+     * compose it from {@code conductor.elasticsearch.index-prefix} as {@code {prefix}_workflow}.
+     */
+    private String workflowIndexName = "";
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getCron() {
+        return cron;
+    }
+
+    public void setCron(String cron) {
+        this.cron = cron;
+    }
+
+    public String getZone() {
+        return zone;
+    }
+
+    public void setZone(String zone) {
+        this.zone = zone;
+    }
+
+    public int getRetentionDays() {
+        return retentionDays;
+    }
+
+    public void setRetentionDays(int retentionDays) {
+        this.retentionDays = retentionDays;
+    }
+
+    public int getCatchUpDays() {
+        return catchUpDays;
+    }
+
+    public void setCatchUpDays(int catchUpDays) {
+        this.catchUpDays = catchUpDays;
+    }
+
+    public int getMaxIterationsPerDay() {
+        return maxIterationsPerDay;
+    }
+
+    public void setMaxIterationsPerDay(int maxIterationsPerDay) {
+        this.maxIterationsPerDay = maxIterationsPerDay;
+    }
+
+    public int getProcessedCacheSize() {
+        return processedCacheSize;
+    }
+
+    public void setProcessedCacheSize(int processedCacheSize) {
+        this.processedCacheSize = processedCacheSize;
+    }
+
+    public Duration getBatchPause() {
+        return batchPause;
+    }
+
+    public void setBatchPause(Duration batchPause) {
+        this.batchPause = batchPause;
+    }
+
+    public Duration getIndexRefreshWait() {
+        return indexRefreshWait;
+    }
+
+    public void setIndexRefreshWait(Duration indexRefreshWait) {
+        this.indexRefreshWait = indexRefreshWait;
+    }
+
+    public String getLockId() {
+        return lockId;
+    }
+
+    public void setLockId(String lockId) {
+        this.lockId = lockId;
+    }
+
+    public Duration getLockLeaseTime() {
+        return lockLeaseTime;
+    }
+
+    public void setLockLeaseTime(Duration lockLeaseTime) {
+        this.lockLeaseTime = lockLeaseTime;
+    }
+
+    public String getWorkflowIndexName() {
+        return workflowIndexName;
+    }
+
+    public void setWorkflowIndexName(String workflowIndexName) {
+        this.workflowIndexName = workflowIndexName;
+    }
+}

--- a/core/src/test/java/com/netflix/conductor/core/reconciliation/TestWorkflowHistoryCleaner.java
+++ b/core/src/test/java/com/netflix/conductor/core/reconciliation/TestWorkflowHistoryCleaner.java
@@ -1,0 +1,410 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.reconciliation;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.springframework.core.env.Environment;
+
+import com.netflix.conductor.core.dal.ExecutionDAOFacade;
+import com.netflix.conductor.core.sync.Lock;
+import com.netflix.conductor.dao.IndexDAO;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestWorkflowHistoryCleaner {
+
+    private ExecutionDAOFacade executionDAOFacade;
+    private IndexDAO indexDAO;
+    private Lock lock;
+    private WorkflowHistoryCleanupProperties properties;
+    private Environment environment;
+
+    @Before
+    public void setUp() {
+        executionDAOFacade = mock(ExecutionDAOFacade.class);
+        indexDAO = mock(IndexDAO.class);
+        lock = mock(Lock.class);
+
+        properties = new WorkflowHistoryCleanupProperties();
+        properties.setEnabled(true);
+        properties.setRetentionDays(30);
+        properties.setCatchUpDays(2);
+        properties.setMaxIterationsPerDay(20);
+        properties.setBatchPause(Duration.ZERO);
+        properties.setIndexRefreshWait(Duration.ZERO);
+        properties.setLockLeaseTime(Duration.ofMinutes(10));
+        properties.setProcessedCacheSize(5_000);
+
+        environment = mock(Environment.class);
+        when(environment.getProperty(
+                        eq("conductor.elasticsearch.index-prefix"), eq(String.class), anyString()))
+                .thenReturn("conductor");
+    }
+
+    private WorkflowHistoryCleaner newCleaner() {
+        WorkflowHistoryCleaner cleaner =
+                new WorkflowHistoryCleaner(
+                        executionDAOFacade, indexDAO, lock, properties, environment);
+        // LifecycleAwareComponent extends SmartLifecycle; isRunning() returns true only after
+        // start().
+        cleaner.start();
+        return cleaner;
+    }
+
+    @Test
+    public void usesIndexPrefixToComposeIndexName() {
+        when(lock.acquireLock(anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenReturn(true);
+        when(indexDAO.searchArchivableWorkflows(anyString(), anyLong()))
+                .thenReturn(Collections.emptyList());
+
+        newCleaner().cleanup();
+
+        // retentionDays(30) + catchUpDays(2) iterates ttlDays 30 and 31.
+        verify(indexDAO, times(1)).searchArchivableWorkflows("conductor_workflow", 30L);
+        verify(indexDAO, times(1)).searchArchivableWorkflows("conductor_workflow", 31L);
+    }
+
+    @Test
+    public void honorsExplicitIndexName() {
+        properties.setWorkflowIndexName("my_custom_workflow");
+        when(lock.acquireLock(anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenReturn(true);
+        when(indexDAO.searchArchivableWorkflows(anyString(), anyLong()))
+                .thenReturn(Collections.emptyList());
+
+        newCleaner().cleanup();
+
+        verify(indexDAO).searchArchivableWorkflows(eq("my_custom_workflow"), eq(30L));
+    }
+
+    @Test
+    public void deletesAllReturnedWorkflowsAndReleasesLock() {
+        when(lock.acquireLock(anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenReturn(true);
+        // First call returns two candidates, subsequent calls are empty.
+        when(indexDAO.searchArchivableWorkflows("conductor_workflow", 30L))
+                .thenReturn(Arrays.asList("wf-1", "wf-2"))
+                .thenReturn(Collections.emptyList());
+        when(indexDAO.searchArchivableWorkflows("conductor_workflow", 31L))
+                .thenReturn(Collections.emptyList());
+
+        newCleaner().cleanup();
+
+        verify(executionDAOFacade).removeWorkflow("wf-1", false);
+        verify(executionDAOFacade).removeWorkflow("wf-2", false);
+        verify(lock).releaseLock(properties.getLockId());
+    }
+
+    @Test
+    public void skipsRunWhenLockCannotBeAcquired() {
+        when(lock.acquireLock(anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenReturn(false);
+
+        newCleaner().cleanup();
+
+        verify(indexDAO, never()).searchArchivableWorkflows(anyString(), anyLong());
+        verify(executionDAOFacade, never()).removeWorkflow(anyString(), eq(false));
+        // The losing instance must not release the lock or it would break the winner's hold.
+        verify(lock, never()).releaseLock(anyString());
+    }
+
+    @Test
+    public void usesNonBlockingTryLockSemantics() {
+        when(lock.acquireLock(anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenReturn(true);
+        when(indexDAO.searchArchivableWorkflows(anyString(), anyLong()))
+                .thenReturn(Collections.emptyList());
+
+        newCleaner().cleanup();
+
+        // timeToTry must be 0L so a contending instance returns immediately instead of queueing.
+        verify(lock)
+                .acquireLock(
+                        eq(properties.getLockId()), eq(0L), anyLong(), eq(TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void continuesAfterRemoveWorkflowFailure() {
+        when(lock.acquireLock(anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenReturn(true);
+        when(indexDAO.searchArchivableWorkflows("conductor_workflow", 30L))
+                .thenReturn(Arrays.asList("wf-bad", "wf-good"))
+                .thenReturn(Collections.emptyList());
+        when(indexDAO.searchArchivableWorkflows("conductor_workflow", 31L))
+                .thenReturn(Collections.emptyList());
+        doThrow(new RuntimeException("boom"))
+                .when(executionDAOFacade)
+                .removeWorkflow("wf-bad", false);
+
+        newCleaner().cleanup();
+
+        verify(executionDAOFacade).removeWorkflow("wf-bad", false);
+        verify(executionDAOFacade).removeWorkflow("wf-good", false);
+        verify(lock).releaseLock(properties.getLockId());
+    }
+
+    @Test
+    public void skipsWorkflowsAlreadyProcessedWhenIndexRemovalIsAsync() {
+        when(lock.acquireLock(anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenReturn(true);
+
+        // The async index delete lags, so the same ids keep coming back from the search.
+        when(indexDAO.searchArchivableWorkflows("conductor_workflow", 30L))
+                .thenReturn(Arrays.asList("wf-a", "wf-b"))
+                .thenReturn(Arrays.asList("wf-a", "wf-b"))
+                .thenReturn(Arrays.asList("wf-a", "wf-b"))
+                .thenReturn(Collections.emptyList());
+        when(indexDAO.searchArchivableWorkflows("conductor_workflow", 31L))
+                .thenReturn(Collections.emptyList());
+
+        newCleaner().cleanup();
+
+        verify(executionDAOFacade, times(1)).removeWorkflow("wf-a", false);
+        verify(executionDAOFacade, times(1)).removeWorkflow("wf-b", false);
+    }
+
+    @Test
+    public void iteratesOverCatchUpRange() {
+        properties.setRetentionDays(30);
+        properties.setCatchUpDays(5);
+
+        when(lock.acquireLock(anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenReturn(true);
+
+        Set<Long> seenTtlDays = new HashSet<>();
+        when(indexDAO.searchArchivableWorkflows(anyString(), anyLong()))
+                .thenAnswer(
+                        (InvocationOnMock inv) -> {
+                            seenTtlDays.add(inv.getArgument(1, Long.class));
+                            return Collections.<String>emptyList();
+                        });
+
+        newCleaner().cleanup();
+
+        assertEquals(new HashSet<>(Arrays.asList(30L, 31L, 32L, 33L, 34L)), seenTtlDays);
+    }
+
+    @Test
+    public void boundsRecentIdCacheSoEvictedIdsGetReprocessed() {
+        // Force the cache to size 2. When the async index delete lags, the oldest id (wf-a) is
+        // evicted by the time the next page lands, so it should be retried.
+        properties.setProcessedCacheSize(2);
+        properties.setMaxIterationsPerDay(10);
+
+        when(lock.acquireLock(anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenReturn(true);
+        when(indexDAO.searchArchivableWorkflows("conductor_workflow", 30L))
+                .thenReturn(Arrays.asList("wf-a", "wf-b", "wf-c"))
+                .thenReturn(Arrays.asList("wf-a", "wf-b", "wf-c"))
+                .thenReturn(Collections.emptyList());
+        when(indexDAO.searchArchivableWorkflows("conductor_workflow", 31L))
+                .thenReturn(Collections.emptyList());
+
+        newCleaner().cleanup();
+
+        verify(executionDAOFacade, times(2)).removeWorkflow("wf-a", false);
+        verify(executionDAOFacade, times(1)).removeWorkflow("wf-b", false);
+        verify(executionDAOFacade, times(1)).removeWorkflow("wf-c", false);
+    }
+
+    @Test
+    public void tryLockReturnsFalseWhenAcquireLockThrows() {
+        // A lock client throwing (e.g. Redis connection drop) must not leak the exception or NPE
+        // into the caller.
+        when(lock.acquireLock(anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenThrow(new RuntimeException("lock client unavailable"));
+
+        newCleaner().cleanup();
+
+        verify(indexDAO, never()).searchArchivableWorkflows(anyString(), anyLong());
+        verify(executionDAOFacade, never()).removeWorkflow(anyString(), eq(false));
+        verify(lock, never()).releaseLock(anyString());
+    }
+
+    @Test
+    public void releasesLockEvenWhenCleanupBodyThrows() {
+        when(lock.acquireLock(anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenReturn(true);
+        when(indexDAO.searchArchivableWorkflows(anyString(), anyLong()))
+                .thenThrow(new RuntimeException("index unavailable"));
+
+        newCleaner().cleanup();
+
+        verify(lock).releaseLock(properties.getLockId());
+    }
+
+    @Test
+    public void swallowsExceptionFromReleaseLock() {
+        // releaseLock may throw (for example if the lock has already expired); the caller must
+        // not see that exception.
+        when(lock.acquireLock(anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenReturn(true);
+        when(indexDAO.searchArchivableWorkflows(anyString(), anyLong()))
+                .thenReturn(Collections.emptyList());
+        doThrow(new IllegalStateException("Lock released due to expiration"))
+                .when(lock)
+                .releaseLock(anyString());
+
+        newCleaner().cleanup();
+
+        verify(lock).releaseLock(properties.getLockId());
+    }
+
+    @Test
+    public void treatsNullCandidatesAsEmpty() {
+        // An IndexDAO returning null must not NPE; the batch advances to the next ttlDays bucket.
+        when(lock.acquireLock(anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenReturn(true);
+        when(indexDAO.searchArchivableWorkflows(anyString(), anyLong())).thenReturn(null);
+
+        newCleaner().cleanup();
+
+        verify(executionDAOFacade, never()).removeWorkflow(anyString(), eq(false));
+        verify(lock).releaseLock(properties.getLockId());
+    }
+
+    @Test
+    public void treatsNonPositiveCatchUpDaysAsSingleDay() {
+        // Misconfigured catchUpDays (0 or negative) must still process at least the retention day.
+        properties.setCatchUpDays(0);
+        when(lock.acquireLock(anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenReturn(true);
+        when(indexDAO.searchArchivableWorkflows(anyString(), anyLong()))
+                .thenReturn(Collections.emptyList());
+
+        newCleaner().cleanup();
+
+        verify(indexDAO, times(1)).searchArchivableWorkflows("conductor_workflow", 30L);
+        verify(indexDAO, never()).searchArchivableWorkflows("conductor_workflow", 31L);
+    }
+
+    @Test
+    public void handlesNonPositiveProcessedCacheSizeGracefully() {
+        // processedCacheSize=0 should be clamped to capacity=1 instead of producing an NPE.
+        properties.setProcessedCacheSize(0);
+        when(lock.acquireLock(anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenReturn(true);
+        when(indexDAO.searchArchivableWorkflows("conductor_workflow", 30L))
+                .thenReturn(Arrays.asList("wf-a", "wf-b"))
+                .thenReturn(Collections.emptyList());
+        when(indexDAO.searchArchivableWorkflows("conductor_workflow", 31L))
+                .thenReturn(Collections.emptyList());
+
+        newCleaner().cleanup();
+
+        verify(executionDAOFacade).removeWorkflow("wf-a", false);
+        verify(executionDAOFacade).removeWorkflow("wf-b", false);
+    }
+
+    @Test
+    public void skipsRunWhenComponentStopped() {
+        // After SmartLifecycle.stop() the trigger may still fire; the batch must not even attempt
+        // the lock.
+        WorkflowHistoryCleaner cleaner =
+                new WorkflowHistoryCleaner(
+                        executionDAOFacade, indexDAO, lock, properties, environment);
+        cleaner.start();
+        cleaner.stop();
+
+        cleaner.cleanup();
+
+        verify(lock, never()).acquireLock(anyString(), anyLong(), anyLong(), any(TimeUnit.class));
+        verify(indexDAO, never()).searchArchivableWorkflows(anyString(), anyLong());
+    }
+
+    @Test
+    public void abortsMidRunWhenComponentStops() {
+        // stop() called mid-run cuts the next workflow and the next ttlDays bucket short.
+        properties.setCatchUpDays(3);
+        when(lock.acquireLock(anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenReturn(true);
+
+        WorkflowHistoryCleaner cleaner =
+                new WorkflowHistoryCleaner(
+                        executionDAOFacade, indexDAO, lock, properties, environment);
+        cleaner.start();
+
+        when(indexDAO.searchArchivableWorkflows("conductor_workflow", 30L))
+                .thenReturn(Arrays.asList("wf-1", "wf-2"))
+                .thenReturn(Collections.emptyList());
+        when(indexDAO.searchArchivableWorkflows("conductor_workflow", 31L))
+                .thenReturn(Collections.emptyList());
+        when(indexDAO.searchArchivableWorkflows("conductor_workflow", 32L))
+                .thenReturn(Collections.emptyList());
+        doAnswer(
+                        (InvocationOnMock inv) -> {
+                            cleaner.stop();
+                            return null;
+                        })
+                .when(executionDAOFacade)
+                .removeWorkflow("wf-1", false);
+
+        cleaner.cleanup();
+
+        // wf-1 was in flight when stop() ran, so it completes; wf-2 must not be touched.
+        verify(executionDAOFacade).removeWorkflow("wf-1", false);
+        verify(executionDAOFacade, never()).removeWorkflow("wf-2", false);
+        // The remaining catchUp buckets must also be skipped.
+        verify(indexDAO, never()).searchArchivableWorkflows("conductor_workflow", 31L);
+        verify(indexDAO, never()).searchArchivableWorkflows("conductor_workflow", 32L);
+        // The lock still has to be released in finally.
+        verify(lock).releaseLock(properties.getLockId());
+    }
+
+    @Test
+    public void respectsMaxIterationsPerDay() {
+        properties.setMaxIterationsPerDay(2);
+        when(lock.acquireLock(anyString(), anyLong(), anyLong(), any(TimeUnit.class)))
+                .thenReturn(true);
+
+        // Each call returns a fresh id; without the safety cap this would loop forever.
+        List<String> callSeq = new ArrayList<>();
+        when(indexDAO.searchArchivableWorkflows("conductor_workflow", 30L))
+                .thenAnswer(
+                        (InvocationOnMock inv) -> {
+                            String id = "wf-" + callSeq.size();
+                            callSeq.add(id);
+                            return Collections.singletonList(id);
+                        });
+        when(indexDAO.searchArchivableWorkflows("conductor_workflow", 31L))
+                .thenReturn(Collections.emptyList());
+
+        newCleaner().cleanup();
+
+        // ttlDays=30 must be polled exactly maxIterationsPerDay (=2) times.
+        verify(indexDAO, times(2)).searchArchivableWorkflows("conductor_workflow", 30L);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1081.

Adds `WorkflowHistoryCleaner`, a Spring `@Scheduled` component that periodically deletes terminal workflows (`COMPLETED`/`FAILED`/`TERMINATED`/`TIMED_OUT`) older than the configured retention threshold.

- Pages candidates with `IndexDAO#searchArchivableWorkflows` and delegates the actual removal to `ExecutionDAOFacade#removeWorkflow`, reusing the existing execution-store / index ordering guarantees.
- Single-instance execution is enforced through the pluggable `com.netflix.conductor.core.sync.Lock` abstraction with **non-blocking `tryLock` semantics** — contenders exit immediately instead of queueing on the lock.
- Cooperative shutdown via `LifecycleAwareComponent`: any in-flight run checks `isRunning()` between iterations and at workflow boundaries.
- Safety rails: bounded iterations per day, fixed-size LRU of recently-processed ids (mitigates async index-delete lag), and configurable batch pauses.
- Disabled by default to keep existing deployments unaffected; opt in with `conductor.workflow-history-cleanup.enabled=true`.

Rolling indices (`conductor_task_log_*`, `conductor_event_*`, `conductor_message_*`) are out of scope — manage their retention through index-level lifecycle policies (e.g. OpenSearch ISM).

## Key Properties

| Property | Default | Description |
|---|---|---|
| `conductor.workflow-history-cleanup.enabled` | `false` | Master switch |
| `conductor.workflow-history-cleanup.cron` | `0 0 * * * *` | Schedule (top of the hour) |
| `conductor.workflow-history-cleanup.zone` | `UTC` | Cron time zone |
| `conductor.workflow-history-cleanup.retention-days` | `30` | Lower bound of the deletion window |
| `conductor.workflow-history-cleanup.catch-up-days` | `7` | Number of day-buckets walked per run |
| `conductor.workflow-history-cleanup.max-iterations-per-day` | `200` | Safety cap on the iteration loop |
| `conductor.workflow-history-cleanup.processed-cache-size` | `5000` | LRU size for recently-processed ids |
| `conductor.workflow-history-cleanup.batch-pause` | `500ms` | Pause between iterations |
| `conductor.workflow-history-cleanup.index-refresh-wait` | `2s` | Wait when the same ids keep coming back |
| `conductor.workflow-history-cleanup.lock-id` | `workflow-history-cleanup` | Lock identifier |
| `conductor.workflow-history-cleanup.lock-lease-time` | `2h` | Lock TTL |
| `conductor.workflow-history-cleanup.workflow-index-name` | (derived from `index-prefix`) | Override only if needed |

`SchedulerConfiguration` thread pool size bumped from 3 to 4 to accommodate the new scheduled job.

## Test plan
- [x] `./gradlew :conductor-core:test` — 18 new test cases in `TestWorkflowHistoryCleaner` cover lock contention, async index-delete lag, mid-run shutdown, exception handling, iteration caps, and null-result edge cases.
- [x] `./gradlew :conductor-core:spotlessCheck`
- [x] `./gradlew :conductor-core:compileJava :conductor-core:compileTestJava`
- [ ] Manual smoke test against a real Conductor deployment with OpenSearch (reviewer to validate end-to-end behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)