### PR TITLE
feat: complete SWITCH task at map time and align defaultCase fallback with Orkes

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/mapper/SwitchTaskMapper.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/mapper/SwitchTaskMapper.java
@@ -110,16 +110,11 @@ public class SwitchTaskMapper implements TaskMapper {
         switchTask.addOutput("evaluationResult", List.of(evalResult));
         switchTask.addOutput("selectedCase", evalResult);
         switchTask.setStartTime(System.currentTimeMillis());
-        switchTask.setStatus(TaskModel.Status.IN_PROGRESS);
+        switchTask.setStatus(TaskModel.Status.COMPLETED);
         tasksToBeScheduled.add(switchTask);
 
         // get the list of tasks based on the evaluated expression
-        List<WorkflowTask> selectedTasks = workflowTask.getDecisionCases().get(evalResult);
-        // fall back to defaultCase only when no case key matched (null); an explicitly empty case
-        // list means the branch intentionally has no tasks and should not execute the default
-        if (selectedTasks == null) {
-            selectedTasks = workflowTask.getDefaultCase();
-        }
+        List<WorkflowTask> selectedTasks = getSwitchCaseTasks(workflowTask, evalResult);
         // once there are selected tasks that need to proceeded as part of the switch, get the next
         // task to be scheduled by using the decider service
         if (selectedTasks != null && !selectedTasks.isEmpty()) {
@@ -139,5 +134,29 @@ public class SwitchTaskMapper implements TaskMapper {
             switchTask.getInputData().put("hasChildren", "true");
         }
         return tasksToBeScheduled;
+    }
+
+    /**
+     * Resolves the list of tasks for the evaluated case. Falls back to the {@link
+     * WorkflowTask#getDefaultCase()} only when no case key matches the evaluated result
+     * (case-insensitively); an explicitly empty case list means the branch intentionally has no
+     * tasks and must not execute the default case.
+     */
+    protected static List<WorkflowTask> getSwitchCaseTasks(
+            WorkflowTask workflowTask, String evalResult) {
+        List<WorkflowTask> selectedTasks = workflowTask.getDecisionCases().get(evalResult);
+
+        boolean defaultOrNonExistentCase =
+                workflowTask.getDecisionCases().entrySet().stream()
+                        .noneMatch(
+                                entry ->
+                                        entry.getKey() != null
+                                                && entry.getKey().equalsIgnoreCase(evalResult));
+
+        // If the case is default or non-existent always go to defaultCase
+        if (defaultOrNonExistentCase) {
+            selectedTasks = workflowTask.getDefaultCase();
+        }
+        return selectedTasks;
     }
 }

--- a/core/src/test/java/com/netflix/conductor/core/execution/mapper/SwitchTaskMapperTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/mapper/SwitchTaskMapperTest.java
@@ -46,6 +46,7 @@ import com.netflix.conductor.model.WorkflowModel;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -281,6 +282,38 @@ public class SwitchTaskMapperTest {
         // Only the SWITCH task itself; defaultCase task must not be scheduled.
         assertEquals(1, mappedTasks.size());
         assertEquals("switchTask", mappedTasks.get(0).getReferenceTaskName());
+        // The SWITCH task is completed at map time rather than left IN_PROGRESS.
+        assertEquals(TaskModel.Status.COMPLETED, mappedTasks.get(0).getStatus());
+    }
+
+    @Test
+    public void getSwitchCaseTasks() {
+        WorkflowTask switchTask = new WorkflowTask();
+        Map<String, List<WorkflowTask>> decisionCases = new HashMap<>();
+        decisionCases.put("CASE-1", Collections.emptyList());
+        decisionCases.put("", Collections.emptyList());
+        decisionCases.put("CASE-2", Collections.singletonList(task2));
+        List<WorkflowTask> defaultCase = Collections.singletonList(task1);
+        switchTask.setDefaultCase(defaultCase);
+        switchTask.setDecisionCases(decisionCases);
+
+        // No matching key -> defaultCase.
+        assertEquals(
+                defaultCase, SwitchTaskMapper.getSwitchCaseTasks(switchTask, "case-not-exist"));
+        // Matched empty cases -> the (empty) matched list, NOT defaultCase.
+        assertEquals(decisionCases.get(""), SwitchTaskMapper.getSwitchCaseTasks(switchTask, ""));
+        assertEquals(
+                decisionCases.get("CASE-1"),
+                SwitchTaskMapper.getSwitchCaseTasks(switchTask, "CASE-1"));
+        // Matched non-empty case -> its tasks.
+        assertEquals(
+                decisionCases.get("CASE-2"),
+                SwitchTaskMapper.getSwitchCaseTasks(switchTask, "CASE-2"));
+        // Known case-sensitivity quirk: the fallthrough check is case-insensitive but the case
+        // lookup is exact. An evaluated result that matches a key only case-insensitively is NOT
+        // treated as "non-existent" (so defaultCase is skipped), yet the exact lookup misses — so
+        // neither the matched case nor the default is selected (returns null).
+        assertNull(SwitchTaskMapper.getSwitchCaseTasks(switchTask, "case-2"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Aligns the OSS `SwitchTaskMapper` with `OrkesSwitchTaskMapper` in three ways:

1. **Complete the SWITCH task at map time.** The SWITCH task is now marked `COMPLETED` instead of `IN_PROGRESS`. Previously it was left `IN_PROGRESS` and flipped to `COMPLETED` a step later by the `Switch` system task's `execute()` inside the decide loop. Setting it terminal directly in the mapper — the same approach `FORK` already uses — reaches the identical end state in one fewer decide cycle. The `NON_TERMINAL_TASK` execute path in `WorkflowExecutorOps` is simply skipped since the task is already terminal.

2. **defaultCase fallback keyed on case-label existence.** The fallback logic is extracted into `getSwitchCaseTasks()` and now falls back to `defaultCase` only when *no case key matches* the evaluated result, rather than when the selected list is empty. A matched-but-empty case (e.g. `"true": []`) no longer falls through to `defaultCase` — consistent with the fix in #1159, just reached structurally.

3. **Case-insensitive case matching.** Case keys are now matched case-insensitively for the fallthrough decision (mirrors Orkes).

## Behavioral notes

- **Known case-sensitivity quirk (carried over from Orkes, now documented in a test):** the fallthrough check is case-insensitive but the case *lookup* (`decisionCases.get(evalResult)`) is exact. So an evaluated result that matches a key only case-insensitively (e.g. key `CASE-2`, result `case-2`) is treated as "a case exists" — skipping `defaultCase` — yet the exact lookup misses, so neither the matched case nor the default is scheduled. This is asserted explicitly in `getSwitchCaseTasks` so the behavior is intentional and visible.

## Tests

- `getSwitchCaseTasks` (new): default fallback on no match, matched-but-empty cases return the empty list (not default), matched non-empty case returns its tasks, and the case-insensitive quirk.
- `getMappedTasksWithEmptyMatchedCase`: now also asserts the SWITCH task is `COMPLETED`.

```
./gradlew :conductor-core:test --tests "com.netflix.conductor.core.execution.mapper.SwitchTaskMapperTest"
./gradlew :conductor-core:test --tests "com.netflix.conductor.core.execution.TestDeciderOutcomes"
./gradlew :conductor-test-harness:test --tests "com.netflix.conductor.test.integration.SwitchTaskSpec"
```
All pass (5 unit + decider outcomes + 7 integration).

## Relationship to #1159

Builds on #1159 (already merged), replacing its inline `== null` fallback with the extracted `getSwitchCaseTasks` helper while preserving its empty-matched-case behavior.