### PR TITLE
fix(test): de-flake hierarchical fork/join rerun & restart specs

### DIFF
--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/HierarchicalForkJoinSubworkflowRerunSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/HierarchicalForkJoinSubworkflowRerunSpec.groovy
@@ -186,7 +186,10 @@ class HierarchicalForkJoinSubworkflowRerunSpec extends AbstractSpecification {
             tasks[2].taskType == 'integration_task_2'
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].taskType == TASK_TYPE_JOIN
-            tasks[3].status == Task.Status.CANCELED
+            // The reopened parent is also pushed for background evaluation, so by the time we
+            // read this snapshot the JOIN may still be CANCELED (from the failed run) or already
+            // reopened to IN_PROGRESS by the sweeper. Either is valid; only completion is not.
+            tasks[3].status in [Task.Status.CANCELED, Task.Status.IN_PROGRESS]
         }
 
         when: "the root level workflow is 'decided'"
@@ -203,7 +206,10 @@ class HierarchicalForkJoinSubworkflowRerunSpec extends AbstractSpecification {
             tasks[2].taskType == 'integration_task_2'
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].taskType == TASK_TYPE_JOIN
-            tasks[3].status == Task.Status.CANCELED
+            // The reopened parent is also pushed for background evaluation, so by the time we
+            // read this snapshot the JOIN may still be CANCELED (from the failed run) or already
+            // reopened to IN_PROGRESS by the sweeper. Either is valid; only completion is not.
+            tasks[3].status in [Task.Status.CANCELED, Task.Status.IN_PROGRESS]
         }
         //endregion
     }
@@ -450,7 +456,10 @@ class HierarchicalForkJoinSubworkflowRerunSpec extends AbstractSpecification {
             tasks[2].taskType == 'integration_task_2'
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].taskType == TASK_TYPE_JOIN
-            tasks[3].status == Task.Status.CANCELED
+            // The reopened parent is also pushed for background evaluation, so by the time we
+            // read this snapshot the JOIN may still be CANCELED (from the failed run) or already
+            // reopened to IN_PROGRESS by the sweeper. Either is valid; only completion is not.
+            tasks[3].status in [Task.Status.CANCELED, Task.Status.IN_PROGRESS]
         }
 
         and: "verify that the root workflow is updated"
@@ -464,7 +473,10 @@ class HierarchicalForkJoinSubworkflowRerunSpec extends AbstractSpecification {
             tasks[2].taskType == 'integration_task_2'
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].taskType == TASK_TYPE_JOIN
-            tasks[3].status == Task.Status.CANCELED
+            // The reopened parent is also pushed for background evaluation, so by the time we
+            // read this snapshot the JOIN may still be CANCELED (from the failed run) or already
+            // reopened to IN_PROGRESS by the sweeper. Either is valid; only completion is not.
+            tasks[3].status in [Task.Status.CANCELED, Task.Status.IN_PROGRESS]
         }
 
         when: "the mid level and root workflows are sweeped"

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/HierarchicalForkJoinSubworkflowRestartSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/HierarchicalForkJoinSubworkflowRestartSpec.groovy
@@ -183,7 +183,10 @@ class HierarchicalForkJoinSubworkflowRestartSpec extends AbstractSpecification {
             tasks[2].taskType == 'integration_task_2'
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].taskType == TASK_TYPE_JOIN
-            tasks[3].status == Task.Status.CANCELED
+            // The reopened parent is also pushed for background evaluation, so by the time we
+            // read this snapshot the JOIN may still be CANCELED (from the failed run) or already
+            // reopened to IN_PROGRESS by the sweeper. Either is valid; only completion is not.
+            tasks[3].status in [Task.Status.CANCELED, Task.Status.IN_PROGRESS]
         }
 
         when: "the root level workflow is 'decided'"
@@ -200,7 +203,10 @@ class HierarchicalForkJoinSubworkflowRestartSpec extends AbstractSpecification {
             tasks[2].taskType == 'integration_task_2'
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].taskType == TASK_TYPE_JOIN
-            tasks[3].status == Task.Status.CANCELED
+            // The reopened parent is also pushed for background evaluation, so by the time we
+            // read this snapshot the JOIN may still be CANCELED (from the failed run) or already
+            // reopened to IN_PROGRESS by the sweeper. Either is valid; only completion is not.
+            tasks[3].status in [Task.Status.CANCELED, Task.Status.IN_PROGRESS]
         }
         //endregion
     }
@@ -360,7 +366,10 @@ class HierarchicalForkJoinSubworkflowRestartSpec extends AbstractSpecification {
             tasks[2].taskType == 'integration_task_2'
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].taskType == TASK_TYPE_JOIN
-            tasks[3].status == Task.Status.CANCELED
+            // The reopened parent is also pushed for background evaluation, so by the time we
+            // read this snapshot the JOIN may still be CANCELED (from the failed run) or already
+            // reopened to IN_PROGRESS by the sweeper. Either is valid; only completion is not.
+            tasks[3].status in [Task.Status.CANCELED, Task.Status.IN_PROGRESS]
         }
 
         when: "poll and complete the integration_task_2 task in the mid level workflow"
@@ -448,7 +457,10 @@ class HierarchicalForkJoinSubworkflowRestartSpec extends AbstractSpecification {
             tasks[2].taskType == 'integration_task_2'
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].taskType == TASK_TYPE_JOIN
-            tasks[3].status == Task.Status.CANCELED
+            // The reopened parent is also pushed for background evaluation, so by the time we
+            // read this snapshot the JOIN may still be CANCELED (from the failed run) or already
+            // reopened to IN_PROGRESS by the sweeper. Either is valid; only completion is not.
+            tasks[3].status in [Task.Status.CANCELED, Task.Status.IN_PROGRESS]
         }
 
         and: "verify that the root workflow is updated"
@@ -462,7 +474,10 @@ class HierarchicalForkJoinSubworkflowRestartSpec extends AbstractSpecification {
             tasks[2].taskType == 'integration_task_2'
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].taskType == TASK_TYPE_JOIN
-            tasks[3].status == Task.Status.CANCELED
+            // The reopened parent is also pushed for background evaluation, so by the time we
+            // read this snapshot the JOIN may still be CANCELED (from the failed run) or already
+            // reopened to IN_PROGRESS by the sweeper. Either is valid; only completion is not.
+            tasks[3].status in [Task.Status.CANCELED, Task.Status.IN_PROGRESS]
         }
 
         when: "the mid level and root workflows are sweeped"


### PR DESCRIPTION
## Problem

CI run [28075964600](https://github.com/conductor-oss/conductor/actions/runs/28075964600) failed in the `test-harness` job with two failures, both the same assertion:

```
tasks[3].status == Task.Status.CANCELED
|    |   IN_PROGRESS   false
```

- `HierarchicalForkJoinSubworkflowRerunSpec > Test rerun on the leaf-level in a 3-level subworkflow`
- `HierarchicalForkJoinSubworkflowRestartSpec > Test restart on the leaf in a 3-level subworkflow`

## Root cause

This is a flaky-test race, not a product bug. These integration specs run a real engine with a background sweeper (`AbstractSpecification` sets `sweeperThreadCount=1`; the new `WorkflowSweeper` spawns threads that continuously poll the decider queue).

When the leaf workflow is rerun/restarted, the reopened parent workflows are pushed onto the decider queue. The test then takes a single snapshot and asserts the parent's `JOIN` is still `CANCELED` (the state left by the original failure). On a loaded CI runner, the background sweeper can decide the parent first and reopen the `JOIN` to `IN_PROGRESS` before the snapshot is read.

The same race was already handled for the *post-sweep* assertions in the restart spec (the `await()` / `joinIsUpdated()` block, with the comment that "parent workflows are also pushed for expedited background evaluation"), but the *pre-sweep* snapshot blocks were missed.

The tests pass consistently locally — the flake only surfaces under CI timing.

## Fix

Relax the pre-sweep snapshot assertion in both specs (mid-level and root blocks) to accept either valid transient state:

```groovy
tasks[3].status in [Task.Status.CANCELED, Task.Status.IN_PROGRESS]
```

`CANCELED` = not yet decided; `IN_PROGRESS` = already reopened by the sweeper. Completion is impossible while the `SUB_WORKFLOW` is still `IN_PROGRESS`, so the meaningful coverage (workflow `RUNNING`, `SUB_WORKFLOW` reopened, `integration_task_2` `COMPLETED`) is preserved. The deterministic post-sweep assertions are untouched.

## Testing

- Both specs pass (`./gradlew :conductor-test-harness:test --tests ... --rerun-tasks`)
- `./gradlew :conductor-test-harness:spotlessCheck` is clean
- Test-only change; no production code touched