### PR TITLE
fix(ai): attach user media to Anthropic requests

### DIFF
--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicChatModel.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicChatModel.java
@@ -170,7 +170,31 @@ public class AnthropicChatModel implements ChatModel {
         switch (msg.getMessageType()) {
             case USER -> {
                 UserMessage userMsg = (UserMessage) msg;
-                messages.add(Message.user(userMsg.getText()));
+                List<org.springframework.ai.content.Media> media = userMsg.getMedia();
+                if (media != null && !media.isEmpty()) {
+                    // Multi-modal: text + image content blocks. Without this the
+                    // image is silently dropped and the model never sees it.
+                    List<ContentBlock> blocks = new ArrayList<>();
+                    if (userMsg.getText() != null && !userMsg.getText().isBlank()) {
+                        blocks.add(ContentBlock.text(userMsg.getText()));
+                    }
+                    for (org.springframework.ai.content.Media m : media) {
+                        String mediaType =
+                                m.getMimeType() != null
+                                        ? m.getMimeType().toString()
+                                        : "application/octet-stream";
+                        // Conductor downloads media URLs to bytes upstream; encode
+                        // to the base64 payload Anthropic's image source expects.
+                        String base64 =
+                                m.getData() instanceof byte[] bytes
+                                        ? java.util.Base64.getEncoder().encodeToString(bytes)
+                                        : m.getData().toString();
+                        blocks.add(ContentBlock.image(mediaType, base64));
+                    }
+                    messages.add(Message.user(blocks));
+                } else {
+                    messages.add(Message.user(userMsg.getText()));
+                }
             }
 
             case ASSISTANT -> {

--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/api/AnthropicMessagesApi.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/anthropic/api/AnthropicMessagesApi.java
@@ -293,6 +293,24 @@ public class AnthropicMessagesApi {
                     "tool_result", null, null, null, null, toolUseId, content, null, null);
         }
 
+        /**
+         * Image content block from base64-encoded data. {@code mediaType} is the image MIME type
+         * (e.g. {@code image/png}); {@code base64Data} is the raw base64 payload without any {@code
+         * data:} URI prefix.
+         */
+        public static ContentBlock image(String mediaType, String base64Data) {
+            return new ContentBlock(
+                    "image",
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    new Source("base64", mediaType, base64Data));
+        }
+
         @JsonInclude(JsonInclude.Include.NON_NULL)
         public record Source(
                 String type, // "base64"

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicChatModelMediaTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicChatModelMediaTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.providers.anthropic;
+
+import java.util.Base64;
+import java.util.List;
+
+import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi;
+import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.ContentBlock;
+import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.Message;
+import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.MessagesRequest;
+import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.MessagesResponse;
+import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.ResponseContentBlock;
+import org.conductoross.conductor.ai.providers.anthropic.api.AnthropicMessagesApi.ResponseUsage;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.content.Media;
+import org.springframework.util.MimeTypeUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that image media on a {@link UserMessage} is forwarded to the Anthropic Messages API as
+ * an {@code image} content block. Regression test for a bug where {@code convertMessage} took only
+ * {@code UserMessage.getText()} and silently dropped {@code getMedia()}, so vision-capable Claude
+ * models never received the image.
+ *
+ * <p>The HTTP layer is stubbed via Mockito; the request built by {@link AnthropicChatModel} is
+ * captured and inspected.
+ */
+class AnthropicChatModelMediaTest {
+
+    private static final byte[] PNG_BYTES = {(byte) 0x89, 'P', 'N', 'G', 1, 2, 3, 4};
+
+    private static ResponseContentBlock textBlock(String text) {
+        return new ResponseContentBlock("text", text, null, null, null, null, null, null);
+    }
+
+    @Test
+    void userMediaIsForwardedAsImageContentBlock() throws Exception {
+        AnthropicMessagesApi api = mock(AnthropicMessagesApi.class);
+        MessagesResponse canned =
+                new MessagesResponse(
+                        "msg_img",
+                        "message",
+                        "assistant",
+                        List.of(textBlock("MELON7391")),
+                        "claude-sonnet-4-5",
+                        "end_turn",
+                        null,
+                        new ResponseUsage(10, 5, null, null));
+        when(api.createMessage(any(MessagesRequest.class))).thenReturn(canned);
+
+        AnthropicChatModel chatModel = new AnthropicChatModel(api);
+
+        UserMessage userMsg =
+                UserMessage.builder()
+                        .text("Transcribe the text in the image.")
+                        .media(
+                                List.of(
+                                        Media.builder()
+                                                .data(PNG_BYTES)
+                                                .mimeType(MimeTypeUtils.IMAGE_PNG)
+                                                .build()))
+                        .build();
+
+        AnthropicChatOptions options =
+                AnthropicChatOptions.builder().model("claude-sonnet-4-5").maxTokens(1024).build();
+        chatModel.call(new Prompt(List.of(userMsg), options));
+
+        ArgumentCaptor<MessagesRequest> captor = ArgumentCaptor.forClass(MessagesRequest.class);
+        verify(api).createMessage(captor.capture());
+        MessagesRequest sent = captor.getValue();
+
+        Message user = sent.messages().get(sent.messages().size() - 1);
+        assertEquals("user", user.role());
+        assertInstanceOf(
+                List.class,
+                user.content(),
+                "user message with media must serialize to a content-block list, not a bare string");
+
+        @SuppressWarnings("unchecked")
+        List<ContentBlock> blocks = (List<ContentBlock>) user.content();
+
+        List<ContentBlock> imageBlocks =
+                blocks.stream().filter(b -> "image".equals(b.type())).toList();
+        assertFalse(
+                imageBlocks.isEmpty(),
+                "image content block missing — media was dropped (the original bug)");
+
+        ContentBlock img = imageBlocks.get(0);
+        assertEquals("base64", img.source().type());
+        assertEquals("image/png", img.source().mediaType());
+        assertEquals(
+                Base64.getEncoder().encodeToString(PNG_BYTES),
+                img.source().data(),
+                "image bytes must be base64-encoded verbatim");
+
+        // The text prompt must still be present alongside the image.
+        assertTrue(
+                blocks.stream()
+                        .anyMatch(
+                                b ->
+                                        "text".equals(b.type())
+                                                && "Transcribe the text in the image."
+                                                        .equals(b.text())),
+                "text content block must accompany the image");
+    }
+}


### PR DESCRIPTION
## Problem

Images passed as input via the `media` path never reached Anthropic (Claude) models. The model received a **text-only** message and hallucinated a response instead of reading the image.

The pipeline was correct up to the provider conversion: media is stored on the `ChatMessage`, and `LLMHelper.getMessage()` downloads the URL to bytes and builds a Spring AI `UserMessage` **with** media. But `AnthropicChatModel.convertMessage()` built the user message from `userMsg.getText()` only and silently dropped `userMsg.getMedia()`:

```java
case USER -> {
    UserMessage userMsg = (UserMessage) msg;
    messages.add(Message.user(userMsg.getText()));   // getMedia() ignored
}
```

The OpenAI provider (`OpenAIResponsesChatModel.convertMessage()`) already forwards media as image content parts; the Anthropic converter never got that treatment. The Anthropic `ContentBlock` API already modeled `type="image"` with a base64 `Source` — the capability existed, it just wasn't wired up.

## Fix

- `AnthropicChatModel.convertMessage()`: when a `UserMessage` carries media, build a `text` block plus one `image` block per media item (base64-encoding the downloaded bytes), mirroring the OpenAI path. Text-only messages are unchanged.
- `AnthropicMessagesApi`: add a `ContentBlock.image(mediaType, base64Data)` factory.

## Test

Adds `AnthropicChatModelMediaTest`, which mocks the Messages API, captures the outgoing `MessagesRequest`, and asserts the user message serializes to a content-block list containing an `image` block with `source.type=base64`, `media_type=image/png`, and the verbatim base64 payload — plus the accompanying text block.

Validated both directions:
- **Before the fix:** FAILS — user content serializes to a bare `String` (media dropped).
- **After the fix:** PASSES.

```
./gradlew :conductor-ai:test --tests "org.conductoross.conductor.ai.providers.anthropic.AnthropicChatModel*"
BUILD SUCCESSFUL
```

## Scope

Anthropic provider only; OpenAI/Gemini media paths are untouched. `convertMessage` is the single message-building path for Anthropic (used by the normal call path), so all Anthropic requests are covered.

## End-to-end validation (full agentspan SDK e2e suite)

Built a server carrying this fix (the 0.3.0 agentspan server baseline + this exact `conductor-ai` change) and ran the **full agentspan Python SDK e2e suite** against it.

**Result: 123 passed, 8 failed, 19 skipped/xfailed** (150 tests, 23m).

**The media-input suite (Suite 25) passes in full, including the Anthropic case** — which is the direct target of this fix and was previously failing/skipped:

```
test_vision_reads_text_from_image[openai]       PASSED
test_vision_reads_text_from_image[anthropic]    PASSED   ← fixed by this PR (was: hallucinated, no image)
test_without_media_token_is_absent[openai]      PASSED
test_without_media_token_is_absent[anthropic]   PASSED
```

A direct probe confirms it: `anthropic/claude-sonnet-4-5` + an image of the text `MELON7391` now returns `MELON7391` (before the fix the model received no image and hallucinated unrelated text).

**The 8 failures are unrelated to this PR** — all are a pre-existing version mismatch between the newer standalone `agentspan` Go CLI and the older 0.3.0 server's REST API (not the Anthropic provider):

- `TestSuite16CliSkills` (5) — CLI `skill --version` flag unknown / `skill load` HTTP 400 against the 0.3.0 server.
- `TestSuite2ToolCalling`, `TestSuite4McpTools`, `TestSuite5HttpTools` (1 each) — `credentials delete` → HTTP 404 `No static resource api/credentials/...` (endpoint absent on the 0.3.0 server).

None touch the LLM provider path; they fail identically with or without this change.


**Exact-version confirmation:** the same result was reproduced building `conductor-ai` from the **`v3.32.0-rc.3`** tag with this fix cherry-picked (not just the 3.30.2 baseline) and running it inside the matching agentspan server — `AnthropicChatModelMediaTest` passes at that source, and Suite 25 passes end-to-end (`4 passed`, Anthropic included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

