### PR TITLE
fix: strip iteration suffix from DO_WHILE task ref in loopCondition context

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
@@ -515,7 +515,12 @@ public class DoWhile extends WorkflowSystemTask {
                         workflow,
                         task.getTaskId(),
                         taskDefinition);
-        conditionInput.put(task.getReferenceTaskName(), task.getOutputData());
+        // Strip iteration suffix (e.g. "dwdw_inner__1" → "dwdw_inner") so that
+        // $.taskRef in the loopCondition resolves correctly when this DO_WHILE is
+        // nested inside another DO_WHILE whose iteration suffix is appended at runtime.
+        conditionInput.put(
+                TaskUtils.removeIterationFromTaskRefName(task.getReferenceTaskName()),
+                task.getOutputData());
         List<TaskModel> loopOver =
                 workflow.getTasks().stream()
                         .filter(


### PR DESCRIPTION
Fixes #1307.

## Problem

When a `DO_WHILE` task is nested inside another `DO_WHILE`, the inner loop's
`loopCondition` evaluation throws:

```
TypeError: Cannot read property 'iteration' of undefined
```

`DoWhile.java::evaluateCondition()` builds the condition-input map by calling:

```java
conditionInput.put(task.getReferenceTaskName(), task.getOutputData());
```

At runtime, a nested DO_WHILE task has its outer iteration suffix appended to its
reference name (e.g. `inner__1` instead of `inner`). The `loopCondition` expression
references the bare name (`$.inner['iteration']`), so the lookup returns `undefined`
and the expression throws.

## Fix

Apply `TaskUtils.removeIterationFromTaskRefName()` — the same helper already used
for loop body tasks in lines 534-536 of the same method — to the self-entry:

```java
// Before
conditionInput.put(task.getReferenceTaskName(), task.getOutputData());

// After
conditionInput.put(
    TaskUtils.removeIterationFromTaskRefName(task.getReferenceTaskName()),
    task.getOutputData());
```

One-line change, no new imports (TaskUtils is already imported).

## User impact

First-time and experienced users writing nested DO_WHILE workflows would hit an
opaque TypeError and have no path to fix it (the `loopCondition` syntax was
correct; the engine was at fault). After this fix, nested DO_WHILE loops with
correct `loopCondition` expressions evaluate cleanly.

## Test

Reproducible with the `ks_combo_do_while_do_while` workflow in
[conductor-oss/conductor-test-harness](https://github.com/nthmost-orkes/conductor-test-harness)
kitchen-sink battery. With this fix deployed, the nested DO_WHILE runs to
COMPLETED correctly (outer=1 iteration).

Note: A companion bug (#1308) exists where outer>1 iterations cause body-task
naming collisions. That is a separate, deeper issue.