### PR TITLE
LLM Task in workflow definition with both topP and temperature errors for claude and should be null if not defined

### DIFF
--- a/ui-next/src/components/FlatMapForm/ConductorAutocompleteVariables.tsx
+++ b/ui-next/src/components/FlatMapForm/ConductorAutocompleteVariables.tsx
@@ -43,7 +43,8 @@ import { customFilterOptions, VARIABLE_REGEX } from "./formOptions";
 type CohercesToNumber = "integer" | "double";
 
 type TypeCohersionNumber = {
-  onChange: (change: number) => void;
+  /** null when clearEmptyNumberAsNull and the field is cleared */
+  onChange: (change: number | null) => void;
   coerceTo: CohercesToNumber;
 };
 type TypeCohersionString = {
@@ -81,6 +82,11 @@ export type ConductorAutocompleteVariablesProps = {
   disabled?: boolean;
   onInputChange?: (val: any) => void;
   onBlur?: (val: string) => void;
+  /**
+   * When true, clearing a numeric field emits null instead of coercing "" → 0.
+   * Opt-in — default preserves historical behavior for non-LLM forms.
+   */
+  clearEmptyNumberAsNull?: boolean;
   renderOption?: (
     props: HTMLAttributes<HTMLLIElement>,
     option: string | number,
@@ -136,6 +142,7 @@ const ConductorAutocompleteVariablesNoContext = ({
   disabled,
   onInputChange,
   onBlur,
+  clearEmptyNumberAsNull = false,
   renderOption,
   getOptionLabel: customGetOptionLabel,
 }: ConductorAutocompleteVariablesProps) => {
@@ -303,6 +310,13 @@ const ConductorAutocompleteVariablesNoContext = ({
               onChange(b);
             }
           }
+        } else if (
+          clearEmptyNumberAsNull &&
+          assertOnChangeNumber(onChange, coerceTo) &&
+          (_isNil(b) || b === "") &&
+          b !== value
+        ) {
+          (onChange as (val: number | null) => void)(null);
         }
       }}
       onInputChange={(event: any, o) => {
@@ -311,8 +325,12 @@ const ConductorAutocompleteVariablesNoContext = ({
           return;
         }
         if (o !== value) {
-          if (assertOnChangeNumber(onChange, coerceTo) && !isNaN(o as any)) {
-            onChange(Number(o));
+          if (assertOnChangeNumber(onChange, coerceTo)) {
+            if (clearEmptyNumberAsNull && (o === "" || o == null)) {
+              (onChange as (val: number | null) => void)(null);
+            } else if (!isNaN(o as any)) {
+              onChange(Number(o));
+            }
           } else if (assertOnChangeString(onChange, coerceTo)) {
             onChange(String(o));
           } else {

--- a/ui-next/src/components/FlatMapForm/ConductorAutocompleteVariables.tsx
+++ b/ui-next/src/components/FlatMapForm/ConductorAutocompleteVariables.tsx
@@ -291,32 +291,41 @@ const ConductorAutocompleteVariablesNoContext = ({
       }}
       openOnFocus={openOnFocus}
       autoComplete
-      onChange={(a, b) => {
-        if (!_isNil(b) && b !== value) {
-          if (assertOnChangeNumber(onChange, coerceTo) && !isNaN(b as any)) {
-            onChange(Number(b));
-          } else if (assertOnChangeString(onChange, coerceTo)) {
-            if (typeof b === "string") {
-              const newValue = b as string;
-              const currentValue = value.toString();
-              if (currentValue.endsWith("$")) {
-                onChange(replaceLastrDolarWithValue(currentValue, newValue));
-              } else if (VARIABLE_REGEX.test(currentValue)) {
-                onChange(currentValue.replace(VARIABLE_REGEX, newValue));
-              } else {
-                onChange(newValue);
-              }
-            } else {
-              onChange(b);
-            }
-          }
-        } else if (
+      onChange={(_event, selectedValue) => {
+        if (selectedValue === value) return;
+
+        // Must run before numeric coercion: "" is not nil and Number("") === 0.
+        if (
           clearEmptyNumberAsNull &&
           assertOnChangeNumber(onChange, coerceTo) &&
-          (_isNil(b) || b === "") &&
-          b !== value
+          (_isNil(selectedValue) || selectedValue === "")
         ) {
           (onChange as (val: number | null) => void)(null);
+          return;
+        }
+
+        if (!_isNil(selectedValue)) {
+          if (
+            assertOnChangeNumber(onChange, coerceTo) &&
+            !isNaN(selectedValue as any)
+          ) {
+            onChange(Number(selectedValue));
+          } else if (assertOnChangeString(onChange, coerceTo)) {
+            if (typeof selectedValue === "string") {
+              const currentValue = value.toString();
+              if (currentValue.endsWith("$")) {
+                onChange(
+                  replaceLastrDolarWithValue(currentValue, selectedValue),
+                );
+              } else if (VARIABLE_REGEX.test(currentValue)) {
+                onChange(currentValue.replace(VARIABLE_REGEX, selectedValue));
+              } else {
+                onChange(selectedValue);
+              }
+            } else {
+              onChange(selectedValue);
+            }
+          }
         }
       }}
       onInputChange={(event: any, o) => {

--- a/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/LLMFormFields/LLMAutocompleteVariables.tsx
+++ b/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/LLMFormFields/LLMAutocompleteVariables.tsx
@@ -1,0 +1,19 @@
+import {
+  ConductorAutocompleteVariables,
+  ConductorAutocompleteVariablesProps,
+} from "components/FlatMapForm/ConductorAutocompleteVariables";
+
+/**
+ * Autocomplete for optional LLM numeric params (temperature, topP, …).
+ * Clears empty values to null so they are omitted from the task payload —
+ * important for providers like Claude that reject temperature + top_p together,
+ * and that treat 0 differently from "unset".
+ *
+ * Non-LLM forms should keep using {@link ConductorAutocompleteVariables}, which
+ * preserves the historical "" → 0 coercion for numeric fields.
+ */
+export function LLMAutocompleteVariables(
+  props: ConductorAutocompleteVariablesProps,
+) {
+  return <ConductorAutocompleteVariables {...props} clearEmptyNumberAsNull />;
+}

--- a/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/LLMFormFields/LLMFormFieldsWrapper.tsx
+++ b/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/LLMFormFields/LLMFormFieldsWrapper.tsx
@@ -67,20 +67,28 @@ const LLMFormFieldsWrapper = ({
             taskWithVariables,
           );
 
-          // Auto-populate temperature if available in the prompt
+          // Auto-populate sampling params when defined on the prompt.
+          // Claude rejects temperature + top_p together — prefer temperature and clear the other.
           if (maybeAvailablePromptName.temperature != null) {
             taskWithSelectedPromptName = updateField(
               `inputParameters.${UiIntegrationsFieldType.TEMPERATURE}`,
               maybeAvailablePromptName.temperature,
               taskWithSelectedPromptName,
             );
-          }
-
-          // Auto-populate topP if available in the prompt
-          if (maybeAvailablePromptName.topP != null) {
+            taskWithSelectedPromptName = updateField(
+              `inputParameters.${UiIntegrationsFieldType.TOP_P}`,
+              null,
+              taskWithSelectedPromptName,
+            );
+          } else if (maybeAvailablePromptName.topP != null) {
             taskWithSelectedPromptName = updateField(
               `inputParameters.${UiIntegrationsFieldType.TOP_P}`,
               maybeAvailablePromptName.topP,
+              taskWithSelectedPromptName,
+            );
+            taskWithSelectedPromptName = updateField(
+              `inputParameters.${UiIntegrationsFieldType.TEMPERATURE}`,
+              null,
               taskWithSelectedPromptName,
             );
           }
@@ -136,20 +144,28 @@ const LLMFormFieldsWrapper = ({
             taskWithVariables,
           );
 
-          // Auto-populate temperature if available in the prompt
+          // Auto-populate sampling params when defined on the prompt.
+          // Claude rejects temperature + top_p together — prefer temperature and clear the other.
           if (maybeAvailablePromptName.temperature != null) {
             taskWithSelectedPromptName = updateField(
               `inputParameters.${UiIntegrationsFieldType.TEMPERATURE}`,
               maybeAvailablePromptName.temperature,
               taskWithSelectedPromptName,
             );
-          }
-
-          // Auto-populate topP if available in the prompt
-          if (maybeAvailablePromptName.topP != null) {
+            taskWithSelectedPromptName = updateField(
+              `inputParameters.${UiIntegrationsFieldType.TOP_P}`,
+              null,
+              taskWithSelectedPromptName,
+            );
+          } else if (maybeAvailablePromptName.topP != null) {
             taskWithSelectedPromptName = updateField(
               `inputParameters.${UiIntegrationsFieldType.TOP_P}`,
               maybeAvailablePromptName.topP,
+              taskWithSelectedPromptName,
+            );
+            taskWithSelectedPromptName = updateField(
+              `inputParameters.${UiIntegrationsFieldType.TEMPERATURE}`,
+              null,
               taskWithSelectedPromptName,
             );
           }

--- a/ui-next/src/utils/fieldHelpers.tsx
+++ b/ui-next/src/utils/fieldHelpers.tsx
@@ -6,6 +6,7 @@ import MuiTypography from "components/ui/MuiTypography";
 import { path as _path, clone, setWith } from "lodash/fp";
 import { ConductorValueInput } from "pages/definition/EditorPanel/TaskFormTab/forms/ConductorValueInput";
 import { ConductorArrayMapFormBase } from "pages/definition/EditorPanel/TaskFormTab/forms/LLMFormFields/ConductorArrayMapForm";
+import { LLMAutocompleteVariables } from "pages/definition/EditorPanel/TaskFormTab/forms/LLMFormFields/LLMAutocompleteVariables";
 import {
   LLMFormFieldsEvents,
   LLMFormFieldsMachineContext,
@@ -457,7 +458,7 @@ const aiFieldTypes = {
       task,
     );
     return (
-      <ConductorAutocompleteVariables
+      <LLMAutocompleteVariables
         openOnFocus
         onChange={(value) => onChange(setValue(value))}
         value={ipValue}
@@ -472,7 +473,7 @@ const aiFieldTypes = {
       task,
     );
     return (
-      <ConductorAutocompleteVariables
+      <LLMAutocompleteVariables
         openOnFocus
         onChange={(value) => onChange(setValue(value))}
         value={ipValue}


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
- Fix LLM task/prompt sampling params so cleared temperature / topP become null (omitted) instead of 0, which breaks Claude and other providers that treat 0 as set or reject both params together.
- Keep the change LLM-scoped via new LLMAutocompleteVariables (clearEmptyNumberAsNull); shared ConductorAutocompleteVariables retains historical "" → 0 for non-LLM forms.
- When selecting a prompt that defines temperature or topP, prefer temperature and explicitly clear the other to null.