### PR TITLE
fix: SWITCH task no longer falls through to defaultCase when matched case is empty

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SwitchTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SwitchTaskMapper.java
@@ -115,9 +115,9 @@ public class SwitchTaskMapper implements TaskMapper {
 
         // get the list of tasks based on the evaluated expression
         List<WorkflowTask> selectedTasks = workflowTask.getDecisionCases().get(evalResult);
-        // if the tasks returned are empty based on evaluated result, then get the default case if
-        // there is one
-        if (selectedTasks == null || selectedTasks.isEmpty()) {
+        // fall back to defaultCase only when no case key matched (null); an explicitly empty case
+        // list means the branch intentionally has no tasks and should not execute the default
+        if (selectedTasks == null) {
             selectedTasks = workflowTask.getDefaultCase();
         }
         // once there are selected tasks that need to proceeded as part of the switch, get the next

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/SwitchTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/SwitchTaskMapperTest.java
@@ -244,6 +244,46 @@ public class SwitchTaskMapperTest {
     }
 
     @Test
+    public void getMappedTasksWithEmptyMatchedCase() {
+        // A case key matches but has no tasks — should NOT fall through to defaultCase.
+        WorkflowTask switchTask = new WorkflowTask();
+        switchTask.setType(TaskType.SWITCH.name());
+        switchTask.setName("Switch");
+        switchTask.setTaskReferenceName("switchTask");
+        switchTask.setDefaultCase(Collections.singletonList(task1));
+        switchTask.setEvaluatorType(JavascriptEvaluator.NAME);
+        switchTask.setExpression("'true'");
+        Map<String, List<WorkflowTask>> decisionCases = new HashMap<>();
+        decisionCases.put("true", Collections.emptyList());
+        switchTask.setDecisionCases(decisionCases);
+
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setSchemaVersion(2);
+        WorkflowModel workflowModel = new WorkflowModel();
+        workflowModel.setWorkflowDefinition(workflowDef);
+
+        Map<String, Object> input =
+                parametersUtils.getTaskInput(
+                        switchTask.getInputParameters(), workflowModel, null, null);
+
+        TaskMapperContext taskMapperContext =
+                TaskMapperContext.newBuilder()
+                        .withWorkflowModel(workflowModel)
+                        .withWorkflowTask(switchTask)
+                        .withTaskInput(input)
+                        .withRetryCount(0)
+                        .withTaskId(idGenerator.generate())
+                        .withDeciderService(deciderService)
+                        .build();
+
+        List<TaskModel> mappedTasks = switchTaskMapper.getMappedTasks(taskMapperContext);
+
+        // Only the SWITCH task itself; defaultCase task must not be scheduled.
+        assertEquals(1, mappedTasks.size());
+        assertEquals("switchTask", mappedTasks.get(0).getReferenceTaskName());
+    }
+
+    @Test
     public void getMappedTasksWhenEvaluatorThrowsException() {
 
         // Given


### PR DESCRIPTION
## Summary

- When a `SWITCH` task evaluates to a case key that exists in `decisionCases` but has an empty task list (e.g. `"true": []`), the workflow was incorrectly executing the `defaultCase` tasks.
- Root cause: `SwitchTaskMapper` treated `selectedTasks.isEmpty()` the same as `selectedTasks == null`, collapsing the distinction between "no key matched" and "key matched, no tasks."
- Fix: remove the `isEmpty()` check so the fallback only triggers on `null` (no matching key).

## User impact

Users who intentionally defined an empty SWITCH branch (a "no-op" path) saw their workflow take the `defaultCase` path instead — potentially triggering termination tasks or other unintended steps even though the expression evaluated correctly.

## Changes

- `SwitchTaskMapper.java`: remove `|| selectedTasks.isEmpty()` from the defaultCase fallback condition
- `SwitchTaskMapperTest.java`: add `getMappedTasksWithEmptyMatchedCase` test asserting only the SWITCH task itself is scheduled when the matched case has no tasks

Fixes #396