### PR TITLE
fix: response timeout never fires for signal-wait WAIT tasks

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -909,7 +909,12 @@ public class DeciderService {
 
         // calculate pendingTime
         long now = System.currentTimeMillis();
-        long callbackTime = 1000L * task.getCallbackAfterSeconds();
+        long callbackAfterSecs = task.getCallbackAfterSeconds();
+        // Integer.MAX_VALUE is WaitTaskMapper's sentinel for "wait indefinitely for an external
+        // signal" (no duration/until). Adding ~68 years to the timeout window makes
+        // isResponseTimedOut permanently return false — treat it as zero callback delay instead.
+        long callbackTime =
+                (callbackAfterSecs >= Integer.MAX_VALUE) ? 0 : 1000L * callbackAfterSecs;
         long referenceTime =
                 task.getUpdateTime() > 0 ? task.getUpdateTime() : task.getScheduledTime();
         long pendingTime = now - (referenceTime + callbackTime);

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -1548,6 +1548,31 @@ public class TestDeciderService {
     }
 
     @Test
+    public void testIsResponseTimedOut_signalWaitWithMaxCallbackAfterSeconds() {
+        // Signal-wait WAIT tasks (no duration/until) use Integer.MAX_VALUE as a sentinel meaning
+        // "never re-queue to AsyncSystemTaskExecutor". Before the fix, this made
+        // adjustedResponseTimeout ~68 years, permanently disabling response-timeout enforcement.
+        TaskDef taskDef = new TaskDef();
+        taskDef.setName("wait_task");
+        taskDef.setResponseTimeoutSeconds(10);
+
+        TaskModel task = new TaskModel();
+        task.setTaskDefName("wait_task");
+        task.setStatus(TaskModel.Status.IN_PROGRESS);
+        task.setTaskId("wait-1");
+        task.setTaskType(TaskType.TASK_TYPE_WAIT);
+        task.setCallbackAfterSeconds(Integer.MAX_VALUE);
+
+        // 11 s since last update — past the 10 s response timeout; must fire
+        task.setUpdateTime(System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(11));
+        assertTrue(deciderService.isResponseTimedOut(taskDef, task));
+
+        // 5 s since last update — still within the 10 s window; must not fire
+        task.setUpdateTime(System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(5));
+        assertFalse(deciderService.isResponseTimedOut(taskDef, task));
+    }
+
+    @Test
     public void testFilterNextLoopOverTasks() {
 
         WorkflowModel workflow = new WorkflowModel();


### PR DESCRIPTION
## Root cause

`WaitTaskMapper.setCallbackAfter()` sets `task.callbackAfterSeconds = Integer.MAX_VALUE` for WAIT tasks that have no `duration`/`until` input (signal-wait mode). This sentinel tells `addTaskToQueue` to push the task to the system-task queue with a ~68-year delivery offset so `AsyncSystemTaskExecutor` never processes it — which is the desired behaviour for a task that waits for an external signal.

The problem is that `DeciderService.isResponseTimedOut` also uses `callbackAfterSeconds` when computing the tolerance window:

```java
long callbackTime = 1000L * task.getCallbackAfterSeconds();   // ~68 years in ms
long adjustedResponseTimeout = responseTimeout + callbackTime; // ~68 years
long noResponseTime = now - task.getUpdateTime();              // seconds/minutes
// noResponseTime < adjustedResponseTimeout → always true → timeout never fires
```

Any `responseTimeoutSeconds` configured on the task definition is therefore silently ignored for all signal-wait WAIT tasks.

## Fix

Cap `callbackAfterSeconds` at `Integer.MAX_VALUE` before converting to milliseconds inside `isResponseTimedOut`. The sentinel value means "no executor callback is expected" — the task is waiting for an external signal — so the callback-delay contribution to the response-timeout window should be zero, not 68 years.

```java
long callbackAfterSecs = task.getCallbackAfterSeconds();
long callbackTime =
        (callbackAfterSecs >= Integer.MAX_VALUE) ? 0 : 1000L * callbackAfterSecs;
```

`checkTaskTimeout` (wall-clock elapsed since `startTime`) and `checkTotalTimeout` (elapsed since `firstScheduledTime`) are unaffected — they don't use `callbackAfterSeconds` — and continue to fire via the sweeper's `decide()` cycle.

## User impact

First-time users and anyone configuring a WAIT task with `responseTimeoutSeconds` to act as a deadline would find the timeout silently ignored: the WAIT task stayed IN_PROGRESS long past the configured limit. After this fix, `responseTimeoutSeconds` is enforced correctly.

## Test

`TestDeciderService.testIsResponseTimedOut_signalWaitWithMaxCallbackAfterSeconds` — two assertions: timeout fires when elapsed > configured limit, does not fire when still within the window.

## Orkes parity

No Orkes parallel — this is a bug fix to an existing OSS-side calculation; no new classes or interfaces introduced.

## OSS-side additions

None.

Fixes conductor-oss/conductor#1146