### PR TITLE
ci(dependabot): reduce PR noise via monthly schedule and grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    # Keep the firehose down: cap concurrent PRs and batch routine bumps.
+    open-pull-requests-limit: 5
     reviewers:
       - "v1r3n"
       - "boney9"
@@ -35,11 +37,27 @@ updates:
       # All GraalVM polyglot artifacts must share the same version.
       # Mixing versions (e.g. polyglot:24.x with js:25.x) causes a runtime
       # "polyglot version X is not compatible with Truffle Y" failure.
+      # (Listed first so GraalVM artifacts group here regardless of update type.)
       graalvm:
         patterns:
           - "org.graalvm.*"
+      # Batch all routine minor/patch bumps into a single monthly PR instead
+      # of one PR per dependency. Major bumps fall outside this group and still
+      # open individually, since they warrant per-dependency review.
+      gradle-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    # One PR for all action bumps rather than one per action.
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Dials down the volume of Dependabot version-update PRs.

Previously both the `gradle` and `github-actions` ecosystems checked **weekly** and opened **one PR per dependency**, producing a steady stream of individual bump PRs.

This PR:
- Moves both ecosystems from **weekly → monthly** checks.
- Batches routine **gradle minor/patch** bumps into a single grouped PR (`gradle-minor-patch`). Major bumps fall outside the group and still open individually, since those warrant per-dependency review.
- Groups **all github-actions** bumps into one PR.
- Adds an explicit `open-pull-requests-limit: 5` to both ecosystems.

The existing `graalvm` group and the `protoc`/`protobuf-java` pins are preserved untouched; `graalvm` is listed first so those artifacts group together regardless of update type.

## Why

Routine bump PRs were arriving roughly one-per-dependency every week. After this change the steady state is approximately **2 grouped PRs/month** (one gradle minor/patch batch, one github-actions batch) plus the occasional individual major bump.

## Security coverage is unchanged

This only affects **version-update** PRs. Alert-driven **security updates** are independent of the `schedule` and grouping settings, so nothing here weakens the repo's security posture.

## Scope

Intentionally narrow — config-only noise reduction. It does **not** touch the existing npm security-alert backlog in `ui/` / `ui-next/` (npm is still not configured as a Dependabot ecosystem); that's a separate follow-up.