### PR TITLE
fix(core): defer human-parked workflows in the decider queue instead of removing them

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
@@ -51,13 +51,6 @@ public class ConductorProperties {
     @DurationUnit(ChronoUnit.SECONDS)
     private Duration maxPostponeDurationSeconds = Duration.ofSeconds(3600);
 
-    /**
-     * If set to true, a workflow blocked on an IN_PROGRESS HUMAN task is removed from the decider
-     * queue instead of being repeatedly re-swept. It is re-queued automatically when the HUMAN task
-     * is updated to a terminal status (see WorkflowExecutorOps#updateTask).
-     */
-    private boolean humanTaskPreventsDeciderQueue = true;
-
     /** The number of threads to use to do background sweep on active workflows. */
     private int sweeperThreadCount = Runtime.getRuntime().availableProcessors() * 2;
 
@@ -291,14 +284,6 @@ public class ConductorProperties {
 
     public void setMaxPostponeDurationSeconds(Duration maxPostponeDurationSeconds) {
         this.maxPostponeDurationSeconds = maxPostponeDurationSeconds;
-    }
-
-    public boolean isHumanTaskPreventsDeciderQueue() {
-        return humanTaskPreventsDeciderQueue;
-    }
-
-    public void setHumanTaskPreventsDeciderQueue(boolean humanTaskPreventsDeciderQueue) {
-        this.humanTaskPreventsDeciderQueue = humanTaskPreventsDeciderQueue;
     }
 
     public int getSweeperThreadCount() {

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
@@ -61,7 +61,6 @@ import static com.netflix.conductor.core.utils.Utils.DECIDER_QUEUE;
 import static com.netflix.conductor.model.TaskModel.Status.*;
 
 import static org.conductoross.conductor.core.execution.ExecutorUtils.computePostpone;
-import static org.conductoross.conductor.core.execution.ExecutorUtils.hasInProgressHumanTask;
 
 /** Workflow services provider interface */
 @Trace
@@ -1054,20 +1053,6 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
                     task.getTaskDefName(), lastDuration, false, task.getStatus());
         }
 
-        if (properties.isHumanTaskPreventsDeciderQueue()
-                && TaskType.TASK_TYPE_HUMAN.equals(task.getTaskType())
-                && task.getStatus().isTerminal()) {
-            // The sweeper removes workflows blocked on a HUMAN task from the decider queue.
-            // Re-queue this workflow so it is evaluated immediately now that the HUMAN task has
-            // reached a terminal status.
-            queueDAO.push(DECIDER_QUEUE, workflowId, workflowInstance.getPriority(), 0);
-            LOGGER.debug(
-                    "Waking up workflow {} because HUMAN task {} reached terminal status {}",
-                    workflowId,
-                    task.getTaskId(),
-                    task.getStatus());
-        }
-
         if (!isLazyEvaluateWorkflow(workflowInstance.getWorkflowDefinition(), task)) {
             decide(workflowId);
         }
@@ -1332,33 +1317,22 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
 
                 Duration timeout = properties.getWorkflowOffsetTimeout();
                 if (!workflow.getStatus().isTerminal()) {
-                    if (properties.isHumanTaskPreventsDeciderQueue()
-                            && hasInProgressHumanTask(workflow)) {
-                        // A workflow blocked on a HUMAN task can wait indefinitely for external
-                        // input. Keeping it in the decider queue only churns the sweeper, so
-                        // remove it; updateTask() re-queues the workflow when the HUMAN task
-                        // reaches a terminal status.
+                    // A workflow parked only on a HUMAN task is DEFERRED (not removed) by
+                    // computePostpone, so it stays in the decider queue as a recovery backstop
+                    // while no longer churning the sweeper every offset.
+                    Duration updatedOffset =
+                            computePostpone(
+                                    workflow, timeout, properties.getMaxPostponeDurationSeconds());
+                    if (updatedOffset.getSeconds() != timeout.getSeconds()) {
+                        // we have a new value, setUnack uses time in millis
                         LOGGER.debug(
-                                "Removing workflow {} from decider queue; blocked on HUMAN task",
-                                workflow.getWorkflowId());
-                        queueDAO.remove(DECIDER_QUEUE, workflow.getWorkflowId());
-                    } else {
-                        Duration updatedOffset =
-                                computePostpone(
-                                        workflow,
-                                        timeout,
-                                        properties.getMaxPostponeDurationSeconds());
-                        if (updatedOffset.getSeconds() != timeout.getSeconds()) {
-                            // we have a new value, setUnack uses time in millis
-                            LOGGER.debug(
-                                    "Pushing the workflow {} into decider queue by {} millis",
-                                    workflow.getWorkflowId(),
-                                    updatedOffset.getSeconds() * 1000);
-                            queueDAO.setUnackTimeout(
-                                    DECIDER_QUEUE,
-                                    workflow.getWorkflowId(),
-                                    updatedOffset.getSeconds() * 1000);
-                        }
+                                "Pushing the workflow {} into decider queue by {} millis",
+                                workflow.getWorkflowId(),
+                                updatedOffset.getSeconds() * 1000);
+                        queueDAO.setUnackTimeout(
+                                DECIDER_QUEUE,
+                                workflow.getWorkflowId(),
+                                updatedOffset.getSeconds() * 1000);
                     }
                 }
             }

--- a/core/src/main/java/org/conductoross/conductor/core/execution/ExecutorUtils.java
+++ b/core/src/main/java/org/conductoross/conductor/core/execution/ExecutorUtils.java
@@ -16,11 +16,17 @@ import java.time.Duration;
 
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.tasks.TaskType;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_DO_WHILE;
+import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_FORK_JOIN;
+import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_FORK_JOIN_DYNAMIC;
+import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_HUMAN;
 import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_WAIT;
 
 @Slf4j
@@ -92,6 +98,17 @@ public class ExecutorUtils {
         long currentTimeMillis = System.currentTimeMillis();
         long workflowOffsetTimeoutSeconds = workflowOffsetTimeout.getSeconds();
         long maxPostponeSeconds = maxPostponeDuration.getSeconds();
+
+        // A workflow whose only pending work is HUMAN task(s) is waiting on a person, not the
+        // sweeper: re-deciding every offset just churns the decider queue. Defer it to maxPostpone
+        // instead. Unlike PR #1171, we keep the workflow IN the decider queue (deferred, not
+        // removed) so the periodic re-sweep still recovers it if the completion event is ever
+        // missed. Completion wakes it promptly regardless: updateTask() calls decide()
+        // synchronously.
+        Long humanOnlyPostpone = humanOnlyPostpone(workflowModel, maxPostponeSeconds);
+        if (humanOnlyPostpone != null) {
+            return Duration.ofSeconds(humanOnlyPostpone);
+        }
 
         Long postponeDurationSeconds = null;
         for (TaskModel taskModel : workflowModel.getTasks()) {
@@ -178,15 +195,53 @@ public class ExecutorUtils {
     }
 
     /**
-     * Returns true when the workflow has at least one IN_PROGRESS HUMAN task. Such a workflow is
-     * blocked on external human input and may remain in this state indefinitely, so it should be
-     * removed from the decider queue rather than re-swept on every offset.
+     * When the only pending work is HUMAN task(s) waiting on a person (ignoring a wrapping {@code
+     * DO_WHILE} loop), returns the seconds to defer the next sweep ({@code maxPostponeSeconds}).
+     * Returns {@code null} the moment any other task is still pending, or when the definition
+     * contains a FORK — in which case the caller keeps the normal offset cadence.
+     *
+     * <p>The FORK exclusion is deliberate and gated on the static definition, not the live task
+     * list: a fork branch parked on a HUMAN can momentarily be the only pending leaf, and some
+     * persistence layers can transiently omit the still-pending JOIN from the live task list
+     * mid-decide. Deferring then would strip the branch-coordination re-sweep and strand the
+     * workflow. The definition is race-free, so it is the safe thing to gate on.
      */
-    public static boolean hasInProgressHumanTask(WorkflowModel workflow) {
-        return workflow.getTasks().stream()
-                .anyMatch(
-                        task ->
-                                TaskType.TASK_TYPE_HUMAN.equals(task.getTaskType())
-                                        && task.getStatus() == TaskModel.Status.IN_PROGRESS);
+    static Long humanOnlyPostpone(WorkflowModel workflowModel, long maxPostponeSeconds) {
+        if (maxPostponeSeconds <= 0) {
+            return null; // no ceiling configured — cannot defer safely
+        }
+        boolean anyHuman = false;
+        for (TaskModel taskModel : workflowModel.getTasks()) {
+            TaskModel.Status status = taskModel.getStatus();
+            if (status != TaskModel.Status.IN_PROGRESS && status != TaskModel.Status.SCHEDULED) {
+                continue; // terminal — not pending
+            }
+            String taskType = taskModel.getTaskType();
+            if (TASK_TYPE_HUMAN.equals(taskType)) {
+                anyHuman = true;
+            } else if (TASK_TYPE_DO_WHILE.equals(taskType)) {
+                // only wraps the running HUMAN leaf inside its loop
+            } else {
+                return null; // any other pending leaf (incl. FORK/JOIN, null type) — normal cadence
+            }
+        }
+        if (!anyHuman || hasForkStructure(workflowModel)) {
+            return null;
+        }
+        return maxPostponeSeconds;
+    }
+
+    private static boolean hasForkStructure(WorkflowModel workflowModel) {
+        WorkflowDef workflowDef = workflowModel.getWorkflowDefinition();
+        if (workflowDef == null) {
+            return false;
+        }
+        for (WorkflowTask workflowTask : workflowDef.collectTasks()) {
+            String type = workflowTask.getType();
+            if (TASK_TYPE_FORK_JOIN.equals(type) || TASK_TYPE_FORK_JOIN_DYNAMIC.equals(type)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/core/src/main/java/org/conductoross/conductor/core/execution/ExecutorUtils.java
+++ b/core/src/main/java/org/conductoross/conductor/core/execution/ExecutorUtils.java
@@ -42,6 +42,12 @@ public class ExecutorUtils {
      * Computes how long to postpone the next sweep/re-check of a workflow so that the scheduler
      * does not poll more frequently than necessary.
      *
+     * <p>Special case first: if the only pending work is HUMAN task(s) (looking past a wrapping
+     * {@code DO_WHILE}, and provided the definition has no FORK), the workflow is deferred by
+     * {@link #humanOnlyPostpone} to the human's timeout deadline, or {@code maxPostponeDuration}
+     * when the human has no timeout — it is waiting on a person, not the sweeper. Otherwise the
+     * per-task algorithm below runs.
+     *
      * <p>Algorithm:
      *
      * <ol>

--- a/core/src/main/java/org/conductoross/conductor/core/execution/ExecutorUtils.java
+++ b/core/src/main/java/org/conductoross/conductor/core/execution/ExecutorUtils.java
@@ -210,7 +210,9 @@ public class ExecutorUtils {
         if (maxPostponeSeconds <= 0) {
             return null; // no ceiling configured — cannot defer safely
         }
+        long now = System.currentTimeMillis();
         boolean anyHuman = false;
+        long postponeSeconds = maxPostponeSeconds;
         for (TaskModel taskModel : workflowModel.getTasks()) {
             TaskModel.Status status = taskModel.getStatus();
             if (status != TaskModel.Status.IN_PROGRESS && status != TaskModel.Status.SCHEDULED) {
@@ -219,6 +221,15 @@ public class ExecutorUtils {
             String taskType = taskModel.getTaskType();
             if (TASK_TYPE_HUMAN.equals(taskType)) {
                 anyHuman = true;
+                // Wake by the human's own timeout deadline so DeciderService.checkTaskTimeout can
+                // enforce it on schedule; only a human with no timeout configured is deferred the
+                // full maxPostpone (indefinite).
+                long timeoutSeconds = humanTimeoutSeconds(taskModel, now);
+                long candidateSeconds =
+                        (timeoutSeconds > 0)
+                                ? Math.min(timeoutSeconds, maxPostponeSeconds)
+                                : maxPostponeSeconds;
+                postponeSeconds = Math.min(postponeSeconds, candidateSeconds);
             } else if (TASK_TYPE_DO_WHILE.equals(taskType)) {
                 // only wraps the running HUMAN leaf inside its loop
             } else {
@@ -228,7 +239,38 @@ public class ExecutorUtils {
         if (!anyHuman || hasForkStructure(workflowModel)) {
             return null;
         }
-        return maxPostponeSeconds;
+        return postponeSeconds;
+    }
+
+    /**
+     * Seconds until a HUMAN task's soonest configured timeout deadline (the OSS analog of an SLA),
+     * derived from its {@link TaskDef} {@code timeoutSeconds}/{@code responseTimeoutSeconds} and
+     * its start time. Returns {@code 0} when the task has no timeout configured (indefinite) or has
+     * not started yet — matching {@code DeciderService.checkTaskTimeout}, which does not time out a
+     * task with {@code timeoutSeconds <= 0} or {@code startTime <= 0}.
+     */
+    private static long humanTimeoutSeconds(TaskModel taskModel, long now) {
+        TaskDef taskDef = taskModel.getTaskDefinition().orElse(null);
+        if (taskDef == null || taskModel.getStartTime() <= 0) {
+            return 0;
+        }
+        long deadlineSeconds = 0;
+        if (taskDef.getTimeoutSeconds() > 0) {
+            deadlineSeconds = taskDef.getTimeoutSeconds();
+        }
+        if (taskDef.getResponseTimeoutSeconds() > 0) {
+            deadlineSeconds =
+                    (deadlineSeconds == 0)
+                            ? taskDef.getResponseTimeoutSeconds()
+                            : Math.min(deadlineSeconds, taskDef.getResponseTimeoutSeconds());
+        }
+        if (deadlineSeconds == 0) {
+            return 0; // no timeout configured — indefinite
+        }
+        long elapsedSeconds = Math.max(0, (now - taskModel.getStartTime()) / 1000);
+        // +1 gives a one-second buffer past the deadline before re-evaluating; floor at 1 so an
+        // already-overdue task wakes on the next sweep rather than immediately churning.
+        return Math.max(1, deadlineSeconds - elapsedSeconds + 1);
     }
 
     private static boolean hasForkStructure(WorkflowModel workflowModel) {

--- a/core/src/test/java/org/conductoross/conductor/core/execution/ExecutorUtilsTest.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/ExecutorUtilsTest.java
@@ -292,6 +292,22 @@ public class ExecutorUtilsTest {
     }
 
     @Test
+    public void computePostponeDefersHumanWrappedInDoWhile() {
+        WorkflowModel workflow =
+                newWorkflow(
+                        Arrays.asList(
+                                newTask(TaskType.TASK_TYPE_DO_WHILE, TaskModel.Status.IN_PROGRESS),
+                                newTask(TaskType.TASK_TYPE_HUMAN, TaskModel.Status.IN_PROGRESS)),
+                        0);
+        // The DO_WHILE only wraps the running HUMAN leaf, so the workflow still defers to
+        // maxPostpone.
+        Duration result =
+                ExecutorUtils.computePostpone(
+                        workflow, Duration.ofSeconds(30), Duration.ofSeconds(3600));
+        assertEquals(3600, result.getSeconds());
+    }
+
+    @Test
     public void computePostponeDoesNotDeferHumanInsideFork() {
         WorkflowDef workflowDef = new WorkflowDef();
         WorkflowTask fork = new WorkflowTask();

--- a/core/src/test/java/org/conductoross/conductor/core/execution/ExecutorUtilsTest.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/ExecutorUtilsTest.java
@@ -26,7 +26,6 @@ import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ExecutorUtilsTest {
@@ -247,31 +246,73 @@ public class ExecutorUtilsTest {
     }
 
     @Test
-    public void hasInProgressHumanTaskTrueForInProgressHuman() {
+    public void computePostponeDefersHumanOnlyWorkflowToMaxPostpone() {
         WorkflowModel workflow =
                 newWorkflow(
                         Arrays.asList(
                                 newTask(TaskType.TASK_TYPE_SIMPLE, TaskModel.Status.COMPLETED),
                                 newTask(TaskType.TASK_TYPE_HUMAN, TaskModel.Status.IN_PROGRESS)),
                         0);
-        assertTrue(ExecutorUtils.hasInProgressHumanTask(workflow));
+        // Parked only on a HUMAN (no FORK in the definition): defer to maxPostpone rather than
+        // churn the sweeper every offset. The workflow stays in the decider queue (deferred, not
+        // removed) as a recovery backstop.
+        Duration result =
+                ExecutorUtils.computePostpone(
+                        workflow, Duration.ofSeconds(30), Duration.ofSeconds(3600));
+        assertEquals(3600, result.getSeconds());
     }
 
     @Test
-    public void hasInProgressHumanTaskFalseWhenNoInProgressHuman() {
-        WorkflowModel noHuman =
+    public void computePostponeDoesNotDeferHumanBesideAnotherPendingTask() {
+        WorkflowModel workflow =
                 newWorkflow(
                         Arrays.asList(
+                                newTask(TaskType.TASK_TYPE_HUMAN, TaskModel.Status.IN_PROGRESS),
                                 newTask(TaskType.TASK_TYPE_SIMPLE, TaskModel.Status.IN_PROGRESS)),
                         0);
-        assertFalse(ExecutorUtils.hasInProgressHumanTask(noHuman));
+        // A non-HUMAN pending leaf can still make progress -> keep the normal offset cadence.
+        Duration result =
+                ExecutorUtils.computePostpone(
+                        workflow, Duration.ofSeconds(30), Duration.ofSeconds(3600));
+        assertEquals(30, result.getSeconds());
+    }
 
-        WorkflowModel terminalHuman =
+    @Test
+    public void computePostponeDoesNotDeferHumanOnlyWhenMaxPostponeDisabled() {
+        WorkflowModel workflow =
                 newWorkflow(
                         Arrays.asList(
-                                newTask(TaskType.TASK_TYPE_HUMAN, TaskModel.Status.COMPLETED)),
+                                newTask(TaskType.TASK_TYPE_HUMAN, TaskModel.Status.IN_PROGRESS)),
                         0);
-        assertFalse(ExecutorUtils.hasInProgressHumanTask(terminalHuman));
+        // No maxPostpone ceiling configured -> cannot defer safely; keep the offset cadence.
+        Duration result =
+                ExecutorUtils.computePostpone(
+                        workflow, Duration.ofSeconds(30), Duration.ofSeconds(0));
+        assertEquals(30, result.getSeconds());
+    }
+
+    @Test
+    public void computePostponeDoesNotDeferHumanInsideFork() {
+        WorkflowDef workflowDef = new WorkflowDef();
+        WorkflowTask fork = new WorkflowTask();
+        fork.setType(TaskType.FORK_JOIN.name());
+        fork.setTaskReferenceName("fork_ref");
+        workflowDef.setTasks(Arrays.asList(fork));
+
+        WorkflowModel workflow = new WorkflowModel();
+        workflow.setWorkflowId("workflowId");
+        workflow.setWorkflowDefinition(workflowDef);
+        workflow.setTasks(
+                Arrays.asList(newTask(TaskType.TASK_TYPE_HUMAN, TaskModel.Status.IN_PROGRESS)));
+
+        // The FORK in the definition forces the offset cadence so the branch-coordination re-sweep
+        // survives, even though the HUMAN is momentarily the only pending leaf (a fork's JOIN can
+        // be
+        // transiently absent from the live task list on some persistence layers mid-decide).
+        Duration result =
+                ExecutorUtils.computePostpone(
+                        workflow, Duration.ofSeconds(30), Duration.ofSeconds(3600));
+        assertEquals(30, result.getSeconds());
     }
 
     private TaskModel newTask(String taskType, TaskModel.Status status) {

--- a/core/src/test/java/org/conductoross/conductor/core/execution/ExecutorUtilsTest.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/ExecutorUtilsTest.java
@@ -263,6 +263,44 @@ public class ExecutorUtilsTest {
     }
 
     @Test
+    public void computePostponeDefersHumanToItsTimeoutBoundary() {
+        TaskDef humanDef = new TaskDef();
+        humanDef.setTimeoutSeconds(600);
+        WorkflowTask humanWorkflowTask = new WorkflowTask();
+        humanWorkflowTask.setTaskDefinition(humanDef);
+        TaskModel human = newTask(TaskType.TASK_TYPE_HUMAN, TaskModel.Status.IN_PROGRESS);
+        human.setStartTime(System.currentTimeMillis());
+        human.setWorkflowTask(humanWorkflowTask);
+
+        WorkflowModel workflow = newWorkflow(Arrays.asList(human), 0);
+        // A human with a 600s timeout must wake near that boundary (not the 3600s maxPostpone) so
+        // DeciderService.checkTaskTimeout can time it out on schedule.
+        long result =
+                ExecutorUtils.computePostpone(
+                                workflow, Duration.ofSeconds(30), Duration.ofSeconds(3600))
+                        .getSeconds();
+        assertTrue("expected ~600s, got " + result, result >= 595 && result <= 601);
+    }
+
+    @Test
+    public void computePostponeCapsHumanTimeoutAtMaxPostpone() {
+        TaskDef humanDef = new TaskDef();
+        humanDef.setTimeoutSeconds(7200); // 2h, beyond the maxPostpone ceiling
+        WorkflowTask humanWorkflowTask = new WorkflowTask();
+        humanWorkflowTask.setTaskDefinition(humanDef);
+        TaskModel human = newTask(TaskType.TASK_TYPE_HUMAN, TaskModel.Status.IN_PROGRESS);
+        human.setStartTime(System.currentTimeMillis());
+        human.setWorkflowTask(humanWorkflowTask);
+
+        WorkflowModel workflow = newWorkflow(Arrays.asList(human), 0);
+        long result =
+                ExecutorUtils.computePostpone(
+                                workflow, Duration.ofSeconds(30), Duration.ofSeconds(3600))
+                        .getSeconds();
+        assertEquals(3600, result);
+    }
+
+    @Test
     public void computePostponeDoesNotDeferHumanBesideAnotherPendingTask() {
         WorkflowModel workflow =
                 newWorkflow(

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/http/functional/WorkflowFunctionalTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/http/functional/WorkflowFunctionalTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.common.metadata.tasks.TaskResult;
 import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.common.metadata.workflow.StartWorkflowRequest;
 import com.netflix.conductor.common.metadata.workflow.SubWorkflowParams;
@@ -93,6 +94,56 @@ public class WorkflowFunctionalTest extends FunctionalTestBase {
                             Workflow wf = workflowClient.getWorkflow(workflowId, true);
                             assertEquals(WorkflowStatus.COMPLETED, wf.getStatus());
                             assertEquals(2, wf.getTasks().size());
+                        });
+    }
+
+    @Test
+    public void testHumanTaskWorkflowDefersThenCompletes() {
+        // Workflow whose only work is a HUMAN task. The sweeper DEFERS it (parked only on the
+        // human) instead of removing it from the decider queue; completing the human must still
+        // wake and complete the workflow promptly. If deferral stranded it, this test times out.
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setName("func_test_human_defer");
+        workflowDef.setVersion(1);
+        workflowDef.setOwnerEmail(OWNER_EMAIL);
+        workflowDef.setTimeoutSeconds(120);
+        WorkflowTask human = new WorkflowTask();
+        human.setName("func_human");
+        human.setTaskReferenceName("human_ref");
+        human.setWorkflowTaskType(TaskType.HUMAN);
+        workflowDef.getTasks().add(human);
+        metadataClient.registerWorkflowDef(workflowDef);
+
+        String workflowId =
+                workflowClient.startWorkflow(
+                        new StartWorkflowRequest().withName("func_test_human_defer"));
+        assertNotNull(workflowId);
+
+        // Parked on the HUMAN task -> RUNNING with the human IN_PROGRESS.
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            Workflow wf = workflowClient.getWorkflow(workflowId, true);
+                            assertEquals(WorkflowStatus.RUNNING, wf.getStatus());
+                            assertEquals(1, wf.getTasks().size());
+                            assertEquals(Task.Status.IN_PROGRESS, wf.getTasks().get(0).getStatus());
+                        });
+
+        // Complete the HUMAN task.
+        Task humanTask = workflowClient.getWorkflow(workflowId, true).getTasks().get(0);
+        TaskResult result = new TaskResult();
+        result.setWorkflowInstanceId(workflowId);
+        result.setTaskId(humanTask.getTaskId());
+        result.setStatus(TaskResult.Status.COMPLETED);
+        taskClient.updateTask(result);
+
+        // Workflow wakes and completes promptly (deferral kept it in the queue, updateTask
+        // decides).
+        await().atMost(15, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            Workflow wf = workflowClient.getWorkflow(workflowId, true);
+                            assertEquals(WorkflowStatus.COMPLETED, wf.getStatus());
                         });
     }
 


### PR DESCRIPTION
## Problem

PR #1171 ("prevent HUMAN tasks from churning the decider queue") added `humanTaskPreventsDeciderQueue` (default **true**). When a workflow has an in-progress `HUMAN` task, `WorkflowExecutorOps.decide()` **removes** it from the decider queue entirely:

```java
if (properties.isHumanTaskPreventsDeciderQueue() && hasInProgressHumanTask(workflow)) {
    queueDAO.remove(DECIDER_QUEUE, workflow.getWorkflowId());
}
```

and relies solely on `updateTask()` re-pushing it when the HUMAN reaches a terminal status.

The intent (stop churning the sweeper every offset while waiting on a human) is right, but **removing the workflow deletes the decider queue's recovery backstop.** The workflow now depends entirely on that single re-push. If it is ever missed — a crash between the task reaching terminal and the push, a completion path that doesn't hit that branch, or a lost queue message — the workflow is **orphaned from the sweeper permanently** and hangs in RUNNING with no mechanism to recover.

## Fix (forward-fix, keeps the intent)

Keep the workflow **in** the decider queue but **defer** it instead of removing it:

- `ExecutorUtils.computePostpone()` now returns `maxPostponeDuration` when the only pending work is `HUMAN` task(s) (looking past a wrapping `DO_WHILE`). The sweeper no longer re-decides every offset, but the periodic re-sweep still recovers the workflow if the completion event is ever missed (worst case: re-evaluated at `maxPostpone`, default 1h).
- Completion still wakes it promptly — `updateTask()` already calls `decide()` synchronously — so the deferral costs nothing on the happy path.
- `decide()` drops the `queueDAO.remove(...)` branch and always takes the `computePostpone` → `setUnackTimeout` path.

### Why FORK workflows are never deferred

A fork branch parked on a HUMAN can momentarily be the only pending leaf, while the branch's still-pending `JOIN` may be transiently absent from the *live* task list mid-decide on some persistence layers. Deferring then would strip the branch-coordination re-sweep and strand the workflow. So the defer is gated on the **static workflow definition** (`collectTasks()` for `FORK_JOIN`/`FORK_JOIN_DYNAMIC`), which is race-free — never on the live task list. A workflow containing a FORK keeps the normal offset cadence.

### Cleanup

Removes the now-unused `humanTaskPreventsDeciderQueue` flag, `ExecutorUtils.hasInProgressHumanTask`, and the `updateTask()` HUMAN re-push special case.

## Tests

`ExecutorUtilsTest`: human-only workflow → defers to maxPostpone; human beside another pending task → normal cadence; maxPostpone disabled (0) → normal cadence (no unsafe unbounded defer); **human inside a FORK → not deferred**. Existing `computePostpone` cases, `TestWorkflowExecutor`, and decider-service tests remain green; `spotlessCheck` passes.
