### PR TITLE
fix(ui): keep post-save redirect on the saved workflow URL

### DIFF
--- a/ui-next/src/pages/definition/state/hook.ts
+++ b/ui-next/src/pages/definition/state/hook.ts
@@ -10,7 +10,7 @@ import {
 import { usePanelChanges } from "pages/definition/state/usePanelChanges";
 import { removeDeletedWorkflow } from "pages/runWorkflow/runWorkflowUtils";
 import { fetchWithContext, useFetchContext } from "plugins/fetch";
-import { useContext, useEffect, useMemo } from "react";
+import { useCallback, useContext, useEffect, useMemo } from "react";
 import { useQueryClient } from "react-query";
 import { Location, useLocation, useNavigate, useParams } from "react-router";
 import { useQueryState } from "react-router-use-location-state";
@@ -25,6 +25,7 @@ import { WORKFLOW_DEFINITION_URL } from "utils/constants/route";
 import { useActionWithPath, useAuthHeaders } from "utils/query";
 import { ActorRef, State } from "xstate";
 import { workflowDefinitionMachine } from "./machine";
+import { nextQueryString } from "./queryParam";
 
 const WORKFLOW_FETCH_FAILED = "Failed to fetch workflow";
 const WORKFLOW_FETCH_FORBIDDEN =
@@ -37,21 +38,41 @@ export const useWorkflowDefinition = (currentUser: User) => {
   const queryClient = useQueryClient();
   const fetchContext = useFetchContext(); // Maintain compatibility
   const { setMessage } = useContext(MessageContext);
-  const [timeInParameter, setTimeInParameter] = useQueryState<string>(
-    "showImportSuccess",
-    "",
-  );
+  // Read-only; writers are defined below (see setLiveQueryParam).
+  const [timeInParameter] = useQueryState<string>("showImportSuccess", "");
   const [blogUrl] = useQueryState<string>("blogUrl", "");
-  const [taskReferenceName, handleTaskReferenceName] = useQueryState<string>(
-    "taskReferenceName",
-    "",
-  );
+  const [taskReferenceName] = useQueryState<string>("taskReferenceName", "");
   const authHeaders = useAuthHeaders();
 
   const setDefinitionService = useSetAtom(setDefinitionServiceAtom);
 
   // Needed stuff for compatibility mode
   const navigate = useNavigate();
+
+  // Writes a query param off the live window.location (not a render-captured
+  // one) and skips no-op writes, so a setter firing right after pushToHistory
+  // can't rebuild a stale url and revert the navigation.
+  const setLiveQueryParam = useCallback(
+    (key: string, value: string | undefined) => {
+      const { pathname, search } = window.location;
+      const next = nextQueryString(search, key, value);
+      if (next === null) {
+        return;
+      }
+      navigate({ pathname, search: next }, { replace: true });
+    },
+    [navigate],
+  );
+
+  const handleTaskReferenceName = useCallback(
+    (value: string | undefined) => setLiveQueryParam("taskReferenceName", value),
+    [setLiveQueryParam],
+  );
+
+  const setTimeInParameter = useCallback(
+    (value: string) => setLiveQueryParam("showImportSuccess", value),
+    [setLiveQueryParam],
+  );
 
   const { authService } = useContext(AuthContext);
 

--- a/ui-next/src/pages/definition/state/hook.ts
+++ b/ui-next/src/pages/definition/state/hook.ts
@@ -65,7 +65,8 @@ export const useWorkflowDefinition = (currentUser: User) => {
   );
 
   const handleTaskReferenceName = useCallback(
-    (value: string | undefined) => setLiveQueryParam("taskReferenceName", value),
+    (value: string | undefined) =>
+      setLiveQueryParam("taskReferenceName", value),
     [setLiveQueryParam],
   );
 

--- a/ui-next/src/pages/definition/state/queryParam.test.ts
+++ b/ui-next/src/pages/definition/state/queryParam.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { nextQueryString } from "./queryParam";
+
+describe("nextQueryString", () => {
+  it("adds a new param to an empty search", () => {
+    expect(nextQueryString("", "taskReferenceName", "simple_ref")).toEqual(
+      "taskReferenceName=simple_ref",
+    );
+  });
+
+  it("adds a param while preserving existing ones", () => {
+    expect(nextQueryString("?foo=bar", "taskReferenceName", "ref")).toEqual(
+      "foo=bar&taskReferenceName=ref",
+    );
+  });
+
+  it("updates an existing param's value", () => {
+    expect(nextQueryString("?taskReferenceName=old", "taskReferenceName", "new")).toEqual(
+      "taskReferenceName=new",
+    );
+  });
+
+  it("removes a param when the value is empty", () => {
+    expect(nextQueryString("?taskReferenceName=ref&foo=bar", "taskReferenceName", "")).toEqual(
+      "foo=bar",
+    );
+  });
+
+  it("removes a param when the value is undefined", () => {
+    expect(nextQueryString("?taskReferenceName=ref", "taskReferenceName", undefined)).toEqual(
+      "",
+    );
+  });
+
+  it("returns null (skip navigation) when setting the same value", () => {
+    expect(nextQueryString("?taskReferenceName=ref", "taskReferenceName", "ref")).toBeNull();
+  });
+
+  it("returns null (skip navigation) when clearing a param that is absent", () => {
+    // The dismissImportSuccessfullParam case: clearing showImportSuccess when
+    // it isn't present must not trigger a navigation.
+    expect(nextQueryString("?foo=bar", "showImportSuccess", "")).toBeNull();
+  });
+
+  it("returns null when clearing on an empty search", () => {
+    expect(nextQueryString("", "showImportSuccess", "")).toBeNull();
+  });
+});

--- a/ui-next/src/pages/definition/state/queryParam.test.ts
+++ b/ui-next/src/pages/definition/state/queryParam.test.ts
@@ -15,25 +15,31 @@ describe("nextQueryString", () => {
   });
 
   it("updates an existing param's value", () => {
-    expect(nextQueryString("?taskReferenceName=old", "taskReferenceName", "new")).toEqual(
-      "taskReferenceName=new",
-    );
+    expect(
+      nextQueryString("?taskReferenceName=old", "taskReferenceName", "new"),
+    ).toEqual("taskReferenceName=new");
   });
 
   it("removes a param when the value is empty", () => {
-    expect(nextQueryString("?taskReferenceName=ref&foo=bar", "taskReferenceName", "")).toEqual(
-      "foo=bar",
-    );
+    expect(
+      nextQueryString(
+        "?taskReferenceName=ref&foo=bar",
+        "taskReferenceName",
+        "",
+      ),
+    ).toEqual("foo=bar");
   });
 
   it("removes a param when the value is undefined", () => {
-    expect(nextQueryString("?taskReferenceName=ref", "taskReferenceName", undefined)).toEqual(
-      "",
-    );
+    expect(
+      nextQueryString("?taskReferenceName=ref", "taskReferenceName", undefined),
+    ).toEqual("");
   });
 
   it("returns null (skip navigation) when setting the same value", () => {
-    expect(nextQueryString("?taskReferenceName=ref", "taskReferenceName", "ref")).toBeNull();
+    expect(
+      nextQueryString("?taskReferenceName=ref", "taskReferenceName", "ref"),
+    ).toBeNull();
   });
 
   it("returns null (skip navigation) when clearing a param that is absent", () => {

--- a/ui-next/src/pages/definition/state/queryParam.ts
+++ b/ui-next/src/pages/definition/state/queryParam.ts
@@ -1,0 +1,22 @@
+/**
+ * Computes the next query string after setting/removing a single param.
+ *
+ * Returns `null` when the param would not actually change, signalling the
+ * caller to skip navigation (a no-op write would otherwise rebuild a stale url
+ * and revert the current navigation). When a value is falsy the key is removed.
+ */
+export function nextQueryString(
+  search: string,
+  key: string,
+  value: string | undefined,
+): string | null {
+  const params = new URLSearchParams(search);
+  const current = params.toString();
+  if (value) {
+    params.set(key, value);
+  } else {
+    params.delete(key);
+  }
+  const next = params.toString();
+  return next === current ? null : next;
+}


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
## Fixes (development env)

### Issue
When creating a new workflow and confirming save, the URL should change from `/newWorkflowDef` to `/<workflowName>/<version>` . Locally it does — but only for a millisecond, then it snaps back to `/newWorkflowDef` . This doesn't happen in production. Likely two parallel/overriding events firing, which surfaces locally because it's faster than production. The same occurs when creating a new version from a definition: the URL switches to the new version briefly, then reverts. Despite the URL staying as /newWorkflowDef, all operations (edit, save, update, delete) work fine.

### Solution
After saving a new workflow, a query-param write went through react-router-use-location-state, which rebuilt the URL from a stale location and sent the user back to /newWorkflowDef. Write the param against the live window.location and skip writes that change nothing. Add nextQueryString plus unit tests.
