### PR TITLE
Fix error handling on DELETE of Event Handler

### DIFF
--- a/ui-next/src/pages/definition/EventHandler/eventhandlers/state/services.ts
+++ b/ui-next/src/pages/definition/EventHandler/eventhandlers/state/services.ts
@@ -3,7 +3,7 @@ import { fetchWithContext } from "plugins/fetch";
 import { SaveEventHandlerMachineContext } from "./types";
 import { queryClient } from "../../../../../queryClient";
 import { fetchContextNonHook } from "plugins/fetch";
-import { tryFunc } from "utils";
+import { getErrors, logger, tryFunc } from "utils";
 import { NEW_EVENT_HANDLER_TEMPLATE } from "../eventHandlerSchema";
 
 const fetchContext = fetchContextNonHook();
@@ -94,15 +94,23 @@ export const deleteEventHandler = async (
   { eventHandlerName, authHeaders }: SaveEventHandlerMachineContext,
   __: any,
 ) => {
-  return tryFunc({
-    fn: async () => {
-      const path = `/event/${encodeURIComponent(eventHandlerName)}`;
-      const result = await fetchWithContext(path, fetchContext, {
-        method: "DELETE",
-        headers: authHeaders,
+  try {
+    const path = `/event/${encodeURIComponent(eventHandlerName)}`;
+    return await fetchWithContext(path, fetchContext, {
+      method: "DELETE",
+      headers: authHeaders,
+    });
+  } catch (error: any) {
+    logger.error("[deleteEventHandler] error:", error);
+    if (error?.status === 403) {
+      return Promise.reject({
+        message: "You do not have permission to delete this event handler.",
       });
-
-      return result;
-    },
-  });
+    }
+    const details = await getErrors(error);
+    return Promise.reject({
+      originalError: details,
+      message: details?.message,
+    });
+  }
 };

--- a/ui-next/src/pages/definitions/EventHandler.tsx
+++ b/ui-next/src/pages/definitions/EventHandler.tsx
@@ -37,6 +37,7 @@ import { colors } from "theme/tokens/variables";
 import { ConductorEvent } from "types/Events";
 import { TagDto } from "types/Tag";
 import { createSearchableTags, logger } from "utils";
+import { parseErrorResponse } from "utils/helpers";
 import { ACTIVE_FILTER_QUERY_PARAM } from "utils/constants/common";
 import { EVENT_HANDLERS_URL } from "utils/constants/route";
 import useCustomPagination from "utils/hooks/useCustomPagination";
@@ -260,8 +261,21 @@ export default function EventDefinitionList() {
     onSuccess: () => {
       refetch();
     },
-    onError: (err: Error) => {
+    onError: async (err: Response) => {
       logger.error(err);
+      const errorMessage =
+        err.status === 403
+          ? "You do not have permission to delete this event handler."
+          : await parseErrorResponse({
+              response: err,
+              module: "event handler",
+              operation: "deleting",
+            });
+      setToast({
+        isOpen: true,
+        message: errorMessage,
+        status: "error",
+      });
       refetch();
     },
   });
@@ -308,12 +322,14 @@ export default function EventDefinitionList() {
         <SnackbarMessage
           autoHideDuration={3000}
           message={toast.message}
-          severity={toast.status === "paused" ? "warning" : "success"}
+          severity={
+            toast.status === "error"
+              ? "error"
+              : toast.status === "paused"
+                ? "warning"
+                : "success"
+          }
           onDismiss={() => setToast({ isOpen: false, message: "", status: "" })}
-          anchorOrigin={{
-            vertical: "bottom",
-            horizontal: "right",
-          }}
         />
       )}
 


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Improves delete error handling for Event Handlers so permission failures and other API errors surface clearly in the UI instead of failing silently.

- Event Handler list page (EventHandler.tsx): On delete failure, shows a top-center snackbar with a user-friendly message. 403 responses display a specific permission-denied message; other errors use parseErrorResponse. Snackbar severity now supports error in addition to success/warning.
- Event Handler editor (services.ts): Replaces generic tryFunc wrapping on delete with explicit error handling. Maps 403 to a clear permission message and propagates parsed API errors for the editor state machine to display.