### PR TITLE
Fix test-harness failures

### DIFF
--- a/scheduler/core/src/main/java/io/orkes/conductor/scheduler/rest/SchedulerBulkResource.java
+++ b/scheduler/core/src/main/java/io/orkes/conductor/scheduler/rest/SchedulerBulkResource.java
@@ -14,7 +14,7 @@ package io.orkes.conductor.scheduler.rest;
 
 import java.util.List;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.netflix.conductor.common.model.BulkResponse;
 
+import io.orkes.conductor.scheduler.config.SchedulerConditions;
 import io.orkes.conductor.scheduler.service.SchedulerBulkService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -34,7 +35,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
  * <p>All endpoints are relative to {@code /api/scheduler/bulk}.
  */
 @RestController
-@ConditionalOnBean(SchedulerBulkService.class)
+@Conditional(SchedulerConditions.class)
 @RequestMapping("/api/scheduler/bulk")
 @Tag(name = "Scheduler Bulk", description = "Bulk scheduler operations")
 public class SchedulerBulkResource {

--- a/scheduler/core/src/main/java/io/orkes/conductor/scheduler/rest/SchedulerResource.java
+++ b/scheduler/core/src/main/java/io/orkes/conductor/scheduler/rest/SchedulerResource.java
@@ -32,9 +32,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.netflix.conductor.common.run.SearchResult;
 
+import io.orkes.conductor.scheduler.config.SchedulerConditions;
 import io.orkes.conductor.scheduler.model.WorkflowSchedule;
 import io.orkes.conductor.scheduler.model.WorkflowScheduleExecutionModel;
-import io.orkes.conductor.scheduler.config.SchedulerConditions;
 import io.orkes.conductor.scheduler.service.SchedulerService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/scheduler/core/src/main/java/io/orkes/conductor/scheduler/rest/SchedulerResource.java
+++ b/scheduler/core/src/main/java/io/orkes/conductor/scheduler/rest/SchedulerResource.java
@@ -17,7 +17,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,6 +34,7 @@ import com.netflix.conductor.common.run.SearchResult;
 
 import io.orkes.conductor.scheduler.model.WorkflowSchedule;
 import io.orkes.conductor.scheduler.model.WorkflowScheduleExecutionModel;
+import io.orkes.conductor.scheduler.config.SchedulerConditions;
 import io.orkes.conductor.scheduler.service.SchedulerService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -47,7 +48,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
  * {@code /api/scheduler}.
  */
 @RestController
-@ConditionalOnBean(SchedulerService.class)
+@Conditional(SchedulerConditions.class)
 @RequestMapping("/api/scheduler")
 @Tag(name = "Scheduler", description = "Workflow scheduling API")
 public class SchedulerResource {


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Root cause: @ConditionalOnBean is only reliable when used on @Bean methods inside @Configuration classes — not on component-scanned @RestController classes. When Spring's component scan evaluates @ConditionalOnBean(SchedulerService.class) on SchedulerResource, the SchedulerOssConfiguration (which creates SchedulerService) hasn't necessarily been processed yet. The condition evaluates to false, the controller is never registered, and all requests to /api/scheduler/** fall through to the static resource 404 handler.