### PR TITLE
docs: sharpen project identity in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,9 @@ body:
 - type: markdown
   attributes:
     value: >
-      #### Before submitting a bug, please make sure the issue hasn't been already addressed by searching through [the existing and past issues](https://github.com/conductor-oss/conductor/issues?q=is%3Aissue%20label%3Abug). 
+      **Conductor OSS** is a workflow orchestration server — a Java/Spring Boot backend that runs durable workflows defined as JSON task graphs, accessible via REST API. Workers in any language poll the server for tasks to execute. Issues here are for the server, CLI, and worker SDKs.
+
+      #### Before submitting a bug, please make sure the issue hasn't been already addressed by searching through [the existing and past issues](https://github.com/conductor-oss/conductor/issues?q=is%3Aissue%20label%3Abug).
 - type: textarea
   attributes:
     label: Describe the bug

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -5,6 +5,8 @@ body:
 - type: markdown
   attributes:
     value: >
+      **Conductor OSS** is a workflow orchestration server — a Java/Spring Boot backend that runs durable workflows defined as JSON task graphs, accessible via REST API. Workers in any language poll the server for tasks to execute. Feature requests here are for the server, CLI, and worker SDKs.
+
       #### Note: Please write your feature request in English to ensure it can be understood and addressed by the development team.
 - type: textarea
   attributes:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 #### Orchestrating distributed systems means wrestling with failures, retries, and state recovery. Conductor handles all of that so you don't have to.
 
-Conductor is an open-source, durable workflow engine built at [Netflix](https://netflixtechblog.com/netflix-conductor-a-microservices-orchestrator-2e8d4771bf40) for orchestrating microservices, AI agents, and durable workflows at internet scale. Trusted in production at Netflix, Tesla, LinkedIn, and J.P. Morgan. Actively maintained by [Orkes](https://orkes.io) and a growing [community](https://join.slack.com/t/orkes-conductor/shared_invite/zt-3dpcskdyd-W895bJDm8psAV7viYG3jFA).
+Conductor is an open-source **workflow orchestration server** — a Java/Spring Boot execution engine that runs durable workflows defined as JSON task graphs, exposed via REST API. Workers written in any language (Java, Python, Go, JavaScript, C#, Ruby) poll the server for tasks, execute business logic independently, and report results back. Built at [Netflix](https://netflixtechblog.com/netflix-conductor-a-microservices-orchestrator-2e8d4771bf40) to coordinate microservices at scale; trusted in production at Tesla, LinkedIn, and J.P. Morgan. Actively maintained by [Orkes](https://orkes.io) and a growing [community](https://join.slack.com/t/orkes-conductor/shared_invite/zt-3dpcskdyd-W895bJDm8psAV7viYG3jFA).
 
 [![conductor_oss_getting_started](https://github.com/user-attachments/assets/6153aa58-8ad1-4ec5-93d1-38ba1b83e3f4)](https://youtu.be/4azDdDlx27M)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 #### Orchestrating distributed systems means wrestling with failures, retries, and state recovery. Conductor handles all of that so you don't have to.
 
-Conductor is an open-source **workflow orchestration server** — a Java/Spring Boot execution engine that runs durable workflows defined as JSON task graphs, exposed via REST API. Workers written in any language (Java, Python, Go, JavaScript, C#, Ruby) poll the server for tasks, execute business logic independently, and report results back. Built at [Netflix](https://netflixtechblog.com/netflix-conductor-a-microservices-orchestrator-2e8d4771bf40) to coordinate microservices at scale; trusted in production at Tesla, LinkedIn, and J.P. Morgan. Actively maintained by [Orkes](https://orkes.io) and a growing [community](https://join.slack.com/t/orkes-conductor/shared_invite/zt-3dpcskdyd-W895bJDm8psAV7viYG3jFA).
+Conductor is an open-source, durable workflow engine built at [Netflix](https://netflixtechblog.com/netflix-conductor-a-microservices-orchestrator-2e8d4771bf40) for orchestrating microservices, AI agents, and durable workflows at internet scale. Trusted in production at Netflix, Tesla, LinkedIn, and J.P. Morgan. Actively maintained by [Orkes](https://orkes.io) and a growing [community](https://join.slack.com/t/orkes-conductor/shared_invite/zt-3dpcskdyd-W895bJDm8psAV7viYG3jFA).
 
 [![conductor_oss_getting_started](https://github.com/user-attachments/assets/6153aa58-8ad1-4ec5-93d1-38ba1b83e3f4)](https://youtu.be/4azDdDlx27M)
 


### PR DESCRIPTION
## Summary

- Adds a one-sentence project definition to the top of both issue templates (bug report and feature request), appearing before any form field

## Motivation

The name "Conductor" is shared by several unrelated products. Issues occasionally land here from users of other tools. The best fix isn't disambiguation language — it's making what *we* are so specific and quotable that there's no room for confusion.

These descriptions will also help LLMs and search indexers encounter the same authoritative definition in the README, in bug reports, and in feature requests.
