### PR TITLE
feat: prevent HUMAN tasks from churning the decider queue (#795)

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
@@ -51,6 +51,13 @@ public class ConductorProperties {
     @DurationUnit(ChronoUnit.SECONDS)
     private Duration maxPostponeDurationSeconds = Duration.ofSeconds(3600);
 
+    /**
+     * If set to true, a workflow blocked on an IN_PROGRESS HUMAN task is removed from the decider
+     * queue instead of being repeatedly re-swept. It is re-queued automatically when the HUMAN task
+     * is updated to a terminal status (see WorkflowExecutorOps#updateTask).
+     */
+    private boolean humanTaskPreventsDeciderQueue = true;
+
     /** The number of threads to use to do background sweep on active workflows. */
     private int sweeperThreadCount = Runtime.getRuntime().availableProcessors() * 2;
 
@@ -284,6 +291,14 @@ public class ConductorProperties {
 
     public void setMaxPostponeDurationSeconds(Duration maxPostponeDurationSeconds) {
         this.maxPostponeDurationSeconds = maxPostponeDurationSeconds;
+    }
+
+    public boolean isHumanTaskPreventsDeciderQueue() {
+        return humanTaskPreventsDeciderQueue;
+    }
+
+    public void setHumanTaskPreventsDeciderQueue(boolean humanTaskPreventsDeciderQueue) {
+        this.humanTaskPreventsDeciderQueue = humanTaskPreventsDeciderQueue;
     }
 
     public int getSweeperThreadCount() {

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
@@ -61,6 +61,7 @@ import static com.netflix.conductor.core.utils.Utils.DECIDER_QUEUE;
 import static com.netflix.conductor.model.TaskModel.Status.*;
 
 import static org.conductoross.conductor.core.execution.ExecutorUtils.computePostpone;
+import static org.conductoross.conductor.core.execution.ExecutorUtils.hasInProgressHumanTask;
 
 /** Workflow services provider interface */
 @Trace
@@ -982,6 +983,20 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
                     task.getTaskDefName(), lastDuration, false, task.getStatus());
         }
 
+        if (properties.isHumanTaskPreventsDeciderQueue()
+                && TaskType.TASK_TYPE_HUMAN.equals(task.getTaskType())
+                && task.getStatus().isTerminal()) {
+            // The sweeper removes workflows blocked on a HUMAN task from the decider queue.
+            // Re-queue this workflow so it is evaluated immediately now that the HUMAN task has
+            // reached a terminal status.
+            queueDAO.push(DECIDER_QUEUE, workflowId, workflowInstance.getPriority(), 0);
+            LOGGER.debug(
+                    "Waking up workflow {} because HUMAN task {} reached terminal status {}",
+                    workflowId,
+                    task.getTaskId(),
+                    task.getStatus());
+        }
+
         if (!isLazyEvaluateWorkflow(workflowInstance.getWorkflowDefinition(), task)) {
             decide(workflowId);
         }
@@ -1247,19 +1262,33 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
 
                 Duration timeout = properties.getWorkflowOffsetTimeout();
                 if (!workflow.getStatus().isTerminal()) {
-                    Duration updatedOffset =
-                            computePostpone(
-                                    workflow, timeout, properties.getMaxPostponeDurationSeconds());
-                    if (updatedOffset.getSeconds() != timeout.getSeconds()) {
-                        // we have a new value, setUnack uses time in millis
+                    if (properties.isHumanTaskPreventsDeciderQueue()
+                            && hasInProgressHumanTask(workflow)) {
+                        // A workflow blocked on a HUMAN task can wait indefinitely for external
+                        // input. Keeping it in the decider queue only churns the sweeper, so
+                        // remove it; updateTask() re-queues the workflow when the HUMAN task
+                        // reaches a terminal status.
                         LOGGER.debug(
-                                "Pushing the workflow {} into decider queue by {} millis",
-                                workflow.getWorkflowId(),
-                                updatedOffset.getSeconds() * 1000);
-                        queueDAO.setUnackTimeout(
-                                DECIDER_QUEUE,
-                                workflow.getWorkflowId(),
-                                updatedOffset.getSeconds() * 1000);
+                                "Removing workflow {} from decider queue; blocked on HUMAN task",
+                                workflow.getWorkflowId());
+                        queueDAO.remove(DECIDER_QUEUE, workflow.getWorkflowId());
+                    } else {
+                        Duration updatedOffset =
+                                computePostpone(
+                                        workflow,
+                                        timeout,
+                                        properties.getMaxPostponeDurationSeconds());
+                        if (updatedOffset.getSeconds() != timeout.getSeconds()) {
+                            // we have a new value, setUnack uses time in millis
+                            LOGGER.debug(
+                                    "Pushing the workflow {} into decider queue by {} millis",
+                                    workflow.getWorkflowId(),
+                                    updatedOffset.getSeconds() * 1000);
+                            queueDAO.setUnackTimeout(
+                                    DECIDER_QUEUE,
+                                    workflow.getWorkflowId(),
+                                    updatedOffset.getSeconds() * 1000);
+                        }
                     }
                 }
             }

--- a/core/src/main/java/org/conductoross/conductor/core/execution/ExecutorUtils.java
+++ b/core/src/main/java/org/conductoross/conductor/core/execution/ExecutorUtils.java
@@ -176,4 +176,17 @@ public class ExecutorUtils {
                 workflowModel.getWorkflowId());
         return Duration.ofSeconds(Math.max(0, unackSeconds));
     }
+
+    /**
+     * Returns true when the workflow has at least one IN_PROGRESS HUMAN task. Such a workflow is
+     * blocked on external human input and may remain in this state indefinitely, so it should be
+     * removed from the decider queue rather than re-swept on every offset.
+     */
+    public static boolean hasInProgressHumanTask(WorkflowModel workflow) {
+        return workflow.getTasks().stream()
+                .anyMatch(
+                        task ->
+                                TaskType.TASK_TYPE_HUMAN.equals(task.getTaskType())
+                                        && task.getStatus() == TaskModel.Status.IN_PROGRESS);
+    }
 }

--- a/core/src/test/java/org/conductoross/conductor/core/execution/ExecutorUtilsTest.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/ExecutorUtilsTest.java
@@ -26,6 +26,7 @@ import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ExecutorUtilsTest {
@@ -243,6 +244,34 @@ public class ExecutorUtilsTest {
         workflow.setWorkflowDefinition(workflowDef);
         workflow.setTasks(tasks);
         return workflow;
+    }
+
+    @Test
+    public void hasInProgressHumanTaskTrueForInProgressHuman() {
+        WorkflowModel workflow =
+                newWorkflow(
+                        Arrays.asList(
+                                newTask(TaskType.TASK_TYPE_SIMPLE, TaskModel.Status.COMPLETED),
+                                newTask(TaskType.TASK_TYPE_HUMAN, TaskModel.Status.IN_PROGRESS)),
+                        0);
+        assertTrue(ExecutorUtils.hasInProgressHumanTask(workflow));
+    }
+
+    @Test
+    public void hasInProgressHumanTaskFalseWhenNoInProgressHuman() {
+        WorkflowModel noHuman =
+                newWorkflow(
+                        Arrays.asList(
+                                newTask(TaskType.TASK_TYPE_SIMPLE, TaskModel.Status.IN_PROGRESS)),
+                        0);
+        assertFalse(ExecutorUtils.hasInProgressHumanTask(noHuman));
+
+        WorkflowModel terminalHuman =
+                newWorkflow(
+                        Arrays.asList(
+                                newTask(TaskType.TASK_TYPE_HUMAN, TaskModel.Status.COMPLETED)),
+                        0);
+        assertFalse(ExecutorUtils.hasInProgressHumanTask(terminalHuman));
     }
 
     private TaskModel newTask(String taskType, TaskModel.Status status) {


### PR DESCRIPTION
## Summary

Fixes the decider-queue pollution caused by workflows blocked on `IN_PROGRESS` HUMAN tasks. HUMAN tasks are long-lived and wait indefinitely for external input, so re-evaluating their workflows on every sweep wastes CPU on every cycle.

This implements the desired behavior described in #795 (tracked under epic #825):

- **Remove** the workflow from the decider queue while it is blocked on an `IN_PROGRESS` HUMAN task, instead of re-postponing it.
- **Re-queue** the workflow when the HUMAN task reaches a terminal status (wake-up from `WorkflowExecutorOps#updateTask`).
- New opt-out flag `ConductorProperties#humanTaskPreventsDeciderQueue` (default `true`).

This re-raises the intent of the (closed) community PR #701, rebased onto the refactored, default-active sweeper path (`org.conductoross...WorkflowSweeper` → `WorkflowExecutorOps#decide`). The HUMAN handling had regressed when the new sweeper was introduced (#703).

## Changes

- `ConductorProperties`: add `humanTaskPreventsDeciderQueue` (default `true`) with getter/setter.
- `ExecutorUtils.hasInProgressHumanTask(WorkflowModel)`: small, side-effect-free predicate (unit-testable without mocks).
- `WorkflowExecutorOps#decide`: when the workflow is non-terminal and blocked on an `IN_PROGRESS` HUMAN task, `queueDAO.remove(DECIDER_QUEUE, ...)` instead of `setUnackTimeout(...)`.
- `WorkflowExecutorOps#updateTask`: when a HUMAN task reaches a terminal status, `queueDAO.push(DECIDER_QUEUE, ...)` so the workflow is evaluated immediately.
- `ExecutorUtilsTest`: coverage for `hasInProgressHumanTask`.

Only the non-deprecated default path is touched (the legacy `com.netflix...reconciliation.WorkflowSweeper`/`WorkflowReconciler` are `@Deprecated(forRemoval)` and intentionally left alone).

## Relation to #826

Draft #826 only lengthens the postpone interval; it does not remove the workflow from the queue or re-queue it on completion, so the workflow is still re-swept on every offset. This PR fulfills the #795 acceptance criteria (remove + re-queue) directly.

## Testing

Built and tested with JDK 21 (`:conductor-core:test`):

- full `conductor-core` suite: 795 tests, 0 failures
- `ExecutorUtilsTest`: 13 tests, 0 failures (incl. new `hasInProgressHumanTask` cases)
- `TestWorkflowExecutor`: 55 tests, 0 failures (no regression in `decide`)
- `spotlessApply` applied.

Closes #795.
