### PR TITLE
feat: workflow classifier for definitions and execution search

### DIFF
--- a/agentspan-server/build.gradle
+++ b/agentspan-server/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     implementation project(':conductor-core')
     implementation project(':conductor-ai')
 
-    implementation "org.conductoross:conductor-agentspan:0.3.0"
+    // 0.4.2+ supports classifier-based agent filtering (pairs with WorkflowClassifier in
+    // conductor-common and the classifier search field in the index backends).
+    implementation "org.conductoross:conductor-agentspan:0.4.2"
 
 }

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowClassifier.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowClassifier.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.common.metadata.workflow;
+
+import java.util.Map;
+
+/**
+ * Derives the <b>classifier</b> of a workflow definition from its {@code metadata} map.
+ *
+ * <p>The classifier is a tag used to distinguish kinds of definitions/executions: an untagged def
+ * is a plain <b>workflow</b> (classifier {@link #WORKFLOW}); AgentSpan-compiled defs are tagged
+ * {@link #AGENT}. The scheme is open-ended — a def may carry any explicit {@code
+ * metadata.classifier} value, enabling future kinds without schema/code changes.
+ *
+ * <p>Resolution order:
+ *
+ * <ol>
+ *   <li>explicit {@code metadata.classifier} (non-blank) — wins;
+ *   <li>otherwise {@code "agent"} when the AgentSpan stamp is present ({@code metadata.agent_sdk}
+ *       or {@code metadata.agentDef});
+ *   <li>otherwise {@code "workflow"} (a normal, untagged workflow).
+ * </ol>
+ *
+ * <p>Note: unlike the metadata map (where absence of a classifier simply means "plain workflow"),
+ * the resolved value is never {@code null} — untagged defs resolve to the literal {@link #WORKFLOW}
+ * token so that indexed executions can be filtered with plain equality across all index backends.
+ */
+public final class WorkflowClassifier {
+
+    /** Classifier value for AgentSpan agent definitions/executions. */
+    public static final String AGENT = "agent";
+
+    /** Classifier value for plain (untagged) workflow definitions/executions. */
+    public static final String WORKFLOW = "workflow";
+
+    private static final String META_CLASSIFIER = "classifier";
+    private static final String META_AGENT_SDK = "agent_sdk";
+    private static final String META_AGENT_DEF = "agentDef";
+
+    private WorkflowClassifier() {}
+
+    /** Returns the classifier for {@code def}, never {@code null}. */
+    public static String classifierOf(WorkflowDef def) {
+        return def == null ? WORKFLOW : classifierOf(def.getMetadata());
+    }
+
+    /** Returns the classifier derived from a workflow def {@code metadata} map. */
+    public static String classifierOf(Map<String, Object> metadata) {
+        if (metadata == null || metadata.isEmpty()) {
+            return WORKFLOW;
+        }
+        Object explicit = metadata.get(META_CLASSIFIER);
+        if (explicit instanceof String s && !s.isBlank()) {
+            return s;
+        }
+        if (metadata.get(META_AGENT_SDK) != null || metadata.get(META_AGENT_DEF) != null) {
+            return AGENT;
+        }
+        return WORKFLOW;
+    }
+}

--- a/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.netflix.conductor.annotations.protogen.ProtoField;
 import com.netflix.conductor.annotations.protogen.ProtoMessage;
+import com.netflix.conductor.common.metadata.workflow.WorkflowClassifier;
 import com.netflix.conductor.common.run.Workflow.WorkflowStatus;
 import com.netflix.conductor.common.utils.SummaryUtil;
 
@@ -102,6 +103,14 @@ public class WorkflowSummary {
     @ProtoField(id = 22)
     private String parentWorkflowId = "";
 
+    /**
+     * Classifier of the workflow definition this execution was started from (e.g. {@code workflow}
+     * for a plain workflow, {@code agent} for AgentSpan agents). Derived via {@link
+     * WorkflowClassifier} at index time.
+     */
+    @ProtoField(id = 23)
+    private String classifier;
+
     public WorkflowSummary() {}
 
     public WorkflowSummary(Workflow workflow) {
@@ -151,6 +160,7 @@ public class WorkflowSummary {
         this.createdBy = workflow.getCreatedBy();
         this.parentWorkflowId =
                 workflow.getParentWorkflowId() != null ? workflow.getParentWorkflowId() : "";
+        this.classifier = WorkflowClassifier.classifierOf(workflow.getWorkflowDefinition());
     }
 
     /**
@@ -399,6 +409,14 @@ public class WorkflowSummary {
         this.parentWorkflowId = parentWorkflowId;
     }
 
+    public String getClassifier() {
+        return classifier;
+    }
+
+    public void setClassifier(String classifier) {
+        this.classifier = classifier;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -423,7 +441,8 @@ public class WorkflowSummary {
                 && Objects.equals(getEvent(), that.getEvent())
                 && Objects.equals(getCreatedBy(), that.getCreatedBy())
                 && Objects.equals(getTaskToDomain(), that.getTaskToDomain())
-                && Objects.equals(getParentWorkflowId(), that.getParentWorkflowId());
+                && Objects.equals(getParentWorkflowId(), that.getParentWorkflowId())
+                && Objects.equals(getClassifier(), that.getClassifier());
     }
 
     @Override
@@ -444,6 +463,7 @@ public class WorkflowSummary {
                 getPriority(),
                 getCreatedBy(),
                 getTaskToDomain(),
-                getParentWorkflowId());
+                getParentWorkflowId(),
+                getClassifier());
     }
 }

--- a/common/src/test/java/com/netflix/conductor/common/metadata/workflow/WorkflowClassifierTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/metadata/workflow/WorkflowClassifierTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.common.metadata.workflow;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class WorkflowClassifierTest {
+
+    @Test
+    public void nullDefIsWorkflow() {
+        assertEquals(
+                WorkflowClassifier.WORKFLOW, WorkflowClassifier.classifierOf((WorkflowDef) null));
+    }
+
+    @Test
+    public void nullOrEmptyMetadataIsWorkflow() {
+        assertEquals(
+                WorkflowClassifier.WORKFLOW,
+                WorkflowClassifier.classifierOf((Map<String, Object>) null));
+        assertEquals(WorkflowClassifier.WORKFLOW, WorkflowClassifier.classifierOf(new HashMap<>()));
+    }
+
+    @Test
+    public void untaggedDefIsWorkflow() {
+        WorkflowDef def = new WorkflowDef();
+        def.setName("plain");
+        assertEquals(WorkflowClassifier.WORKFLOW, WorkflowClassifier.classifierOf(def));
+    }
+
+    @Test
+    public void agentSdkStampMeansAgent() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("agent_sdk", "python");
+        assertEquals(WorkflowClassifier.AGENT, WorkflowClassifier.classifierOf(metadata));
+    }
+
+    @Test
+    public void agentDefStampMeansAgent() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("agentDef", Map.of("name", "my-agent"));
+        assertEquals(WorkflowClassifier.AGENT, WorkflowClassifier.classifierOf(metadata));
+    }
+
+    @Test
+    public void explicitClassifierWins() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("agent_sdk", "python");
+        metadata.put("classifier", "pipeline");
+        assertEquals("pipeline", WorkflowClassifier.classifierOf(metadata));
+    }
+
+    @Test
+    public void blankExplicitClassifierIsIgnored() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("classifier", "   ");
+        assertEquals(WorkflowClassifier.WORKFLOW, WorkflowClassifier.classifierOf(metadata));
+
+        metadata.put("agent_sdk", "python");
+        assertEquals(WorkflowClassifier.AGENT, WorkflowClassifier.classifierOf(metadata));
+    }
+
+    @Test
+    public void nonStringExplicitClassifierIsIgnored() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("classifier", 42);
+        assertEquals(WorkflowClassifier.WORKFLOW, WorkflowClassifier.classifierOf(metadata));
+    }
+
+    @Test
+    public void defWithMetadataResolvesThroughDefOverload() {
+        WorkflowDef def = new WorkflowDef();
+        def.setName("agentic");
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("agent_sdk", "java");
+        def.setMetadata(metadata);
+        assertEquals(WorkflowClassifier.AGENT, WorkflowClassifier.classifierOf(def));
+    }
+}

--- a/es7-persistence/src/main/resources/mappings_docType_workflow.json
+++ b/es7-persistence/src/main/resources/mappings_docType_workflow.json
@@ -72,6 +72,11 @@
       "type": "keyword",
       "index": true,
       "doc_values": true
+    },
+    "classifier": {
+      "type": "keyword",
+      "index": true,
+      "doc_values": true
     }
   }
 }

--- a/es8-persistence/src/main/resources/template_workflow.json
+++ b/es8-persistence/src/main/resources/template_workflow.json
@@ -83,6 +83,10 @@
         "parentWorkflowId": {
           "type": "keyword",
           "index": true
+        },
+        "classifier": {
+          "type": "keyword",
+          "index": true
         }
       }
     }

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -1428,9 +1428,6 @@ public abstract class AbstractProtoMapper {
         if (from.getFailureWorkflow() != null) {
             to.setFailureWorkflow( from.getFailureWorkflow() );
         }
-        if (from.getFailureWorkflowVersion() != null) {
-            to.setFailureWorkflowVersion( from.getFailureWorkflowVersion() );
-        }
         to.setSchemaVersion( from.getSchemaVersion() );
         to.setRestartable( from.isRestartable() );
         to.setWorkflowStatusListenerEnabled( from.isWorkflowStatusListenerEnabled() );
@@ -1446,6 +1443,9 @@ public abstract class AbstractProtoMapper {
         }
         for (Map.Entry<String, Object> pair : from.getInputTemplate().entrySet()) {
             to.putInputTemplate( pair.getKey(), toProto( pair.getValue() ) );
+        }
+        if (from.getFailureWorkflowVersion() != null) {
+            to.setFailureWorkflowVersion( from.getFailureWorkflowVersion() );
         }
         if (from.getWorkflowStatusListenerSink() != null) {
             to.setWorkflowStatusListenerSink( from.getWorkflowStatusListenerSink() );
@@ -1483,9 +1483,6 @@ public abstract class AbstractProtoMapper {
         }
         to.setOutputParameters(outputParametersMap);
         to.setFailureWorkflow( from.getFailureWorkflow() );
-        if (from.getFailureWorkflowVersion() != 0) {
-            to.setFailureWorkflowVersion( from.getFailureWorkflowVersion() );
-        }
         to.setSchemaVersion( from.getSchemaVersion() );
         to.setRestartable( from.getRestartable() );
         to.setWorkflowStatusListenerEnabled( from.getWorkflowStatusListenerEnabled() );
@@ -1502,6 +1499,7 @@ public abstract class AbstractProtoMapper {
             inputTemplateMap.put( pair.getKey(), fromProto( pair.getValue() ) );
         }
         to.setInputTemplate(inputTemplateMap);
+        to.setFailureWorkflowVersion( from.getFailureWorkflowVersion() );
         to.setWorkflowStatusListenerSink( from.getWorkflowStatusListenerSink() );
         if (from.hasRateLimitConfig()) {
             to.setRateLimitConfig( fromProto( from.getRateLimitConfig() ) );
@@ -1627,6 +1625,9 @@ public abstract class AbstractProtoMapper {
         if (from.getParentWorkflowId() != null) {
             to.setParentWorkflowId( from.getParentWorkflowId() );
         }
+        if (from.getClassifier() != null) {
+            to.setClassifier( from.getClassifier() );
+        }
         return to.build();
     }
 
@@ -1654,6 +1655,7 @@ public abstract class AbstractProtoMapper {
         to.setTaskToDomain( from.getTaskToDomainMap() );
         to.setIdempotencyKey( from.getIdempotencyKey() );
         to.setParentWorkflowId( from.getParentWorkflowId() );
+        to.setClassifier( from.getClassifier() );
         return to;
     }
 

--- a/grpc/src/main/proto/model/workflowsummary.proto
+++ b/grpc/src/main/proto/model/workflowsummary.proto
@@ -30,4 +30,5 @@ message WorkflowSummary {
     map<string, string> task_to_domain = 20;
     string idempotency_key = 21;
     string parent_workflow_id = 22;
+    string classifier = 23;
 }

--- a/os-persistence-v2/src/main/resources/mappings_docType_workflow.json
+++ b/os-persistence-v2/src/main/resources/mappings_docType_workflow.json
@@ -67,6 +67,11 @@
     "event": {
       "type": "keyword",
       "index": true
+    },
+    "classifier": {
+      "type": "keyword",
+      "index": true,
+      "doc_values": true
     }
   }
 }

--- a/os-persistence-v3/src/main/resources/mappings_docType_workflow.json
+++ b/os-persistence-v3/src/main/resources/mappings_docType_workflow.json
@@ -72,6 +72,11 @@
       "type": "keyword",
       "index": true,
       "doc_values": true
+    },
+    "classifier": {
+      "type": "keyword",
+      "index": true,
+      "doc_values": true
     }
   }
 }

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresIndexDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresIndexDAO.java
@@ -82,11 +82,12 @@ public class PostgresIndexDAO extends PostgresBaseDAO implements IndexDAO {
     @Override
     public void indexWorkflow(WorkflowSummary workflow) {
         String INSERT_WORKFLOW_INDEX_SQL =
-                "INSERT INTO workflow_index (workflow_id, correlation_id, workflow_type, start_time, update_time, status, parent_workflow_id, json_data)"
-                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?::JSONB) ON CONFLICT (workflow_id) \n"
+                "INSERT INTO workflow_index (workflow_id, correlation_id, workflow_type, start_time, update_time, status, parent_workflow_id, classifier, json_data)"
+                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?::JSONB) ON CONFLICT (workflow_id) \n"
                         + "DO UPDATE SET correlation_id = EXCLUDED.correlation_id, workflow_type = EXCLUDED.workflow_type, "
                         + "start_time = EXCLUDED.start_time, status = EXCLUDED.status, json_data = EXCLUDED.json_data, "
-                        + "update_time = EXCLUDED.update_time, parent_workflow_id = EXCLUDED.parent_workflow_id "
+                        + "update_time = EXCLUDED.update_time, parent_workflow_id = EXCLUDED.parent_workflow_id, "
+                        + "classifier = EXCLUDED.classifier "
                         + "WHERE EXCLUDED.update_time >= workflow_index.update_time";
 
         if (onlyIndexOnStatusChange) {
@@ -113,6 +114,7 @@ public class PostgresIndexDAO extends PostgresBaseDAO implements IndexDAO {
                                                 workflow.getParentWorkflowId() != null
                                                         ? workflow.getParentWorkflowId()
                                                         : "")
+                                        .addParameter(workflow.getClassifier())
                                         .addJsonParameter(workflow)
                                         .executeUpdate());
         logger.debug("Postgres index workflow rows updated: {}", rowsUpdated);

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilder.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilder.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.netflix.conductor.common.metadata.workflow.WorkflowClassifier;
 import com.netflix.conductor.postgres.config.PostgresProperties;
 
 public class PostgresIndexQueryBuilder {
@@ -51,6 +52,7 @@ public class PostgresIndexQueryBuilder {
         "update_time",
         "json_data",
         "parent_workflow_id",
+        "classifier",
         "jsonb_to_tsvector('english', json_data, '[\"all\"]')"
     };
 
@@ -83,6 +85,9 @@ public class PostgresIndexQueryBuilder {
 
         public String getQueryFragment() {
             if (operator.equals("IN")) {
+                if (classifierMatchesUntagged()) {
+                    return "(" + attribute + " = ANY(?) OR " + attribute + " IS NULL)";
+                }
                 return attribute + " = ANY(?)";
             } else if (operator.equals("@@")) {
                 return attribute + " @@ to_tsquery(?)";
@@ -95,10 +100,24 @@ public class PostgresIndexQueryBuilder {
                         && values.size() == 1
                         && values.get(0).contains("*")) {
                     return attribute + " LIKE ?";
+                } else if (operator.equals("=") && classifierMatchesUntagged()) {
+                    return "(" + attribute + " = ? OR " + attribute + " IS NULL)";
                 } else {
                     return attribute + " " + operator + " ?";
                 }
             }
+        }
+
+        /**
+         * Rows indexed before the classifier column existed have a NULL classifier but are
+         * semantically untagged, i.e. plain workflows. When a filter asks for the untagged token
+         * ({@link WorkflowClassifier#WORKFLOW}), widen the predicate to also match those legacy
+         * NULL rows.
+         */
+        private boolean classifierMatchesUntagged() {
+            return "classifier".equals(attribute)
+                    && values != null
+                    && values.stream().anyMatch(WorkflowClassifier.WORKFLOW::equalsIgnoreCase);
         }
 
         private String getOperator(String op) {

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V17__workflow_index_classifier.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V17__workflow_index_classifier.sql
@@ -1,0 +1,6 @@
+-- Classifier of the workflow definition an execution was started from (e.g. 'workflow' for a
+-- plain workflow, 'agent' for AgentSpan agents). Derived from WorkflowDef.metadata at index time.
+-- Rows indexed before this migration keep a NULL classifier and are treated as untagged
+-- ('workflow') by the search query builder.
+ALTER TABLE workflow_index ADD COLUMN classifier VARCHAR(255);
+CREATE INDEX workflow_index_classifier_idx ON workflow_index (classifier, start_time);

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresIndexDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresIndexDAOTest.java
@@ -368,6 +368,54 @@ public class PostgresIndexDAOTest {
     }
 
     @Test
+    public void testSearchWorkflowSummaryByClassifier() {
+        String correlationId = "classifier-search-correlation-id";
+
+        WorkflowSummary agentWfs = getMockWorkflowSummary("workflow-id-classifier-agent");
+        agentWfs.setCorrelationId(correlationId);
+        agentWfs.setClassifier("agent");
+        indexDAO.indexWorkflow(agentWfs);
+
+        WorkflowSummary plainWfs = getMockWorkflowSummary("workflow-id-classifier-plain");
+        plainWfs.setCorrelationId(correlationId);
+        plainWfs.setClassifier("workflow");
+        indexDAO.indexWorkflow(plainWfs);
+
+        // Simulates a row indexed before the classifier column existed (NULL classifier).
+        WorkflowSummary legacyWfs = getMockWorkflowSummary("workflow-id-classifier-legacy");
+        legacyWfs.setCorrelationId(correlationId);
+        indexDAO.indexWorkflow(legacyWfs);
+
+        String agentQuery =
+                String.format("correlationId='%s' AND classifier='agent'", correlationId);
+        SearchResult<WorkflowSummary> agentResults =
+                indexDAO.searchWorkflowSummary(agentQuery, "*", 0, 15, new ArrayList<>());
+        assertEquals("Wrong number of agent results", 1, agentResults.getResults().size());
+        assertEquals(
+                "Wrong workflow returned",
+                agentWfs.getWorkflowId(),
+                agentResults.getResults().get(0).getWorkflowId());
+
+        // The untagged token must match both explicitly tagged plain workflows and legacy
+        // NULL rows.
+        String workflowQuery =
+                String.format("correlationId='%s' AND classifier='workflow'", correlationId);
+        SearchResult<WorkflowSummary> workflowResults =
+                indexDAO.searchWorkflowSummary(workflowQuery, "*", 0, 15, new ArrayList<>());
+        assertEquals("Wrong number of untagged results", 2, workflowResults.getResults().size());
+
+        String inQuery =
+                String.format("correlationId='%s' AND classifier IN (agent,other)", correlationId);
+        SearchResult<WorkflowSummary> inResults =
+                indexDAO.searchWorkflowSummary(inQuery, "*", 0, 15, new ArrayList<>());
+        assertEquals("Wrong number of IN clause results", 1, inResults.getResults().size());
+
+        indexDAO.removeWorkflow(agentWfs.getWorkflowId());
+        indexDAO.removeWorkflow(plainWfs.getWorkflowId());
+        indexDAO.removeWorkflow(legacyWfs.getWorkflowId());
+    }
+
+    @Test
     public void testFullTextSearchWorkflowSummary() {
         WorkflowSummary wfs = getMockWorkflowSummary("workflow-id");
 

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilderTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilderTest.java
@@ -605,6 +605,88 @@ public class PostgresIndexQueryBuilderTest {
     }
 
     @Test
+    void shouldGenerateQueryForClassifier() throws SQLException {
+        String inputQuery = "classifier=\"agent\"";
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data::TEXT FROM table_name WHERE classifier = ? LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        builder.addPagingParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("agent");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldGenerateQueryForClassifierInClause() throws SQLException {
+        String inputQuery = "classifier IN (agent,pipeline)";
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data::TEXT FROM table_name WHERE classifier = ANY(?) LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        builder.addPagingParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter(new ArrayList<>(List.of("agent", "pipeline")));
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldMatchLegacyNullRowsForUntaggedClassifier() throws SQLException {
+        // Rows indexed before the classifier column existed are untagged plain workflows;
+        // filtering for the "workflow" token must also match those NULL rows.
+        String inputQuery = "classifier=\"workflow\"";
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data::TEXT FROM table_name WHERE (classifier = ? OR classifier IS NULL) LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        builder.addPagingParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("workflow");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldMatchLegacyNullRowsForUntaggedClassifierInClause() throws SQLException {
+        String inputQuery = "classifier IN (agent,workflow)";
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data::TEXT FROM table_name WHERE (classifier = ANY(?) OR classifier IS NULL) LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        builder.addPagingParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter(new ArrayList<>(List.of("agent", "workflow")));
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
     void shouldGenerateQueryForParentWorkflowId() throws SQLException {
         String inputQuery = "parentWorkflowId=\"\"";
         PostgresIndexQueryBuilder builder =

--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/MetadataResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/MetadataResource.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowClassifier;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDefSummary;
 import com.netflix.conductor.common.model.BulkResponse;
@@ -73,8 +74,19 @@ public class MetadataResource {
 
     @Operation(summary = "Retrieves all workflow definition along with blueprint")
     @GetMapping("/workflow")
-    public List<WorkflowDef> getAll() {
-        return metadataService.getWorkflowDefs();
+    public List<WorkflowDef> getAll(
+            @RequestParam(value = "classifier", required = false) String classifier) {
+        List<WorkflowDef> allWorkflows = metadataService.getWorkflowDefs();
+        // Optional classifier filter powering e.g. agent def vs workflow def views. The
+        // classifier is derived from each def's metadata map: "workflow" matches untagged
+        // (plain) defs; any other value matches the derived tag literally.
+        if (classifier == null || classifier.isBlank()) {
+            return allWorkflows;
+        }
+        String wanted = classifier.trim();
+        return allWorkflows.stream()
+                .filter(wd -> wanted.equalsIgnoreCase(WorkflowClassifier.classifierOf(wd)))
+                .toList();
     }
 
     @Operation(summary = "Returns workflow names and versions only (no definition bodies)")

--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/WorkflowResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/WorkflowResource.java
@@ -14,6 +14,7 @@ package com.netflix.conductor.rest.controllers;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -392,8 +393,10 @@ public class WorkflowResource {
             @RequestParam(value = "size", defaultValue = "100", required = false) int size,
             @RequestParam(value = "sort", required = false) String sort,
             @RequestParam(value = "freeText", defaultValue = "*", required = false) String freeText,
-            @RequestParam(value = "query", required = false) String query) {
-        return workflowService.searchWorkflows(start, size, sort, freeText, query);
+            @RequestParam(value = "query", required = false) String query,
+            @RequestParam(value = "classifier", required = false) String classifier) {
+        return workflowService.searchWorkflows(
+                start, size, sort, freeText, withClassifierFilter(query, classifier));
     }
 
     @Operation(
@@ -407,8 +410,32 @@ public class WorkflowResource {
             @RequestParam(value = "size", defaultValue = "100", required = false) int size,
             @RequestParam(value = "sort", required = false) String sort,
             @RequestParam(value = "freeText", defaultValue = "*", required = false) String freeText,
-            @RequestParam(value = "query", required = false) String query) {
-        return workflowService.searchWorkflowsV2(start, size, sort, freeText, query);
+            @RequestParam(value = "query", required = false) String query,
+            @RequestParam(value = "classifier", required = false) String classifier) {
+        return workflowService.searchWorkflowsV2(
+                start, size, sort, freeText, withClassifierFilter(query, classifier));
+    }
+
+    /**
+     * Folds an optional classifier filter (comma-separated values, e.g. {@code agent} or {@code
+     * agent,workflow}) into the structured search query as a {@code classifier IN (...)} clause.
+     * This keeps the IndexDAO contract unchanged: every index backend that understands the {@code
+     * classifier} field in a query string automatically supports the request parameter.
+     */
+    private static String withClassifierFilter(String query, String classifier) {
+        if (classifier == null || classifier.isBlank()) {
+            return query;
+        }
+        String values =
+                Arrays.stream(classifier.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.joining(","));
+        if (values.isEmpty()) {
+            return query;
+        }
+        String clause = "classifier IN (" + values + ")";
+        return (query == null || query.isBlank()) ? clause : query + " AND " + clause;
     }
 
     @Operation(

--- a/rest/src/test/java/com/netflix/conductor/rest/controllers/MetadataResourceTest.java
+++ b/rest/src/test/java/com/netflix/conductor/rest/controllers/MetadataResourceTest.java
@@ -14,7 +14,9 @@ package com.netflix.conductor.rest.controllers;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -90,7 +92,30 @@ public class MetadataResourceTest {
         listOfWorkflowDef.add(workflowDef);
 
         when(mockMetadataService.getWorkflowDefs()).thenReturn(listOfWorkflowDef);
-        assertEquals(listOfWorkflowDef, metadataResource.getAll());
+        assertEquals(listOfWorkflowDef, metadataResource.getAll(null));
+    }
+
+    @Test
+    public void testGetAllWorkflowDefFilteredByClassifier() {
+        WorkflowDef plainDef = new WorkflowDef();
+        plainDef.setName("plain");
+        plainDef.setVersion(1);
+
+        WorkflowDef agentDef = new WorkflowDef();
+        agentDef.setName("agentic");
+        agentDef.setVersion(1);
+        Map<String, Object> agentMetadata = new HashMap<>();
+        agentMetadata.put("agent_sdk", "python");
+        agentDef.setMetadata(agentMetadata);
+
+        List<WorkflowDef> listOfWorkflowDef = new ArrayList<>();
+        listOfWorkflowDef.add(plainDef);
+        listOfWorkflowDef.add(agentDef);
+
+        when(mockMetadataService.getWorkflowDefs()).thenReturn(listOfWorkflowDef);
+        assertEquals(List.of(agentDef), metadataResource.getAll("agent"));
+        assertEquals(List.of(plainDef), metadataResource.getAll("workflow"));
+        assertEquals(listOfWorkflowDef, metadataResource.getAll(" "));
     }
 
     @Test

--- a/rest/src/test/java/com/netflix/conductor/rest/controllers/WorkflowResourceTest.java
+++ b/rest/src/test/java/com/netflix/conductor/rest/controllers/WorkflowResourceTest.java
@@ -277,15 +277,36 @@ public class WorkflowResourceTest {
 
     @Test
     public void testSearch() {
-        workflowResource.search(0, 100, "asc", "*", "*");
+        workflowResource.search(0, 100, "asc", "*", "*", null);
         verify(mockWorkflowService, times(1))
                 .searchWorkflows(anyInt(), anyInt(), anyString(), anyString(), anyString());
     }
 
     @Test
     public void testSearchV2() {
-        workflowResource.searchV2(0, 100, "asc", "*", "*");
+        workflowResource.searchV2(0, 100, "asc", "*", "*", null);
         verify(mockWorkflowService).searchWorkflowsV2(0, 100, "asc", "*", "*");
+    }
+
+    @Test
+    public void testSearchWithClassifierAppendsToQuery() {
+        workflowResource.search(0, 100, "asc", "*", "status IN (RUNNING)", "agent");
+        verify(mockWorkflowService)
+                .searchWorkflows(
+                        0, 100, "asc", "*", "status IN (RUNNING) AND classifier IN (agent)");
+    }
+
+    @Test
+    public void testSearchWithClassifierOnly() {
+        workflowResource.search(0, 100, "asc", "*", null, "agent, workflow");
+        verify(mockWorkflowService)
+                .searchWorkflows(0, 100, "asc", "*", "classifier IN (agent,workflow)");
+    }
+
+    @Test
+    public void testSearchV2WithClassifierAppendsToQuery() {
+        workflowResource.searchV2(0, 100, "asc", "*", null, "agent");
+        verify(mockWorkflowService).searchWorkflowsV2(0, 100, "asc", "*", "classifier IN (agent)");
     }
 
     @Test

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -20,6 +20,9 @@ dependencies {
     implementation project(':conductor-rest')
     implementation project(':conductor-grpc-server')
     implementation project(':conductor-ai')
+    // Embedded AgentSpan runtime (REST controllers, agent services); activated only when
+    // conductor.integrations.ai.enabled=true.
+    implementation project(':conductor-agentspan-server')
 
     //Event Systems
     implementation project(':conductor-amqp')

--- a/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAO.java
+++ b/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAO.java
@@ -79,11 +79,12 @@ public class SqliteIndexDAO extends SqliteBaseDAO implements IndexDAO {
     @Override
     public void indexWorkflow(WorkflowSummary workflow) {
         String INSERT_WORKFLOW_INDEX_SQL =
-                "INSERT INTO workflow_index (workflow_id, correlation_id, workflow_type, start_time, update_time, status, parent_workflow_id, json_data) "
-                        + " VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT (workflow_id) "
+                "INSERT INTO workflow_index (workflow_id, correlation_id, workflow_type, start_time, update_time, status, parent_workflow_id, classifier, json_data) "
+                        + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT (workflow_id) "
                         + " DO UPDATE SET correlation_id = excluded.correlation_id, workflow_type = excluded.workflow_type, "
                         + " start_time = excluded.start_time, status = excluded.status, json_data = excluded.json_data, "
-                        + " update_time = excluded.update_time, parent_workflow_id = excluded.parent_workflow_id "
+                        + " update_time = excluded.update_time, parent_workflow_id = excluded.parent_workflow_id, "
+                        + " classifier = excluded.classifier "
                         + " WHERE excluded.update_time >= workflow_index.update_time";
 
         if (onlyIndexOnStatusChange) {
@@ -110,6 +111,7 @@ public class SqliteIndexDAO extends SqliteBaseDAO implements IndexDAO {
                                                 workflow.getParentWorkflowId() != null
                                                         ? workflow.getParentWorkflowId()
                                                         : "")
+                                        .addParameter(workflow.getClassifier())
                                         .addJsonParameter(workflow)
                                         .executeUpdate());
         logger.debug("Sqlite index workflow rows updated: {}", rowsUpdated);

--- a/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilder.java
+++ b/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilder.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.netflix.conductor.common.metadata.workflow.WorkflowClassifier;
 import com.netflix.conductor.sqlite.config.SqliteProperties;
 
 public class SqliteIndexQueryBuilder {
@@ -49,7 +50,8 @@ public class SqliteIndexQueryBuilder {
         "task_def_name",
         "update_time",
         "json_data",
-        "parent_workflow_id"
+        "parent_workflow_id",
+        "classifier"
     };
 
     private static final String[] VALID_SORT_ORDER = {"ASC", "DESC"};
@@ -82,10 +84,15 @@ public class SqliteIndexQueryBuilder {
         public String getQueryFragment() {
             if (operator.equals("IN")) {
                 // Create proper IN clause for SQLite
-                return attribute
-                        + " IN ("
-                        + String.join(",", Collections.nCopies(values.size(), "?"))
-                        + ")";
+                String inClause =
+                        attribute
+                                + " IN ("
+                                + String.join(",", Collections.nCopies(values.size(), "?"))
+                                + ")";
+                if (classifierMatchesUntagged()) {
+                    return "(" + inClause + " OR " + attribute + " IS NULL)";
+                }
+                return inClause;
             } else if (operator.equals("MATCH")) {
                 // SQLite FTS5 full-text search
                 return "json_data MATCH ?";
@@ -101,10 +108,24 @@ public class SqliteIndexQueryBuilder {
                         && values.size() == 1
                         && values.get(0).contains("*")) {
                     return "lower(" + attribute + ") LIKE lower(?)";
+                } else if (operator.equals("=") && classifierMatchesUntagged()) {
+                    return "(" + attribute + " = ? OR " + attribute + " IS NULL)";
                 } else {
                     return attribute + " " + operator + " ?";
                 }
             }
+        }
+
+        /**
+         * Rows indexed before the classifier column existed have a NULL classifier but are
+         * semantically untagged, i.e. plain workflows. When a filter asks for the untagged token
+         * ({@link WorkflowClassifier#WORKFLOW}), widen the predicate to also match those legacy
+         * NULL rows.
+         */
+        private boolean classifierMatchesUntagged() {
+            return "classifier".equals(attribute)
+                    && values != null
+                    && values.stream().anyMatch(WorkflowClassifier.WORKFLOW::equalsIgnoreCase);
         }
 
         private String getOperator(String op) {

--- a/sqlite-persistence/src/main/resources/db/migration_sqlite/V5__workflow_index_classifier.sql
+++ b/sqlite-persistence/src/main/resources/db/migration_sqlite/V5__workflow_index_classifier.sql
@@ -1,0 +1,6 @@
+-- Classifier of the workflow definition an execution was started from (e.g. 'workflow' for a
+-- plain workflow, 'agent' for AgentSpan agents). Derived from WorkflowDef.metadata at index time.
+-- Rows indexed before this migration keep a NULL classifier and are treated as untagged
+-- ('workflow') by the search query builder.
+ALTER TABLE workflow_index ADD COLUMN classifier TEXT;
+CREATE INDEX workflow_index_classifier_idx ON workflow_index (classifier, start_time);

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAOTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAOTest.java
@@ -366,6 +366,54 @@ public class SqliteIndexDAOTest {
     }
 
     @Test
+    public void testSearchWorkflowSummaryByClassifier() {
+        String correlationId = "classifier-search-correlation-id";
+
+        WorkflowSummary agentWfs = getMockWorkflowSummary("workflow-id-classifier-agent");
+        agentWfs.setCorrelationId(correlationId);
+        agentWfs.setClassifier("agent");
+        indexDAO.indexWorkflow(agentWfs);
+
+        WorkflowSummary plainWfs = getMockWorkflowSummary("workflow-id-classifier-plain");
+        plainWfs.setCorrelationId(correlationId);
+        plainWfs.setClassifier("workflow");
+        indexDAO.indexWorkflow(plainWfs);
+
+        // Simulates a row indexed before the classifier column existed (NULL classifier).
+        WorkflowSummary legacyWfs = getMockWorkflowSummary("workflow-id-classifier-legacy");
+        legacyWfs.setCorrelationId(correlationId);
+        indexDAO.indexWorkflow(legacyWfs);
+
+        String agentQuery =
+                String.format("correlationId='%s' AND classifier='agent'", correlationId);
+        SearchResult<WorkflowSummary> agentResults =
+                indexDAO.searchWorkflowSummary(agentQuery, "*", 0, 15, new ArrayList<>());
+        assertEquals("Wrong number of agent results", 1, agentResults.getResults().size());
+        assertEquals(
+                "Wrong workflow returned",
+                agentWfs.getWorkflowId(),
+                agentResults.getResults().get(0).getWorkflowId());
+
+        // The untagged token must match both explicitly tagged plain workflows and legacy
+        // NULL rows.
+        String workflowQuery =
+                String.format("correlationId='%s' AND classifier='workflow'", correlationId);
+        SearchResult<WorkflowSummary> workflowResults =
+                indexDAO.searchWorkflowSummary(workflowQuery, "*", 0, 15, new ArrayList<>());
+        assertEquals("Wrong number of untagged results", 2, workflowResults.getResults().size());
+
+        String inQuery =
+                String.format("correlationId='%s' AND classifier IN (agent,other)", correlationId);
+        SearchResult<WorkflowSummary> inResults =
+                indexDAO.searchWorkflowSummary(inQuery, "*", 0, 15, new ArrayList<>());
+        assertEquals("Wrong number of IN clause results", 1, inResults.getResults().size());
+
+        indexDAO.removeWorkflow(agentWfs.getWorkflowId());
+        indexDAO.removeWorkflow(plainWfs.getWorkflowId());
+        indexDAO.removeWorkflow(legacyWfs.getWorkflowId());
+    }
+
+    @Test
     public void testFullTextSearchWorkflowSummary() {
         WorkflowSummary wfs = getMockWorkflowSummary("workflow-id");
 

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilderTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilderTest.java
@@ -130,6 +130,69 @@ public class SqliteIndexQueryBuilderTest {
     }
 
     @Test
+    void shouldGenerateQueryForClassifier() throws SQLException {
+        String inputQuery = "classifier=\"agent\"";
+        SqliteIndexQueryBuilder builder =
+                new SqliteIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data FROM table_name WHERE classifier = ? LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        builder.addPagingParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("agent");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldMatchLegacyNullRowsForUntaggedClassifier() throws SQLException {
+        // Rows indexed before the classifier column existed are untagged plain workflows;
+        // filtering for the "workflow" token must also match those NULL rows.
+        String inputQuery = "classifier=\"workflow\"";
+        SqliteIndexQueryBuilder builder =
+                new SqliteIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data FROM table_name WHERE (classifier = ? OR classifier IS NULL) LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        builder.addPagingParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("workflow");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
+    void shouldMatchLegacyNullRowsForUntaggedClassifierInClause() throws SQLException {
+        String inputQuery = "classifier IN (agent,workflow)";
+        SqliteIndexQueryBuilder builder =
+                new SqliteIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data FROM table_name WHERE (classifier IN (?,?) OR classifier IS NULL) LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        builder.addPagingParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("agent");
+        inOrder.verify(mockQuery).addParameter("workflow");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
+    @Test
     void shouldGenerateQueryForParentWorkflowId() throws SQLException {
         String inputQuery = "parentWorkflowId=\"\"";
         SqliteIndexQueryBuilder builder =


### PR DESCRIPTION
## Summary

Adds a **workflow classifier** — a tag that distinguishes kinds of workflow definitions and executions (plain workflows vs AgentSpan agents vs any future kind), derived from `WorkflowDef.metadata`:

1. explicit `metadata.classifier` (non-blank) wins;
2. otherwise `agent` when the AgentSpan stamp (`agent_sdk` / `agentDef`) is present;
3. otherwise `workflow` (plain, untagged def).

This is the OSS equivalent of the classifier support in Orkes Conductor, adapted to the OSS IndexDAO architecture. It pairs with `conductor-agentspan:0.4.2` (agentspan-ai/agentspan#306), which uses it for classifier-based agent filtering.

## Changes

### common
- New `WorkflowClassifier` utility (+ unit tests).
- `WorkflowSummary` gains a `classifier` field (proto field 23), populated at index time from the execution's workflow definition; protos regenerated.

### REST
- `GET /api/metadata/workflow?classifier=agent|workflow|<tag>` — filters definitions by derived classifier.
- `GET /api/workflow/search` and `/search-v2` accept `&classifier=` (comma-separated), folded into the structured query as `classifier IN (...)` — the IndexDAO contract is unchanged, and raw `query=classifier IN (agent)` works too.

### Index backends
- **Postgres**: Flyway `V17` adds a `classifier` column + `(classifier, start_time)` index on `workflow_index`; written on index, whitelisted in `PostgresIndexQueryBuilder`. Filtering for the `workflow` token also matches pre-migration NULL rows.
- **SQLite**: same, via `V5` + `SqliteIndexDAO`/`SqliteIndexQueryBuilder`.
- **ES7 / ES8 / OS v2 / OS v3**: `classifier` keyword mapping on workflow documents (required for ES8's `dynamic: false`); the query parsers pass field names through generically, so no parser changes.

### AgentSpan embedding
- `conductor-agentspan` bumped 0.3.0 → **0.4.2** (first published version with classifier-based agent filtering: `&classifier=` on `/api/agent/executions` and `/api/agent/executions/search`).
- Fixed a packaging gap: nothing put `:conductor-agentspan-server` on the server classpath after the embedded glue was split out of the `ai` module, so the embedded agent endpoints 404'd on a stock build. The module is now included; activation remains gated on `conductor.integrations.ai.enabled`.

## Testing

- Unit tests: `WorkflowClassifierTest`, classifier cases in `PostgresIndexQueryBuilderTest` / `SqliteIndexQueryBuilderTest` (incl. legacy-NULL-row semantics), REST controller tests for the new params.
- Integration: classifier index/search scenarios in `PostgresIndexDAOTest` (Testcontainers) and `SqliteIndexDAOTest`.
- **Live end-to-end** against a local Postgres-backed server with AgentSpan embedded: agent deployed/run via the Python SDK (`agent_sdk` stamp → `classifier=agent`), explicit `metadata.classifier=pipeline` def, untagged def; verified `?classifier=` on `/metadata/workflow`, `&classifier=` and `query=classifier IN (...)` on `/workflow/search`, `/api/agent/list`, `/api/agent/executions?classifier=agent`, `/api/agent/executions/search?classifier=`, and that hand-inserted pre-migration NULL rows match the `workflow` token without leaking into `agent`.
- `spotlessApply` clean; full-repo main+test compilation passes.

## Notes for reviewers

- Untagged executions index the literal `workflow` (never NULL going forward) so filtering is plain equality across every backend; the NULL-handling in the Postgres/SQLite builders exists only for rows indexed before the migration. Pre-existing ES/OS documents won't match classifier filters until re-indexed.
- `search-by-tasks` endpoints are unchanged — classifier is a workflow-level concept.