### PR TITLE
feat: add schema management API

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorCoreConfiguration.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorCoreConfiguration.java
@@ -21,6 +21,8 @@ import java.util.concurrent.ThreadFactory;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
+import org.conductoross.conductor.dao.InMemorySchemaDAO;
+import org.conductoross.conductor.dao.SchemaDAO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -132,6 +134,12 @@ public class ConductorCoreConfiguration {
             List<EventQueueProvider> eventQueueProviders) {
         return eventQueueProviders.stream()
                 .collect(Collectors.toMap(EventQueueProvider::getQueueType, identity()));
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(SchemaDAO.class)
+    public SchemaDAO schemaDAO() {
+        return new InMemorySchemaDAO();
     }
 
     @Bean

--- a/core/src/main/java/org/conductoross/conductor/dao/InMemorySchemaDAO.java
+++ b/core/src/main/java/org/conductoross/conductor/dao/InMemorySchemaDAO.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.dao;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.netflix.conductor.common.metadata.SchemaDef;
+import com.netflix.conductor.core.exception.NotFoundException;
+
+public class InMemorySchemaDAO implements SchemaDAO {
+
+    private final Map<String, Map<String, Map<Integer, SchemaDef>>> schemas =
+            new ConcurrentHashMap<>();
+
+    @Override
+    public void save(String orgId, SchemaDef schemaDef) {
+        schemas.computeIfAbsent(orgId, ignored -> new ConcurrentHashMap<>())
+                .computeIfAbsent(schemaDef.getName(), ignored -> new ConcurrentHashMap<>())
+                .put(schemaDef.getVersion(), copy(schemaDef));
+    }
+
+    @Override
+    public Optional<SchemaDef> getSchemaByNameWithLatestVersion(String orgId, String name) {
+        return schemas.getOrDefault(orgId, Map.of()).getOrDefault(name, Map.of()).values().stream()
+                .max(Comparator.comparingInt(SchemaDef::getVersion))
+                .map(this::copy);
+    }
+
+    @Override
+    public Optional<SchemaDef> getSchemaByNameAndVersion(String orgId, String name, int version) {
+        return Optional.ofNullable(
+                        schemas.getOrDefault(orgId, Map.of())
+                                .getOrDefault(name, Map.of())
+                                .get(version))
+                .map(this::copy);
+    }
+
+    @Override
+    public List<SchemaDef> getAllSchemas(String orgId) {
+        List<SchemaDef> result = new ArrayList<>();
+        schemas.getOrDefault(orgId, Map.of()).values().forEach(
+                byVersion ->
+                        byVersion.values().forEach(schema -> result.add(copy(schema))));
+        result.sort(
+                Comparator.comparing(SchemaDef::getName)
+                        .thenComparingInt(SchemaDef::getVersion));
+        return result;
+    }
+
+    @Override
+    public void deleteSchemaByName(String orgId, String name) {
+        Map<String, Map<Integer, SchemaDef>> byName = schemas.get(orgId);
+        if (byName == null || byName.remove(name) == null) {
+            throw new NotFoundException("No such schema found by name: %s", name);
+        }
+    }
+
+    @Override
+    public void deleteSchemaByNameAndVersion(String orgId, String name, int version) {
+        Map<Integer, SchemaDef> byVersion = schemas.getOrDefault(orgId, Map.of()).get(name);
+        if (byVersion == null || byVersion.remove(version) == null) {
+            throw new NotFoundException(
+                    "No such schema found by name: %s, version: %d", name, version);
+        }
+        if (byVersion.isEmpty()) {
+            schemas.getOrDefault(orgId, Map.of()).remove(name);
+        }
+    }
+
+    private SchemaDef copy(SchemaDef source) {
+        SchemaDef copy = new SchemaDef();
+        copy.setName(source.getName());
+        copy.setVersion(source.getVersion());
+        copy.setType(source.getType());
+        copy.setData(source.getData() == null ? null : new HashMap<>(source.getData()));
+        copy.setExternalRef(source.getExternalRef());
+        copy.setOwnerApp(source.getOwnerApp());
+        copy.setCreateTime(source.getCreateTime());
+        copy.setUpdateTime(source.getUpdateTime());
+        copy.setCreatedBy(source.getCreatedBy());
+        copy.setUpdatedBy(source.getUpdatedBy());
+        return copy;
+    }
+
+    @Override
+    public Optional<Integer> getLatestVersion(String orgId, String name) {
+        return schemas.getOrDefault(orgId, Map.of()).getOrDefault(name, Map.of()).keySet().stream()
+                .max(Integer::compareTo);
+    }
+}

--- a/core/src/main/java/org/conductoross/conductor/dao/SchemaDAO.java
+++ b/core/src/main/java/org/conductoross/conductor/dao/SchemaDAO.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.dao;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.netflix.conductor.common.metadata.SchemaDef;
+
+/** Data access layer for centrally managed input and output schema definitions. */
+public interface SchemaDAO {
+
+    /**
+     * Save the supplied schema in the scope identified by {@code orgId}. The org id is part of the
+     * OSS contract so Orkes can inject its tenant id while OSS always uses the default org.
+     */
+    void save(String orgId, SchemaDef schemaDef);
+
+    Optional<SchemaDef> getSchemaByNameWithLatestVersion(String orgId, String name);
+
+    Optional<SchemaDef> getSchemaByNameAndVersion(String orgId, String name, int version);
+
+    List<SchemaDef> getAllSchemas(String orgId);
+
+    void deleteSchemaByName(String orgId, String name);
+
+    void deleteSchemaByNameAndVersion(String orgId, String name, int version);
+
+    Optional<Integer> getLatestVersion(String orgId, String name);
+}

--- a/core/src/main/java/org/conductoross/conductor/service/SchemaService.java
+++ b/core/src/main/java/org/conductoross/conductor/service/SchemaService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.service;
+
+import java.util.List;
+
+import org.springframework.validation.annotation.Validated;
+
+import com.netflix.conductor.common.metadata.SchemaDef;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+@Validated
+public interface SchemaService {
+
+    void save(
+            @NotNull(message = "SchemaDef cannot be null") @Valid SchemaDef schemaDef,
+            boolean newVersion);
+
+    SchemaDef getSchemaByNameWithLatestVersion(
+            @NotEmpty(message = "Schema name cannot be null or empty") String name);
+
+    SchemaDef getSchemaByNameAndVersion(
+            @NotEmpty(message = "Schema name cannot be null or empty") String name,
+            @NotNull(message = "Version cannot be null") Integer version);
+
+    List<SchemaDef> getAllSchemas(boolean shortResult);
+
+    void deleteSchemaByName(
+            @NotEmpty(message = "Schema name cannot be null or empty") String name);
+
+    void deleteSchemaByNameAndVersion(
+            @NotEmpty(message = "Schema name cannot be null or empty") String name,
+            @NotNull(message = "Version cannot be null") Integer version);
+}

--- a/core/src/main/java/org/conductoross/conductor/service/SchemaServiceImpl.java
+++ b/core/src/main/java/org/conductoross/conductor/service/SchemaServiceImpl.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.service;
+
+import java.util.List;
+
+import org.conductoross.conductor.dao.SchemaDAO;
+import org.springframework.stereotype.Service;
+
+import com.netflix.conductor.common.metadata.SchemaDef;
+import com.netflix.conductor.core.WorkflowContext;
+import com.netflix.conductor.core.exception.NotFoundException;
+
+@Service
+public class SchemaServiceImpl implements SchemaService {
+
+    public static final String DEFAULT_ORG_ID = "default";
+
+    private final SchemaDAO schemaDAO;
+
+    public SchemaServiceImpl(SchemaDAO schemaDAO) {
+        this.schemaDAO = schemaDAO;
+    }
+
+    @Override
+    public void save(SchemaDef schemaDef, boolean newVersion) {
+        long now = System.currentTimeMillis();
+        if (newVersion) {
+            int latestVersion =
+                    schemaDAO.getLatestVersion(DEFAULT_ORG_ID, schemaDef.getName()).orElse(0);
+            schemaDef.setVersion(latestVersion + 1);
+            schemaDef.setCreateTime(now);
+            schemaDef.setCreatedBy(WorkflowContext.get().getClientApp());
+            schemaDef.setUpdateTime(null);
+            schemaDef.setUpdatedBy(null);
+        } else {
+            schemaDAO.getSchemaByNameAndVersion(
+                            DEFAULT_ORG_ID, schemaDef.getName(), schemaDef.getVersion())
+                    .ifPresentOrElse(
+                            existing -> {
+                                schemaDef.setCreateTime(existing.getCreateTime());
+                                schemaDef.setCreatedBy(existing.getCreatedBy());
+                                schemaDef.setUpdateTime(now);
+                                schemaDef.setUpdatedBy(WorkflowContext.get().getClientApp());
+                            },
+                            () -> {
+                                schemaDef.setCreateTime(now);
+                                schemaDef.setCreatedBy(WorkflowContext.get().getClientApp());
+                                schemaDef.setUpdateTime(null);
+                                schemaDef.setUpdatedBy(null);
+                            });
+        }
+        schemaDAO.save(DEFAULT_ORG_ID, schemaDef);
+    }
+
+    @Override
+    public SchemaDef getSchemaByNameWithLatestVersion(String name) {
+        return schemaDAO.getSchemaByNameWithLatestVersion(DEFAULT_ORG_ID, name)
+                .orElseThrow(() -> new NotFoundException("No such schema found by name: %s", name));
+    }
+
+    @Override
+    public SchemaDef getSchemaByNameAndVersion(String name, Integer version) {
+        return schemaDAO.getSchemaByNameAndVersion(DEFAULT_ORG_ID, name, version)
+                .orElseThrow(
+                        () ->
+                                new NotFoundException(
+                                        "No such schema found by name: %s, version: %d",
+                                        name, version));
+    }
+
+    @Override
+    public List<SchemaDef> getAllSchemas(boolean shortResult) {
+        List<SchemaDef> schemas = schemaDAO.getAllSchemas(DEFAULT_ORG_ID);
+        if (!shortResult) {
+            return schemas;
+        }
+        return schemas.stream().map(this::toShortSchema).toList();
+    }
+
+    @Override
+    public void deleteSchemaByName(String name) {
+        if (schemaDAO.getSchemaByNameWithLatestVersion(DEFAULT_ORG_ID, name).isEmpty()) {
+            throw new NotFoundException("No such schema found by name: %s", name);
+        }
+        schemaDAO.deleteSchemaByName(DEFAULT_ORG_ID, name);
+    }
+
+    @Override
+    public void deleteSchemaByNameAndVersion(String name, Integer version) {
+        if (schemaDAO.getSchemaByNameAndVersion(DEFAULT_ORG_ID, name, version).isEmpty()) {
+            throw new NotFoundException(
+                    "No such schema found by name: %s, version: %d", name, version);
+        }
+        schemaDAO.deleteSchemaByNameAndVersion(DEFAULT_ORG_ID, name, version);
+    }
+
+    private SchemaDef toShortSchema(SchemaDef schemaDef) {
+        SchemaDef shortSchema = new SchemaDef();
+        shortSchema.setName(schemaDef.getName());
+        shortSchema.setVersion(schemaDef.getVersion());
+        shortSchema.setType(schemaDef.getType());
+        shortSchema.setCreatedBy(schemaDef.getCreatedBy());
+        shortSchema.setCreateTime(schemaDef.getCreateTime());
+        shortSchema.setUpdatedBy(schemaDef.getUpdatedBy());
+        shortSchema.setUpdateTime(schemaDef.getUpdateTime());
+        return shortSchema;
+    }
+}

--- a/core/src/test/java/org/conductoross/conductor/service/SchemaServiceImplTest.java
+++ b/core/src/test/java/org/conductoross/conductor/service/SchemaServiceImplTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.conductoross.conductor.dao.InMemorySchemaDAO;
+import org.junit.Test;
+
+import com.netflix.conductor.common.metadata.SchemaDef;
+import com.netflix.conductor.core.WorkflowContext;
+import com.netflix.conductor.core.exception.NotFoundException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+public class SchemaServiceImplTest {
+
+    @Test
+    public void saveCreatesNewVersionsAndReturnsShortSchemas() {
+        WorkflowContext.set(new WorkflowContext("test-app"));
+        SchemaService service = new SchemaServiceImpl(new InMemorySchemaDAO());
+
+        SchemaDef schema = schema("customer", 1, "first");
+        service.save(schema, false);
+
+        schema.setData(new HashMap<>(Map.of("title", "updated")));
+        service.save(schema, true);
+
+        SchemaDef latest = service.getSchemaByNameWithLatestVersion("customer");
+        assertEquals(2, latest.getVersion());
+        assertEquals("updated", latest.getData().get("title"));
+        assertEquals("test-app", latest.getCreatedBy());
+
+        List<SchemaDef> shortSchemas = service.getAllSchemas(true);
+        assertEquals(2, shortSchemas.size());
+        assertNull(shortSchemas.get(0).getData());
+    }
+
+    @Test
+    public void missingSchemaThrowsNotFound() {
+        SchemaService service = new SchemaServiceImpl(new InMemorySchemaDAO());
+
+        assertThrows(
+                NotFoundException.class,
+                () -> service.getSchemaByNameAndVersion("missing", 1));
+    }
+
+    private SchemaDef schema(String name, int version, String title) {
+        SchemaDef schema = new SchemaDef();
+        schema.setName(name);
+        schema.setVersion(version);
+        schema.setType(SchemaDef.Type.JSON);
+        schema.setData(new HashMap<>(Map.of("title", title, "type", "object")));
+        return schema;
+    }
+}

--- a/mysql-persistence/src/main/java/com/netflix/conductor/mysql/config/MySQLConfiguration.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/mysql/config/MySQLConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.backoff.NoBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
@@ -33,6 +34,7 @@ import org.springframework.retry.support.RetryTemplate;
 import com.netflix.conductor.mysql.dao.MySQLExecutionDAO;
 import com.netflix.conductor.mysql.dao.MySQLMetadataDAO;
 import com.netflix.conductor.mysql.dao.MySQLQueueDAO;
+import com.netflix.conductor.mysql.dao.MySQLSchemaDAO;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -54,6 +56,16 @@ public class MySQLConfiguration {
             DataSource dataSource,
             MySQLProperties properties) {
         return new MySQLMetadataDAO(retryTemplate, objectMapper, dataSource, properties);
+    }
+
+    @Bean
+    @DependsOn({"flyway", "flywayInitializer"})
+    @Primary
+    public MySQLSchemaDAO mySqlSchemaDAO(
+            @Qualifier("mysqlRetryTemplate") RetryTemplate retryTemplate,
+            ObjectMapper objectMapper,
+            DataSource dataSource) {
+        return new MySQLSchemaDAO(retryTemplate, objectMapper, dataSource);
     }
 
     @Bean

--- a/mysql-persistence/src/main/java/com/netflix/conductor/mysql/dao/MySQLSchemaDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/mysql/dao/MySQLSchemaDAO.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.mysql.dao;
+
+import java.util.List;
+import java.util.Optional;
+
+import javax.sql.DataSource;
+
+import org.conductoross.conductor.dao.SchemaDAO;
+import org.springframework.retry.support.RetryTemplate;
+
+import com.netflix.conductor.common.metadata.SchemaDef;
+import com.netflix.conductor.core.exception.NotFoundException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+
+public class MySQLSchemaDAO extends MySQLBaseDAO implements SchemaDAO {
+
+    public MySQLSchemaDAO(
+            RetryTemplate retryTemplate, ObjectMapper objectMapper, DataSource dataSource) {
+        super(retryTemplate, objectMapper, dataSource);
+    }
+
+    @Override
+    public void save(String orgId, SchemaDef schemaDef) {
+        validate(orgId, schemaDef);
+
+        final String UPDATE_SCHEMA_QUERY =
+                "UPDATE meta_schema_def SET json_data = ?, modified_on = CURRENT_TIMESTAMP "
+                        + "WHERE org_id = ? AND name = ? AND version = ?";
+        final String INSERT_SCHEMA_QUERY =
+                "INSERT INTO meta_schema_def "
+                        + "(org_id, name, version, json_data) VALUES (?, ?, ?, ?)";
+
+        withTransaction(
+                tx ->
+                        execute(
+                                tx,
+                                UPDATE_SCHEMA_QUERY,
+                                update -> {
+                                    int updated =
+                                            update.addJsonParameter(schemaDef)
+                                                    .addParameter(orgId)
+                                                    .addParameter(schemaDef.getName())
+                                                    .addParameter(schemaDef.getVersion())
+                                                    .executeUpdate();
+                                    if (updated == 0) {
+                                        execute(
+                                                tx,
+                                                INSERT_SCHEMA_QUERY,
+                                                insert ->
+                                                        insert.addParameter(orgId)
+                                                                .addParameter(schemaDef.getName())
+                                                                .addParameter(
+                                                                        schemaDef.getVersion())
+                                                                .addJsonParameter(schemaDef)
+                                                                .executeUpdate());
+                                    }
+                                }));
+    }
+
+    @Override
+    public Optional<SchemaDef> getSchemaByNameWithLatestVersion(String orgId, String name) {
+        final String QUERY =
+                "SELECT json_data FROM meta_schema_def WHERE org_id = ? AND name = ? "
+                        + "ORDER BY version DESC LIMIT 1";
+        return Optional.ofNullable(
+                queryWithTransaction(
+                        QUERY,
+                        q ->
+                                q.addParameter(orgId)
+                                        .addParameter(name)
+                                        .executeAndFetchFirst(SchemaDef.class)));
+    }
+
+    @Override
+    public Optional<SchemaDef> getSchemaByNameAndVersion(String orgId, String name, int version) {
+        final String QUERY =
+                "SELECT json_data FROM meta_schema_def "
+                        + "WHERE org_id = ? AND name = ? AND version = ?";
+        return Optional.ofNullable(
+                queryWithTransaction(
+                        QUERY,
+                        q ->
+                                q.addParameter(orgId)
+                                        .addParameter(name)
+                                        .addParameter(version)
+                                        .executeAndFetchFirst(SchemaDef.class)));
+    }
+
+    @Override
+    public List<SchemaDef> getAllSchemas(String orgId) {
+        final String QUERY =
+                "SELECT json_data FROM meta_schema_def WHERE org_id = ? ORDER BY name, version";
+        return queryWithTransaction(
+                QUERY, q -> q.addParameter(orgId).executeAndFetch(SchemaDef.class));
+    }
+
+    @Override
+    public void deleteSchemaByName(String orgId, String name) {
+        final String QUERY = "DELETE FROM meta_schema_def WHERE org_id = ? AND name = ?";
+        executeWithTransaction(
+                QUERY,
+                q -> {
+                    if (!q.addParameter(orgId).addParameter(name).executeDelete()) {
+                        throw new NotFoundException("No such schema found by name: %s", name);
+                    }
+                });
+    }
+
+    @Override
+    public void deleteSchemaByNameAndVersion(String orgId, String name, int version) {
+        final String QUERY =
+                "DELETE FROM meta_schema_def WHERE org_id = ? AND name = ? AND version = ?";
+        executeWithTransaction(
+                QUERY,
+                q -> {
+                    if (!q.addParameter(orgId)
+                            .addParameter(name)
+                            .addParameter(version)
+                            .executeDelete()) {
+                        throw new NotFoundException(
+                                "No such schema found by name: %s, version: %d", name, version);
+                    }
+                });
+    }
+
+    @Override
+    public Optional<Integer> getLatestVersion(String orgId, String name) {
+        final String QUERY =
+                "SELECT max(version) AS version FROM meta_schema_def WHERE org_id = ? AND name = ?";
+        Integer version =
+                queryWithTransaction(
+                        QUERY,
+                        q ->
+                                q.addParameter(orgId)
+                                        .addParameter(name)
+                                        .executeAndFetch(
+                                                rs -> {
+                                                    if (!rs.next()) {
+                                                        return null;
+                                                    }
+                                                    int value = rs.getInt(1);
+                                                    return rs.wasNull() ? null : value;
+                                                }));
+        return Optional.ofNullable(version);
+    }
+
+    private void validate(String orgId, SchemaDef schemaDef) {
+        Preconditions.checkNotNull(orgId, "orgId cannot be null");
+        Preconditions.checkNotNull(schemaDef, "SchemaDef object cannot be null");
+        Preconditions.checkNotNull(schemaDef.getName(), "SchemaDef name cannot be null");
+        Preconditions.checkNotNull(schemaDef.getType(), "SchemaDef type cannot be null");
+    }
+}

--- a/mysql-persistence/src/main/resources/db/migration/V10__schema_def.sql
+++ b/mysql-persistence/src/main/resources/db/migration/V10__schema_def.sql
@@ -1,0 +1,12 @@
+CREATE TABLE meta_schema_def (
+  id INT NOT NULL AUTO_INCREMENT,
+  created_on TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  modified_on TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  org_id varchar(255) NOT NULL,
+  name varchar(255) NOT NULL,
+  version int NOT NULL,
+  json_data TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE UNIQUE INDEX unique_schema_def_org_name_version ON meta_schema_def (org_id, name, version);
+CREATE INDEX schema_def_org_name_index ON meta_schema_def (org_id, name);

--- a/mysql-persistence/src/test/java/com/netflix/conductor/mysql/dao/MySQLSchemaDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/mysql/dao/MySQLSchemaDAOTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.mysql.dao;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.flywaydb.core.Flyway;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
+import com.netflix.conductor.common.metadata.SchemaDef;
+import com.netflix.conductor.mysql.config.MySQLConfiguration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@ContextConfiguration(
+        classes = {
+            TestObjectMapperConfiguration.class,
+            MySQLConfiguration.class,
+            FlywayAutoConfiguration.class
+        })
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = "spring.flyway.clean-disabled=false")
+public class MySQLSchemaDAOTest {
+
+    private static final String ORG_ID = "default";
+
+    @Autowired private MySQLSchemaDAO schemaDAO;
+
+    @Autowired private Flyway flyway;
+
+    @Before
+    public void before() {
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    @Test
+    public void testSchemaOperations() {
+        String name = "schema_" + UUID.randomUUID();
+        SchemaDef schema = schema(name, 1, "first");
+
+        schemaDAO.save(ORG_ID, schema);
+
+        SchemaDef found = schemaDAO.getSchemaByNameAndVersion(ORG_ID, name, 1).get();
+        assertEquals(schema.getName(), found.getName());
+        assertEquals(schema.getVersion(), found.getVersion());
+        assertEquals(schema.getType(), found.getType());
+        assertEquals("first", found.getData().get("title"));
+
+        schema.setData(new HashMap<>(Map.of("title", "updated")));
+        schemaDAO.save(ORG_ID, schema);
+        found = schemaDAO.getSchemaByNameAndVersion(ORG_ID, name, 1).get();
+        assertEquals("updated", found.getData().get("title"));
+
+        schemaDAO.save(ORG_ID, schema(name, 2, "second"));
+        assertEquals(2, (int) schemaDAO.getLatestVersion(ORG_ID, name).get());
+        assertEquals(
+                2, schemaDAO.getSchemaByNameWithLatestVersion(ORG_ID, name).get().getVersion());
+
+        List<SchemaDef> all = schemaDAO.getAllSchemas(ORG_ID).stream()
+                .filter(def -> def.getName().equals(name))
+                .toList();
+        assertEquals(2, all.size());
+
+        schemaDAO.deleteSchemaByNameAndVersion(ORG_ID, name, 2);
+        assertFalse(schemaDAO.getSchemaByNameAndVersion(ORG_ID, name, 2).isPresent());
+        assertEquals(
+                1, schemaDAO.getSchemaByNameWithLatestVersion(ORG_ID, name).get().getVersion());
+
+        schemaDAO.deleteSchemaByName(ORG_ID, name);
+        assertFalse(schemaDAO.getSchemaByNameWithLatestVersion(ORG_ID, name).isPresent());
+    }
+
+    @Test
+    public void testSchemasAreScopedByOrg() {
+        String name = "schema_" + UUID.randomUUID();
+        schemaDAO.save(ORG_ID, schema(name, 1, "default"));
+        schemaDAO.save("other", schema(name, 1, "other"));
+
+        assertEquals(
+                "default",
+                schemaDAO.getSchemaByNameWithLatestVersion(ORG_ID, name)
+                        .get()
+                        .getData()
+                        .get("title"));
+        assertEquals(
+                "other",
+                schemaDAO.getSchemaByNameWithLatestVersion("other", name)
+                        .get()
+                        .getData()
+                        .get("title"));
+        assertTrue(schemaDAO.getAllSchemas("missing").isEmpty());
+    }
+
+    private SchemaDef schema(String name, int version, String title) {
+        SchemaDef schema = new SchemaDef();
+        schema.setName(name);
+        schema.setVersion(version);
+        schema.setType(SchemaDef.Type.JSON);
+        schema.setData(new HashMap<>(Map.of("title", title, "type", "object")));
+        return schema;
+    }
+}

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
@@ -91,6 +91,15 @@ public class PostgresConfiguration {
 
     @Bean
     @DependsOn({"flywayForPrimaryDb"})
+    @Primary
+    public PostgresSchemaDAO postgresSchemaDAO(
+            @Qualifier("postgresRetryTemplate") RetryTemplate retryTemplate,
+            ObjectMapper objectMapper) {
+        return new PostgresSchemaDAO(retryTemplate, objectMapper, dataSource);
+    }
+
+    @Bean
+    @DependsOn({"flywayForPrimaryDb"})
     public PostgresExecutionDAO postgresExecutionDAO(
             @Qualifier("postgresRetryTemplate") RetryTemplate retryTemplate,
             ObjectMapper objectMapper,

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresSchemaDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresSchemaDAO.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.postgres.dao;
+
+import java.util.List;
+import java.util.Optional;
+
+import javax.sql.DataSource;
+
+import org.conductoross.conductor.dao.SchemaDAO;
+import org.springframework.retry.support.RetryTemplate;
+
+import com.netflix.conductor.common.metadata.SchemaDef;
+import com.netflix.conductor.core.exception.NotFoundException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+
+public class PostgresSchemaDAO extends PostgresBaseDAO implements SchemaDAO {
+
+    public PostgresSchemaDAO(
+            RetryTemplate retryTemplate, ObjectMapper objectMapper, DataSource dataSource) {
+        super(retryTemplate, objectMapper, dataSource);
+    }
+
+    @Override
+    public void save(String orgId, SchemaDef schemaDef) {
+        validate(orgId, schemaDef);
+
+        final String UPDATE_SCHEMA_QUERY =
+                "UPDATE meta_schema_def SET json_data = ?, modified_on = CURRENT_TIMESTAMP "
+                        + "WHERE org_id = ? AND name = ? AND version = ?";
+        final String INSERT_SCHEMA_QUERY =
+                "INSERT INTO meta_schema_def "
+                        + "(org_id, name, version, json_data) VALUES (?, ?, ?, ?)";
+
+        withTransaction(
+                tx ->
+                        execute(
+                                tx,
+                                UPDATE_SCHEMA_QUERY,
+                                update -> {
+                                    int updated =
+                                            update.addJsonParameter(schemaDef)
+                                                    .addParameter(orgId)
+                                                    .addParameter(schemaDef.getName())
+                                                    .addParameter(schemaDef.getVersion())
+                                                    .executeUpdate();
+                                    if (updated == 0) {
+                                        execute(
+                                                tx,
+                                                INSERT_SCHEMA_QUERY,
+                                                insert ->
+                                                        insert.addParameter(orgId)
+                                                                .addParameter(schemaDef.getName())
+                                                                .addParameter(
+                                                                        schemaDef.getVersion())
+                                                                .addJsonParameter(schemaDef)
+                                                                .executeUpdate());
+                                    }
+                                }));
+    }
+
+    @Override
+    public Optional<SchemaDef> getSchemaByNameWithLatestVersion(String orgId, String name) {
+        final String QUERY =
+                "SELECT json_data FROM meta_schema_def WHERE org_id = ? AND name = ? "
+                        + "ORDER BY version DESC LIMIT 1";
+        return Optional.ofNullable(
+                queryWithTransaction(
+                        QUERY,
+                        q ->
+                                q.addParameter(orgId)
+                                        .addParameter(name)
+                                        .executeAndFetchFirst(SchemaDef.class)));
+    }
+
+    @Override
+    public Optional<SchemaDef> getSchemaByNameAndVersion(String orgId, String name, int version) {
+        final String QUERY =
+                "SELECT json_data FROM meta_schema_def "
+                        + "WHERE org_id = ? AND name = ? AND version = ?";
+        return Optional.ofNullable(
+                queryWithTransaction(
+                        QUERY,
+                        q ->
+                                q.addParameter(orgId)
+                                        .addParameter(name)
+                                        .addParameter(version)
+                                        .executeAndFetchFirst(SchemaDef.class)));
+    }
+
+    @Override
+    public List<SchemaDef> getAllSchemas(String orgId) {
+        final String QUERY =
+                "SELECT json_data FROM meta_schema_def WHERE org_id = ? ORDER BY name, version";
+        return queryWithTransaction(
+                QUERY, q -> q.addParameter(orgId).executeAndFetch(SchemaDef.class));
+    }
+
+    @Override
+    public void deleteSchemaByName(String orgId, String name) {
+        final String QUERY = "DELETE FROM meta_schema_def WHERE org_id = ? AND name = ?";
+        executeWithTransaction(
+                QUERY,
+                q -> {
+                    if (!q.addParameter(orgId).addParameter(name).executeDelete()) {
+                        throw new NotFoundException("No such schema found by name: %s", name);
+                    }
+                });
+    }
+
+    @Override
+    public void deleteSchemaByNameAndVersion(String orgId, String name, int version) {
+        final String QUERY =
+                "DELETE FROM meta_schema_def WHERE org_id = ? AND name = ? AND version = ?";
+        executeWithTransaction(
+                QUERY,
+                q -> {
+                    if (!q.addParameter(orgId)
+                            .addParameter(name)
+                            .addParameter(version)
+                            .executeDelete()) {
+                        throw new NotFoundException(
+                                "No such schema found by name: %s, version: %d", name, version);
+                    }
+                });
+    }
+
+    @Override
+    public Optional<Integer> getLatestVersion(String orgId, String name) {
+        final String QUERY =
+                "SELECT max(version) AS version FROM meta_schema_def WHERE org_id = ? AND name = ?";
+        Integer version =
+                queryWithTransaction(
+                        QUERY,
+                        q ->
+                                q.addParameter(orgId)
+                                        .addParameter(name)
+                                        .executeAndFetch(
+                                                rs -> {
+                                                    if (!rs.next()) {
+                                                        return null;
+                                                    }
+                                                    int value = rs.getInt(1);
+                                                    return rs.wasNull() ? null : value;
+                                                }));
+        return Optional.ofNullable(version);
+    }
+
+    private void validate(String orgId, SchemaDef schemaDef) {
+        Preconditions.checkNotNull(orgId, "orgId cannot be null");
+        Preconditions.checkNotNull(schemaDef, "SchemaDef object cannot be null");
+        Preconditions.checkNotNull(schemaDef.getName(), "SchemaDef name cannot be null");
+        Preconditions.checkNotNull(schemaDef.getType(), "SchemaDef type cannot be null");
+    }
+}

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V16__schema_def.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V16__schema_def.sql
@@ -1,0 +1,12 @@
+CREATE TABLE meta_schema_def (
+  id SERIAL,
+  created_on TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  modified_on TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  org_id varchar(255) NOT NULL,
+  name varchar(255) NOT NULL,
+  version int NOT NULL,
+  json_data TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+CREATE UNIQUE INDEX unique_schema_def_org_name_version ON meta_schema_def (org_id, name, version);
+CREATE INDEX schema_def_org_name_index ON meta_schema_def (org_id, name);

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresSchemaDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresSchemaDAOTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.postgres.dao;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.flywaydb.core.Flyway;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
+import com.netflix.conductor.common.metadata.SchemaDef;
+import com.netflix.conductor.postgres.config.PostgresConfiguration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@ContextConfiguration(
+        classes = {
+            TestObjectMapperConfiguration.class,
+            PostgresConfiguration.class,
+            FlywayAutoConfiguration.class
+        })
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = "spring.flyway.clean-disabled=true")
+public class PostgresSchemaDAOTest {
+
+    private static final String ORG_ID = "default";
+
+    @Autowired private PostgresSchemaDAO schemaDAO;
+
+    @Autowired private Flyway flyway;
+
+    @Before
+    public void before() {
+        flyway.migrate();
+    }
+
+    @Test
+    public void testSchemaOperations() {
+        String name = "schema_" + UUID.randomUUID();
+        SchemaDef schema = schema(name, 1, "first");
+
+        schemaDAO.save(ORG_ID, schema);
+
+        SchemaDef found = schemaDAO.getSchemaByNameAndVersion(ORG_ID, name, 1).get();
+        assertEquals(schema.getName(), found.getName());
+        assertEquals(schema.getVersion(), found.getVersion());
+        assertEquals(schema.getType(), found.getType());
+        assertEquals("first", found.getData().get("title"));
+
+        schema.setData(new HashMap<>(Map.of("title", "updated")));
+        schemaDAO.save(ORG_ID, schema);
+        found = schemaDAO.getSchemaByNameAndVersion(ORG_ID, name, 1).get();
+        assertEquals("updated", found.getData().get("title"));
+
+        schemaDAO.save(ORG_ID, schema(name, 2, "second"));
+        assertEquals(2, (int) schemaDAO.getLatestVersion(ORG_ID, name).get());
+        assertEquals(
+                2, schemaDAO.getSchemaByNameWithLatestVersion(ORG_ID, name).get().getVersion());
+
+        List<SchemaDef> all = schemaDAO.getAllSchemas(ORG_ID).stream()
+                .filter(def -> def.getName().equals(name))
+                .toList();
+        assertEquals(2, all.size());
+
+        schemaDAO.deleteSchemaByNameAndVersion(ORG_ID, name, 2);
+        assertFalse(schemaDAO.getSchemaByNameAndVersion(ORG_ID, name, 2).isPresent());
+        assertEquals(
+                1, schemaDAO.getSchemaByNameWithLatestVersion(ORG_ID, name).get().getVersion());
+
+        schemaDAO.deleteSchemaByName(ORG_ID, name);
+        assertFalse(schemaDAO.getSchemaByNameWithLatestVersion(ORG_ID, name).isPresent());
+    }
+
+    @Test
+    public void testSchemasAreScopedByOrg() {
+        String name = "schema_" + UUID.randomUUID();
+        schemaDAO.save(ORG_ID, schema(name, 1, "default"));
+        schemaDAO.save("other", schema(name, 1, "other"));
+
+        assertEquals(
+                "default",
+                schemaDAO.getSchemaByNameWithLatestVersion(ORG_ID, name)
+                        .get()
+                        .getData()
+                        .get("title"));
+        assertEquals(
+                "other",
+                schemaDAO.getSchemaByNameWithLatestVersion("other", name)
+                        .get()
+                        .getData()
+                        .get("title"));
+        assertTrue(schemaDAO.getAllSchemas("missing").isEmpty());
+    }
+
+    private SchemaDef schema(String name, int version, String title) {
+        SchemaDef schema = new SchemaDef();
+        schema.setName(name);
+        schema.setVersion(version);
+        schema.setType(SchemaDef.Type.JSON);
+        schema.setData(new HashMap<>(Map.of("title", title, "type", "object")));
+        return schema;
+    }
+}

--- a/rest/src/main/java/org/conductoross/conductor/rest/SchemaResource.java
+++ b/rest/src/main/java/org/conductoross/conductor/rest/SchemaResource.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.rest;
+
+import java.util.List;
+
+import org.conductoross.conductor.service.SchemaService;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.netflix.conductor.common.metadata.SchemaDef;
+
+import io.swagger.v3.oas.annotations.Operation;
+
+@RestController
+@RequestMapping("/api/schema")
+public class SchemaResource {
+
+    private final SchemaService schemaService;
+
+    public SchemaResource(SchemaService schemaService) {
+        this.schemaService = schemaService;
+    }
+
+    @PostMapping
+    @Operation(summary = "Create or update a schema definition")
+    public void save(
+            @RequestBody SchemaDef schemaDef,
+            @RequestParam(value = "newVersion", defaultValue = "false") boolean newVersion) {
+        schemaService.save(schemaDef, newVersion);
+    }
+
+    @GetMapping("/{name}")
+    @Operation(summary = "Retrieves the latest version of a schema definition")
+    public SchemaDef getSchemaByNameWithLatestVersion(@PathVariable("name") String name) {
+        return schemaService.getSchemaByNameWithLatestVersion(name);
+    }
+
+    @GetMapping("/{name}/{version}")
+    @Operation(summary = "Retrieves a schema definition by name and version")
+    public SchemaDef getSchemaByNameAndVersion(
+            @PathVariable("name") String name, @PathVariable("version") Integer version) {
+        return schemaService.getSchemaByNameAndVersion(name, version);
+    }
+
+    @GetMapping
+    @Operation(summary = "Retrieves all schema definitions")
+    public List<SchemaDef> getAllSchemas(
+            @RequestParam(value = "short", defaultValue = "false") boolean shortResult) {
+        return schemaService.getAllSchemas(shortResult);
+    }
+
+    @DeleteMapping("/{name}")
+    @Operation(summary = "Deletes all versions of a schema definition")
+    public void deleteSchemaByName(@PathVariable("name") String name) {
+        schemaService.deleteSchemaByName(name);
+    }
+
+    @DeleteMapping("/{name}/{version}")
+    @Operation(summary = "Deletes a schema definition by name and version")
+    public void deleteSchemaByNameAndVersion(
+            @PathVariable("name") String name, @PathVariable("version") Integer version) {
+        schemaService.deleteSchemaByNameAndVersion(name, version);
+    }
+}


### PR DESCRIPTION
Closes #1118

## Summary
- Adds the `/api/schema` REST resource and OSS schema service using the existing `SchemaDef` model
- Adds org-aware `SchemaDAO` with in-memory fallback plus Postgres and MySQL implementations
- Adds Flyway migrations and DAO/service coverage for schema CRUD and versioning

## Testing
- `git diff --cached --check`
- `./gradlew spotlessApply` (fails: no Java Runtime is installed in this environment)
- `./gradlew :core:compileJava :rest:compileJava :postgres-persistence:compileJava :mysql-persistence:compileJava` (fails: no Java Runtime is installed in this environment)
