### PR TITLE
feat(ui): LLM guardrail config + execution Guardrails panel

### DIFF
--- a/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/GuardrailsForm.tsx
+++ b/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/GuardrailsForm.tsx
@@ -1,4 +1,5 @@
-import { Box, FormControlLabel, Grid, Switch } from "@mui/material";
+import { Box, FormControlLabel, Grid, Switch, Typography } from "@mui/material";
+import { ConductorCodeBlockInput } from "components/ui/inputs/ConductorCodeBlockInput";
 import ConductorInput from "components/ui/inputs/ConductorInput";
 import ConductorSelect from "components/ui/inputs/ConductorSelect";
 import { FunctionComponent, useState } from "react";
@@ -28,13 +29,28 @@ const FAILURE_ITEMS = [
 const targetLabel = (type?: GuardrailType) => {
   switch (type) {
     case "JAVASCRIPT":
-      return "JavaScript expression (reads $.prompt)";
+      return "JavaScript expression";
     case "HTTP":
-      return "HTTP endpoint URL (POST {prompt})";
+      return "HTTP endpoint URL";
     case "WORKFLOW":
       return "Guardrail workflow name";
     default:
       return "Target";
+  }
+};
+
+// The text to scrub is passed to every guardrail under `prompt`, and the
+// scrubbed text must be returned under `prompt`. Shown as contract hints.
+const contractHint = (type?: GuardrailType) => {
+  switch (type) {
+    case "JAVASCRIPT":
+      return "Reads the text as $.prompt and must return the scrubbed string. e.g. $.prompt.replace(/[0-9]{13,19}/g, '[REDACTED]')";
+    case "HTTP":
+      return 'Method POST · request body { "prompt": "<text>" } · expected response body { "prompt": "<scrubbed text>" }. Failure or a missing prompt is treated per the failure mode.';
+    case "WORKFLOW":
+      return 'Started with input { "prompt": "<text>" }; must output { "prompt": "<scrubbed text>" }.';
+    default:
+      return "";
   }
 };
 
@@ -121,7 +137,18 @@ const GuardrailEditor: FunctionComponent<{
             />
           </Grid>
           <Grid size={12}>
-            {value.type === "WORKFLOW" ? (
+            {value.type === "JAVASCRIPT" ? (
+              <ConductorCodeBlockInput
+                label={targetLabel(value.type)}
+                language="javascript"
+                languageLabel="ECMASCRIPT"
+                value={value.target ?? ""}
+                onChange={(v) => patch({ target: v })}
+                height={160}
+                minHeight={140}
+                error={!!targetError}
+              />
+            ) : value.type === "WORKFLOW" ? (
               <ConductorFlexibleAutoCompleteVariables
                 label={targetLabel(value.type)}
                 options={workflowNames}
@@ -132,13 +159,29 @@ const GuardrailEditor: FunctionComponent<{
               <ConductorInput
                 label={targetLabel(value.type)}
                 fullWidth
-                multiline={value.type === "JAVASCRIPT"}
-                minRows={value.type === "JAVASCRIPT" ? 2 : 1}
+                placeholder={value.type === "HTTP" ? "https://host/scrub" : undefined}
                 value={value.target ?? ""}
                 error={!!targetError}
                 helperText={targetError ? "Target is required" : undefined}
                 onTextInputChange={(v) => patch({ target: v })}
               />
+            )}
+            {value.type && (
+              <Typography
+                variant="caption"
+                sx={{ display: "block", mt: 0.5, opacity: 0.6 }}
+              >
+                {contractHint(value.type)}
+              </Typography>
+            )}
+            {value.type === "JAVASCRIPT" && targetError && (
+              <Typography
+                variant="caption"
+                color="error"
+                sx={{ display: "block" }}
+              >
+                Target is required
+              </Typography>
             )}
           </Grid>
         </Grid>

--- a/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/GuardrailsForm.tsx
+++ b/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/GuardrailsForm.tsx
@@ -2,8 +2,10 @@ import { Box, FormControlLabel, Grid, Switch, Typography } from "@mui/material";
 import { ConductorCodeBlockInput } from "components/ui/inputs/ConductorCodeBlockInput";
 import ConductorInput from "components/ui/inputs/ConductorInput";
 import ConductorSelect from "components/ui/inputs/ConductorSelect";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import { Button, IconButton } from "@mui/material";
 import { FunctionComponent, useState } from "react";
-import { useWorkflowNames } from "utils/query";
+import { useWorkflowNames, useWorkflowNamesAndVersions } from "utils/query";
 import ConductorFlexibleAutoCompleteVariables from "./ConductorFlexibleAutoCompleteVariables";
 
 interface GuardrailsFormProps {
@@ -17,6 +19,8 @@ type FailureMode = "FAIL" | "WARN";
 interface GuardrailConfig {
   type?: GuardrailType;
   target?: string;
+  version?: number;
+  headers?: Record<string, string>;
   failureMode?: FailureMode;
 }
 
@@ -65,7 +69,16 @@ const GuardrailEditor: FunctionComponent<{
   taskJson: any;
   onChange: (value: any) => void;
   workflowNames: string[];
-}> = ({ title, description, paramKey, taskJson, onChange, workflowNames }) => {
+  versionsByName: Map<string, number[]>;
+}> = ({
+  title,
+  description,
+  paramKey,
+  taskJson,
+  onChange,
+  workflowNames,
+  versionsByName,
+}) => {
   const existing: GuardrailConfig | undefined =
     taskJson?.inputParameters?.[paramKey];
   const [enabled, setEnabled] = useState<boolean>(!!existing);
@@ -93,6 +106,23 @@ const GuardrailEditor: FunctionComponent<{
   };
 
   const patch = (p: Partial<GuardrailConfig>) => writeConfig({ ...value, ...p });
+
+  // HTTP headers are edited as key/value rows, persisted as a Record on the config.
+  const [headerRows, setHeaderRows] = useState<{ key: string; value: string }[]>(
+    () =>
+      Object.entries(value.headers ?? {}).map(([k, v]) => ({
+        key: k,
+        value: String(v),
+      })),
+  );
+  const writeHeaders = (rows: { key: string; value: string }[]) => {
+    setHeaderRows(rows);
+    const obj: Record<string, string> = {};
+    rows.forEach((r) => {
+      if (r.key.trim()) obj[r.key.trim()] = r.value;
+    });
+    patch({ headers: Object.keys(obj).length ? obj : undefined });
+  };
 
   // Client-side validation mirrors the server's GuardrailConfigValidator.
   const typeError = enabled && !value.type;
@@ -149,12 +179,34 @@ const GuardrailEditor: FunctionComponent<{
                 error={!!targetError}
               />
             ) : value.type === "WORKFLOW" ? (
-              <ConductorFlexibleAutoCompleteVariables
-                label={targetLabel(value.type)}
-                options={workflowNames}
-                value={value.target ?? ""}
-                onChange={(v: any) => patch({ target: v })}
-              />
+              <Grid container spacing={2}>
+                <Grid size={8}>
+                  <ConductorFlexibleAutoCompleteVariables
+                    label={targetLabel(value.type)}
+                    options={workflowNames}
+                    value={value.target ?? ""}
+                    onChange={(v: any) =>
+                      patch({ target: v, version: undefined })
+                    }
+                  />
+                </Grid>
+                <Grid size={4}>
+                  <ConductorSelect
+                    label="Version (optional)"
+                    fullWidth
+                    items={[
+                      { label: "Latest", value: "" },
+                      ...(versionsByName.get(value.target ?? "") ?? []).map(
+                        (v) => ({ label: `v${v}`, value: String(v) }),
+                      ),
+                    ]}
+                    value={value.version != null ? String(value.version) : ""}
+                    onTextInputChange={(v) =>
+                      patch({ version: v ? Number(v) : undefined })
+                    }
+                  />
+                </Grid>
+              </Grid>
             ) : (
               <ConductorInput
                 label={targetLabel(value.type)}
@@ -184,6 +236,63 @@ const GuardrailEditor: FunctionComponent<{
               </Typography>
             )}
           </Grid>
+
+          {value.type === "HTTP" && (
+            <Grid size={12}>
+              <Box sx={{ fontWeight: 600, color: "#767676", mb: 1 }}>
+                Headers (optional)
+              </Box>
+              {headerRows.map((row, i) => (
+                <Box
+                  key={i}
+                  sx={{ display: "flex", gap: 1, mb: 1, alignItems: "center" }}
+                >
+                  <ConductorInput
+                    label="Header"
+                    placeholder="Authorization"
+                    value={row.key}
+                    onTextInputChange={(v) =>
+                      writeHeaders(
+                        headerRows.map((r, j) =>
+                          j === i ? { ...r, key: v } : r,
+                        ),
+                      )
+                    }
+                  />
+                  <ConductorInput
+                    label="Value"
+                    placeholder="Bearer ..."
+                    fullWidth
+                    value={row.value}
+                    onTextInputChange={(v) =>
+                      writeHeaders(
+                        headerRows.map((r, j) =>
+                          j === i ? { ...r, value: v } : r,
+                        ),
+                      )
+                    }
+                  />
+                  <IconButton
+                    size="small"
+                    aria-label="Remove header"
+                    onClick={() =>
+                      writeHeaders(headerRows.filter((_, j) => j !== i))
+                    }
+                  >
+                    <DeleteOutlineIcon fontSize="small" />
+                  </IconButton>
+                </Box>
+              ))}
+              <Button
+                size="small"
+                onClick={() =>
+                  writeHeaders([...headerRows, { key: "", value: "" }])
+                }
+              >
+                + Add header
+              </Button>
+            </Grid>
+          )}
         </Grid>
       )}
     </Box>
@@ -195,12 +304,15 @@ export const GuardrailsForm: FunctionComponent<GuardrailsFormProps> = ({
   taskJson,
 }) => {
   const workflowNames = useWorkflowNames();
+  const versionsByName = useWorkflowNamesAndVersions();
   return (
     <Box>
       <Box style={{ opacity: 0.5 }}>
         Guardrails scrub or validate the prompt before it reaches the LLM
         (input) and the response before it returns (output). Each guardrail runs
-        as a linked sub-workflow.
+        as a linked sub-workflow that receives the text as{" "}
+        <code>{`{ "prompt": "<text>" }`}</code> and must return{" "}
+        <code>{`{ "prompt": "<scrubbed text>" }`}</code>.
       </Box>
       <GuardrailEditor
         title="Input guardrail"
@@ -209,6 +321,7 @@ export const GuardrailsForm: FunctionComponent<GuardrailsFormProps> = ({
         taskJson={taskJson}
         onChange={onChange}
         workflowNames={workflowNames}
+        versionsByName={versionsByName}
       />
       <GuardrailEditor
         title="Output guardrail"
@@ -217,6 +330,7 @@ export const GuardrailsForm: FunctionComponent<GuardrailsFormProps> = ({
         taskJson={taskJson}
         onChange={onChange}
         workflowNames={workflowNames}
+        versionsByName={versionsByName}
       />
     </Box>
   );

--- a/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/GuardrailsForm.tsx
+++ b/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/GuardrailsForm.tsx
@@ -1,0 +1,180 @@
+import { Box, FormControlLabel, Grid, Switch } from "@mui/material";
+import ConductorInput from "components/ui/inputs/ConductorInput";
+import ConductorSelect from "components/ui/inputs/ConductorSelect";
+import { FunctionComponent, useState } from "react";
+import { useWorkflowNames } from "utils/query";
+import ConductorFlexibleAutoCompleteVariables from "./ConductorFlexibleAutoCompleteVariables";
+
+interface GuardrailsFormProps {
+  onChange: (value: any) => void;
+  taskJson: any;
+}
+
+type GuardrailType = "JAVASCRIPT" | "HTTP" | "WORKFLOW";
+type FailureMode = "FAIL" | "WARN";
+
+interface GuardrailConfig {
+  type?: GuardrailType;
+  target?: string;
+  failureMode?: FailureMode;
+}
+
+const TYPE_ITEMS = ["JAVASCRIPT", "HTTP", "WORKFLOW"];
+const FAILURE_ITEMS = [
+  { label: "FAIL (hard gate)", value: "FAIL" },
+  { label: "WARN (soft gate)", value: "WARN" },
+];
+
+const targetLabel = (type?: GuardrailType) => {
+  switch (type) {
+    case "JAVASCRIPT":
+      return "JavaScript expression (reads $.prompt)";
+    case "HTTP":
+      return "HTTP endpoint URL (POST {prompt})";
+    case "WORKFLOW":
+      return "Guardrail workflow name";
+    default:
+      return "Target";
+  }
+};
+
+/**
+ * Editor for a single guardrail (input or output) stored at
+ * inputParameters.<paramKey> as { type, target, failureMode }.
+ */
+const GuardrailEditor: FunctionComponent<{
+  title: string;
+  description: string;
+  paramKey: "inputGuardrail" | "outputGuardrail";
+  taskJson: any;
+  onChange: (value: any) => void;
+  workflowNames: string[];
+}> = ({ title, description, paramKey, taskJson, onChange, workflowNames }) => {
+  const existing: GuardrailConfig | undefined =
+    taskJson?.inputParameters?.[paramKey];
+  const [enabled, setEnabled] = useState<boolean>(!!existing);
+
+  const value: GuardrailConfig = existing ?? {};
+
+  const writeConfig = (next: GuardrailConfig | undefined) => {
+    const inputParameters = { ...(taskJson.inputParameters ?? {}) };
+    if (next === undefined) {
+      delete inputParameters[paramKey];
+    } else {
+      inputParameters[paramKey] = next;
+    }
+    onChange({ ...taskJson, inputParameters });
+  };
+
+  const toggle = () => {
+    if (enabled) {
+      writeConfig(undefined);
+      setEnabled(false);
+    } else {
+      writeConfig({ failureMode: "FAIL" });
+      setEnabled(true);
+    }
+  };
+
+  const patch = (p: Partial<GuardrailConfig>) => writeConfig({ ...value, ...p });
+
+  // Client-side validation mirrors the server's GuardrailConfigValidator.
+  const typeError = enabled && !value.type;
+  const targetError =
+    enabled && (!value.target || `${value.target}`.trim() === "");
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <FormControlLabel
+        labelPlacement="end"
+        checked={enabled}
+        control={<Switch color="primary" onChange={toggle} />}
+        label={<Box sx={{ fontWeight: 600, color: "#767676" }}>{title}</Box>}
+      />
+      <Box style={{ opacity: 0.5 }}>{description}</Box>
+      {enabled && (
+        <Grid
+          container
+          spacing={2}
+          marginTop={1}
+          justifyContent="flex-start"
+          alignItems="flex-start"
+        >
+          <Grid size={6}>
+            <ConductorSelect
+              label="Type"
+              fullWidth
+              items={TYPE_ITEMS}
+              value={value.type ?? ""}
+              error={!!typeError}
+              helperText={typeError ? "Type is required" : undefined}
+              onTextInputChange={(v) => patch({ type: v as GuardrailType })}
+            />
+          </Grid>
+          <Grid size={6}>
+            <ConductorSelect
+              label="Failure mode"
+              fullWidth
+              items={FAILURE_ITEMS}
+              value={value.failureMode ?? "FAIL"}
+              onTextInputChange={(v) => patch({ failureMode: v as FailureMode })}
+            />
+          </Grid>
+          <Grid size={12}>
+            {value.type === "WORKFLOW" ? (
+              <ConductorFlexibleAutoCompleteVariables
+                label={targetLabel(value.type)}
+                options={workflowNames}
+                value={value.target ?? ""}
+                onChange={(v: any) => patch({ target: v })}
+              />
+            ) : (
+              <ConductorInput
+                label={targetLabel(value.type)}
+                fullWidth
+                multiline={value.type === "JAVASCRIPT"}
+                minRows={value.type === "JAVASCRIPT" ? 2 : 1}
+                value={value.target ?? ""}
+                error={!!targetError}
+                helperText={targetError ? "Target is required" : undefined}
+                onTextInputChange={(v) => patch({ target: v })}
+              />
+            )}
+          </Grid>
+        </Grid>
+      )}
+    </Box>
+  );
+};
+
+export const GuardrailsForm: FunctionComponent<GuardrailsFormProps> = ({
+  onChange,
+  taskJson,
+}) => {
+  const workflowNames = useWorkflowNames();
+  return (
+    <Box>
+      <Box style={{ opacity: 0.5 }}>
+        Guardrails scrub or validate the prompt before it reaches the LLM
+        (input) and the response before it returns (output). Each guardrail runs
+        as a linked sub-workflow.
+      </Box>
+      <GuardrailEditor
+        title="Input guardrail"
+        description="Runs on the prompt (instructions, user input, and messages) before the LLM call."
+        paramKey="inputGuardrail"
+        taskJson={taskJson}
+        onChange={onChange}
+        workflowNames={workflowNames}
+      />
+      <GuardrailEditor
+        title="Output guardrail"
+        description="Runs on the LLM response before it returns to the workflow."
+        paramKey="outputGuardrail"
+        taskJson={taskJson}
+        onChange={onChange}
+        workflowNames={workflowNames}
+      />
+    </Box>
+  );
+};

--- a/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/LLMChatCompleteTaskForm.tsx
+++ b/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/LLMChatCompleteTaskForm.tsx
@@ -2,6 +2,7 @@ import { Box } from "@mui/material";
 import { UiIntegrationsFieldType } from "types/FormFieldTypes";
 import { fieldsToFieldsFieldsComponents } from "utils/fieldHelpers";
 import { ConductorCacheOutput } from "./ConductorCacheOutputForm";
+import { GuardrailsForm } from "./GuardrailsForm";
 import { LLMFormFields } from "./LLMFormFields/LLMFormFields";
 import LLMFormFieldsWrapper from "./LLMFormFields/LLMFormFieldsWrapper";
 import { Optional } from "./OptionalFieldForm";
@@ -68,6 +69,9 @@ export const LLMChatCompleteTaskForm = ({ task, onChange }: TaskFormProps) => {
               fieldFieldComponents={modelFieldComponents}
               actor={actor}
             />
+          </TaskFormSection>
+          <TaskFormSection title="Guardrails">
+            <GuardrailsForm onChange={onChange} taskJson={task} />
           </TaskFormSection>
           <TaskFormSection title="Structured Messages">
             <LLMFormFields

--- a/ui-next/src/pages/execution/RightPanel/RightPanel.tsx
+++ b/ui-next/src/pages/execution/RightPanel/RightPanel.tsx
@@ -28,6 +28,7 @@ import { ActorRef } from "xstate";
 import { UpdateTaskStatusForm } from "..";
 import {
   DEFINITION_TAB,
+  GUARDRAILS_TAB,
   INPUT_TAB,
   JSON_TAB,
   LOGS_TAB,
@@ -36,6 +37,7 @@ import {
 } from "../state/constants";
 import TaskLogs from "../TaskLogs";
 import TaskSummary from "../TaskSummary";
+import TaskGuardrails from "../TaskGuardrails";
 import { RightPanelContextEventTypes, RightPanelEvents } from "./state";
 import { useRightPanelActor } from "./state/hook";
 import { SummaryTask } from "./SummaryTask";
@@ -335,6 +337,15 @@ export const RightPanel: FunctionComponent<RightPanelProps> = ({
             label="Definition"
             onClick={() => changeCurrentTab(DEFINITION_TAB)}
           />
+          {(`${selectedTask?.taskType}`.startsWith("LLM_") ||
+            selectedTask?.taskType === "PARSE_DOCUMENT") && (
+            <Tab
+              label="Guardrails"
+              value={GUARDRAILS_TAB}
+              onClick={() => changeCurrentTab(GUARDRAILS_TAB)}
+              disabled={!selectedTask.status}
+            />
+          )}
         </Tabs>
         <Paper square elevation={0}>
           {currentTab === SUMMARY_TAB && (
@@ -411,6 +422,17 @@ export const RightPanel: FunctionComponent<RightPanelProps> = ({
               workflowName={workflowName}
               editorHeight="calc(100vh - 280px)"
             />
+          )}
+          {currentTab === GUARDRAILS_TAB && (
+            <Box
+              style={{
+                overflowY: "auto",
+                overflowX: "hidden",
+                maxHeight: "calc(100vh - 100px)",
+              }}
+            >
+              <TaskGuardrails taskResult={selectedTask} />
+            </Box>
           )}
         </Paper>
       </>

--- a/ui-next/src/pages/execution/TaskGuardrails.tsx
+++ b/ui-next/src/pages/execution/TaskGuardrails.tsx
@@ -1,5 +1,7 @@
+import RefreshIcon from "@mui/icons-material/Refresh";
 import {
   Box,
+  Button,
   CircularProgress,
   Paper,
   Table,
@@ -72,28 +74,45 @@ function GuardrailRow({
 
 export default function TaskGuardrails({ taskResult }: TaskGuardrailsProps) {
   const taskId = taskResult?.taskId;
-  const { data, isLoading, error } = useWorkflowSearch<any>(
-    {
-      rowsPerPage: 100,
-      page: 1,
-      sort: "startTime:ASC",
-      query: `correlationId="guardrail:${taskId}"`,
-    },
-    { enabled: !!taskId },
-  );
+  // Guardrail sub-workflows are created during execution and indexed with a small
+  // lag, so always refetch on mount (and offer a manual refresh) rather than serve
+  // a possibly-stale empty result cached from an earlier open of this tab.
+  const { data, isLoading, isFetching, error, refetch } =
+    useWorkflowSearch<any>(
+      {
+        rowsPerPage: 100,
+        page: 1,
+        sort: "startTime:ASC",
+        query: `correlationId="guardrail:${taskId}"`,
+      },
+      { enabled: !!taskId },
+      { staleTime: 0, refetchOnMount: "always" },
+    );
 
   const results: any[] = data?.results ?? [];
 
   return (
     <Paper variant="outlined" sx={{ margin: 3 }}>
       <Box p={2}>
-        <Typography variant="subtitle1" gutterBottom>
-          Guardrail executions
-        </Typography>
+        <Box
+          sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}
+        >
+          <Typography variant="subtitle1" gutterBottom>
+            Guardrail executions
+          </Typography>
+          <Button
+            size="small"
+            startIcon={<RefreshIcon />}
+            disabled={isFetching}
+            onClick={() => refetch()}
+          >
+            Refresh
+          </Button>
+        </Box>
         <Typography variant="body2" sx={{ opacity: 0.6, mb: 2 }}>
           Each guardrail runs as a linked sub-workflow (correlationId{" "}
           <code>guardrail:{taskId}</code>). Input = before scrubbing, output =
-          after.
+          after. Runs may take a moment to appear — use Refresh if empty.
         </Typography>
 
         {isLoading && <CircularProgress size={20} />}

--- a/ui-next/src/pages/execution/TaskGuardrails.tsx
+++ b/ui-next/src/pages/execution/TaskGuardrails.tsx
@@ -1,0 +1,135 @@
+import {
+  Box,
+  CircularProgress,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import { NavLink } from "components";
+import { ExecutionTask } from "types/Execution";
+import { useFetch, useWorkflowSearch } from "utils/query";
+
+interface TaskGuardrailsProps {
+  taskResult: ExecutionTask;
+}
+
+const promptOf = (obj: any): string | undefined =>
+  obj && obj.prompt != null ? String(obj.prompt) : undefined;
+
+const cellSx = {
+  maxWidth: 320,
+  verticalAlign: "top" as const,
+};
+
+// Long before/after text (e.g. a full LLM response) scrolls inside the cell
+// instead of ballooning the row.
+const textBoxSx = {
+  maxHeight: 180,
+  overflowY: "auto" as const,
+  whiteSpace: "pre-wrap" as const,
+  wordBreak: "break-word" as const,
+  fontSize: "0.8em",
+};
+
+/**
+ * One guardrail run. The workflow-search summary serializes input/output as
+ * non-JSON strings, so we fetch the child workflow to read its real
+ * input.prompt (before) and output.prompt (after).
+ */
+function GuardrailRow({
+  workflowId,
+  fallbackType,
+}: {
+  workflowId: string;
+  fallbackType?: string;
+}) {
+  const { data: wf } = useFetch<any>(`/workflow/${workflowId}`, {
+    enabled: !!workflowId,
+  });
+  const name = wf?.workflowName ?? fallbackType ?? workflowId;
+  const status = wf?.status;
+  const before = promptOf(wf?.input);
+  const after = promptOf(wf?.output);
+  return (
+    <TableRow>
+      <TableCell>
+        <NavLink path={`/execution/${workflowId}`}>{name}</NavLink>
+      </TableCell>
+      <TableCell sx={{ verticalAlign: "top" }}>{status ?? "—"}</TableCell>
+      <TableCell sx={cellSx}>
+        <Box sx={textBoxSx}>{before ?? "—"}</Box>
+      </TableCell>
+      <TableCell sx={cellSx}>
+        <Box sx={textBoxSx}>{after ?? "—"}</Box>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export default function TaskGuardrails({ taskResult }: TaskGuardrailsProps) {
+  const taskId = taskResult?.taskId;
+  const { data, isLoading, error } = useWorkflowSearch<any>(
+    {
+      rowsPerPage: 100,
+      page: 1,
+      sort: "startTime:ASC",
+      query: `correlationId="guardrail:${taskId}"`,
+    },
+    { enabled: !!taskId },
+  );
+
+  const results: any[] = data?.results ?? [];
+
+  return (
+    <Paper variant="outlined" sx={{ margin: 3 }}>
+      <Box p={2}>
+        <Typography variant="subtitle1" gutterBottom>
+          Guardrail executions
+        </Typography>
+        <Typography variant="body2" sx={{ opacity: 0.6, mb: 2 }}>
+          Each guardrail runs as a linked sub-workflow (correlationId{" "}
+          <code>guardrail:{taskId}</code>). Input = before scrubbing, output =
+          after.
+        </Typography>
+
+        {isLoading && <CircularProgress size={20} />}
+        {error && (
+          <Typography color="error" variant="body2">
+            Failed to load guardrail executions.
+          </Typography>
+        )}
+        {!isLoading && !error && results.length === 0 && (
+          <Typography variant="body2" sx={{ opacity: 0.6 }}>
+            No guardrail executions for this task.
+          </Typography>
+        )}
+
+        {results.length > 0 && (
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Guardrail workflow</TableCell>
+                <TableCell>Status</TableCell>
+                <TableCell>Before</TableCell>
+                <TableCell>After</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {results.map((r) => (
+                <GuardrailRow
+                  key={r.workflowId}
+                  workflowId={r.workflowId}
+                  fallbackType={r.workflowType ?? r.workflowName}
+                />
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </Box>
+    </Paper>
+  );
+}

--- a/ui-next/src/pages/execution/state/constants.ts
+++ b/ui-next/src/pages/execution/state/constants.ts
@@ -5,3 +5,4 @@ export const OUTPUT_TAB = 2;
 export const LOGS_TAB = 3;
 export const JSON_TAB = 4;
 export const DEFINITION_TAB = 5;
+export const GUARDRAILS_TAB = 6;


### PR DESCRIPTION
## Summary

UI for **LLM task PII guardrails**: a configuration section in the workflow editor and a read-only Guardrails panel in the execution view. Pairs with the backend that runs each guardrail as a linked sub-workflow (orkes-conductor). **No backend changes here** — the execution panel reuses the existing workflow-search API.

## Changes

**1. Definition editor — Guardrails section** (`GuardrailsForm.tsx`, wired into `LLMChatCompleteTaskForm` under *Provider and Model*)
- Independent **Input** and **Output** guardrail toggles.
- Each: **Type** (JAVASCRIPT / HTTP / WORKFLOW), **Failure mode** (FAIL hard gate / WARN soft gate), and a **Target** that adapts — multiline JS expression, HTTP URL, or a workflow-name autocomplete.
- Writes `inputGuardrail` / `outputGuardrail` into the task's `inputParameters`; removed cleanly when toggled off.
- Client-side validation (type + target required) mirroring the server validator.
- Built with the shared form components (`ConductorSelect`, `ConductorInput`, `ConductorFlexibleAutoCompleteVariables`) and `Grid` layout to match the other sections.

**2. Execution view — Guardrails tab** (`TaskGuardrails.tsx`, added to `RightPanel`; shown only for `LLM_*` / `PARSE_DOCUMENT` tasks)
- Auto-queries `correlationId="guardrail:<taskId>"` via the existing `useWorkflowSearch`.
- Fetches each child workflow for clean **before** (`input.prompt`) / **after** (`output.prompt`) — the search summary serializes these as non-JSON strings, so we read the full workflow per row.
- Each row links to the child execution (`/execution/<id>`); long output scrolls within the cell.

## Files
- `pages/definition/EditorPanel/TaskFormTab/forms/GuardrailsForm.tsx` (new)
- `pages/definition/EditorPanel/TaskFormTab/forms/LLMChatCompleteTaskForm.tsx`
- `pages/execution/TaskGuardrails.tsx` (new)
- `pages/execution/RightPanel/RightPanel.tsx`
- `pages/execution/state/constants.ts` (adds `GUARDRAILS_TAB`)

## Testing
- `tsc` clean. Verified live against a running server: configuring guardrails persists into the workflow definition; the execution Guardrails tab lists the child guardrail workflows with before/after and links (input guardrail scrubbed `411111` → `[OUT-REDACTED]`).

