### PR TITLE
Provider/model filtering only looked at promptName, but chat complete…

### DIFF
--- a/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/LLMTextCompleteTaskForm.tsx
+++ b/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/LLMTextCompleteTaskForm.tsx
@@ -1,7 +1,12 @@
-import { Box } from "@mui/material";
+import { Box, Grid } from "@mui/material";
+import ConductorInput from "components/ui/inputs/ConductorInput";
+import { path as _path } from "lodash/fp";
 import { LLMFormFields } from "pages/definition/EditorPanel/TaskFormTab/forms/LLMFormFields";
 import { UiIntegrationsFieldType } from "types/FormFieldTypes";
-import { fieldsToFieldsFieldsComponents } from "utils/fieldHelpers";
+import {
+  fieldsToFieldsFieldsComponents,
+  updateField,
+} from "utils/fieldHelpers";
 import { ConductorCacheOutput } from "./ConductorCacheOutputForm";
 import { Optional } from "./OptionalFieldForm";
 import TaskFormSection from "./TaskFormSection";
@@ -13,8 +18,6 @@ const modelFields = [
   UiIntegrationsFieldType.MODEL,
 ];
 
-const promptFields = [UiIntegrationsFieldType.PROMPT_NAME];
-
 const fineTuningFields = [
   UiIntegrationsFieldType.TEMPERATURE,
   UiIntegrationsFieldType.TOP_P,
@@ -23,17 +26,19 @@ const fineTuningFields = [
 ];
 
 const modelFieldComponents = fieldsToFieldsFieldsComponents(modelFields);
-const promptFieldComponents = fieldsToFieldsFieldsComponents(promptFields);
 const fineTuningFieldComponents =
   fieldsToFieldsFieldsComponents(fineTuningFields);
 
+// prompt is a plain textarea (below), not the saved-prompt picker (PROMPT_NAME).
+// Enterprise plugins override with the saved AI Prompt picker (see conductor-ui).
 const allFieldComponents = [
   ...modelFieldComponents,
-  ...promptFieldComponents,
   ...fineTuningFieldComponents,
 ];
 
 export const LLMTextCompleteTaskForm = ({ task, onChange }: TaskFormProps) => {
+  const prompt = _path("inputParameters.prompt", task) || "";
+
   return (
     <LLMFormFieldsWrapper
       task={task}
@@ -42,13 +47,26 @@ export const LLMTextCompleteTaskForm = ({ task, onChange }: TaskFormProps) => {
     >
       {(actor) => (
         <Box padding={1} width="100%">
-          <TaskFormSection title="Prompt and Variables">
-            <LLMFormFields
-              task={task}
-              onChange={onChange}
-              fieldFieldComponents={promptFieldComponents}
-              actor={actor}
-            />
+          <TaskFormSection
+            accordionAdditionalProps={{ defaultExpanded: true }}
+            title="Prompt"
+          >
+            <Grid container sx={{ width: "100%" }}>
+              <Grid size={12}>
+                <ConductorInput
+                  label="Prompt"
+                  name="prompt"
+                  value={prompt}
+                  onTextInputChange={(v) =>
+                    onChange(updateField("inputParameters.prompt", v, task))
+                  }
+                  multiline
+                  rows={6}
+                  fullWidth
+                  placeholder="Enter the text prompt to complete..."
+                />
+              </Grid>
+            </Grid>
           </TaskFormSection>
           <TaskFormSection
             accordionAdditionalProps={{ defaultExpanded: true }}

--- a/ui-next/src/utils/fieldHelpers.tsx
+++ b/ui-next/src/utils/fieldHelpers.tsx
@@ -19,6 +19,10 @@ import { PromptDef } from "types/Prompts";
 import { ActorRef, State } from "xstate";
 import { MEDIA_TYPE_SUGGESTIONS } from "./constants/httpSuggestions";
 
+/** LLM text complete stores the prompt in promptName; chat complete uses instructions. */
+const selectedPromptNameFromTask = (task: Partial<TaskDef>) =>
+  task?.inputParameters?.promptName ?? task?.inputParameters?.instructions;
+
 export type FieldComponentType = FunctionComponent<{
   onChange: (t: Partial<TaskDef>) => void;
   actor: ActorRef<LLMFormFieldsEvents>;
@@ -77,7 +81,7 @@ const aiFieldTypes = {
     );
 
     // Filter options based on selected prompt's integrations
-    const selectedPromptName = task?.inputParameters?.promptName;
+    const selectedPromptName = selectedPromptNameFromTask(task);
     const selectedPrompt = promptNameOptions.find(
       (prompt: PromptDef) => prompt.name === selectedPromptName,
     );
@@ -137,7 +141,7 @@ const aiFieldTypes = {
     const selectedProvider = task?.inputParameters?.llmProvider;
 
     // Filter options based on selected prompt's integrations
-    const selectedPromptName = task?.inputParameters?.promptName;
+    const selectedPromptName = selectedPromptNameFromTask(task);
     const selectedPrompt = promptNameOptions.find(
       (prompt: PromptDef) => prompt.name === selectedPromptName,
     );


### PR DESCRIPTION
… stores the selected prompt in instructions. It now checks both, so choosing a prompt correctly narrows the provider and model dropdowns.

Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Aligns OSS LLM task forms with the fact that OSS has no AI Prompt builder. LLM_TEXT_COMPLETE now uses an inline Prompt textarea (inputParameters.prompt) instead of the saved-prompt Prompt Name picker. Also fixes provider/model dropdown filtering when the selected prompt is stored under instructions (chat complete) rather than promptName.

LLM_CHAT_COMPLETE already uses an inline instructions textarea on main; this PR brings Text Complete in line with that pattern.

<img width="1800" height="916" alt="Screenshot 2026-07-09 at 10 50 33 AM" src="https://github.com/user-attachments/assets/5632f3c0-e570-4f5d-9b89-1874a9a562a1" />
<img width="1800" height="926" alt="Screenshot 2026-07-09 at 10 50 43 AM" src="https://github.com/user-attachments/assets/90de3207-a7bf-42ec-98c5-2d5db52606a9" />
