### PR TITLE
fix(ci): update server-lite workflow to build ui-next

### DIFF
--- a/.github/workflows/publish_build.yaml
+++ b/.github/workflows/publish_build.yaml
@@ -78,14 +78,16 @@ jobs:
         with:
           node-version: 'lts/*'
 
-      - name: Build UI
+      - name: Build ui-next and embed into server static resources
         run: |
-          cd ui
-          corepack enable && corepack prepare yarn@stable --activate
-          export REACT_APP_MONACO_EDITOR_USING_CDN=false
-          export REACT_APP_ENABLE_ERRORS_INSPECTOR=true
-          yarn config set network-timeout 600000 -g
-          yarn install && cp -r node_modules/monaco-editor public/ && yarn build
+          corepack enable
+          cd ui-next
+          pnpm install
+          NODE_OPTIONS=--max-old-space-size=4096 pnpm build
+          cd ..
+          mkdir -p server/src/main/resources/static
+          rm -rf server/src/main/resources/static/*
+          cp -r ui-next/dist/. server/src/main/resources/static/
 
       - name: Stage artifacts for Docker build
         run: |


### PR DESCRIPTION
`publish_build.yaml` was missed by #1168 — it still ran `cd ui && yarn build` but the Dockerfile now expects `ui-next/dist`. Aligns it with `publish.yml`.

Broke on rc6: [failing run](https://github.com/conductor-oss/conductor/actions/runs/28083232218)

🤖 Generated with [Claude Code](https://claude.com/claude-code)