### PR TITLE
fix(executor): notify TaskStatusListener on sync system task state change

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
@@ -1845,6 +1845,20 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
                     }
                     startedSystemTasks = true;
                     executionDAOFacade.updateTask(task);
+                    // Synchronous system tasks (e.g. HUMAN) transition their own status inside
+                    // start(...) here in the decide loop, and never reach the
+                    // updateTask(TaskResult)
+                    // hand-off path that notifies the listener. Notify explicitly so status changes
+                    // such as IN_PROGRESS are not silently dropped. See issue #1176.
+                    try {
+                        notifyTaskStatusListener(task);
+                    } catch (Exception e) {
+                        String errorMsg =
+                                String.format(
+                                        "Error while notifying TaskStatusListener: %s for workflow: %s",
+                                        task.getTaskId(), workflow.getWorkflowId());
+                        LOGGER.error(errorMsg, e);
+                    }
                 } else {
                     tasksToBeQueued.add(task);
                 }
@@ -1893,6 +1907,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
             WorkflowSystemTask systemTask, WorkflowModel workflow, TaskModel task) {
         Map<String, Object> literalInput = task.getInputData();
         try {
+            task.setInputData(parametersUtils.substituteSecrets(literalInput));
             task.setInputData(parametersUtils.substituteSecrets(literalInput));
             systemTask.start(workflow, task, this);
         } finally {

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -109,6 +109,11 @@ public class TestWorkflowExecutor {
             return new Wait();
         }
 
+        @Bean(TASK_TYPE_HUMAN)
+        public Human human() {
+            return new Human();
+        }
+
         @Bean("HTTP")
         public WorkflowSystemTask http() {
             return new WorkflowSystemTaskStub("HTTP") {
@@ -343,6 +348,104 @@ public class TestWorkflowExecutor {
         assertTrue(stateChanged);
         assertFalse(httpTask.isStarted());
         assertTrue(http2Task.isStarted());
+    }
+
+    // --- #1176: TaskStatusListener notification for synchronous system tasks ---
+
+    private WorkflowModel newWorkflowForScheduling() {
+        WorkflowModel workflow = new WorkflowModel();
+        workflow.setWorkflowId("wf_1176");
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setName("wf_1176");
+        workflowDef.setVersion(1);
+        workflow.setWorkflowDefinition(workflowDef);
+        return workflow;
+    }
+
+    private TaskModel newScheduledSystemTask(
+            String taskType, String refName, WorkflowModel workflow, IDGenerator idGenerator) {
+        WorkflowTask workflowTask = new WorkflowTask();
+        workflowTask.setType(taskType);
+        workflowTask.setTaskReferenceName(refName);
+
+        TaskModel task = new TaskModel();
+        task.setTaskType(taskType);
+        task.setTaskDefName(taskType);
+        task.setReferenceTaskName(refName);
+        task.setWorkflowInstanceId(workflow.getWorkflowId());
+        task.setCorrelationId(workflow.getCorrelationId());
+        task.setScheduledTime(System.currentTimeMillis());
+        task.setTaskId(idGenerator.generate());
+        task.setInputData(new HashMap<>());
+        task.setStatus(TaskModel.Status.SCHEDULED);
+        task.setRetryCount(0);
+        task.setWorkflowTask(workflowTask);
+        return task;
+    }
+
+    /**
+     * #1176: a synchronous HUMAN task transitions to IN_PROGRESS inside start() during
+     * scheduleTask, and must notify the TaskStatusListener of that transition (previously dropped).
+     */
+    @Test
+    public void testScheduleTaskNotifiesListenerForSyncHumanInProgress() {
+        IDGenerator idGenerator = new IDGenerator();
+        WorkflowModel workflow = newWorkflowForScheduling();
+        TaskModel human =
+                newScheduledSystemTask(TASK_TYPE_HUMAN, "human_ref", workflow, idGenerator);
+
+        List<TaskModel> tasks = new LinkedList<>();
+        tasks.add(human);
+        when(executionDAOFacade.createTasks(tasks)).thenReturn(tasks);
+
+        workflowExecutor.scheduleTask(workflow, tasks);
+
+        assertEquals(TaskModel.Status.IN_PROGRESS, human.getStatus());
+        verify(taskStatusListener, times(1)).onTaskInProgressIfEnabled(human);
+        verify(taskStatusListener, never()).onTaskCompletedIfEnabled(any());
+    }
+
+    /**
+     * #1176: notifyTaskStatusListener dispatches by current status. A synchronous system task that
+     * reaches a terminal status directly inside start() must fire the terminal event (COMPLETED),
+     * not IN_PROGRESS. The HTTP2 stub is synchronous and sets COMPLETED in start().
+     */
+    @Test
+    public void testScheduleTaskNotifiesListenerForSyncTaskCompletingImmediately() {
+        IDGenerator idGenerator = new IDGenerator();
+        WorkflowModel workflow = newWorkflowForScheduling();
+        TaskModel task = newScheduledSystemTask("HTTP2", "http2_ref", workflow, idGenerator);
+
+        List<TaskModel> tasks = new LinkedList<>();
+        tasks.add(task);
+        when(executionDAOFacade.createTasks(tasks)).thenReturn(tasks);
+
+        workflowExecutor.scheduleTask(workflow, tasks);
+
+        assertEquals(TaskModel.Status.COMPLETED, task.getStatus());
+        verify(taskStatusListener, times(1)).onTaskCompletedIfEnabled(task);
+        verify(taskStatusListener, never()).onTaskInProgressIfEnabled(any());
+    }
+
+    /**
+     * #1176: the fix only covers the synchronous branch. Asynchronous system tasks are queued and
+     * notified later via their own execution path, so scheduleTask must not fire IN_PROGRESS /
+     * COMPLETED notifications for them (guards against double notification). HTTP stub is async.
+     */
+    @Test
+    public void testScheduleTaskDoesNotNotifyListenerForAsyncSystemTask() {
+        IDGenerator idGenerator = new IDGenerator();
+        WorkflowModel workflow = newWorkflowForScheduling();
+        TaskModel task = newScheduledSystemTask("HTTP", "http_ref", workflow, idGenerator);
+
+        List<TaskModel> tasks = new LinkedList<>();
+        tasks.add(task);
+        when(executionDAOFacade.createTasks(tasks)).thenReturn(tasks);
+
+        workflowExecutor.scheduleTask(workflow, tasks);
+
+        verify(taskStatusListener, never()).onTaskInProgressIfEnabled(any());
+        verify(taskStatusListener, never()).onTaskCompletedIfEnabled(any());
     }
 
     @Test(expected = TerminateWorkflowException.class)


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix

Changes in this PR
----
A synchronous system task (`HUMAN` is the canonical one) sets its own status to `IN_PROGRESS` inside `start()` while it is being scheduled. That branch of `scheduleTask()` persists the task with `executionDAOFacade.updateTask(task)` but never calls `notifyTaskStatusListener`, which today only runs on the `updateTask(TaskResult)` hand-off and the cancel path. So a registered `TaskStatusListener` never sees `onTaskInProgress` for a HUMAN task, even though it does get the terminal `COMPLETED` event later (that arrives via `POST /api/tasks`). The result is a listener that reports the end of a wait but not the start of it.

This notifies the listener right after the task is persisted in the synchronous branch of `scheduleTask()`. `notifyTaskStatusListener` already dispatches by the task's current status, so it also fires the correct terminal event for a sync task that reaches a terminal status directly inside `start()`, and it stays a no-op for `SCHEDULED`.

Added tests in `TestWorkflowExecutor`:
- a sync HUMAN task fires `onTaskInProgress` once
- a sync task that completes inside `start()` fires `onTaskCompleted`, not `onTaskInProgress`
- an async system task is not notified from `scheduleTask` (it is queued and notified on its own path), so there is no double notification

Fixes #1176

Alternatives considered
----
The same gap exists in `AsyncSystemTaskExecutor.executeSystemTask()`, which also transitions a task to `IN_PROGRESS` and persists it without notifying the listener. It has no `TaskStatusListener` dependency today, so wiring it up is a larger change. I left it out of this PR to keep the fix focused on the sync path, but I'm happy to extend it here or in a follow-up if you'd prefer.
