### PR TITLE
prevent WorkflowMonitor OOM by projecting only metric fields

### DIFF
--- a/core/src/main/java/com/netflix/conductor/dao/MetadataDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/MetadataDAO.java
@@ -125,4 +125,38 @@ public interface MetadataDAO {
                         })
                 .collect(Collectors.toList());
     }
+
+    /**
+     * Lightweight projection of the latest version of each workflow definition, used to publish
+     * monitoring metrics without loading full definition bodies.
+     *
+     * <p>The default implementation projects from {@link #getAllWorkflowDefsLatestVersions()}.
+     * Persistence modules backed by a query-capable store should override this to project the
+     * fields at the database.
+     *
+     * @return one {@link WorkflowMetricInfo} per workflow name (latest version)
+     */
+    default List<WorkflowMetricInfo> getWorkflowMetricInfo() {
+        return getAllWorkflowDefsLatestVersions().stream()
+                .map(def -> new WorkflowMetricInfo(def.getName(), def.getOwnerApp()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Lightweight projection of task definitions, used to publish monitoring metrics without
+     * loading full definition bodies.
+     *
+     * <p>The default implementation projects from {@link #getAllTaskDefs()}. Persistence modules
+     * backed by a query-capable store should override this to project the fields at the database.
+     *
+     * @return one {@link TaskMetricInfo} per task definition
+     */
+    default List<TaskMetricInfo> getTaskMetricInfo() {
+        return getAllTaskDefs().stream()
+                .map(
+                        def ->
+                                new TaskMetricInfo(
+                                        def.getName(), def.getOwnerApp(), def.concurrencyLimit()))
+                .collect(Collectors.toList());
+    }
 }

--- a/core/src/main/java/com/netflix/conductor/dao/TaskMetricInfo.java
+++ b/core/src/main/java/com/netflix/conductor/dao/TaskMetricInfo.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.dao;
+
+/**
+ * Lightweight projection of a task definition carrying only the fields needed to publish monitoring
+ * metrics. Avoids deserializing the full {@code json_data} body when only the name, owner app and
+ * concurrency limit are required.
+ */
+public record TaskMetricInfo(String name, String ownerApp, int concurrencyLimit) {}

--- a/core/src/main/java/com/netflix/conductor/dao/WorkflowMetricInfo.java
+++ b/core/src/main/java/com/netflix/conductor/dao/WorkflowMetricInfo.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.dao;
+
+/**
+ * Lightweight projection of a workflow definition carrying only the fields needed to publish
+ * monitoring metrics. Avoids deserializing the full {@code json_data} body when only the name and
+ * owner app are required.
+ */
+public record WorkflowMetricInfo(String name, String ownerApp) {}

--- a/core/src/main/java/com/netflix/conductor/metrics/WorkflowMonitor.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/WorkflowMonitor.java
@@ -12,14 +12,8 @@
  */
 package com.netflix.conductor.metrics;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,12 +23,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import com.netflix.conductor.annotations.VisibleForTesting;
-import com.netflix.conductor.common.metadata.tasks.TaskDef;
-import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.core.dal.ExecutionDAOFacade;
 import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
 import com.netflix.conductor.dao.QueueDAO;
+import com.netflix.conductor.dao.TaskMetricInfo;
+import com.netflix.conductor.dao.WorkflowMetricInfo;
 import com.netflix.conductor.service.MetadataService;
 
 import static com.netflix.conductor.core.execution.tasks.SystemTaskRegistry.ASYNC_SYSTEM_TASKS_QUALIFIER;
@@ -54,8 +47,8 @@ public class WorkflowMonitor {
     private final int metadataRefreshInterval;
     private final Set<WorkflowSystemTask> asyncSystemTasks;
 
-    private List<TaskDef> taskDefs;
-    private List<WorkflowDef> workflowDefs;
+    private List<TaskMetricInfo> taskMetricInfos;
+    private List<WorkflowMetricInfo> workflowMetricInfos;
     private int refreshCounter = 0;
 
     public WorkflowMonitor(
@@ -79,28 +72,27 @@ public class WorkflowMonitor {
     public void reportMetrics() {
         try {
             if (refreshCounter <= 0) {
-                workflowDefs = metadataService.getWorkflowDefs();
-                taskDefs = new ArrayList<>(metadataService.getTaskDefs());
+                workflowMetricInfos = metadataService.getWorkflowMetricInfo();
+                taskMetricInfos = metadataService.getTaskMetricInfo();
                 refreshCounter = metadataRefreshInterval;
             }
 
-            getPendingWorkflowToOwnerAppMap(workflowDefs)
-                    .forEach(
-                            (workflowName, ownerApp) -> {
-                                long count =
-                                        executionDAOFacade.getPendingWorkflowCount(workflowName);
-                                Monitors.recordRunningWorkflows(count, workflowName, ownerApp);
-                            });
+            workflowMetricInfos.forEach(
+                    workflow -> {
+                        long count = executionDAOFacade.getPendingWorkflowCount(workflow.name());
+                        Monitors.recordRunningWorkflows(
+                                count, workflow.name(), workflow.ownerApp());
+                    });
 
-            taskDefs.forEach(
-                    taskDef -> {
-                        long size = queueDAO.getSize(taskDef.getName());
+            taskMetricInfos.forEach(
+                    task -> {
+                        long size = queueDAO.getSize(task.name());
                         long inProgressCount =
-                                executionDAOFacade.getInProgressTaskCount(taskDef.getName());
-                        Monitors.recordQueueDepth(taskDef.getName(), size, taskDef.getOwnerApp());
-                        if (taskDef.concurrencyLimit() > 0) {
+                                executionDAOFacade.getInProgressTaskCount(task.name());
+                        Monitors.recordQueueDepth(task.name(), size, task.ownerApp());
+                        if (task.concurrencyLimit() > 0) {
                             Monitors.recordTaskInProgress(
-                                    taskDef.getName(), inProgressCount, taskDef.getOwnerApp());
+                                    task.name(), inProgressCount, task.ownerApp());
                         }
                     });
 
@@ -119,27 +111,5 @@ public class WorkflowMonitor {
         } catch (Exception e) {
             LOGGER.error("Error while publishing scheduled metrics", e);
         }
-    }
-
-    /**
-     * Pending workflow data does not contain information about version. We only need the owner app
-     * and workflow name, and we only need to query for the workflow once.
-     */
-    @VisibleForTesting
-    Map<String, String> getPendingWorkflowToOwnerAppMap(List<WorkflowDef> workflowDefs) {
-        final Map<String, List<WorkflowDef>> groupedWorkflowDefs =
-                workflowDefs.stream().collect(Collectors.groupingBy(WorkflowDef::getName));
-
-        Map<String, String> workflowNameToOwnerMap = new HashMap<>();
-        groupedWorkflowDefs.forEach(
-                (key, value) -> {
-                    final WorkflowDef workflowDef =
-                            value.stream()
-                                    .max(Comparator.comparing(WorkflowDef::getVersion))
-                                    .orElseThrow(NoSuchElementException::new);
-
-                    workflowNameToOwnerMap.put(key, workflowDef.getOwnerApp());
-                });
-        return workflowNameToOwnerMap;
     }
 }

--- a/core/src/main/java/com/netflix/conductor/service/MetadataService.java
+++ b/core/src/main/java/com/netflix/conductor/service/MetadataService.java
@@ -23,6 +23,8 @@ import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDefSummary;
 import com.netflix.conductor.common.model.BulkResponse;
+import com.netflix.conductor.dao.TaskMetricInfo;
+import com.netflix.conductor.dao.WorkflowMetricInfo;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
@@ -170,4 +172,16 @@ public interface MetadataService {
      */
     List<WorkflowDefSummary> getWorkflowVersions(
             @NotEmpty(message = "Workflow name cannot be null or empty") String name);
+
+    /**
+     * @return Lightweight projection of the latest version of each workflow definition (name and
+     *     owner app only), used to publish monitoring metrics.
+     */
+    List<WorkflowMetricInfo> getWorkflowMetricInfo();
+
+    /**
+     * @return Lightweight projection of task definitions (name, owner app, concurrency limit), used
+     *     to publish monitoring metrics.
+     */
+    List<TaskMetricInfo> getTaskMetricInfo();
 }

--- a/core/src/main/java/com/netflix/conductor/service/MetadataServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/MetadataServiceImpl.java
@@ -33,6 +33,8 @@ import com.netflix.conductor.core.config.ConductorProperties;
 import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.dao.EventHandlerDAO;
 import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.dao.TaskMetricInfo;
+import com.netflix.conductor.dao.WorkflowMetricInfo;
 import com.netflix.conductor.validations.ValidationContext;
 
 @Service
@@ -223,6 +225,16 @@ public class MetadataServiceImpl implements MetadataService {
     @Override
     public List<WorkflowDef> getWorkflowDefsLatestVersions() {
         return metadataDAO.getAllWorkflowDefsLatestVersions();
+    }
+
+    @Override
+    public List<WorkflowMetricInfo> getWorkflowMetricInfo() {
+        return metadataDAO.getWorkflowMetricInfo();
+    }
+
+    @Override
+    public List<TaskMetricInfo> getTaskMetricInfo() {
+        return metadataDAO.getTaskMetricInfo();
     }
 
     public Map<String, ? extends Iterable<WorkflowDefSummary>> getWorkflowNamesAndVersions() {

--- a/core/src/test/java/com/netflix/conductor/metrics/WorkflowMonitorTest.java
+++ b/core/src/test/java/com/netflix/conductor/metrics/WorkflowMonitorTest.java
@@ -13,20 +13,25 @@
 package com.netflix.conductor.metrics;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.core.dal.ExecutionDAOFacade;
 import com.netflix.conductor.dao.QueueDAO;
+import com.netflix.conductor.dao.TaskMetricInfo;
+import com.netflix.conductor.dao.WorkflowMetricInfo;
 import com.netflix.conductor.service.MetadataService;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
 public class WorkflowMonitorTest {
@@ -43,32 +48,59 @@ public class WorkflowMonitorTest {
                 new WorkflowMonitor(metadataService, queueDAO, executionDAOFacade, 1000, Set.of());
     }
 
-    private WorkflowDef makeDef(String name, int version, String ownerApp) {
-        WorkflowDef wd = new WorkflowDef();
-        wd.setName(name);
-        wd.setVersion(version);
-        wd.setOwnerApp(ownerApp);
-        return wd;
+    @Test
+    public void testReportMetricsQueriesPerWorkflowName() {
+        when(metadataService.getWorkflowMetricInfo())
+                .thenReturn(
+                        List.of(
+                                new WorkflowMetricInfo("workflow1", "owner1"),
+                                new WorkflowMetricInfo("workflow2", "owner2")));
+        when(metadataService.getTaskMetricInfo()).thenReturn(List.of());
+
+        workflowMonitor.reportMetrics();
+
+        verify(executionDAOFacade).getPendingWorkflowCount("workflow1");
+        verify(executionDAOFacade).getPendingWorkflowCount("workflow2");
     }
 
     @Test
-    public void testPendingWorkflowDataMap() {
-        WorkflowDef test1_1 = makeDef("test1", 1, null);
-        WorkflowDef test1_2 = makeDef("test1", 2, "name1");
+    public void testReportMetricsRecordsInProgressOnlyWhenConcurrencyLimited() {
+        when(metadataService.getWorkflowMetricInfo()).thenReturn(List.of());
+        when(metadataService.getTaskMetricInfo())
+                .thenReturn(
+                        List.of(
+                                new TaskMetricInfo("limited", "owner", 5),
+                                new TaskMetricInfo("unlimited", "owner", 0)));
 
-        WorkflowDef test2_1 = makeDef("test2", 1, "first");
-        WorkflowDef test2_2 = makeDef("test2", 2, "mid");
-        WorkflowDef test2_3 = makeDef("test2", 3, "last");
+        workflowMonitor.reportMetrics();
 
-        final Map<String, String> mapping =
-                workflowMonitor.getPendingWorkflowToOwnerAppMap(
-                        List.of(test1_1, test1_2, test2_1, test2_2, test2_3));
+        // Queue depth is recorded for every task; in-progress count is queried for both, but
+        // only the concurrency-limited task should drive an in-progress metric.
+        verify(queueDAO).getSize("limited");
+        verify(queueDAO).getSize("unlimited");
+        verify(executionDAOFacade).getInProgressTaskCount("limited");
+    }
 
-        Assert.assertEquals(2, mapping.keySet().size());
-        Assert.assertTrue(mapping.containsKey("test1"));
-        Assert.assertTrue(mapping.containsKey("test2"));
+    @Test
+    public void testRefreshHappensOncePerInterval() {
+        when(metadataService.getWorkflowMetricInfo()).thenReturn(List.of());
+        when(metadataService.getTaskMetricInfo()).thenReturn(List.of());
 
-        Assert.assertEquals("name1", mapping.get("test1"));
-        Assert.assertEquals("last", mapping.get("test2"));
+        workflowMonitor.reportMetrics();
+        workflowMonitor.reportMetrics();
+
+        // metadataRefreshInterval is 1000, so the cached defs are reused on the second call.
+        verify(metadataService, times(1)).getWorkflowMetricInfo();
+        verify(metadataService, times(1)).getTaskMetricInfo();
+    }
+
+    @Test
+    public void testNoMetricsWhenCatalogEmpty() {
+        when(metadataService.getWorkflowMetricInfo()).thenReturn(List.of());
+        when(metadataService.getTaskMetricInfo()).thenReturn(List.of());
+
+        workflowMonitor.reportMetrics();
+
+        verify(executionDAOFacade, never()).getPendingWorkflowCount(anyString());
     }
 }

--- a/mysql-persistence/src/main/java/com/netflix/conductor/mysql/dao/MySQLMetadataDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/mysql/dao/MySQLMetadataDAO.java
@@ -33,6 +33,8 @@ import com.netflix.conductor.core.exception.ConflictException;
 import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.dao.EventHandlerDAO;
 import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.dao.TaskMetricInfo;
+import com.netflix.conductor.dao.WorkflowMetricInfo;
 import com.netflix.conductor.metrics.Monitors;
 import com.netflix.conductor.mysql.config.MySQLProperties;
 
@@ -201,6 +203,51 @@ public class MySQLMetadataDAO extends MySQLBaseDAO implements MetadataDAO, Event
         return queryWithTransaction(
                 GET_ALL_WORKFLOW_DEF_LATEST_VERSIONS_QUERY,
                 q -> q.executeAndFetch(WorkflowDef.class));
+    }
+
+    @Override
+    public List<WorkflowMetricInfo> getWorkflowMetricInfo() {
+        final String QUERY =
+                "SELECT name, JSON_UNQUOTE(JSON_EXTRACT(json_data, '$.ownerApp')) AS owner_app "
+                        + "FROM meta_workflow_def wd WHERE wd.version = "
+                        + "(SELECT MAX(version) FROM meta_workflow_def wd2 WHERE wd2.name = wd.name)";
+        return queryWithTransaction(
+                QUERY,
+                q ->
+                        q.executeAndFetch(
+                                rs -> {
+                                    List<WorkflowMetricInfo> result = new ArrayList<>();
+                                    while (rs.next()) {
+                                        result.add(
+                                                new WorkflowMetricInfo(
+                                                        rs.getString("name"),
+                                                        rs.getString("owner_app")));
+                                    }
+                                    return result;
+                                }));
+    }
+
+    @Override
+    public List<TaskMetricInfo> getTaskMetricInfo() {
+        final String QUERY =
+                "SELECT name, JSON_UNQUOTE(JSON_EXTRACT(json_data, '$.ownerApp')) AS owner_app, "
+                        + "COALESCE(CAST(JSON_EXTRACT(json_data, '$.concurrentExecLimit') AS SIGNED), 0) AS concurrency_limit "
+                        + "FROM meta_task_def";
+        return queryWithTransaction(
+                QUERY,
+                q ->
+                        q.executeAndFetch(
+                                rs -> {
+                                    List<TaskMetricInfo> result = new ArrayList<>();
+                                    while (rs.next()) {
+                                        result.add(
+                                                new TaskMetricInfo(
+                                                        rs.getString("name"),
+                                                        rs.getString("owner_app"),
+                                                        rs.getInt("concurrency_limit")));
+                                    }
+                                    return result;
+                                }));
     }
 
     public List<WorkflowDef> getAllLatest() {

--- a/mysql-persistence/src/test/java/com/netflix/conductor/mysql/dao/MySQLMetadataDAOTest.java
+++ b/mysql-persistence/src/test/java/com/netflix/conductor/mysql/dao/MySQLMetadataDAOTest.java
@@ -37,6 +37,8 @@ import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.core.exception.NonTransientException;
+import com.netflix.conductor.dao.TaskMetricInfo;
+import com.netflix.conductor.dao.WorkflowMetricInfo;
 import com.netflix.conductor.mysql.config.MySQLConfiguration;
 
 import static org.junit.Assert.assertEquals;
@@ -318,5 +320,57 @@ public class MySQLMetadataDAOTest {
         assertEquals(1, allMap.get("test1").getVersion());
         assertEquals(2, allMap.get("test2").getVersion());
         assertEquals(3, allMap.get("test3").getVersion());
+    }
+
+    @Test
+    public void testGetWorkflowMetricInfo() {
+        WorkflowDef def = new WorkflowDef();
+        def.setName("metricWf");
+        def.setVersion(1);
+        def.setOwnerApp("ownerV1");
+        metadataDAO.createWorkflowDef(def);
+
+        def.setVersion(2);
+        def.setOwnerApp("ownerV2");
+        metadataDAO.createWorkflowDef(def);
+
+        Map<String, WorkflowMetricInfo> byName =
+                metadataDAO.getWorkflowMetricInfo().stream()
+                        .collect(Collectors.toMap(WorkflowMetricInfo::name, Function.identity()));
+
+        // Only the latest version is projected, carrying its ownerApp.
+        assertTrue(byName.containsKey("metricWf"));
+        assertEquals("ownerV2", byName.get("metricWf").ownerApp());
+
+        // Clean up: the suite shares one DB across tests and several assert on total counts.
+        metadataDAO.removeWorkflowDef("metricWf", 2);
+        metadataDAO.removeWorkflowDef("metricWf", 1);
+    }
+
+    @Test
+    public void testGetTaskMetricInfo() {
+        TaskDef limited = new TaskDef();
+        limited.setName("limitedTask");
+        limited.setOwnerApp("taskOwner");
+        limited.setConcurrentExecLimit(7);
+        metadataDAO.createTaskDef(limited);
+
+        TaskDef unlimited = new TaskDef();
+        unlimited.setName("unlimitedTask");
+        unlimited.setOwnerApp("taskOwner");
+        metadataDAO.createTaskDef(unlimited);
+
+        Map<String, TaskMetricInfo> byName =
+                metadataDAO.getTaskMetricInfo().stream()
+                        .collect(Collectors.toMap(TaskMetricInfo::name, Function.identity()));
+
+        assertEquals("taskOwner", byName.get("limitedTask").ownerApp());
+        assertEquals(7, byName.get("limitedTask").concurrencyLimit());
+        // Missing concurrentExecLimit projects to 0.
+        assertEquals(0, byName.get("unlimitedTask").concurrencyLimit());
+
+        // Clean up: the suite shares one DB across tests and several assert on total counts.
+        metadataDAO.removeTaskDef("limitedTask");
+        metadataDAO.removeTaskDef("unlimitedTask");
     }
 }

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAO.java
@@ -31,6 +31,8 @@ import com.netflix.conductor.core.exception.ConflictException;
 import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.dao.EventHandlerDAO;
 import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.dao.TaskMetricInfo;
+import com.netflix.conductor.dao.WorkflowMetricInfo;
 import com.netflix.conductor.metrics.Monitors;
 import com.netflix.conductor.postgres.config.PostgresProperties;
 import com.netflix.conductor.postgres.util.ExecutorsUtil;
@@ -227,6 +229,51 @@ public class PostgresMetadataDAO extends PostgresBaseDAO implements MetadataDAO,
         return queryWithTransaction(
                 GET_ALL_WORKFLOW_DEF_LATEST_VERSIONS_QUERY,
                 q -> q.executeAndFetch(WorkflowDef.class));
+    }
+
+    @Override
+    public List<WorkflowMetricInfo> getWorkflowMetricInfo() {
+        final String QUERY =
+                "SELECT name, json_data::jsonb->>'ownerApp' AS owner_app "
+                        + "FROM meta_workflow_def wd WHERE wd.version = "
+                        + "(SELECT MAX(version) FROM meta_workflow_def wd2 WHERE wd2.name = wd.name)";
+        return queryWithTransaction(
+                QUERY,
+                q ->
+                        q.executeAndFetch(
+                                rs -> {
+                                    List<WorkflowMetricInfo> result = new ArrayList<>();
+                                    while (rs.next()) {
+                                        result.add(
+                                                new WorkflowMetricInfo(
+                                                        rs.getString("name"),
+                                                        rs.getString("owner_app")));
+                                    }
+                                    return result;
+                                }));
+    }
+
+    @Override
+    public List<TaskMetricInfo> getTaskMetricInfo() {
+        final String QUERY =
+                "SELECT name, json_data::jsonb->>'ownerApp' AS owner_app, "
+                        + "COALESCE((json_data::jsonb->>'concurrentExecLimit')::int, 0) AS concurrency_limit "
+                        + "FROM meta_task_def";
+        return queryWithTransaction(
+                QUERY,
+                q ->
+                        q.executeAndFetch(
+                                rs -> {
+                                    List<TaskMetricInfo> result = new ArrayList<>();
+                                    while (rs.next()) {
+                                        result.add(
+                                                new TaskMetricInfo(
+                                                        rs.getString("name"),
+                                                        rs.getString("owner_app"),
+                                                        rs.getInt("concurrency_limit")));
+                                    }
+                                    return result;
+                                }));
     }
 
     public List<WorkflowDef> getAllLatest() {

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAOTest.java
@@ -40,6 +40,8 @@ import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDefSummary;
 import com.netflix.conductor.core.exception.NonTransientException;
+import com.netflix.conductor.dao.TaskMetricInfo;
+import com.netflix.conductor.dao.WorkflowMetricInfo;
 import com.netflix.conductor.postgres.config.PostgresConfiguration;
 
 import static org.junit.Assert.assertEquals;
@@ -376,5 +378,57 @@ public class PostgresMetadataDAOTest {
         List<WorkflowDefSummary> empty = metadataDAO.getWorkflowVersions("nonexistent_workflow");
         assertNotNull(empty);
         assertTrue(empty.isEmpty());
+    }
+
+    @Test
+    public void testGetWorkflowMetricInfo() {
+        WorkflowDef def = new WorkflowDef();
+        def.setName("metricWf");
+        def.setVersion(1);
+        def.setOwnerApp("ownerV1");
+        metadataDAO.createWorkflowDef(def);
+
+        def.setVersion(2);
+        def.setOwnerApp("ownerV2");
+        metadataDAO.createWorkflowDef(def);
+
+        Map<String, WorkflowMetricInfo> byName =
+                metadataDAO.getWorkflowMetricInfo().stream()
+                        .collect(Collectors.toMap(WorkflowMetricInfo::name, Function.identity()));
+
+        // Only the latest version is projected, carrying its ownerApp.
+        assertTrue(byName.containsKey("metricWf"));
+        assertEquals("ownerV2", byName.get("metricWf").ownerApp());
+
+        // Clean up: the suite shares one DB across tests and several assert on total counts.
+        metadataDAO.removeWorkflowDef("metricWf", 2);
+        metadataDAO.removeWorkflowDef("metricWf", 1);
+    }
+
+    @Test
+    public void testGetTaskMetricInfo() {
+        TaskDef limited = new TaskDef();
+        limited.setName("limitedTask");
+        limited.setOwnerApp("taskOwner");
+        limited.setConcurrentExecLimit(7);
+        metadataDAO.createTaskDef(limited);
+
+        TaskDef unlimited = new TaskDef();
+        unlimited.setName("unlimitedTask");
+        unlimited.setOwnerApp("taskOwner");
+        metadataDAO.createTaskDef(unlimited);
+
+        Map<String, TaskMetricInfo> byName =
+                metadataDAO.getTaskMetricInfo().stream()
+                        .collect(Collectors.toMap(TaskMetricInfo::name, Function.identity()));
+
+        assertEquals("taskOwner", byName.get("limitedTask").ownerApp());
+        assertEquals(7, byName.get("limitedTask").concurrencyLimit());
+        // Missing concurrentExecLimit projects to 0.
+        assertEquals(0, byName.get("unlimitedTask").concurrencyLimit());
+
+        // Clean up: the suite shares one DB across tests and several assert on total counts.
+        metadataDAO.removeTaskDef("limitedTask");
+        metadataDAO.removeTaskDef("unlimitedTask");
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR


  `WorkflowMonitor.reportMetrics()` runs on every node (enabled by default) and
  loaded
  **every version of every** workflow/task definition via
  `getWorkflowDefs()`/`getTaskDefs()`,
  deserializing the full `json_data` into `WorkflowDef`/`TaskDef` objects just to
  read `name`,
  `ownerApp`, and `concurrencyLimit`. At ~100K definitions this peaked at hundreds
  of MB of heap
  per refresh, causing a recurring `OutOfMemoryError` that cascaded into sweeper,
  polling, and
  HikariPool failures.

  This PR adds lightweight projections:
  - New DTOs `WorkflowMetricInfo(name, ownerApp)` and `TaskMetricInfo(name,
  ownerApp, concurrencyLimit)`.
  - `getWorkflowMetricInfo()` / `getTaskMetricInfo()` on `MetadataDAO` with a
  **default**
    implementation projecting from `getAllWorkflowDefsLatestVersions()` /
  `getAllTaskDefs()`
    (Redis/Cassandra/SQLite unchanged); **Postgres** and **MySQL** override with
  of catalog size,
  with no change to the emitted metrics.

  Issue #  https://github.com/conductor-oss/conductor/issues/1006

Alternatives considered
----

Set conductor.workflow-monitor.enabled=false on deployments that don't need these metrics and increase heap on deployments where it stays enabled.
