### PR TITLE
Add query parameters to workflow input

### DIFF
--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/WorkflowResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/WorkflowResource.java
@@ -78,7 +78,21 @@ public class WorkflowResource {
     @Operation(
             summary =
                     "Start a new workflow with StartWorkflowRequest, which allows task to be executed in a domain")
-    public String startWorkflow(@RequestBody StartWorkflowRequest request) {
+    public String startWorkflow(
+            @RequestBody StartWorkflowRequest request,
+            @RequestParam Map<String, String> queryParams) {
+
+        if (queryParams != null && !queryParams.isEmpty()) {
+            Map<String, Object> input = request.getInput();
+
+            if (input == null) {
+                input = new HashMap<>();
+                request.setInput(input);
+            }
+
+            input.putAll(queryParams);
+        }
+
         return workflowService.startWorkflow(request);
     }
 

--- a/rest/src/test/java/com/netflix/conductor/rest/controllers/WorkflowResourceTest.java
+++ b/rest/src/test/java/com/netflix/conductor/rest/controllers/WorkflowResourceTest.java
@@ -55,6 +55,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import org.mockito.ArgumentCaptor;
 
 public class WorkflowResourceTest {
 
@@ -82,7 +83,7 @@ public class WorkflowResourceTest {
         String workflowID = "w112";
         when(mockWorkflowService.startWorkflow(any(StartWorkflowRequest.class)))
                 .thenReturn(workflowID);
-        assertEquals("w112", workflowResource.startWorkflow(startWorkflowRequest));
+        assertEquals("w112",  workflowResource.startWorkflow(startWorkflowRequest, new HashMap<>()));
     }
 
     @Test
@@ -94,6 +95,33 @@ public class WorkflowResourceTest {
                         anyString(), anyInt(), anyString(), anyInt(), anyMap()))
                 .thenReturn(workflowID);
         assertEquals("w112", workflowResource.startWorkflow("test1", 1, "c123", 0, input));
+    }
+    @Test
+    public void testStartWorkflowWithQueryParams() {
+        StartWorkflowRequest startWorkflowRequest = new StartWorkflowRequest();
+        startWorkflowRequest.setName("w123");
+
+        Map<String, Object> input = new HashMap<>();
+        input.put("1", "abc");
+        startWorkflowRequest.setInput(input);
+
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("url_param", "1234");
+
+        String workflowID = "w112";
+        when(mockWorkflowService.startWorkflow(any(StartWorkflowRequest.class)))
+                .thenReturn(workflowID);
+
+        assertEquals("w112", workflowResource.startWorkflow(startWorkflowRequest, queryParams));
+
+        ArgumentCaptor<StartWorkflowRequest> requestCaptor =
+                ArgumentCaptor.forClass(StartWorkflowRequest.class);
+
+        verify(mockWorkflowService).startWorkflow(requestCaptor.capture());
+
+        Map<String, Object> capturedInput = requestCaptor.getValue().getInput();
+        assertEquals("abc", capturedInput.get("1"));
+        assertEquals("1234", capturedInput.get("url_param"));
     }
 
     @Test


### PR DESCRIPTION
This PR fixes the start workflow API so query parameters passed in the request URL are added to the workflow input.

Before this change, a request like:

`POST /api/workflow?url_param=1234`

with body input:

```json
{
  "name": "test_workflow",
  "input": {
    "first": "xyz"
  }
}
```

would start the workflow with only the body input:

```json
{
  "first": "xyz"
}
```

Because of that, `${workflow.input.url_param}` was not available during workflow execution.

With this change, query parameters are merged into `StartWorkflowRequest.input` before the workflow is started, so the workflow input becomes:

```json
{
  "first": "xyz",
  "url_param": "1234"
}
```

The implementation also handles cases where the request input is null by creating an input map before adding query parameters.

Added a unit test to verify that the controller passes the updated `StartWorkflowRequest` to `WorkflowService` with both the original body input and query parameter values included.
