### PR TITLE
Redirect nginx logs to stdout/stderr in server image

### DIFF
--- a/docker/server/nginx/nginx.conf
+++ b/docker/server/nginx/nginx.conf
@@ -1,3 +1,6 @@
+access_log /dev/stdout;
+error_log /dev/stderr;
+
 server {
   listen 5000;
   server_name conductor;


### PR DESCRIPTION
Fixes #1231.

Nginx was writing access and error logs to `/var/log/nginx/` with no rotation in place. Redirecting to `/dev/stdout` and `/dev/stderr` is the idiomatic container fix — Docker captures them via `docker logs` and no rotation machinery is needed.

**User impact:** Long-running containers would slowly fill disk as nginx access logs accumulated with no way to rotate them.