### PR TITLE
fix(ui-next): agent execution renders terminal-failed tasks as running

### DIFF
--- a/ui-next/src/pages/execution/AgentExecution/agentExecutionUtils.test.ts
+++ b/ui-next/src/pages/execution/AgentExecution/agentExecutionUtils.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isFailedTaskStatus,
+  mapTaskStatus,
+  taskSuccess,
+} from "./agentExecutionUtils";
+import { AgentStatus } from "./types";
+
+// Regression coverage for issue #4260: a FAILED_WITH_TERMINAL_ERROR task (and
+// the other terminal-failure statuses) previously fell through to RUNNING,
+// rendering a perpetual "running" chip + spinner for an already-failed task.
+
+describe("mapTaskStatus", () => {
+  it("maps COMPLETED to COMPLETED", () => {
+    expect(mapTaskStatus("COMPLETED")).toBe(AgentStatus.COMPLETED);
+  });
+
+  it.each([
+    "FAILED",
+    "FAILED_WITH_TERMINAL_ERROR",
+    "TIMED_OUT",
+    "CANCELED",
+  ])("maps terminal-failure status %s to FAILED", (status) => {
+    expect(mapTaskStatus(status)).toBe(AgentStatus.FAILED);
+  });
+
+  it.each(["IN_PROGRESS", "SCHEDULED", "PENDING"])(
+    "maps in-progress status %s to RUNNING",
+    (status) => {
+      expect(mapTaskStatus(status)).toBe(AgentStatus.RUNNING);
+    },
+  );
+
+  it("does not fall through to RUNNING for unknown/other terminal statuses", () => {
+    expect(mapTaskStatus("SKIPPED")).toBe(AgentStatus.FAILED);
+    expect(mapTaskStatus("COMPLETED_WITH_ERRORS")).toBe(AgentStatus.FAILED);
+    expect(mapTaskStatus("SOME_FUTURE_STATUS")).toBe(AgentStatus.FAILED);
+  });
+});
+
+describe("taskSuccess", () => {
+  it("returns true for COMPLETED", () => {
+    expect(taskSuccess("COMPLETED")).toBe(true);
+  });
+
+  it.each([
+    "FAILED",
+    "FAILED_WITH_TERMINAL_ERROR",
+    "TIMED_OUT",
+    "CANCELED",
+  ])("returns false for terminal-failure status %s", (status) => {
+    expect(taskSuccess(status)).toBe(false);
+  });
+
+  it.each(["IN_PROGRESS", "SCHEDULED", "PENDING"])(
+    "returns undefined (spinner) for in-progress status %s",
+    (status) => {
+      expect(taskSuccess(status)).toBeUndefined();
+    },
+  );
+
+  it("never returns undefined (perpetual spinner) for a terminal status", () => {
+    expect(taskSuccess("SKIPPED")).toBe(false);
+    expect(taskSuccess("COMPLETED_WITH_ERRORS")).toBe(false);
+    expect(taskSuccess("NULL")).toBe(false);
+  });
+});
+
+describe("isFailedTaskStatus", () => {
+  it.each([
+    "FAILED",
+    "FAILED_WITH_TERMINAL_ERROR",
+    "TIMED_OUT",
+    "CANCELED",
+  ])("treats %s as a terminal failure", (status) => {
+    expect(isFailedTaskStatus(status)).toBe(true);
+  });
+
+  it.each(["COMPLETED", "IN_PROGRESS", "SCHEDULED", "SKIPPED"])(
+    "does not treat %s as a terminal failure",
+    (status) => {
+      expect(isFailedTaskStatus(status)).toBe(false);
+    },
+  );
+});

--- a/ui-next/src/pages/execution/AgentExecution/agentExecutionUtils.ts
+++ b/ui-next/src/pages/execution/AgentExecution/agentExecutionUtils.ts
@@ -133,11 +133,40 @@ function toMs(value: string | number | undefined | null): number {
   return typeof value === "number" ? value : parseInt(value, 10) || 0;
 }
 
+/** Task statuses Conductor considers terminal failures (no further progress). */
+const FAILED_TASK_STATUSES = new Set([
+  "FAILED",
+  "FAILED_WITH_TERMINAL_ERROR",
+  "TIMED_OUT",
+  "CANCELED",
+]);
+
+/** Task statuses that are still actively progressing (caller shows a spinner). */
+const IN_PROGRESS_TASK_STATUSES = new Set([
+  "IN_PROGRESS",
+  "SCHEDULED",
+  "PENDING",
+]);
+
+/**
+ * Whether a task status represents a terminal failure. Use this instead of
+ * comparing against the literal "FAILED" — Conductor has several terminal
+ * failure statuses (FAILED_WITH_TERMINAL_ERROR, TIMED_OUT, CANCELED) and
+ * treating only "FAILED" as failed leaves the others rendering as running.
+ */
+export function isFailedTaskStatus(status: string): boolean {
+  return FAILED_TASK_STATUSES.has(status);
+}
+
 /** Maps task status to a tri-state success flag: true=completed, false=failed, undefined=in-progress */
-function taskSuccess(status: string): boolean | undefined {
+export function taskSuccess(status: string): boolean | undefined {
   if (status === "COMPLETED") return true;
-  if (status === "FAILED" || status === "TIMED_OUT") return false;
-  return undefined; // IN_PROGRESS → caller shows spinner
+  if (FAILED_TASK_STATUSES.has(status)) return false;
+  if (IN_PROGRESS_TASK_STATUSES.has(status)) return undefined; // caller shows spinner
+  // Any other terminal status (SKIPPED, COMPLETED_WITH_ERRORS, NULL, or an
+  // unknown future status) is treated as not-in-progress so the UI never shows
+  // a perpetual spinner for a task the backend has already finished.
+  return false;
 }
 
 /**
@@ -195,16 +224,24 @@ function buildAllAttempts(
   );
 }
 
-function mapTaskStatus(status: string): AgentStatus {
+export function mapTaskStatus(status: string): AgentStatus {
   switch (status) {
     case "COMPLETED":
       return AgentStatus.COMPLETED;
     case "FAILED":
+    case "FAILED_WITH_TERMINAL_ERROR":
+    case "TIMED_OUT":
+    case "CANCELED":
       return AgentStatus.FAILED;
     case "IN_PROGRESS":
+    case "SCHEDULED":
+    case "PENDING":
       return AgentStatus.RUNNING;
     default:
-      return AgentStatus.RUNNING;
+      // Unknown/other terminal statuses (e.g. SKIPPED, COMPLETED_WITH_ERRORS)
+      // must not fall through to RUNNING — that renders a perpetual "running"
+      // chip + spinner for a task the backend has already finished (issue #4260).
+      return AgentStatus.FAILED;
   }
 }
 
@@ -815,7 +852,7 @@ export function transformWorkflowExecutionToAgentRun(
         const idData = (toolTask.inputData ?? {}) as Record<string, unknown>;
         const od = (toolTask.outputData ?? {}) as Record<string, unknown>;
         const toolName = toolTask.taskType;
-        const failed = toolTask.status === "FAILED";
+        const failed = isFailedTaskStatus(toolTask.status);
         const toolDuration =
           toolTask.endTime && toolTask.startTime
             ? toolTask.endTime - toolTask.startTime
@@ -1038,7 +1075,7 @@ export function transformWorkflowExecutionToAgentRun(
         iterTasks.some((t) => t.status === "IN_PROGRESS");
       const anyFailed =
         subStatuses.includes(AgentStatus.FAILED) ||
-        iterTasks.some((t) => t.status === "FAILED");
+        iterTasks.some((t) => isFailedTaskStatus(t.status));
       const turnStatus = anyRunning
         ? AgentStatus.RUNNING
         : anyFailed
@@ -1257,7 +1294,7 @@ export function transformWorkflowExecutionToAgentRun(
         // Root-level tool worker task (no DO_WHILE iteration suffix)
         const od = (task.outputData ?? {}) as Record<string, unknown>;
         const idData = (task.inputData ?? {}) as Record<string, unknown>;
-        const failed = task.status === "FAILED";
+        const failed = isFailedTaskStatus(task.status);
         const dur =
           task.endTime && task.startTime ? task.endTime - task.startTime : 0;
         const cleanInput = Object.fromEntries(


### PR DESCRIPTION
## Summary

The Agent Execution view renders a task as **RUNNING** (chip + spinner) even after it has terminally failed, because the status mappers in `ui-next/src/pages/execution/AgentExecution/agentExecutionUtils.ts` only special-cased the literal `"FAILED"` task status.

Conductor emits several terminal-failure task statuses — `FAILED`, `FAILED_WITH_TERMINAL_ERROR`, `TIMED_OUT`, `CANCELED`. Only `FAILED` (and `TIMED_OUT` in `taskSuccess`) were handled; the rest fell through to the `default` branch:

- `mapTaskStatus(...) default → AgentStatus.RUNNING` → perpetual "running" chip
- `taskSuccess(...) → undefined` → perpetual spinner

So an agent whose LLM task ends in `FAILED_WITH_TERMINAL_ERROR` (e.g. an unresolvable model) shows the workflow as FAILED but the task as **running forever**.

Reported downstream as orkes-io/conductor-ui#4260. Verified against a real failed execution: the backend correctly returns workflow `FAILED` + task `FAILED_WITH_TERMINAL_ERROR`; the defect is purely in this UI mapping.

## Changes

- **`mapTaskStatus`**: map all terminal-failure statuses (`FAILED`, `FAILED_WITH_TERMINAL_ERROR`, `TIMED_OUT`, `CANCELED`) → `FAILED`; restrict `RUNNING` to genuinely-active statuses (`IN_PROGRESS`, `SCHEDULED`, `PENDING`); **default now returns `FAILED`** so an unmapped/future status can never again render a perpetual spinner.
- **`taskSuccess`**: same terminal-vs-active classification; only active statuses return `undefined` (spinner), every terminal status returns a concrete flag.
- Extract **`isFailedTaskStatus()`** and use it at the three remaining `status === "FAILED"` tool/iteration sites (they had the same blind spot).
- Add `agentExecutionUtils.test.ts` covering every task status.

## Verification

- `vitest run` new tests — 26/26 pass
- `tsc --noEmit` — clean
- `eslint --quiet` on changed files — clean
- `vite build` — green