### PR TITLE
[FEATURE]: Introduce URI allow-list for HttpTask to mitigate SSRF

### DIFF
--- a/http-task/src/main/java/com/netflix/conductor/tasks/http/HttpTask.java
+++ b/http-task/src/main/java/com/netflix/conductor/tasks/http/HttpTask.java
@@ -34,6 +34,7 @@ import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
 import com.netflix.conductor.core.utils.Utils;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.tasks.http.config.HttpTaskProperties;
 import com.netflix.conductor.tasks.http.providers.RestTemplateProvider;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -61,18 +62,26 @@ public class HttpTask extends WorkflowSystemTask {
     private final TypeReference<List<Object>> listOfObj = new TypeReference<List<Object>>() {};
     protected ObjectMapper objectMapper;
     protected RestTemplateProvider restTemplateProvider;
+    private final HttpTaskProperties properties;
     private final String requestParameter;
 
     @Autowired
-    public HttpTask(RestTemplateProvider restTemplateProvider, ObjectMapper objectMapper) {
-        this(TASK_TYPE_HTTP, restTemplateProvider, objectMapper);
+    public HttpTask(
+            RestTemplateProvider restTemplateProvider,
+            ObjectMapper objectMapper,
+            HttpTaskProperties properties) {
+        this(TASK_TYPE_HTTP, restTemplateProvider, objectMapper, properties);
     }
 
     public HttpTask(
-            String name, RestTemplateProvider restTemplateProvider, ObjectMapper objectMapper) {
+            String name,
+            RestTemplateProvider restTemplateProvider,
+            ObjectMapper objectMapper,
+            HttpTaskProperties properties) {
         super(name);
         this.restTemplateProvider = restTemplateProvider;
         this.objectMapper = objectMapper;
+        this.properties = properties;
         this.requestParameter = REQUEST_PARAMETER_NAME;
         LOGGER.info("{} initialized...", getTaskType());
     }
@@ -98,6 +107,16 @@ public class HttpTask extends WorkflowSystemTask {
             String reason = "No HTTP method specified";
             task.setReasonForIncompletion(reason);
             task.setStatus(TaskModel.Status.FAILED);
+            return;
+        }
+
+        if (!isUriAllowed(input.getUri())) {
+            String reason =
+                    String.format(
+                            "URI %s is not allowed by the security policy. Please contact your system administrator.",
+                            input.getUri());
+            task.setReasonForIncompletion(reason);
+            task.setStatus(TaskModel.Status.FAILED_WITH_TERMINAL_ERROR);
             return;
         }
 
@@ -141,6 +160,14 @@ public class HttpTask extends WorkflowSystemTask {
                     "Failed to invoke " + getTaskType() + " task due to: " + e);
             task.addOutput("response", e.toString());
         }
+    }
+
+    private boolean isUriAllowed(String uri) {
+        List<String> allowList = properties.getUrlAllowList();
+        if (allowList == null || allowList.isEmpty()) {
+            return true;
+        }
+        return allowList.stream().anyMatch(uri::matches);
     }
 
     /**

--- a/http-task/src/main/java/com/netflix/conductor/tasks/http/config/HttpTaskProperties.java
+++ b/http-task/src/main/java/com/netflix/conductor/tasks/http/config/HttpTaskProperties.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.tasks.http.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("conductor.tasks.http")
+public class HttpTaskProperties {
+
+    /**
+     * List of regular expressions that define allowed URIs for HttpTask. If empty, all URIs are
+     * allowed.
+     */
+    private List<String> urlAllowList = new ArrayList<>();
+
+    public List<String> getUrlAllowList() {
+        return urlAllowList;
+    }
+
+    public void setUrlAllowList(List<String> urlAllowList) {
+        this.urlAllowList = urlAllowList;
+    }
+}

--- a/http-task/src/test/java/com/netflix/conductor/tasks/http/HttpTaskTest.java
+++ b/http-task/src/test/java/com/netflix/conductor/tasks/http/HttpTaskTest.java
@@ -42,6 +42,7 @@ import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.tasks.http.config.HttpTaskProperties;
 import com.netflix.conductor.tasks.http.providers.DefaultRestTemplateProvider;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -117,7 +118,7 @@ public class HttpTaskTest {
         workflowExecutor = mock(WorkflowExecutor.class);
         DefaultRestTemplateProvider defaultRestTemplateProvider =
                 new DefaultRestTemplateProvider(Duration.ofMillis(150), Duration.ofMillis(100));
-        httpTask = new HttpTask(defaultRestTemplateProvider, objectMapper);
+        httpTask = new HttpTask(defaultRestTemplateProvider, objectMapper, mock(HttpTaskProperties.class));
     }
 
     @Test

--- a/http-task/src/test/java/com/netflix/conductor/tasks/http/HttpTaskUnitTest.java
+++ b/http-task/src/test/java/com/netflix/conductor/tasks/http/HttpTaskUnitTest.java
@@ -30,7 +30,10 @@ import com.netflix.conductor.tasks.http.providers.DefaultRestTemplateProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**
@@ -228,7 +231,7 @@ public class HttpTaskUnitTest {
     }
 
     @Test
-    public void testUriAllowed() {
+    public void testUriAllowed() throws Exception {
         TaskModel task = new TaskModel();
         Map<String, Object> input = new HashMap<>();
         input.put("uri", "https://api.example.com/v1/users");
@@ -238,11 +241,14 @@ public class HttpTaskUnitTest {
         when(properties.getUrlAllowList())
                 .thenReturn(Arrays.asList("https://api\\.example\\.com/.*"));
 
-        httpTask.start(workflow, task, workflowExecutor);
+        HttpTask spyTask = spy(httpTask);
+        HttpTask.HttpResponse mockResponse = new HttpTask.HttpResponse();
+        mockResponse.statusCode = 200;
+        doReturn(mockResponse).when(spyTask).httpCall(any());
 
-        // Status will be FAILED because it tries to call real external URI in unit test,
-        // but it should NOT be FAILED_WITH_TERMINAL_ERROR (which is our security failure status).
-        assertNotEquals(TaskModel.Status.FAILED_WITH_TERMINAL_ERROR, task.getStatus());
+        spyTask.start(workflow, task, workflowExecutor);
+
+        assertEquals(TaskModel.Status.COMPLETED, task.getStatus());
     }
 
     @Test
@@ -263,7 +269,7 @@ public class HttpTaskUnitTest {
     }
 
     @Test
-    public void testUriAllowListEmpty() {
+    public void testUriAllowListEmpty() throws Exception {
         TaskModel task = new TaskModel();
         Map<String, Object> input = new HashMap<>();
         input.put("uri", "http://localhost:8080/admin");
@@ -272,9 +278,15 @@ public class HttpTaskUnitTest {
 
         when(properties.getUrlAllowList()).thenReturn(Arrays.asList());
 
-        httpTask.start(workflow, task, workflowExecutor);
+        HttpTask spyTask = spy(httpTask);
+        HttpTask.HttpResponse mockResponse = new HttpTask.HttpResponse();
+        mockResponse.statusCode = 200;
+        doReturn(mockResponse).when(spyTask).httpCall(any());
+
+        spyTask.start(workflow, task, workflowExecutor);
 
         // Should not fail with terminal error when allow-list is empty
         assertNotEquals(TaskModel.Status.FAILED_WITH_TERMINAL_ERROR, task.getStatus());
+        assertEquals(TaskModel.Status.COMPLETED, task.getStatus());
     }
 }

--- a/http-task/src/test/java/com/netflix/conductor/tasks/http/HttpTaskUnitTest.java
+++ b/http-task/src/test/java/com/netflix/conductor/tasks/http/HttpTaskUnitTest.java
@@ -24,12 +24,14 @@ import org.springframework.http.MediaType;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.tasks.http.config.HttpTaskProperties;
 import com.netflix.conductor.tasks.http.providers.DefaultRestTemplateProvider;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for HttpTask that do not require Docker/Testcontainers. Tests input resolution (with
@@ -40,15 +42,17 @@ public class HttpTaskUnitTest {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private WorkflowExecutor workflowExecutor;
     private HttpTask httpTask;
+    private HttpTaskProperties properties;
     private final WorkflowModel workflow = new WorkflowModel();
 
     @Before
     public void setup() {
         workflowExecutor = mock(WorkflowExecutor.class);
+        properties = mock(HttpTaskProperties.class);
         DefaultRestTemplateProvider restTemplateProvider =
                 new DefaultRestTemplateProvider(
                         java.time.Duration.ofMillis(150), java.time.Duration.ofMillis(100));
-        httpTask = new HttpTask(restTemplateProvider, objectMapper);
+        httpTask = new HttpTask(restTemplateProvider, objectMapper, properties);
     }
 
     // ---- Accept parameter tests (Input deserialization) ----
@@ -221,5 +225,56 @@ public class HttpTaskUnitTest {
         assertTrue(
                 "Should fail with missing URI",
                 task.getReasonForIncompletion().contains("Missing HTTP URI"));
+    }
+
+    @Test
+    public void testUriAllowed() {
+        TaskModel task = new TaskModel();
+        Map<String, Object> input = new HashMap<>();
+        input.put("uri", "https://api.example.com/v1/users");
+        input.put("method", "GET");
+        task.getInputData().put(HttpTask.REQUEST_PARAMETER_NAME, input);
+
+        when(properties.getUrlAllowList())
+                .thenReturn(Arrays.asList("https://api\\.example\\.com/.*"));
+
+        httpTask.start(workflow, task, workflowExecutor);
+
+        // Status will be FAILED because it tries to call real external URI in unit test,
+        // but it should NOT be FAILED_WITH_TERMINAL_ERROR (which is our security failure status).
+        assertNotEquals(TaskModel.Status.FAILED_WITH_TERMINAL_ERROR, task.getStatus());
+    }
+
+    @Test
+    public void testUriDisallowed() {
+        TaskModel task = new TaskModel();
+        Map<String, Object> input = new HashMap<>();
+        input.put("uri", "http://localhost:8080/admin");
+        input.put("method", "GET");
+        task.getInputData().put(HttpTask.REQUEST_PARAMETER_NAME, input);
+
+        when(properties.getUrlAllowList())
+                .thenReturn(Arrays.asList("https://api\\.example\\.com/.*"));
+
+        httpTask.start(workflow, task, workflowExecutor);
+
+        assertEquals(TaskModel.Status.FAILED_WITH_TERMINAL_ERROR, task.getStatus());
+        assertTrue(task.getReasonForIncompletion().contains("not allowed by the security policy"));
+    }
+
+    @Test
+    public void testUriAllowListEmpty() {
+        TaskModel task = new TaskModel();
+        Map<String, Object> input = new HashMap<>();
+        input.put("uri", "http://localhost:8080/admin");
+        input.put("method", "GET");
+        task.getInputData().put(HttpTask.REQUEST_PARAMETER_NAME, input);
+
+        when(properties.getUrlAllowList()).thenReturn(Arrays.asList());
+
+        httpTask.start(workflow, task, workflowExecutor);
+
+        // Should not fail with terminal error when allow-list is empty
+        assertNotEquals(TaskModel.Status.FAILED_WITH_TERMINAL_ERROR, task.getStatus());
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----
The current `HttpTask` implementation allows arbitrary HTTP requests to any URI provided in the workflow definition. This poses a significant security risk in multi-tenant or enterprise environments, as it could be exploited for Server-Side Request Forgery (SSRF) to probe internal networks or access sensitive metadata services (e.g., AWS/GCP metadata endpoints).

I've introduced a configurable URI allow-list mechanism using regular expressions. This allows administrators to restrict the set of URIs that `HttpTask` is permitted to interact with.

- Added `HttpTaskProperties` to manage the `conductor.tasks.http.urlAllowList` configuration.
- Implemented URI validation logic in `HttpTask` that checks the destination URI against the configured allow-list.
- If the allow-list is configured and a URI does not match, the task fails with a `FAILED_WITH_TERMINAL_ERROR` and a clear security violation message.
- Maintained backward compatibility: if the allow-list is empty (default), all URIs are allowed.

Alternatives considered
----
Considered implementing a hardcoded block-list for common metadata endpoints, but a configurable allow-list provides better flexibility and security for varying network architectures.
