### PR TITLE
feat: typed Task.guardrailExecutions field for LLM guardrail capture

### DIFF
--- a/ai/src/main/java/org/conductoross/conductor/ai/models/LLMResponse.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/models/LLMResponse.java
@@ -13,9 +13,11 @@
 package org.conductoross.conductor.ai.models;
 
 import java.util.List;
+import java.util.Map;
 
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -38,6 +40,13 @@ public class LLMResponse {
     private String responseId;
     private String reasoning;
     private Integer reasoningTokens;
+
+    /**
+     * Records of any guardrail pre/post hooks that ran for this LLM task (phase, type, target,
+     * before/after text). Serialized only when present, so existing responses are unaffected.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<Map<String, Object>> guardrailExecutions;
 
     public boolean hasToolCalls() {
         return toolCalls != null && !toolCalls.isEmpty();

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/GuardrailExecution.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/GuardrailExecution.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.common.metadata.tasks;
+
+/**
+ * A record of a single LLM guardrail (PII scrub) hook that ran for a task. This is observability /
+ * audit data attached to the task as a first-class field (not in {@code outputData}), so it is not
+ * referenceable via {@code ${...}} expressions.
+ */
+public class GuardrailExecution {
+
+    /** INPUT or OUTPUT. */
+    private String phase;
+
+    /** Guardrail type: HTTP, JAVASCRIPT, WORKER, WORKFLOW. */
+    private String type;
+
+    /** URL / JS expression / worker name / workflow name. */
+    private String target;
+
+    /** FAIL or WARN. */
+    private String failureMode;
+
+    /** Text before scrubbing. */
+    private String input;
+
+    /** Text after scrubbing. */
+    private String output;
+
+    public String getPhase() {
+        return phase;
+    }
+
+    public void setPhase(String phase) {
+        this.phase = phase;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public void setTarget(String target) {
+        this.target = target;
+    }
+
+    public String getFailureMode() {
+        return failureMode;
+    }
+
+    public void setFailureMode(String failureMode) {
+        this.failureMode = failureMode;
+    }
+
+    public String getInput() {
+        return input;
+    }
+
+    public void setInput(String input) {
+        this.input = input;
+    }
+
+    public String getOutput() {
+        return output;
+    }
+
+    public void setOutput(String output) {
+        this.output = output;
+    }
+}

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/Task.java
@@ -212,7 +212,22 @@ public class Task {
     @ProtoField(id = 45)
     private String parentTaskId;
 
+    // LLM guardrail (PII scrub) hook executions for this task. First-class observability field,
+    // not part of inputData/outputData (so not referenceable via ${...}). JSON-only (no ProtoField);
+    // serialized only when present, so existing tasks are unaffected.
+    @com.fasterxml.jackson.annotation.JsonInclude(
+            com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY)
+    private java.util.List<GuardrailExecution> guardrailExecutions;
+
     public Task() {}
+
+    public java.util.List<GuardrailExecution> getGuardrailExecutions() {
+        return guardrailExecutions;
+    }
+
+    public void setGuardrailExecutions(java.util.List<GuardrailExecution> guardrailExecutions) {
+        this.guardrailExecutions = guardrailExecutions;
+    }
 
     /**
      * @return Type of the task

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx4g
 org.gradle.caching=true
-version=3.30.0.rc16-guardrail-local
+version=3.30.0.rc13

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx4g
 org.gradle.caching=true
-version=3.30.0.rc13
+version=3.30.0.rc16-guardrail-local

--- a/ui-next/src/pages/execution/TaskSummary.tsx
+++ b/ui-next/src/pages/execution/TaskSummary.tsx
@@ -210,8 +210,8 @@ export default function TaskSummary({ taskResult }: TaskSummaryProps) {
     }
   }
 
-  // Guardrail pre/post hook executions (scrubbing) captured on the LLM task output.
-  const guardrailExecutions = taskResult.outputData?.guardrailExecutions as
+  // Guardrail pre/post hook executions (scrubbing) - a first-class task field (not output data).
+  const guardrailExecutions = (taskResult as any).guardrailExecutions as
     | Array<Record<string, any>>
     | undefined;
   if (Array.isArray(guardrailExecutions) && guardrailExecutions.length > 0) {

--- a/ui-next/src/pages/execution/TaskSummary.tsx
+++ b/ui-next/src/pages/execution/TaskSummary.tsx
@@ -210,6 +210,33 @@ export default function TaskSummary({ taskResult }: TaskSummaryProps) {
     }
   }
 
+  // Guardrail pre/post hook executions (scrubbing) captured on the LLM task output.
+  const guardrailExecutions = taskResult.outputData?.guardrailExecutions as
+    | Array<Record<string, any>>
+    | undefined;
+  if (Array.isArray(guardrailExecutions) && guardrailExecutions.length > 0) {
+    guardrailExecutions.forEach((g) => {
+      data.push({
+        label: `Guardrail (${g.phase})`,
+        value: (
+          <div style={{ fontSize: "0.85em" }}>
+            <div>
+              <b>{String(g.type)}</b>
+              {g.target ? ` — ${String(g.target)}` : ""}
+              {g.failureMode ? ` (${String(g.failureMode)})` : ""}
+            </div>
+            <div style={{ marginTop: 4 }}>
+              <i>before:</i> {String(g.input)}
+            </div>
+            <div>
+              <i>after:</i> {String(g.output)}
+            </div>
+          </div>
+        ),
+      });
+    });
+  }
+
   return (
     <Paper
       variant="outlined"


### PR DESCRIPTION
## What

Adds a typed, optional field for capturing **LLM guardrail (PII scrubbing) executions** on a task, plus UI rendering. Part of LLM guardrails work (input/output prompt scrubbing for native LLM tasks).

## Changes
- **`GuardrailExecution`** (conductor-common): typed record — `phase`, `type`, `target`, `failureMode`, `input` (before), `output` (after).
- **`Task.guardrailExecutions`** (conductor-common): optional `List<GuardrailExecution>`. `@JsonInclude(NON_EMPTY)`, JSON-only (no proto) → fully backward-compatible; serialized only when present. Audit data, **not** referenceable via `${...}` (not part of `outputData`).
- **`LLMResponse.guardrailExecutions`** (conductor-ai): optional worker-side transport for the records.
- **UI** (`ui-next/TaskSummary.tsx`): renders Guardrail (INPUT/OUTPUT) rows with before/after.

## Notes
- Optional everywhere; no migration; gRPC/proto unaffected.
- Engine-side relocation of the records from `outputData` into the typed field lives in the Orkes layer (separate repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
