### PR TITLE
fix: execution page rendering fix

### DIFF
--- a/ui-next/src/pages/execution/state/executionMapper.test.js
+++ b/ui-next/src/pages/execution/state/executionMapper.test.js
@@ -31,6 +31,12 @@ describe("executionToWorkflowDef", () => {
         sampleExecutedObject.taskId,
       );
     });
+    it("Should return an empty map when the execution has no tasks field", () => {
+      // Executions can come back without a `tasks` field; this used to throw
+      // "Cannot read properties of undefined (reading 'reduce')".
+      expect(() => executionTasksToStatusMap(undefined)).not.toThrow();
+      expect(executionTasksToStatusMap(undefined)).toEqual({});
+    });
   });
   describe("taskStatusUpdater", () => {
     it("Should return tasks with an executionData object", () => {

--- a/ui-next/src/pages/execution/state/executionMapper.ts
+++ b/ui-next/src/pages/execution/state/executionMapper.ts
@@ -50,7 +50,11 @@ type StatusMapTupleAcumulator = [
   StatusMap,
   Record<string, DynamicForkRelations>,
 ];
-export const executionTasksToStatusMap = (executionTasks: ExecutionTask[]) => {
+export const executionTasksToStatusMap = (
+  // Executions can come back without a `tasks` field (e.g. a workflow that has
+  // not started running any tasks yet); treat that as an empty list.
+  executionTasks: ExecutionTask[] = [],
+) => {
   const [statusMap] = executionTasks.reduce(
     (
       [acc, related]: StatusMapTupleAcumulator,


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

## What
Fix a crash when rendering an execution whose JSON has no `tasks` field.

## Why
`executionToWorkflowDef` calls `executionTasksToStatusMap(execution.tasks)`. When `execution.tasks` is `undefined` (e.g. a workflow that hasn't run any tasks yet), `.reduce` throws:

Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'reduce')
  at executionTasksToStatusMap (executionMapper.ts)
  at executionToWorkflowDef (executionMapper.ts)
  at executionToExecutionStatusExpand (actions.ts)

## How
Default `executionTasksToStatusMap`'s param to `[]`, so a missing tasks list
is treated as empty and the status map builds cleanly.

## Test
- Open an execution whose payload omits `tasks` → page renders instead of throwing.
- Existing executions with tasks render unchanged.

## Screenshots
| Before | After |
|--------|--------|
|<img width="1274" height="760" alt="Screenshot 2026-06-10 at 11 48 23 AM" src="https://github.com/user-attachments/assets/9fa63a11-6106-4cc5-b410-a0c0823f9457" /> | <img width="1270" height="752" alt="Screenshot 2026-06-10 at 11 47 52 AM" src="https://github.com/user-attachments/assets/14ef7fc1-2697-4f3c-b4ed-a0d59a2d60fa" /> | 