### PR TITLE
Revert the Scheduler Executions schedule-name dropdown back to using the list

### DIFF
--- a/ui-next/src/utils/hooks/useGetSchedulerDefinitions.ts
+++ b/ui-next/src/utils/hooks/useGetSchedulerDefinitions.ts
@@ -5,26 +5,19 @@ import { useQuery } from "react-query";
 import { IScheduleDto, SchedulerSearchResult } from "types/Schedulers";
 import { STALE_TIME_SEARCH, useAuthHeaders } from "utils/query";
 
+const SCHEDULER_PATH = "/scheduler/schedules";
 const SCHEDULER_SEARCH_PATH = "/scheduler/schedules/search?";
-/** Server-side cap for scheduler search page size. */
-const SCHEDULER_SEARCH_MAX_SIZE = 1000;
 
+/** Full schedule list (used by Scheduler Executions name dropdown / similar lookups). */
 export const useGetSchedulerDefinitions = () => {
   const fetchContext = useFetchContext();
   const fetchParams = { headers: useAuthHeaders() };
 
   return useQuery<IScheduleDto[]>(
-    [fetchContext.stack, SCHEDULER_SEARCH_PATH, "all-names"],
-    async () => {
-      const path =
-        SCHEDULER_SEARCH_PATH +
-        qs.stringify({ start: 0, size: SCHEDULER_SEARCH_MAX_SIZE });
-      const result = (await fetchWithContext(
-        path,
-        fetchContext,
-        fetchParams,
-      )) as SchedulerSearchResult | null;
-      return result?.results ?? [];
+    [fetchContext.stack, SCHEDULER_PATH],
+    () => {
+      const path = SCHEDULER_PATH;
+      return fetchWithContext(path, fetchContext, fetchParams);
     },
     {
       enabled: fetchContext.ready,


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Revert the Scheduler Executions schedule-name dropdown back to using the full list