### PR TITLE
fix(ui-next): Agent Executions page shows plain workflow executions

### DIFF
--- a/ui-next/src/pages/agent/executions/workflowSearchComponents/AdvancedSearch.tsx
+++ b/ui-next/src/pages/agent/executions/workflowSearchComponents/AdvancedSearch.tsx
@@ -209,6 +209,9 @@ export default function AdvancedSearch({
       sort,
       query: queryFT.query,
       freeText: queryFT.freeText,
+      // Scope results to a single classifier: "workflow" for plain workflow
+      // executions, "agent" for AgentSpan agent runs on the Agents pages.
+      classifier: "agent",
       topLevelOnly: hideSubWorkflows,
     },
     {},

--- a/ui-next/src/pages/agent/executions/workflowSearchComponents/BasicSearch.tsx
+++ b/ui-next/src/pages/agent/executions/workflowSearchComponents/BasicSearch.tsx
@@ -279,6 +279,9 @@ export default function BasicSearch({
       sort,
       query: queryFT.query,
       freeText: queryFT.freeText,
+      // Scope results to a single classifier: "workflow" for plain workflow
+      // executions, "agent" for AgentSpan agent runs on the Agents pages.
+      classifier: "agent",
       topLevelOnly: hideSubWorkflows,
     },
     {},


### PR DESCRIPTION
## Problem

The Agent Executions page lists every workflow execution, not just agent runs — plain workflows (smoke tests, traditional workflows, wrapper workflows that merely contain an AGENT task) appear alongside AgentSpan agent executions. Since those rows are plain workflows, they also render with the classic workflow view when opened, which makes the page look inconsistent.

The engine already stamps every indexed execution with a `classifier` (`agent` for AgentSpan-compiled runs, `workflow` for plain ones), and `/api/workflow/search` already supports scoping via the `classifier` request param. The plain Workflow executions page uses it (`classifier="workflow"`), but the Agent Executions search components (ported in #1293) never set it — so the page queried everything.

## Fix

Pass `classifier: "agent"` in the search object in both `BasicSearch` and `AdvancedSearch` under `pages/agent/executions/`, mirroring the workflow page. One-line change in each, same comment style.

## Verification

- `pnpm typecheck` and prettier pass.
- Against a live server whose index holds 15 mixed executions (6 top-level agent runs, 2 agent sub-runs, plain workflows incl. nested subs and wrappers), the exact request the page now sends — `/api/workflow/search?...&classifier=agent&topLevelOnly=true` — returns exactly the 6 top-level agent runs (`t2_langgraph_llm`, `t3_adk_haiku_agent`, `t4_agent_sdk_smoke` ×2, `t5_orchestrator`, `t5_summarizer`); smoke tests, `t1_*` traditional workflows, and wrapper workflows no longer appear. Toggling "Hide sub-agent executions" off adds only the 2 agent sub-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)