### PR TITLE
fix: Bring back SqliteFileMetadataDAO bean

### DIFF
--- a/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/config/SqliteConfiguration.java
+++ b/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/config/SqliteConfiguration.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import javax.sql.DataSource;
 
+import org.conductoross.conductor.sqlite.dao.SqliteFileMetadataDAO;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.configuration.FluentConfiguration;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -195,6 +196,15 @@ public class SqliteConfiguration {
         retryTemplate.setRetryPolicy(retryPolicy);
         retryTemplate.setBackOffPolicy(backOffPolicy);
         return retryTemplate;
+    }
+
+    @Bean
+    @DependsOn({"flywayForPrimaryDb"})
+    @ConditionalOnProperty(name = "conductor.file-storage.enabled", havingValue = "true")
+    public SqliteFileMetadataDAO sqliteFileMetadataDAO(
+            @Qualifier("sqliteRetryTemplate") RetryTemplate retryTemplate,
+            ObjectMapper objectMapper) {
+        return new SqliteFileMetadataDAO(retryTemplate, objectMapper, dataSource);
     }
 
     public static class CustomRetryPolicy extends SimpleRetryPolicy {


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_

Restores the `sqliteFileMetadataDAO` bean registration in `SqliteConfiguration`, which was accidentally removed during PR #1105 (`fix(redis): release postponed task when concurrencyLimit slot frees`).

With the bean missing, the file-storage feature was broken on the SQLite backend: when `conductor.file-storage.enabled=true` and `conductor.db.type=sqlite`, Spring had no `FileMetadataDAO` to inject, so `FileStorageService` could not be wired up and the application failed to start the feature.

This PR brings the bean back, matching the registration pattern used by the other SQLite DAOs and the Postgres equivalent.

Issue # — regression introduced in #1105.

Alternatives considered
----

_Describe alternative implementation you have considered_

None. 
