### PR TITLE
fix: requeue workflows when decide or decideWithLock cannot acquire lock

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
@@ -1125,6 +1125,8 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
         watch.start();
         boolean lockAcquired = executionLockService.acquireLock(workflowId);
         if (!lockAcquired) {
+            enqueueWorkflowForDecision(
+                    workflowId, "workflow execution lock was not available while trying to decide");
             return null;
         }
         try {
@@ -1148,15 +1150,34 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
     @Override
     public WorkflowModel decideWithLock(WorkflowModel workflow) {
         if (!executionLockService.acquireLock(workflow.getWorkflowId())) {
-            LOGGER.debug(
-                    "decideWithLock couldn't acquire lock for workflow {}",
-                    workflow.getWorkflowId());
+            enqueueWorkflowForDecision(
+                    workflow.getWorkflowId(),
+                    "workflow execution lock was not available while trying to decideWithLock");
             return null;
         }
         try {
             return decide(workflow);
         } finally {
             executionLockService.releaseLock(workflow.getWorkflowId());
+        }
+    }
+
+    private void enqueueWorkflowForDecision(String workflowId, String reason) {
+        try {
+            // A task completion is the edge that schedules its successor. If that edge races with
+            // another decide() call holding the workflow lock, the current decide() cannot safely
+            // inspect the newly persisted task state. Re-queue the workflow immediately so the
+            // decider retries after the lock holder exits instead of leaving the completed task as
+            // the last visible workflow event.
+            queueDAO.push(DECIDER_QUEUE, workflowId, EXPEDITED_PRIORITY, 0);
+            LOGGER.info("Pushed workflow {} to {} because {}", workflowId, DECIDER_QUEUE, reason);
+        } catch (Exception e) {
+            LOGGER.warn(
+                    "Unable to push workflow {} to {} after skipped decide: {}",
+                    workflowId,
+                    DECIDER_QUEUE,
+                    reason,
+                    e);
         }
     }
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -985,6 +985,33 @@ public class TestWorkflowExecutor {
         verify(executionLockService, atLeastOnce()).releaseLock("queued-workflow-id");
     }
 
+    @Test
+    public void testDecideRequeuesWorkflowWhenLockIsNotAcquired() {
+        String workflowId = "lock-busy-workflow-id";
+        when(executionLockService.acquireLock(workflowId)).thenReturn(false);
+
+        WorkflowModel result = workflowExecutor.decide(workflowId);
+
+        assertNull(result);
+        verify(queueDAO).push("_deciderQueue", workflowId, 10, 0);
+        verify(executionDAOFacade, never()).getWorkflowModel(anyString(), anyBoolean());
+        verify(executionLockService, never()).releaseLock(workflowId);
+    }
+
+    @Test
+    public void testDecideWithLockRequeuesWorkflowWhenLockIsNotAcquired() {
+        String workflowId = "lock-busy-wl-workflow-id";
+        WorkflowModel workflow = new WorkflowModel();
+        workflow.setWorkflowId(workflowId);
+        when(executionLockService.acquireLock(workflowId)).thenReturn(false);
+
+        WorkflowModel result = workflowExecutor.decideWithLock(workflow);
+
+        assertNull(result);
+        verify(queueDAO).push("_deciderQueue", workflowId, 10, 0);
+        verify(executionLockService, never()).releaseLock(workflowId);
+    }
+
     @Test(expected = NotFoundException.class)
     public void testRetryNonTerminalWorkflow() {
         WorkflowModel workflow = new WorkflowModel();
@@ -2447,6 +2474,8 @@ public class TestWorkflowExecutor {
         // if workflow is in PAUSED state
         workflow.setStatus(WorkflowModel.Status.PAUSED);
         when(executionDAOFacade.getWorkflowModel(workflowId, false)).thenReturn(workflow);
+        when(executionDAOFacade.getWorkflowModel(workflowId, true)).thenReturn(null);
+        when(executionLockService.acquireLock(workflowId)).thenReturn(true);
         workflowExecutor.resumeWorkflow(workflowId);
         assertEquals(WorkflowModel.Status.RUNNING, workflow.getStatus());
         assertTrue(workflow.getLastRetriedTime() > 0);


### PR DESCRIPTION
Fixes #1132

## Root cause

When a task completes, the worker calls `decide(workflowId)` (or `decideWithLock(workflow)` in the Orkes path). If another decider loop is already holding the workflow lock at that instant, `acquireLock` returns `false` and the method returned `null` — silently discarding the signal. The sweep queue eventually picks up the workflow again, but with the default no-priority offset, that retry can lag far behind or be starved entirely, leaving the workflow stalled until a human pauses and resumes it.

## Fix

Both entry points now push the workflow to the decider queue at expedited priority (`EXPEDITED_PRIORITY = 10`, offset 0) when they cannot acquire the lock. The lock holder will finish its decide pass and the queued message ensures the fresh task state is evaluated right afterward.

## Changes

- `decide(String workflowId)` — requeues via `enqueueWorkflowForDecision` when `acquireLock` returns false (approach from PR #1133; credit: Atul Pandey / prod-blip)
- `decideWithLock(WorkflowModel)` — same treatment; this is the code path used by the Orkes sweeper and task-completion handler and was the remaining gap after #1133
- Added `enqueueWorkflowForDecision` private helper used by both
- Two new regression tests covering the lock-busy case for each entry point
- Fixed `testResumeWorkflow` which called into `decide` and needed `acquireLock` stubbed

## User impact

Subworkflows inside FORK_JOIN_DYNAMIC that stall after an HTTP task completes — requiring a manual pause/resume in the UI — should now recover automatically when the lock-contention race occurs.

## Relation to PR #1133

PR #1133 (by prod-blip) covers the `decide(String)` path. This PR covers both paths and supersedes #1133. The test fix for `testResumeWorkflow` (also in #1133) is included here.

## Testing
- `./gradlew spotlessApply`
- `./gradlew :conductor-core:test --tests "*.TestWorkflowExecutor.testDecideRequeuesWorkflowWhenLockIsNotAcquired"`
- `./gradlew :conductor-core:test --tests "*.TestWorkflowExecutor.testDecideWithLockRequeuesWorkflowWhenLockIsNotAcquired"`
- `./gradlew :conductor-core:test` — all pass