### PR TITLE
feat(a2a): server-side message/stream (SSE)

### DIFF
--- a/ai/src/main/java/org/conductoross/conductor/ai/a2a/server/A2AServerProperties.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/a2a/server/A2AServerProperties.java
@@ -57,4 +57,10 @@ public class A2AServerProperties {
     /** Default produced output media types for derived skills. */
     private List<String> defaultOutputModes =
             new ArrayList<>(List.of("application/json", "text/plain"));
+
+    /** How often the {@code message/stream} loop polls the workflow for state changes. */
+    private long streamPollIntervalMillis = 500;
+
+    /** Hard cap on how long a single {@code message/stream} connection stays open. */
+    private long streamMaxDurationSeconds = 300;
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/a2a/server/A2AServerResource.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/a2a/server/A2AServerResource.java
@@ -13,6 +13,8 @@
 package org.conductoross.conductor.ai.a2a.server;
 
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import org.conductoross.conductor.ai.a2a.A2ALogging;
@@ -24,12 +26,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import com.netflix.conductor.common.config.ObjectMapperProvider;
@@ -67,6 +71,15 @@ public class A2AServerResource {
     private final A2AWorkflowAgent agent;
     private final A2AServerProperties properties;
 
+    /** Dedicated daemon pool for SSE streams so they don't tie up request/system-task threads. */
+    private final ExecutorService streamExecutor =
+            Executors.newCachedThreadPool(
+                    r -> {
+                        Thread t = new Thread(r, "a2a-server-stream");
+                        t.setDaemon(true);
+                        return t;
+                    });
+
     public A2AServerResource(A2AWorkflowAgent agent, A2AServerProperties properties) {
         this.agent = agent;
         this.properties = properties;
@@ -90,8 +103,8 @@ public class A2AServerResource {
 
     @PostMapping(
             value = "${conductor.a2a.server.basePath:/a2a}/{workflow}",
-            produces = "application/json")
-    public ResponseEntity<JsonNode> jsonRpc(
+            produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.TEXT_EVENT_STREAM_VALUE})
+    public Object jsonRpc(
             @PathVariable("workflow") String workflow,
             @RequestBody(required = false) JsonNode request) {
         JsonNode id = request == null ? null : request.get("id");
@@ -102,6 +115,9 @@ public class A2AServerResource {
             String method = request.get("method").asText();
             scope.add(A2ALogging.METHOD, method);
             JsonNode params = request.get("params");
+            if ("message/stream".equals(method)) {
+                return streamResponse(workflow, params, id);
+            }
             Object result;
             switch (method) {
                 case "message/send":
@@ -165,6 +181,41 @@ public class A2AServerResource {
     }
 
     // ---- helpers -----------------------------------------------------------------------------
+
+    /**
+     * Handle {@code message/stream}: validate synchronously (so bad requests get a JSON-RPC error,
+     * not a half-open stream), then drive the SSE on the dedicated pool. Each event is written as
+     * one {@code data:} frame; the connection closes when the workflow reaches a terminal /
+     * input-required state or the stream window elapses.
+     */
+    private Object streamResponse(String workflow, JsonNode params, JsonNode id) {
+        if (!agent.isExposed(workflow)) {
+            return ResponseEntity.ok(error(id, -32001, "agent not found: " + workflow));
+        }
+        A2AMessage message;
+        try {
+            message = parseMessage(params);
+        } catch (A2AServerException e) {
+            return ResponseEntity.ok(error(id, e.getCode(), e.getMessage()));
+        }
+        A2AMetrics.serverRequest("message/stream");
+        SseEmitter emitter =
+                new SseEmitter(properties.getStreamMaxDurationSeconds() * 1000L + 5000L);
+        streamExecutor.submit(
+                () -> {
+                    try {
+                        agent.streamMessage(workflow, message, id, emitter::send);
+                        emitter.complete();
+                    } catch (Exception e) {
+                        log.warn(
+                                "A2A message/stream for {} ended with error: {}",
+                                workflow,
+                                e.getMessage());
+                        emitter.completeWithError(e);
+                    }
+                });
+        return emitter;
+    }
 
     private A2AMessage parseMessage(JsonNode params) {
         if (params == null || !params.has("message")) {

--- a/ai/src/main/java/org/conductoross/conductor/ai/a2a/server/A2AStreamSink.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/a2a/server/A2AStreamSink.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.a2a.server;
+
+import java.io.IOException;
+
+/**
+ * Sink for {@code message/stream} events. Each {@code event} is a JSON-RPC envelope ({@code
+ * {jsonrpc, id, result}}) that the transport (e.g. an {@code SseEmitter}) writes as one SSE {@code
+ * data:} frame. Keeping this web-agnostic lets {@link A2AWorkflowAgent} drive the stream without
+ * depending on Spring's SSE types, so it stays unit-testable.
+ */
+@FunctionalInterface
+public interface A2AStreamSink {
+
+    /** Emit one streaming event (a JSON-RPC envelope). */
+    void event(Object jsonRpcEnvelope) throws IOException;
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/a2a/server/A2AWorkflowAgent.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/a2a/server/A2AWorkflowAgent.java
@@ -12,6 +12,7 @@
  */
 package org.conductoross.conductor.ai.a2a.server;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -124,7 +125,9 @@ public class A2AWorkflowAgent {
         card.setPreferredTransport("JSONRPC");
         card.setDefaultInputModes(properties.getDefaultInputModes());
         card.setDefaultOutputModes(properties.getDefaultOutputModes());
-        card.setCapabilities(new AgentCapabilities()); // streaming/push: false (server-side v1)
+        AgentCapabilities capabilities = new AgentCapabilities();
+        capabilities.setStreaming(true); // message/stream (SSE) is supported; push config is not
+        card.setCapabilities(capabilities);
 
         AgentProvider provider = new AgentProvider();
         provider.setOrganization(properties.getProviderOrganization());
@@ -219,6 +222,115 @@ public class A2AWorkflowAgent {
             workflow = loadWorkflow(workflowId, workflowName, false);
         }
         return toA2ATask(workflow);
+    }
+
+    /**
+     * Drive a {@code message/stream} for a workflow-backed agent: start (or resume) the execution,
+     * emit the initial {@code Task}, then poll and emit {@code status-update} events on each state
+     * change and {@code artifact-update} events when output appears, ending with a {@code final}
+     * status-update when the workflow reaches a terminal or input-required state. Each event is a
+     * JSON-RPC envelope written to {@code sink} (one SSE frame). The remote agent execution's
+     * durability is unaffected — the stream is just a live view; a dropped connection can be picked
+     * back up with {@code tasks/get}.
+     */
+    public void streamMessage(
+            String workflowName, A2AMessage message, Object rpcId, A2AStreamSink sink)
+            throws IOException {
+        A2ATask task = sendMessage(workflowName, message); // starts or resumes the execution
+        String workflowId = task.getId();
+        sink.event(envelope(rpcId, task)); // initial Task event (kind:"task")
+
+        if (isStreamFinal(stateOf(task))) {
+            sink.event(envelope(rpcId, statusUpdate(task, true)));
+            return;
+        }
+
+        String last = stateOf(task);
+        long deadline =
+                System.currentTimeMillis() + properties.getStreamMaxDurationSeconds() * 1000L;
+        while (System.currentTimeMillis() < deadline) {
+            sleep(properties.getStreamPollIntervalMillis());
+            A2ATask current = getTask(workflowName, workflowId);
+            String state = stateOf(current);
+            if (isStreamFinal(state)) {
+                if (current.getArtifacts() != null) {
+                    for (Artifact artifact : current.getArtifacts()) {
+                        sink.event(envelope(rpcId, artifactUpdate(current, artifact)));
+                    }
+                }
+                sink.event(envelope(rpcId, statusUpdate(current, true)));
+                return;
+            }
+            if (!java.util.Objects.equals(state, last)) {
+                sink.event(envelope(rpcId, statusUpdate(current, false)));
+                last = state;
+            }
+        }
+        // Hit the max stream duration without a terminal state — close the stream as final and tell
+        // the client to keep tracking via tasks/get (the durable execution keeps running
+        // regardless).
+        A2ATask current = getTask(workflowName, workflowId);
+        TaskStatus status = new TaskStatus();
+        status.setState(stateOf(current));
+        status.setMessage(
+                agentTextMessage(
+                        "Stream window elapsed; the workflow is still running — continue with"
+                                + " tasks/get.",
+                        loadWorkflow(workflowId, workflowName, false)));
+        sink.event(
+                envelope(
+                        rpcId,
+                        statusUpdateEvent(current.getId(), current.getContextId(), status, true)));
+    }
+
+    /** A2A stream ends when the task reaches a terminal OR input/auth-required state. */
+    private boolean isStreamFinal(String state) {
+        return TaskState.isTerminal(state) || TaskState.isInterrupted(state);
+    }
+
+    private String stateOf(A2ATask task) {
+        return task.getStatus() != null ? task.getStatus().getState() : null;
+    }
+
+    private Map<String, Object> envelope(Object rpcId, Object result) {
+        Map<String, Object> envelope = new HashMap<>();
+        envelope.put("jsonrpc", "2.0");
+        envelope.put("id", rpcId);
+        envelope.put("result", result);
+        return envelope;
+    }
+
+    private Map<String, Object> statusUpdate(A2ATask task, boolean isFinal) {
+        return statusUpdateEvent(task.getId(), task.getContextId(), task.getStatus(), isFinal);
+    }
+
+    private Map<String, Object> statusUpdateEvent(
+            String taskId, String contextId, TaskStatus status, boolean isFinal) {
+        Map<String, Object> event = new HashMap<>();
+        event.put("kind", "status-update");
+        event.put("taskId", taskId);
+        event.put("contextId", contextId);
+        event.put("status", status);
+        event.put("final", isFinal);
+        return event;
+    }
+
+    private Map<String, Object> artifactUpdate(A2ATask task, Artifact artifact) {
+        Map<String, Object> event = new HashMap<>();
+        event.put("kind", "artifact-update");
+        event.put("taskId", task.getId());
+        event.put("contextId", task.getContextId());
+        event.put("artifact", artifact);
+        return event;
+    }
+
+    private void sleep(long millis) throws IOException {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("A2A stream interrupted", e);
+        }
     }
 
     // ---- mapping -----------------------------------------------------------------------------

--- a/ai/src/test/java/org/conductoross/conductor/ai/a2a/server/A2ALoopbackTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/a2a/server/A2ALoopbackTest.java
@@ -18,8 +18,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.conductoross.conductor.ai.a2a.A2AService;
+import org.conductoross.conductor.ai.a2a.A2AService.SendResult;
 import org.conductoross.conductor.ai.a2a.AgentTask;
+import org.conductoross.conductor.ai.a2a.model.A2AMessage;
 import org.conductoross.conductor.ai.a2a.model.AgentCard;
+import org.conductoross.conductor.ai.a2a.model.Part;
+import org.conductoross.conductor.ai.a2a.model.TaskState;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,11 +48,14 @@ import com.netflix.conductor.service.WorkflowService;
 import okhttp3.OkHttpClient;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -74,6 +82,17 @@ class A2ALoopbackTest {
     @LocalServerPort private int port;
     @Autowired private WorkflowService workflowService; // the fake bean below
 
+    // Shared across the (singleton) fake bean; reset per test so each test starts from "poll 0".
+    static final AtomicInteger POLLS = new AtomicInteger();
+
+    @BeforeEach
+    void reset() {
+        POLLS.set(0);
+        // The fake bean is a singleton mock shared across tests; clear counts so each test's
+        // verify(...) only sees its own invocations (stubbing is preserved).
+        clearInvocations(workflowService);
+    }
+
     @SpringBootApplication(exclude = DataSourceAutoConfiguration.class)
     static class LoopbackApp {
 
@@ -81,7 +100,6 @@ class A2ALoopbackTest {
         WorkflowService workflowService() {
             WorkflowService service = mock(WorkflowService.class);
             when(service.startWorkflow(any(StartWorkflowRequest.class))).thenReturn("wf-loop-1");
-            AtomicInteger polls = new AtomicInteger();
             when(service.getExecutionStatus(eq("wf-loop-1"), anyBoolean()))
                     .thenAnswer(
                             inv -> {
@@ -90,7 +108,7 @@ class A2ALoopbackTest {
                                 wf.setCorrelationId("ctx-loop");
                                 wf.setWorkflowDefinition(def());
                                 // First poll RUNNING, then COMPLETED — simulates progress.
-                                if (polls.getAndIncrement() == 0) {
+                                if (POLLS.getAndIncrement() == 0) {
                                     wf.setStatus(WorkflowStatus.RUNNING);
                                 } else {
                                     wf.setStatus(WorkflowStatus.COMPLETED);
@@ -147,6 +165,28 @@ class A2ALoopbackTest {
         assertEquals(1, card.getSkills().size());
         assertEquals("order_pizza", card.getSkills().get(0).getId());
         assertEquals(agentUrl(), card.getUrl());
+    }
+
+    @Test
+    void streaming_clientAggregatesServerSseToCompletion() {
+        A2AService service = clientService();
+
+        A2AMessage message = new A2AMessage();
+        Part part = new Part();
+        part.setKind("text");
+        part.setText("one large pepperoni");
+        message.setParts(List.of(part));
+        message.setRole("user");
+        message.setMessageId("stream-m-1");
+        message.setKind("message");
+
+        // Real client message/stream against the real server's SSE endpoint, over HTTP.
+        SendResult result = service.streamMessage(agentUrl(), message, null, null);
+
+        assertTrue(result.isTask());
+        assertEquals(TaskState.COMPLETED, result.getTask().getStatus().getState());
+        assertNotNull(result.getTask().getArtifacts());
+        assertFalse(result.getTask().getArtifacts().isEmpty());
     }
 
     @Test

--- a/ai/src/test/java/org/conductoross/conductor/ai/a2a/server/A2AServerResourceTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/a2a/server/A2AServerResourceTest.java
@@ -71,6 +71,14 @@ class A2AServerResourceTest {
         }
     }
 
+    /**
+     * jsonRpc returns Object (SSE emitter or ResponseEntity); the non-stream paths are the latter.
+     */
+    @SuppressWarnings("unchecked")
+    private ResponseEntity<JsonNode> call(String workflow, JsonNode request) {
+        return (ResponseEntity<JsonNode>) resource.jsonRpc(workflow, request);
+    }
+
     @Test
     void messageSend_dispatchesAndReturnsResult() {
         when(agent.sendMessage(eq("order_pizza"), any(A2AMessage.class)))
@@ -80,7 +88,7 @@ class A2AServerResourceTest {
                 rpc(
                         "message/send",
                         "{\"message\":{\"role\":\"user\",\"kind\":\"message\",\"messageId\":\"m1\",\"parts\":[{\"kind\":\"text\",\"text\":\"hi\"}]}}");
-        ResponseEntity<JsonNode> response = resource.jsonRpc("order_pizza", request);
+        ResponseEntity<JsonNode> response = call("order_pizza", request);
 
         JsonNode body = response.getBody();
         assertEquals(1, body.get("id").asInt());
@@ -93,7 +101,7 @@ class A2AServerResourceTest {
         when(agent.getTask("order_pizza", "wf-1")).thenReturn(task("wf-1", TaskState.COMPLETED));
 
         ResponseEntity<JsonNode> response =
-                resource.jsonRpc("order_pizza", rpc("tasks/get", "{\"id\":\"wf-1\"}"));
+                call("order_pizza", rpc("tasks/get", "{\"id\":\"wf-1\"}"));
 
         assertEquals(
                 TaskState.COMPLETED,
@@ -104,14 +112,14 @@ class A2AServerResourceTest {
     void tasksCancel_dispatches() {
         when(agent.cancelTask("order_pizza", "wf-1")).thenReturn(task("wf-1", TaskState.CANCELED));
 
-        resource.jsonRpc("order_pizza", rpc("tasks/cancel", "{\"id\":\"wf-1\"}"));
+        call("order_pizza", rpc("tasks/cancel", "{\"id\":\"wf-1\"}"));
 
         verify(agent).cancelTask("order_pizza", "wf-1");
     }
 
     @Test
     void unknownMethod_returnsMethodNotFound() {
-        ResponseEntity<JsonNode> response = resource.jsonRpc("order_pizza", rpc("foo/bar", "{}"));
+        ResponseEntity<JsonNode> response = call("order_pizza", rpc("foo/bar", "{}"));
         assertEquals(-32601, response.getBody().get("error").get("code").asInt());
     }
 
@@ -123,7 +131,7 @@ class A2AServerResourceTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        ResponseEntity<JsonNode> response = resource.jsonRpc("order_pizza", request);
+        ResponseEntity<JsonNode> response = call("order_pizza", request);
         assertEquals(-32600, response.getBody().get("error").get("code").asInt());
     }
 
@@ -133,7 +141,7 @@ class A2AServerResourceTest {
                 .thenThrow(A2AServerException.notFound("not found"));
 
         ResponseEntity<JsonNode> response =
-                resource.jsonRpc("order_pizza", rpc("tasks/get", "{\"id\":\"missing\"}"));
+                call("order_pizza", rpc("tasks/get", "{\"id\":\"missing\"}"));
 
         assertEquals(-32001, response.getBody().get("error").get("code").asInt());
     }

--- a/ai/src/test/java/org/conductoross/conductor/ai/a2a/server/A2AWorkflowAgentTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/a2a/server/A2AWorkflowAgentTest.java
@@ -12,6 +12,7 @@
  */
 package org.conductoross.conductor.ai.a2a.server;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +22,7 @@ import org.conductoross.conductor.ai.a2a.model.A2ATask;
 import org.conductoross.conductor.ai.a2a.model.AgentCard;
 import org.conductoross.conductor.ai.a2a.model.Part;
 import org.conductoross.conductor.ai.a2a.model.TaskState;
+import org.conductoross.conductor.ai.a2a.model.TaskStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -222,6 +224,52 @@ class A2AWorkflowAgentTest {
         verify(taskService, never())
                 .updateTask(anyString(), anyString(), any(), anyString(), any());
         verify(workflowService, never()).startWorkflow(any(StartWorkflowRequest.class));
+    }
+
+    // ---- message/stream ----------------------------------------------------------------------
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void streamMessage_emitsTaskThenArtifactThenFinalStatus() throws Exception {
+        properties.setExposedWorkflows(List.of("order_pizza"));
+        properties.setStreamPollIntervalMillis(1); // keep the test fast
+        when(metadataService.getWorkflowDef("order_pizza", null)).thenReturn(def("order_pizza"));
+        when(workflowService.startWorkflow(any(StartWorkflowRequest.class))).thenReturn("wf-1");
+        // sendMessage() loads without tasks -> RUNNING (working).
+        when(workflowService.getExecutionStatus("wf-1", false))
+                .thenReturn(workflow("order_pizza", WorkflowStatus.RUNNING));
+        // poll loop loads with tasks: still working, then completed with output.
+        Workflow completed = workflow("order_pizza", WorkflowStatus.COMPLETED);
+        completed.setOutput(Map.of("orderId", "ORD-1"));
+        when(workflowService.getExecutionStatus("wf-1", true))
+                .thenReturn(workflow("order_pizza", WorkflowStatus.RUNNING))
+                .thenReturn(completed);
+
+        List<Object> events = new ArrayList<>();
+        agent.streamMessage("order_pizza", userMessage(), 7, events::add);
+
+        // First event is the initial Task (working) and carries our JSON-RPC id.
+        Map<String, Object> firstEnvelope = (Map<String, Object>) events.get(0);
+        assertEquals(7, firstEnvelope.get("id"));
+        Object firstResult = firstEnvelope.get("result");
+        assertTrue(firstResult instanceof A2ATask);
+        assertEquals(TaskState.WORKING, ((A2ATask) firstResult).getStatus().getState());
+
+        // An artifact-update carries the workflow output.
+        boolean sawArtifact =
+                events.stream()
+                        .map(e -> ((Map<String, Object>) e).get("result"))
+                        .filter(Map.class::isInstance)
+                        .anyMatch(r -> "artifact-update".equals(((Map<?, ?>) r).get("kind")));
+        assertTrue(sawArtifact, "expected an artifact-update event; got " + events);
+
+        // Last event is a final status-update with state completed.
+        Map<String, Object> lastResult =
+                (Map<String, Object>)
+                        ((Map<String, Object>) events.get(events.size() - 1)).get("result");
+        assertEquals("status-update", lastResult.get("kind"));
+        assertEquals(Boolean.TRUE, lastResult.get("final"));
+        assertEquals(TaskState.COMPLETED, ((TaskStatus) lastResult.get("status")).getState());
     }
 
     // ---- tasks/get ---------------------------------------------------------------------------

--- a/design/a2a/10-a2a-server.md
+++ b/design/a2a/10-a2a-server.md
@@ -13,7 +13,7 @@ convention to invent, and each Agent Card describes exactly one capability.
 
 ```
 GET  {basePath}/{workflow}/.well-known/agent-card.json   (+ /agent.json, v0.2.x)  → discovery
-POST {basePath}/{workflow}                               → JSON-RPC: message/send | tasks/get | tasks/cancel
+POST {basePath}/{workflow}                               → JSON-RPC: message/send | message/stream | tasks/get | tasks/cancel
 GET  {basePath}                                          → convenience listing of exposed agents
 ```
 
@@ -54,8 +54,8 @@ executions (the task's workflow name must match the path agent).
 
 **`WorkflowDef` → Agent Card:** one skill (`id`/`name` = workflow name, description from the def,
 tags from metadata, input/output modes from properties); `url` = `{publicUrl|request-derived}{basePath}/{name}`;
-`version` = def version; `protocolVersion` `0.3.0`; `capabilities.streaming/pushNotifications=false`
-(server-side streaming/push are follow-ups).
+`version` = def version; `protocolVersion` `0.3.0`; `capabilities.streaming=true` (`message/stream`
+via SSE), `capabilities.pushNotifications=false` (push-config endpoints are a follow-up).
 
 ## 10.4 Durability — why this is the differentiator
 
@@ -111,7 +111,8 @@ Or per-workflow opt-in in the definition: `"metadata": { "a2a.enabled": true, "a
   calling Conductor over A2A end-to-end against a stateful fake engine).
 
 ## 10.8 Out of scope (v1, follow-ups)
-- Server-side streaming (`message/stream`/SSE) and push-notification config endpoints.
+- Push-notification config endpoints (`tasks/pushNotificationConfig/*`). Server-side streaming
+  (`message/stream` SSE) now ships — it is listed in the methods table in §10.1/§10.3.
 - Per-workflow OAuth scopes; Agent Card JWS signing.
 - Full client↔server loopback e2e through the **real** engine (decider/sweeper/persistence) in
   `test-harness` — the mocked-engine loopback (`A2ALoopbackTest`) ships now.

--- a/docs/devguide/ai/a2a-integration.md
+++ b/docs/devguide/ai/a2a-integration.md
@@ -269,8 +269,10 @@ conductor.a2a.server.exposed-workflows=order_pizza,book_appointment
 | Method & path | Purpose |
 |---|---|
 | `GET /a2a/{workflow}/.well-known/agent-card.json` | Agent Card (also `/agent.json`). |
-| `POST /a2a/{workflow}` | JSON-RPC: `message/send`, `tasks/get`, `tasks/cancel`. |
+| `POST /a2a/{workflow}` | JSON-RPC: `message/send`, `message/stream` (SSE), `tasks/get`, `tasks/cancel`. |
 | `GET /a2a` | Convenience listing of exposed agents (non-spec). |
+
+Exposed agents advertise `capabilities.streaming=true`.
 
 ### Discover and call
 
@@ -297,6 +299,32 @@ curl -X POST http://localhost:8080/a2a/order_pizza \
 ```
 
 The inbound A2A message is injected into the workflow input as `_a2a_text`, `_a2a_message_id`, `_a2a_context_id` (plus any data parts), and `contextId` becomes the workflow `correlationId`.
+
+### Streaming (message/stream)
+
+Use `message/stream` instead of `message/send` for a Server-Sent Events stream: the initial `Task`,
+then `status-update` events as the workflow's A2A state changes and `artifact-update` events as
+output is produced, ending with a `final` status-update at a terminal / input-required state.
+
+```bash
+curl -N -X POST http://localhost:8080/a2a/order_pizza \
+  -H 'Content-Type: application/json' \
+  -d '{ "jsonrpc":"2.0", "id":1, "method":"message/stream",
+        "params": { "message": { "role":"user", "messageId":"m-1",
+          "parts":[ {"kind":"text","text":"one large pepperoni"} ] } } }'
+```
+
+```text
+data: {"jsonrpc":"2.0","id":1,"result":{"kind":"task","id":"wf-7f3a","status":{"state":"working"}}}
+
+data: {"jsonrpc":"2.0","id":1,"result":{"kind":"artifact-update","taskId":"wf-7f3a","artifact":{"artifactId":"workflow-output","parts":[{"kind":"data","data":{"orderId":"ORD-42"}}]}}}
+
+data: {"jsonrpc":"2.0","id":1,"result":{"kind":"status-update","taskId":"wf-7f3a","status":{"state":"completed"},"final":true}}
+```
+
+The stream is a live view of the durable execution — if the connection drops, resume tracking with
+`tasks/get`. Tuning: `conductor.a2a.server.stream-poll-interval-millis` (default 500) and
+`conductor.a2a.server.stream-max-duration-seconds` (default 300).
 
 ### Durable, idempotent start
 

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/a2a/A2ADurableEngineEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/a2a/A2ADurableEngineEndToEndTest.java
@@ -59,8 +59,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * The durability money-shot, through the <b>real engine</b>: a {@code AGENT} task is driven by
- * the genuine decider + {@link AsyncSystemTaskExecutor} + Redis-backed persistence (not a mocked
+ * The durability money-shot, through the <b>real engine</b>: a {@code AGENT} task is driven by the
+ * genuine decider + {@link AsyncSystemTaskExecutor} + Redis-backed persistence (not a mocked
  * engine), against a slow A2A agent, and proves crash/restart resume.
  *
  * <p>"Durable A2A" claim under test: while the remote agent is still {@code working}, all of the
@@ -72,9 +72,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * The embedded agent stands in for the external agent, which does <i>not</i> crash when Conductor
  * does — it keeps serving and eventually flips to {@code completed}.
  *
- * <p>System-task workers are disabled in test mode, so we drain the {@code AGENT} queue and
- * execute via {@link AsyncSystemTaskExecutor} — the same path {@code SystemTaskWorkerCoordinator}
- * takes in production.
+ * <p>System-task workers are disabled in test mode, so we drain the {@code AGENT} queue and execute
+ * via {@link AsyncSystemTaskExecutor} — the same path {@code SystemTaskWorkerCoordinator} takes in
+ * production.
  */
 @SpringBootTest(classes = ConductorTestApp.class)
 @TestPropertySource(


### PR DESCRIPTION
**Stacked on #1195** (base branch `feat/durable-a2a-protocol`).

Adds server-side **`message/stream`** so exposed workflow-agents stream over SSE — closing the parity gap (the client already streams).

## What
- `POST /a2a/{workflow}` with method `message/stream` returns a `text/event-stream`: the initial **Task**, then **`status-update`** events as the workflow's A2A state changes and **`artifact-update`** events as output appears, ending with a **`final`** status-update at a terminal / input-required state (or when the stream window elapses).
- Driven off a dedicated daemon thread pool (doesn't tie up request/system-task threads); bounded by `stream-max-duration-seconds`.
- Agent Card now advertises `capabilities.streaming=true`.
- Web-agnostic `A2AStreamSink` keeps `SseEmitter` out of `A2AWorkflowAgent` (unit-testable stream driver).

## Config
`conductor.a2a.server.stream-poll-interval-millis` (500), `conductor.a2a.server.stream-max-duration-seconds` (300).

## Tests
- Unit (mocked engine): asserts the `task → artifact-update → final status-update` sequence + JSON-RPC id propagation.
- **Loopback over real HTTP**: our client `message/stream` against the server's SSE, aggregating to a completed task with artifacts (Conductor↔Conductor streaming).
- Full `*a2a*` suite green; Spotless clean.

## Docs
`devguide/ai/a2a-integration.md` gains a Streaming subsection (curl + sample SSE frames); design `10-a2a-server.md` updated (streaming moves from follow-up to shipped).

## Still deferred
Push-notification config endpoints (`tasks/pushNotificationConfig/*`); Agent Card JWS; OAuth scopes; gRPC/ProtoJSON transports.
