### PR TITLE
Expose AgentHumanTask.emitWaiting as the shared agent-HITL WAITING emitter

### DIFF
--- a/agentspan-server/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentHumanTask.java
+++ b/agentspan-server/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentHumanTask.java
@@ -57,8 +57,28 @@ public class AgentHumanTask extends WorkflowSystemTask {
     @Override
     public void start(WorkflowModel workflow, TaskModel task, WorkflowExecutor workflowExecutor) {
         task.setStatus(TaskModel.Status.IN_PROGRESS);
+        emitWaiting(streamRegistry, workflow, task);
+    }
 
-        // Emit WAITING event immediately
+    /**
+     * Emit the agent-HITL {@code WAITING} SSE event for a HUMAN task, with the {@code pendingTool}
+     * payload built from the task input: {@code tool_name}/{@code parameters}, the normalised
+     * {@code toolCalls} batch (see {@link #extractToolCalls}), and the optional {@code
+     * response_schema}/{@code response_ui_schema} form hints.
+     *
+     * <p>This is the single source of truth for the WAITING payload. Embedding hosts that register
+     * their own {@code HUMAN} system task (e.g. orkes-conductor's {@code OrkesHuman}, which layers
+     * agent HITL onto its human-task subsystem) should delegate here rather than rebuild the
+     * payload, so the event shape cannot drift between hosts.
+     *
+     * <p>Null-safe on {@code streamRegistry} (absent when AgentSpan is not embedded) and never
+     * throws: a streaming failure must not fail the HUMAN task.
+     */
+    public static void emitWaiting(
+            AgentStreamRegistry streamRegistry, WorkflowModel workflow, TaskModel task) {
+        if (streamRegistry == null) {
+            return;
+        }
         String wfId = workflow.getWorkflowId();
         String taskRef = task.getReferenceTaskName();
         Map<String, Object> pendingTool = new HashMap<>();

--- a/agentspan-server/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentHumanTaskTest.java
+++ b/agentspan-server/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentHumanTaskTest.java
@@ -182,4 +182,57 @@ class AgentHumanTaskTest {
 
         assertThat(task.getStatus()).isEqualTo(TaskModel.Status.CANCELED);
     }
+
+    /**
+     * {@code emitWaiting} is the shared entry point for embedding hosts (e.g. orkes-conductor's
+     * {@code OrkesHuman}) that autowire the registry with {@code required = false} — a null
+     * registry must be a silent no-op, not an NPE.
+     */
+    @Test
+    void emitWaitingIsNoOpWithNullRegistry() {
+        WorkflowModel workflow = new WorkflowModel();
+        workflow.setWorkflowId("wf-null-reg");
+        TaskModel task = new TaskModel();
+        task.setReferenceTaskName("hitl");
+
+        assertThatCode(() -> AgentHumanTask.emitWaiting(null, workflow, task))
+                .doesNotThrowAnyException();
+    }
+
+    /**
+     * Hosts delegating to {@code emitWaiting} directly must get the same payload {@code start()}
+     * produces — including the {@code toolCalls} batch, whose omission was exactly the drift this
+     * shared method exists to prevent.
+     */
+    @Test
+    void emitWaitingBuildsFullPendingToolPayload() {
+        WorkflowModel workflow = new WorkflowModel();
+        workflow.setWorkflowId("wf-shared");
+
+        TaskModel task = new TaskModel();
+        task.setReferenceTaskName("agent_approval_human");
+        task.setInputData(
+                Map.of(
+                        "tool_calls",
+                        List.of(
+                                Map.of(
+                                        "name",
+                                        "publish_article",
+                                        "inputParameters",
+                                        Map.of("title", "Test"))),
+                        "response_schema",
+                        Map.of("type", "object")));
+
+        AgentHumanTask.emitWaiting(streamRegistry, workflow, task);
+
+        ArgumentCaptor<AgentSSEEvent> captor = ArgumentCaptor.forClass(AgentSSEEvent.class);
+        verify(streamRegistry).send(eq("wf-shared"), captor.capture());
+        Map<String, Object> pendingTool = captor.getValue().getPendingTool();
+        assertThat(pendingTool).containsEntry("taskRefName", "agent_approval_human");
+        assertThat(pendingTool).containsEntry("response_schema", Map.of("type", "object"));
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> calls = (List<Map<String, Object>>) pendingTool.get("toolCalls");
+        assertThat(calls).hasSize(1);
+        assertThat(calls.get(0)).containsEntry("name", "publish_article");
+    }
 }


### PR DESCRIPTION
## Why

Embedding hosts that register their own `HUMAN` system task — orkes-conductor's `OrkesHuman`, which layers agent HITL onto its human-task subsystem and scan-excludes `AgentHumanTaskConfig` — currently copy `AgentHumanTask`'s WAITING `pendingTool` construction. The copy has already drifted: it dropped the `toolCalls` batch array, so batch tool-approval WAITING events are degraded on that host while OSS emits them correctly.

## What

- Extract the WAITING emission out of `AgentHumanTask.start()` into a public static `AgentHumanTask.emitWaiting(AgentStreamRegistry, WorkflowModel, TaskModel)`:
  - single source of truth for the `pendingTool` payload (`tool_name`/`parameters`, normalised `toolCalls` batch, `response_schema`/`response_ui_schema`, `taskRefName`)
  - null-safe on the registry (hosts autowire it `required = false`) and never throws — a streaming failure must not fail the HUMAN task
- `start()` delegates to it; OSS behavior is unchanged.
- Two new tests: null-registry no-op, and full-payload emission including `toolCalls` (the exact drift this prevents).

A companion orkes-conductor PR switches `OrkesHuman.emitAgentWaiting` to delegate here, deleting its drifted copy.

## Testing

`AgentHumanTaskTest`: 8 tests (6 existing + 2 new), 0 failures. Spotless applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)