### PR TITLE
hot-fix:DropdownButton component z-index to default

### DIFF
--- a/ui-next/src/components/ui/buttons/DropdownButton.tsx
+++ b/ui-next/src/components/ui/buttons/DropdownButton.tsx
@@ -103,7 +103,7 @@ export default function DropdownButton({
         role={undefined}
         transition
         disablePortal
-        sx={{ maxHeight: "90vh", zIndex: 1 }}
+        sx={{ maxHeight: "90vh" }}
       >
         {({ TransitionProps, placement }) => (
           <Grow


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Hot-fix : remove the explicitly given z-index:1 from DropdownButton component. 

## Screenshots
| Before | After |
|--------|--------|
| <img width="375" height="327" alt="Screenshot 2026-06-29 at 3 57 14 PM" src="https://github.com/user-attachments/assets/baecfac5-b6f7-483c-82ee-b38b70840150" /> | <img width="301" height="293" alt="Screenshot 2026-06-29 at 3 58 06 PM" src="https://github.com/user-attachments/assets/c56e2b6d-e54e-4577-bbaa-f301c6da7bb0" /> | 
