### PR TITLE
feat: remove workflow template entry points

### DIFF
--- a/ui-next/src/pages/definitions/Workflow.tsx
+++ b/ui-next/src/pages/definitions/Workflow.tsx
@@ -374,7 +374,7 @@ export default function WorkflowDefinitions() {
     }
   }, [data]);
 
-  const handleClickBrowseTemplates = () => {
+  const handleClickGetStarted = () => {
     pushHistory(isPlayground ? "/" : WORKFLOW_DEFINITION_URL.NEW);
   };
 
@@ -528,9 +528,9 @@ export default function WorkflowDefinitions() {
                     title="Workflow Definition"
                     description={INTRO_CONTENT}
                     buttonText={
-                      isPlayground ? "Browse Templates" : "Define a Workflow"
+                      isPlayground ? "Get Started" : "Define a Workflow"
                     }
-                    buttonHandler={handleClickBrowseTemplates}
+                    buttonHandler={handleClickGetStarted}
                   />
                 ) : (
                   <NoDataComponent

--- a/ui-next/src/pages/executions/ResultsTable.tsx
+++ b/ui-next/src/pages/executions/ResultsTable.tsx
@@ -10,7 +10,7 @@ import { ColumnCustomType, LegacyColumn } from "components/ui/DataTable/types";
 import NoDataComponent from "components/ui/NoDataComponent";
 import { colors } from "theme/tokens/variables";
 import { usePushHistory } from "utils/hooks/usePushHistory";
-import { WORKFLOW_EXPLORER_URL } from "utils/constants/route";
+import { WORKFLOW_DEFINITION_URL } from "utils/constants/route";
 
 const LinearIndeterminate = () => {
   return (
@@ -230,8 +230,8 @@ export default function ResultsTable({
     setToggleCleared((t) => !t);
   }, [resultObj]);
 
-  const handleClickBrowseTemplates = () => {
-    pushHistory(WORKFLOW_EXPLORER_URL);
+  const handleClickDefineWorkflow = () => {
+    pushHistory(WORKFLOW_DEFINITION_URL.NEW);
   };
   const handleClickClearSearch = () => {
     handleReset();
@@ -334,8 +334,8 @@ export default function ResultsTable({
               titleBg={colors.warningTag}
               description="Here you’ll see any executed workflows, regardless
               of its status. Let’s define a new workflow!"
-              buttonText="BROWSE TEMPLATES"
-              buttonHandler={handleClickBrowseTemplates}
+              buttonText="DEFINE WORKFLOW"
+              buttonHandler={handleClickDefineWorkflow}
             />
           )
         }

--- a/ui-next/src/pages/executions/SplitWorkflowDefinitionButton/SplitWorkflowDefinitionButton.tsx
+++ b/ui-next/src/pages/executions/SplitWorkflowDefinitionButton/SplitWorkflowDefinitionButton.tsx
@@ -1,10 +1,7 @@
 import { usePushHistory } from "utils/hooks/usePushHistory";
 import SplitButton from "components/ui/buttons/ConductorSplitButton";
 import AddIcon from "components/icons/AddIcon";
-import {
-  WORKFLOW_DEFINITION_URL,
-  WORKFLOW_EXPLORER_URL,
-} from "utils/constants/route";
+import { WORKFLOW_DEFINITION_URL } from "utils/constants/route";
 import { useAuth } from "components/features/auth";
 import { useMemo, useState } from "react";
 import { ImportBPNFileDialog } from "./ImportBPNFileDialog";
@@ -38,10 +35,6 @@ const SplitWorkflowDefinitionButton = ({
           clearNewWorkflowStorage();
           pushHistory(WORKFLOW_DEFINITION_URL.NEW);
         },
-      },
-      {
-        label: "Select Template",
-        onClick: () => pushHistory(WORKFLOW_EXPLORER_URL),
       },
     ];
     if (!isImportBpmnHidden) {

--- a/ui-next/src/pages/executions/TaskResultsTable.tsx
+++ b/ui-next/src/pages/executions/TaskResultsTable.tsx
@@ -11,7 +11,6 @@ import { colors } from "theme/tokens/variables";
 import {
   WORKFLOW_DEFINITION_URL,
   WORKFLOW_EXECUTION_URL,
-  WORKFLOW_EXPLORER_URL,
 } from "utils/constants/route";
 import { calculateTimeFromMillis, totalPages } from "utils/utils";
 import BulkActionModule from "./BulkActionModule";
@@ -240,8 +239,8 @@ export default function ResultsTable({
     setToggleCleared((t) => !t);
   }, [resultObj]);
 
-  const handleClickBrowseTemplates = () => {
-    pushHistory(WORKFLOW_EXPLORER_URL);
+  const handleClickDefineWorkflow = () => {
+    pushHistory(WORKFLOW_DEFINITION_URL.NEW);
   };
   const handleClickClearSearch = () => {
     handleReset();
@@ -348,8 +347,8 @@ export default function ResultsTable({
               titleBg={colors.warningTag}
               description="Here you’ll see any executed tasks, regardless
               of its status. Let’s define a new task!"
-              buttonText="BROWSE TEMPLATES"
-              buttonHandler={handleClickBrowseTemplates}
+              buttonText="DEFINE WORKFLOW"
+              buttonHandler={handleClickDefineWorkflow}
             />
           )
         }

--- a/ui-next/src/routes/__tests__/router.test.tsx
+++ b/ui-next/src/routes/__tests__/router.test.tsx
@@ -86,7 +86,6 @@ vi.mock("utils/constants/route", () => ({
     NAME_VERSION: "/workflowDef/:name/:version",
     NEW: "/workflowDef/new",
   },
-  WORKFLOW_EXPLORER_URL: "/workflow-explorer",
   WORKERS_URL: {
     BASE: "/workers",
   },

--- a/ui-next/src/routes/__tests__/test-utils.tsx
+++ b/ui-next/src/routes/__tests__/test-utils.tsx
@@ -126,7 +126,6 @@ export const mockPageComponents = () => {
     "enterprise/pages/getStarted/GetStarted": "get-started",
     "enterprise/pages/metrics": "metrics-page",
     "enterprise/pages/secrets/Secrets": "secrets",
-    "enterprise/pages/workflowExplorer/Explorer": "explorer",
 
     // Remote services
     "enterprise/pages/remoteServices/edit/ServiceEdit": "service-edit",

--- a/ui-next/src/utils/constants/route.ts
+++ b/ui-next/src/utils/constants/route.ts
@@ -133,8 +133,6 @@ export const AUTHENTICATION_URL = "/authentication";
 
 export const ERROR_URL = "/error";
 
-export const WORKFLOW_EXPLORER_URL = "/workflowExplorer";
-
 export const OIDC_CALLBACK_ROUTE = "/login/oidc/callback";
 
 export const WORKFLOW_EXECUTION_URL = {


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
### Pairs with the [conductor-ui PR](https://github.com/orkes-io/conductor-ui/pull/4191) that deletes the explorer page and hub import flow.

Drop the "Select Template" split-button option and repoint the executions empty-state CTAs to the New Workflow flow. Relabel the playground definitions CTA to "Get Started" and remove the unused WORKFLOW_EXPLORER_URL constant and its test mocks.

- Removes the "Select Template" option from the "Define workflow" split button
- Repoints the executions empty-state "BROWSE TEMPLATES" buttons (ResultsTable, TaskResultsTable) to "DEFINE WORKFLOW" → New Workflow flow
- Relabels the playground definitions empty-state CTA from "Browse Templates" to "Get Started" (it already navigated to the launchpad, not the explorer)
- Deletes the unused WORKFLOW_EXPLORER_URL constant and its references in the router test mocks

