### PR TITLE
fix(ai): remove manual Accept-Encoding header so Mistral gzip responses decode

### DIFF
--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/mistral/MistralAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/mistral/MistralAI.java
@@ -123,15 +123,16 @@ public class MistralAI implements AIModel {
                         : httpClient;
         var factory =
                 new org.springframework.http.client.OkHttp3ClientHttpRequestFactory(effective);
-        // Needs accept-encoding headers
-        // https://github.com/spring-projects/spring-ai/issues/372
+        // Do NOT set the Accept-Encoding header manually here. OkHttp only
+        // decompresses a gzip response transparently when it adds the
+        // Accept-Encoding header itself. Setting it explicitly turns off that
+        // automatic decompression, so the gzipped body reaches Jackson undecoded
+        // and parsing fails with "Illegal character ((CTRL-CHAR, code 31))".
+        // Letting OkHttp manage compression makes responses parse correctly.
         return MistralAiApi.builder()
                 .baseUrl(config.getBaseURL())
                 .apiKey(config.getApiKey())
-                .restClientBuilder(
-                        RestClient.builder()
-                                .requestFactory(factory)
-                                .defaultHeader("Accept-Encoding", "gzip, deflate"))
+                .restClientBuilder(RestClient.builder().requestFactory(factory))
                 .build();
     }
 

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/mistral/MistralAIGzipResponseTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/mistral/MistralAIGzipResponseTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.mistral;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
+
+import org.conductoross.conductor.ai.models.ChatCompletion;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okio.Buffer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression test for the Mistral provider response decoding.
+ *
+ * <p>The client must let OkHttp manage content compression. When the {@code Accept-Encoding} header
+ * was set manually, OkHttp stopped decompressing the gzip response transparently, so the raw gzip
+ * bytes were handed to Jackson and parsing failed with {@code Illegal character ((CTRL-CHAR, code
+ * 31))} (0x1F is the first byte of the gzip magic number). This test serves a gzip-encoded chat
+ * completion and asserts it is decoded correctly.
+ */
+class MistralAIGzipResponseTest {
+
+    private MockWebServer server;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    void chatCompletionDecodesGzipEncodedResponse() throws Exception {
+        String json =
+                "{\"id\":\"cmpl-1\",\"object\":\"chat.completion\",\"created\":1,"
+                        + "\"model\":\"mistral-small-latest\","
+                        + "\"choices\":[{\"index\":0,"
+                        + "\"message\":{\"role\":\"assistant\",\"content\":\"Hallo\"},"
+                        + "\"finish_reason\":\"stop\"}],"
+                        + "\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}";
+
+        ByteArrayOutputStream gzipped = new ByteArrayOutputStream();
+        try (GZIPOutputStream gz = new GZIPOutputStream(gzipped)) {
+            gz.write(json.getBytes(StandardCharsets.UTF_8));
+        }
+        Buffer body = new Buffer();
+        body.write(gzipped.toByteArray());
+
+        server.enqueue(
+                new MockResponse()
+                        .setResponseCode(200)
+                        .addHeader("Content-Type", "application/json")
+                        .addHeader("Content-Encoding", "gzip")
+                        .setBody(body));
+
+        MistralAIConfiguration config = new MistralAIConfiguration();
+        config.setApiKey("test-api-key");
+        config.setBaseURL(server.url("/").toString().replaceAll("/$", ""));
+        MistralAI mistralAI = new MistralAI(config);
+
+        ChatCompletion input = new ChatCompletion();
+        input.setModel("mistral-small-latest");
+        input.setMaxTokens(50);
+
+        ChatModel chatModel = mistralAI.getChatModel();
+        ChatResponse response =
+                chatModel.call(
+                        new Prompt(
+                                List.of(new UserMessage("hi")), mistralAI.getChatOptions(input)));
+
+        assertEquals("Hallo", response.getResult().getOutput().getText());
+    }
+}

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/mistral/MistralAIGzipResponseTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/mistral/MistralAIGzipResponseTest.java
@@ -17,7 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.zip.GZIPOutputStream;
 
-import org.conductoross.conductor.ai.models.ChatCompletion;
+import org.conductoross.conductor.ai.model.ChatCompletion;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Problem

Any LLM task (`LLM_TEXT_COMPLETE`, `LLM_CHAT_COMPLETE`, …) using the **Mistral** provider always fails with:

```
Error while extracting response for type [org.springframework.ai.mistralai.api.MistralAiApi$ChatCompletion]
and content type [application/json] — caused by: Illegal character ((CTRL-CHAR, code 31)):
only regular white space (\r, \n, \t) is allowed between tokens
```

`code 31` is `0x1F` — the first byte of the gzip magic number (`0x1F 0x8B`). Jackson is being handed a gzip-compressed body that was never decompressed.

## Root cause

`MistralAI#createMistralAiApi` builds the `RestClient` on an `OkHttp3ClientHttpRequestFactory` and additionally sets the `Accept-Encoding` header by hand:

```java
RestClient.builder()
    .requestFactory(factory)
    .defaultHeader("Accept-Encoding", "gzip, deflate")
```

OkHttp only decompresses a gzip response **transparently when it adds the `Accept-Encoding` header itself** (via its `BridgeInterceptor`). Setting the header explicitly turns that automatic decompression off, so the gzipped body is passed straight to Jackson and parsing fails on the `0x1F` byte.

The header was originally added to work around spring-ai#372, but it is unnecessary — and now actively harmful — since the client uses the OkHttp request factory, which handles content encoding on its own.

## Fix

Remove the manual `Accept-Encoding` header and let OkHttp manage compression. Mistral responses then decode correctly.

## Tests

Adds `MistralAIGzipResponseTest`, a regression test using `MockWebServer` that serves a **gzip-encoded** chat completion and asserts it is decoded correctly. It fails against the old code (gzip body reaches Jackson undecoded → `code 31`) and passes with this change. The test needs no API key, so it runs in CI — unlike the existing `MistralAITest.IntegrationTests`, which are gated on `MISTRAL_API_KEY` and therefore skipped in CI (which is why this regression went unnoticed).

## Impact / scope

- Present since the initial AI module commit ("Support Agentic flows", #745); affects every release that ships the AI module (3.30.0 onward, including 3.31.0-rc.x).
- Mistral-provider specific; other providers are unaffected by this line.
- Verified against the live Mistral API and via the new test: responses parse once OkHttp manages the encoding.
