### PR TITLE
Update README and publish.ymls to use ui-next instead of the former ui

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+
+      - name: Build ui-next and embed into server static resources
+        run: |
+          corepack enable
+          cd ui-next
+          pnpm install
+          NODE_OPTIONS=--max-old-space-size=4096 pnpm build
+          cd ..
+          mkdir -p server/src/main/resources/static
+          rm -rf server/src/main/resources/static/*
+          cp -r ui-next/dist/. server/src/main/resources/static/
+
       - name: Build Server JAR
         run: |
           export VERSION="${{github.ref_name}}"
@@ -68,20 +84,6 @@ jobs:
           echo Publishing version $PUBLISH_VERSION
           ./gradlew :conductor-server:build -x test -x spotlessCheck -x shadowJar -x :conductor-os-persistence-v3:build \
             -Pversion=$PUBLISH_VERSION
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 'lts/*'
-
-      - name: Build UI
-        run: |
-          cd ui
-          corepack enable && corepack prepare yarn@stable --activate
-          export REACT_APP_MONACO_EDITOR_USING_CDN=false
-          export REACT_APP_ENABLE_ERRORS_INSPECTOR=true
-          yarn config set network-timeout 600000 -g
-          yarn install && cp -r node_modules/monaco-editor public/ && yarn build
 
       - name: Stage artifacts for Docker build
         run: |

--- a/.github/workflows/publish_s3.yaml
+++ b/.github/workflows/publish_s3.yaml
@@ -49,9 +49,15 @@ jobs:
           echo "version=$PUBLISH_VERSION" >> $GITHUB_OUTPUT
           echo "Publishing version: $PUBLISH_VERSION"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+
       - name: Build Server module
         run: |
-          ./build_ui.sh
+          corepack enable
+          ./build_ui_next.sh
           ./gradlew :conductor-server:bootJar -x test -Pversion=${{ steps.version.outputs.version }}
 
       - name: Configure AWS credentials

--- a/README.md
+++ b/README.md
@@ -35,7 +35,14 @@ npm install -g @conductor-oss/conductor-cli
 conductor server start
 ```
 
-Open [http://localhost:8080](http://localhost:8080) — your server is running with the built-in UI.
+Open [http://localhost:8080](http://localhost:8080) — your server is running with the built-in ui-next UI.
+
+> **Upgrading from a previous version?** The CLI caches the server JAR at `~/.conductor-cli/`. If you have an older version cached, force a fresh download:
+> ```shell
+> conductor server start latest
+> # or delete the cache manually
+> rm ~/.conductor-cli/conductor-server-latest.jar && conductor server start
+> ```
 
 **Run your first workflow:**
 
@@ -53,10 +60,11 @@ conductor workflow start -w hello_workflow --sync
 
 See the [Quickstart guide](https://docs.conductor-oss.org/quickstart/) for the full walkthrough, including writing workers and replaying workflows.
 
-**Docker Image for Conductor:**
+**Docker Image for Conductor** (includes the ui-next UI):
 
 ```shell
-docker run -p 8080:8080 conductoross/conductor:latest # replace latest with the published version to pin to a specific version
+# UI at http://localhost:5000  |  API at http://localhost:8080
+docker run -p 5000:5000 -p 8080:8080 conductoross/conductor:next
 ```
 
 All CLI commands have equivalent cURL/API calls. See the [Quickstart](https://docs.conductor-oss.org/quickstart/) for details.
@@ -225,20 +233,38 @@ powershell -c "irm https://conductor-oss.github.io/conductor-skills/install.ps1 
 <details>
 <summary><strong>Requirements and instructions</strong></summary>
 
-**Requirements:** Docker Desktop, Java (JDK) 21+, Node 18 (for UI)
+**Requirements:** Docker Desktop, Java (JDK) 21+, Node.js 18+ and pnpm (for UI)
 
 ```shell
 git clone https://github.com/conductor-oss/conductor
 cd conductor
 ./gradlew build
 
-# (optional) Build UI
-# ./build_ui.sh
+# (optional) Build UI (ui-next) and embed it in the server
+# ./build_ui_next.sh
 
 # Start local server
 cd server
 ../gradlew bootRun
 ```
+
+**Run the UI in dev mode (hot-reload at http://localhost:1234):**
+
+Requires a running Conductor server on `http://localhost:8080`. Enable `corepack` once if you haven't already:
+
+```shell
+corepack enable
+```
+
+Then start the dev server:
+
+```shell
+cd ui-next
+pnpm install
+pnpm dev
+```
+
+Open [http://localhost:1234](http://localhost:1234) — the UI reloads automatically on file changes.
 
 See the [full build guide](docs/devguide/running/source.md) for details.
 </details>


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

## Changes in this PR
Switches the published server artifacts from the legacy `ui/` (yarn/CRA) to `ui-next` (pnpm/Vite) so that `conductor server start` and the Docker image serve the new UI out of the box.
### `publish_s3.yaml`
The workflow that builds and uploads the server JAR to S3:
- Added `actions/setup-node` + `corepack enable` before the build step
- Replaced `./build_ui.sh` with `./build_ui_next.sh` so the JAR bakes in `ui-next/dist/` as Spring Boot static resources
### `publish.yml`
The Docker + Maven Central publish workflow:
- Added `actions/setup-node` + `corepack enable` before the server build
- Replaced the yarn/`ui/` build step with a pnpm/`ui-next` build that copies `dist/` into `server/src/main/resources/static/` before Gradle runs (embeds the UI in the JAR used for the Docker image)
- Removed the old `Build UI` step that built `ui/` with yarn
### `README.md`
- **Quickstart:** updated "built-in UI" copy to reference ui-next; added a note about clearing the `~/.conductor-cli/` JAR cache when upgrading
- **Build from source:** updated the optional UI build command from `build_ui.sh` to `build_ui_next.sh`; added Node.js + pnpm as prerequisites; added a dev server section (`pnpm dev` at `http://localhost:1234`)
- **Docker section:** updated tag from `:latest` to `:next` and port mapping to `-p 5000:5000 -p 8080:8080` to reflect the nginx-served ui-next image
