### PR TITLE
Revert "test(test-harness): fix flaky parent-JOIN assertions in HierarchicalForkJoinSubworkflowRetrySpec"

### DIFF
--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/HierarchicalForkJoinSubworkflowRetrySpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/HierarchicalForkJoinSubworkflowRetrySpec.groovy
@@ -12,8 +12,6 @@
  */
 package com.netflix.conductor.test.integration
 
-import java.util.concurrent.TimeUnit
-
 import org.springframework.beans.factory.annotation.Autowired
 
 import com.netflix.conductor.common.metadata.tasks.Task
@@ -30,8 +28,6 @@ import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_FOR
 import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_JOIN
 import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_SUB_WORKFLOW
 import static com.netflix.conductor.test.util.WorkflowTestUtil.verifyPolledAndAcknowledgedTask
-
-import static org.awaitility.Awaitility.await
 
 class HierarchicalForkJoinSubworkflowRetrySpec extends AbstractSpecification {
 
@@ -344,12 +340,6 @@ class HierarchicalForkJoinSubworkflowRetrySpec extends AbstractSpecification {
         }
 
         and: "verify the SUB_WORKFLOW task in root workflow is IN_PROGRESS state"
-        // retry() updates parents asynchronously via the decider queue; the background
-        // sweeper re-decides the JOIN from CANCELED to IN_PROGRESS (same sweeper race as #1047).
-        await().atMost(10, TimeUnit.SECONDS).until {
-            workflowExecutionService.getExecutionStatus(rootWorkflowId, true)
-                    .tasks[3].status == Task.Status.IN_PROGRESS
-        }
         with(workflowExecutionService.getExecutionStatus(rootWorkflowId, true)) {
             status == Workflow.WorkflowStatus.RUNNING
             tasks.size() == 4
@@ -360,7 +350,7 @@ class HierarchicalForkJoinSubworkflowRetrySpec extends AbstractSpecification {
             tasks[2].taskType == 'integration_task_2'
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].taskType == TASK_TYPE_JOIN
-            tasks[3].status == Task.Status.IN_PROGRESS
+            tasks[3].status == Task.Status.CANCELED
         }
 
         when: "the SUB_WORKFLOW task in mid level workflow is started by issuing a system task call"
@@ -435,12 +425,6 @@ class HierarchicalForkJoinSubworkflowRetrySpec extends AbstractSpecification {
         }
 
         then: "verify that the mid-level workflow's SUB_WORKFLOW task is updated"
-        // retry() updates parents asynchronously via the decider queue; the background
-        // sweeper re-decides the JOIN from CANCELED to IN_PROGRESS (same sweeper race as #1047).
-        await().atMost(10, TimeUnit.SECONDS).until {
-            workflowExecutionService.getExecutionStatus(midLevelWorkflowId, true)
-                    .tasks[3].status == Task.Status.IN_PROGRESS
-        }
         with(workflowExecutionService.getExecutionStatus(midLevelWorkflowId, true)) {
             status == Workflow.WorkflowStatus.RUNNING
             tasks.size() == 4
@@ -451,14 +435,10 @@ class HierarchicalForkJoinSubworkflowRetrySpec extends AbstractSpecification {
             tasks[2].taskType == 'integration_task_2'
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].taskType == TASK_TYPE_JOIN
-            tasks[3].status == Task.Status.IN_PROGRESS
+            tasks[3].status == Task.Status.CANCELED
         }
 
         and: "verify that the root workflow's SUB_WORKFLOW task is updated"
-        await().atMost(10, TimeUnit.SECONDS).until {
-            workflowExecutionService.getExecutionStatus(rootWorkflowId, true)
-                    .tasks[3].status == Task.Status.IN_PROGRESS
-        }
         with(workflowExecutionService.getExecutionStatus(rootWorkflowId, true)) {
             status == Workflow.WorkflowStatus.RUNNING
             tasks.size() == 4
@@ -469,7 +449,7 @@ class HierarchicalForkJoinSubworkflowRetrySpec extends AbstractSpecification {
             tasks[2].taskType == 'integration_task_2'
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].taskType == TASK_TYPE_JOIN
-            tasks[3].status == Task.Status.IN_PROGRESS
+            tasks[3].status == Task.Status.CANCELED
         }
 
         when: "the mid level and root workflows are 'decided'"
@@ -554,12 +534,6 @@ class HierarchicalForkJoinSubworkflowRetrySpec extends AbstractSpecification {
         workflowExecutor.retry(rootWorkflowId, true)
 
         then: "verify that the sub workflow task in root workflow is IN_PROGRESS state"
-        // retry() updates parents asynchronously via the decider queue; the background
-        // sweeper re-decides the JOIN from CANCELED to IN_PROGRESS (same sweeper race as #1047).
-        await().atMost(10, TimeUnit.SECONDS).until {
-            workflowExecutionService.getExecutionStatus(rootWorkflowId, true)
-                    .tasks[3].status == Task.Status.IN_PROGRESS
-        }
         with(workflowExecutionService.getExecutionStatus(rootWorkflowId, true)) {
             status == Workflow.WorkflowStatus.RUNNING
             tasks.size() == 4
@@ -570,14 +544,10 @@ class HierarchicalForkJoinSubworkflowRetrySpec extends AbstractSpecification {
             tasks[2].taskType == 'integration_task_2'
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].taskType == TASK_TYPE_JOIN
-            tasks[3].status == Task.Status.IN_PROGRESS
+            tasks[3].status == Task.Status.CANCELED
         }
 
         and: "verify that the sub workflow task in mid level workflow is IN_PROGRESS state"
-        await().atMost(10, TimeUnit.SECONDS).until {
-            workflowExecutionService.getExecutionStatus(midLevelWorkflowId, true)
-                    .tasks[3].status == Task.Status.IN_PROGRESS
-        }
         with(workflowExecutionService.getExecutionStatus(midLevelWorkflowId, true)) {
             status == Workflow.WorkflowStatus.RUNNING
             tasks.size() == 4
@@ -588,7 +558,7 @@ class HierarchicalForkJoinSubworkflowRetrySpec extends AbstractSpecification {
             tasks[2].taskType == 'integration_task_2'
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].taskType == TASK_TYPE_JOIN
-            tasks[3].status == Task.Status.IN_PROGRESS
+            tasks[3].status == Task.Status.CANCELED
         }
 
         and: "verify that the previously failed task in leaf workflow is in SCHEDULED state"
@@ -684,12 +654,6 @@ class HierarchicalForkJoinSubworkflowRetrySpec extends AbstractSpecification {
         workflowExecutor.retry(midLevelWorkflowId, true)
 
         then: "verify that the sub workflow task in root workflow is updated"
-        // retry() updates parents asynchronously via the decider queue; the background
-        // sweeper re-decides the JOIN from CANCELED to IN_PROGRESS (same sweeper race as #1047).
-        await().atMost(10, TimeUnit.SECONDS).until {
-            workflowExecutionService.getExecutionStatus(rootWorkflowId, true)
-                    .tasks[3].status == Task.Status.IN_PROGRESS
-        }
         with(workflowExecutionService.getExecutionStatus(rootWorkflowId, true)) {
             status == Workflow.WorkflowStatus.RUNNING
             tasks.size() == 4
@@ -700,14 +664,10 @@ class HierarchicalForkJoinSubworkflowRetrySpec extends AbstractSpecification {
             tasks[2].taskType == 'integration_task_2'
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].taskType == TASK_TYPE_JOIN
-            tasks[3].status == Task.Status.IN_PROGRESS
+            tasks[3].status == Task.Status.CANCELED
         }
 
         and: "verify that the sub workflow task in mid level workflow is updated"
-        await().atMost(10, TimeUnit.SECONDS).until {
-            workflowExecutionService.getExecutionStatus(midLevelWorkflowId, true)
-                    .tasks[3].status == Task.Status.IN_PROGRESS
-        }
         with(workflowExecutionService.getExecutionStatus(midLevelWorkflowId, true)) {
             status == Workflow.WorkflowStatus.RUNNING
             tasks.size() == 4
@@ -718,7 +678,7 @@ class HierarchicalForkJoinSubworkflowRetrySpec extends AbstractSpecification {
             tasks[2].taskType == 'integration_task_2'
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].taskType == TASK_TYPE_JOIN
-            tasks[3].status == Task.Status.IN_PROGRESS
+            tasks[3].status == Task.Status.CANCELED
         }
 
         and: "verify that the previously failed task in leaf workflow is in SCHEDULED state"
@@ -826,12 +786,6 @@ class HierarchicalForkJoinSubworkflowRetrySpec extends AbstractSpecification {
         }
 
         then: "verify that the mid-level workflow is updated"
-        // retry() updates parents asynchronously via the decider queue; the background
-        // sweeper re-decides the JOIN from CANCELED to IN_PROGRESS (same sweeper race as #1047).
-        await().atMost(10, TimeUnit.SECONDS).until {
-            workflowExecutionService.getExecutionStatus(midLevelWorkflowId, true)
-                    .tasks[3].status == Task.Status.IN_PROGRESS
-        }
         with(workflowExecutionService.getExecutionStatus(midLevelWorkflowId, true)) {
             status == Workflow.WorkflowStatus.RUNNING
             tasks.size() == 4
@@ -842,14 +796,10 @@ class HierarchicalForkJoinSubworkflowRetrySpec extends AbstractSpecification {
             tasks[2].taskType == 'integration_task_2'
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].taskType == TASK_TYPE_JOIN
-            tasks[3].status == Task.Status.IN_PROGRESS
+            tasks[3].status == Task.Status.CANCELED
         }
 
         and: "verify that the root workflow is updated"
-        await().atMost(10, TimeUnit.SECONDS).until {
-            workflowExecutionService.getExecutionStatus(rootWorkflowId, true)
-                    .tasks[3].status == Task.Status.IN_PROGRESS
-        }
         with(workflowExecutionService.getExecutionStatus(rootWorkflowId, true)) {
             status == Workflow.WorkflowStatus.RUNNING
             tasks.size() == 4
@@ -860,7 +810,7 @@ class HierarchicalForkJoinSubworkflowRetrySpec extends AbstractSpecification {
             tasks[2].taskType == 'integration_task_2'
             tasks[2].status == Task.Status.COMPLETED
             tasks[3].taskType == TASK_TYPE_JOIN
-            tasks[3].status == Task.Status.IN_PROGRESS
+            tasks[3].status == Task.Status.CANCELED
         }
 
         when: "the mid level and root workflows are 'decided'"


### PR DESCRIPTION
Reverts conductor-oss/conductor#1148