### PR TITLE
fix: import FlywayAutoConfiguration in MySQLConfiguration (#1104)

### DIFF
--- a/mysql-persistence/src/main/java/com/netflix/conductor/mysql/config/MySQLConfiguration.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/mysql/config/MySQLConfiguration.java
@@ -19,6 +19,7 @@ import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -41,9 +42,10 @@ import static com.mysql.cj.exceptions.MysqlErrorNumbers.ER_LOCK_DEADLOCK;
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(MySQLProperties.class)
 @ConditionalOnProperty(name = "conductor.db.type", havingValue = "mysql")
-// Import the DataSourceAutoConfiguration when mysql database is selected.
-// By default the datasource configuration is excluded in the main module.
-@Import(DataSourceAutoConfiguration.class)
+// Import DataSourceAutoConfiguration and FlywayAutoConfiguration when mysql database is selected.
+// By default these are excluded in the main module. FlywayAutoConfiguration is required so that
+// the 'flyway' and 'flywayInitializer' beans exist before the MySQL DAOs are initialized.
+@Import({DataSourceAutoConfiguration.class, FlywayAutoConfiguration.class})
 public class MySQLConfiguration {
 
     @Bean


### PR DESCRIPTION
## Summary

- **Root cause:** `MySQLConfiguration` only imported `DataSourceAutoConfiguration`, so Spring Boot's `FlywayAutoConfiguration` never ran. This left the `flyway` and `flywayInitializer` beans unregistered, causing all MySQL DAO beans (which declare `@DependsOn({"flyway", "flywayInitializer"})`) to fail at context initialization.
- **Fix:** Add `FlywayAutoConfiguration.class` to the `@Import` annotation alongside the existing `DataSourceAutoConfiguration.class`. This mirrors how the main module normally wires up Flyway via auto-configuration.
- **No test changes needed:** All three MySQL DAO tests already include `FlywayAutoConfiguration.class` in their `@ContextConfiguration`, so they continue to work as-is.

Closes #1104.

## Test plan

- [ ] Run `./gradlew :mysql-persistence:test` — all three DAO tests should pass
- [ ] Bring up `docker-compose-mysql.yaml` and verify `conductor-server` starts without the missing flyway bean error
- [ ] Confirm `conductor.db.type=mysql` with Redis lock starts cleanly end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)