### PR TITLE
fix(ai): normalize OpenAI base URL to always include /v1

### DIFF
--- a/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAI.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/providers/openai/OpenAI.java
@@ -69,7 +69,11 @@ public class OpenAI implements AIModel {
 
     public OpenAI(OpenAIConfiguration config, OkHttpClient httpClient) {
         this.config = config;
-        String baseUrl = config.getBaseURL();
+        // Normalize the configured base URL so it always ends in "/v1". The embeddings/responses/
+        // image/speech APIs append paths like "/embeddings" and expect the "/v1" segment to be
+        // present, so a host-only base URL (e.g. "https://api.openai.com") would otherwise 404.
+        // This keeps the base URL backward compatible: host-only, ".../v1", or blank all work.
+        String baseUrl = ensureV1(config.getBaseURL());
         String baseUrlNoV1 = stripV1(baseUrl);
 
         this.responsesApi = new OpenAIResponsesApi(httpClient, config.getApiKey(), baseUrl, false);
@@ -264,5 +268,20 @@ public class OpenAI implements AIModel {
             return baseUrl.substring(0, baseUrl.length() - 3);
         }
         return baseUrl;
+    }
+
+    /**
+     * Ensures the base URL ends with "/v1" (idempotent). Strips a trailing slash first so both
+     * "https://api.openai.com" and "https://api.openai.com/" become "https://api.openai.com/v1",
+     * while an already-correct "https://api.openai.com/v1" is left unchanged. Returns {@code null}
+     * unchanged so callers fall back to their own default.
+     */
+    private static String ensureV1(String baseUrl) {
+        if (baseUrl == null || baseUrl.isBlank()) {
+            return baseUrl;
+        }
+        String trimmed =
+                baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        return trimmed.endsWith("/v1") ? trimmed : trimmed + "/v1";
     }
 }


### PR DESCRIPTION
## Issue

OpenAI chat/embeddings tasks return `404` when the integration **Base URL** is host-only (e.g. `https://api.openai.com`). The OpenAI provider's API clients (`OpenAIEmbeddingsApi`, `OpenAIResponsesApi`, `OpenAIImageGenApi`, `OpenAISpeechApi`) append paths like `/embeddings`, `/responses` and **expect the `/v1` segment to already be in the base URL**. So:

- Base URL `https://api.openai.com` → `https://api.openai.com/embeddings` → **404**
- Base URL `https://api.openai.com/v1` → `https://api.openai.com/v1/embeddings` → OK

This is also a **backward-compatibility regression**: older builds had the client append `/v1` itself, so a host-only Base URL used to work. The same integration config that worked before now 404s (and vice-versa), depending on build.

## Fix

Normalize the configured base URL in the **OpenAI provider** so it always ends in `/v1` (idempotent), via a small `ensureV1(...)` helper in `OpenAI.java`:

- `https://api.openai.com` → `https://api.openai.com/v1`
- `https://api.openai.com/` → `https://api.openai.com/v1`
- `https://api.openai.com/v1` → unchanged (no double `/v1`)
- blank/null → falls back to the existing default

The `/v1`-stripped base is still passed to the video API (which adds `/v1` on its own), exactly as before.

## Scope / why this is safe

The change is confined to `OpenAI.java` (the OpenAI provider). The **shared** API classes are intentionally left untouched, so other consumers are unaffected:

- **Azure OpenAI** — uses the same API classes with `azureAuth=true` and a base like `https://<resource>.openai.azure.com/openai/v1`; changing the shared classes would have doubled its `/v1`.
- **Perplexity / Grok** — use `OpenAIChatCompletionsApi` with their own base URLs and completions paths.

Net: OpenAI works whether the Base URL is host-only, includes `/v1`, or is left blank — it can no longer 404 on the `/v1` segment.

## Testing

- `./gradlew compileJava -p ai` → **BUILD SUCCESSFUL**.
- Runtime: with an OpenAI integration Base URL set to `https://api.openai.com` (no `/v1`), run `LLM_TEXT_COMPLETE` and `LLM_GENERATE_EMBEDDINGS` / `LLM_INDEX_TEXT` → succeeds (previously 404). Also verify `https://api.openai.com/v1` and a blank Base URL still work, and that Azure OpenAI is unaffected.