### PR TITLE
Undo the ai task cards height so the padding is equal on top and bott…

### DIFF
--- a/ui-next/src/components/features/flow/nodes/mapper/layout.js
+++ b/ui-next/src/components/features/flow/nodes/mapper/layout.js
@@ -12,42 +12,8 @@ const computeAdditionalWidth = (portsAmount) =>
     ? (portsAmount - MIN_AMOUNT_OF_SWITCH_PORTS) * SWITCH_SIZE_INCREMENTER
     : 0;
 
-// AI / agentic task cards render header-only content (no custom body like HTTP/SIMPLE), so they
-// size to a snug header height instead of the taller DEFAULT, avoiding empty space below the label.
-const HEADER_ONLY_AI_HEIGHT = 80;
-const HEADER_ONLY_AI_TASKS = new Set([
-  TaskType.LLM_CHAT_COMPLETE,
-  TaskType.LLM_TEXT_COMPLETE,
-  TaskType.LLM_GENERATE_EMBEDDINGS,
-  TaskType.LLM_GET_EMBEDDINGS,
-  TaskType.LLM_STORE_EMBEDDINGS,
-  TaskType.LLM_SEARCH_INDEX,
-  TaskType.LLM_SEARCH_EMBEDDINGS,
-  TaskType.LLM_INDEX_TEXT,
-  TaskType.LLM_INDEX_DOCUMENT,
-  TaskType.GET_DOCUMENT,
-  TaskType.CHUNK_TEXT,
-  TaskType.LIST_FILES,
-  TaskType.PARSE_DOCUMENT,
-  TaskType.AGENT,
-  TaskType.GET_AGENT_CARD,
-  TaskType.CANCEL_AGENT,
-  TaskType.LIST_MCP_TOOLS,
-  TaskType.CALL_MCP_TOOL,
-  TaskType.GENERATE_IMAGE,
-  TaskType.GENERATE_AUDIO,
-  TaskType.GENERATE_VIDEO,
-  TaskType.GENERATE_PDF,
-]);
-
 export const taskToSize = (task) => {
   const { type, executionData = null } = task;
-  if (HEADER_ONLY_AI_TASKS.has(type)) {
-    return {
-      width: theme.nodeTypes.DEFAULT.width,
-      height: HEADER_ONLY_AI_HEIGHT,
-    };
-  }
   switch (type) {
     case TaskType.START:
     case TaskType.TERMINAL:


### PR DESCRIPTION
…om again

Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Reverts the 80px "header-only" node height introduced in #1195 for AI/agentic task types. Those cards again use the default 100px flow node height so top and bottom padding look balanced.

<img width="377" height="610" alt="Screenshot 2026-07-08 at 1 37 27 PM" src="https://github.com/user-attachments/assets/c4977c80-a62c-4a3d-ae33-8202c732ce85" />
