### PR TITLE
fix(ai): exclude openhtmltopdf-pdfbox from flexmark-all to fix GENERATE_PDF on PDFBox 3.x

### DIFF
--- a/ai/build.gradle
+++ b/ai/build.gradle
@@ -27,7 +27,14 @@ dependencies {
     api "org.apache.commons:commons-lang3"
 
     // Markdown parsing and PDF generation
-    implementation "com.vladsch.flexmark:flexmark-all:${revFlexmark}"
+    // Exclude openhtmltopdf-pdfbox (pulled in by flexmark-pdf-converter inside flexmark-all):
+    // it was compiled against fontbox 2.x and calls TTFParser.parse(InputStream) which was
+    // removed in fontbox 3.x, causing a NoSuchMethodError at runtime in GENERATE_PDF tasks.
+    // The custom MarkdownToPdfConverter uses PDFBox 3.x directly and does not need openhtmltopdf.
+    implementation("com.vladsch.flexmark:flexmark-all:${revFlexmark}") {
+        exclude group: "com.openhtmltopdf", module: "openhtmltopdf-pdfbox"
+        exclude group: "de.rototor.pdfbox", module: "graphics2d"
+    }
     implementation "org.apache.pdfbox:pdfbox:3.0.5"
 
     //Vector Databases


### PR DESCRIPTION
## Problem

`GENERATE_PDF` workflow tasks fail at runtime with:

```
NoSuchMethodError: 'org.apache.fontbox.ttf.TrueTypeFont org.apache.fontbox.ttf.TTFParser.parse(java.io.InputStream)'
```

## Root cause

`flexmark-all` includes `flexmark-pdf-converter`, which transitively pulls in `openhtmltopdf-pdfbox:1.0.10`. That library was compiled against **fontbox 2.x** which exposes `TTFParser.parse(InputStream)`. The runtime classpath only has **fontbox 3.0.5** (via `pdfbox:3.0.5`), where that method was removed — causing a `NoSuchMethodError` whenever PDF generation runs.

Classpath conflict confirmed via `lsof` on the running server:
- `fontbox-3.0.5.jar` ✓ (correct)
- `openhtmltopdf-pdfbox-1.0.10.jar` ✗ (compiled against fontbox 2.x)
- `graphics2d-0.32.jar` ✗ (also compiled against fontbox 2.x)

## Fix

Exclude the two conflicting transitive deps from `flexmark-all`. The custom `MarkdownToPdfConverter` uses PDFBox 3.x APIs directly (`Standard14Fonts`, `PDType1Font`, etc.) and has zero dependency on `openhtmltopdf` — the exclusion is safe.

## Test

Run a `GENERATE_PDF` workflow task end-to-end. The Washishti GTM Mavericks workflow (`gtm_mavericks_v1`) was used to validate — all prior tasks complete, PDF generation succeeds after this fix.