### PR TITLE
fix(core): persist start marker before async system task execution to stop sweeper repair race

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -152,6 +152,16 @@ public class AsyncSystemTaskExecutor {
                 task.incrementPollCount();
             }
 
+            if (task.getStatus() == TaskModel.Status.SCHEDULED) {
+                task.setStartTime(System.currentTimeMillis());
+                Monitors.recordQueueWaitTime(task.getTaskType(), task.getQueueWaitTime());
+                // Persist the start marker before running the task. The queue message is already
+                // acked, so until this write the task is indistinguishable from an orphaned one;
+                // the sweeper would repush it mid-execution and the task would run twice. Must
+                // happen before secrets substitution so resolved secrets are never persisted.
+                persistStartMarkerQuietly(task);
+            }
+
             if (task.getStatus() == TaskModel.Status.SCHEDULED
                     || task.getStatus() == TaskModel.Status.IN_PROGRESS) {
                 Map<String, Object> literalInput = task.getInputData();
@@ -166,8 +176,6 @@ public class AsyncSystemTaskExecutor {
                 task.setInputData(parametersUtils.substituteSecrets(literalInput));
                 try {
                     if (task.getStatus() == TaskModel.Status.SCHEDULED) {
-                        task.setStartTime(System.currentTimeMillis());
-                        Monitors.recordQueueWaitTime(task.getTaskType(), task.getQueueWaitTime());
                         systemTask.start(workflow, task, workflowExecutor);
                     } else {
                         systemTask.execute(workflow, task, workflowExecutor);
@@ -219,6 +227,19 @@ public class AsyncSystemTaskExecutor {
             if (hasTaskExecutionCompleted) {
                 workflowExecutor.decide(workflowId);
             }
+        }
+    }
+
+    private void persistStartMarkerQuietly(TaskModel task) {
+        try {
+            executionDAOFacade.updateTask(task);
+        } catch (Exception e) {
+            // A failed marker write must not block execution; the worst case is the legacy
+            // behavior (sweeper may repush the task while it runs).
+            LOGGER.warn(
+                    "Could not persist start marker for task: {} before execution",
+                    task.getTaskId(),
+                    e);
         }
     }
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -159,7 +159,7 @@ public class AsyncSystemTaskExecutor {
                 // acked, so until this write the task is indistinguishable from an orphaned one;
                 // the sweeper would repush it mid-execution and the task would run twice. Must
                 // happen before secrets substitution so resolved secrets are never persisted.
-                persistStartMarkerQuietly(task);
+                executionDAOFacade.updateTask(task);
             }
 
             if (task.getStatus() == TaskModel.Status.SCHEDULED
@@ -227,19 +227,6 @@ public class AsyncSystemTaskExecutor {
             if (hasTaskExecutionCompleted) {
                 workflowExecutor.decide(workflowId);
             }
-        }
-    }
-
-    private void persistStartMarkerQuietly(TaskModel task) {
-        try {
-            executionDAOFacade.updateTask(task);
-        } catch (Exception e) {
-            // A failed marker write must not block execution; the worst case is the legacy
-            // behavior (sweeper may repush the task while it runs).
-            LOGGER.warn(
-                    "Could not persist start marker for task: {} before execution",
-                    task.getTaskId(),
-                    e);
         }
     }
 

--- a/core/src/main/java/org/conductoross/conductor/core/execution/SweeperProperties.java
+++ b/core/src/main/java/org/conductoross/conductor/core/execution/SweeperProperties.java
@@ -27,4 +27,13 @@ import lombok.ToString;
 public class SweeperProperties {
     private int sweepBatchSize = 2;
     private int queuePopTimeout = 100;
+
+    /**
+     * Grace period (ms) during which a system task whose execution has started (persisted
+     * startTime) is not repaired even if its queue message is missing. The message is acked before
+     * the task executes, so a missing message plus a recent startTime means "in flight", not
+     * "orphaned"; repushing it would double-execute the task. Size above the worst-case system
+     * task execution time. 0 disables the grace (legacy behavior).
+     */
+    private long startedTaskRepairGraceMillis = 60_000;
 }

--- a/core/src/main/java/org/conductoross/conductor/core/execution/WorkflowSweeper.java
+++ b/core/src/main/java/org/conductoross/conductor/core/execution/WorkflowSweeper.java
@@ -105,6 +105,16 @@ public class WorkflowSweeper extends LifecycleAwareComponent {
                 if (systemTaskRegistry.isSystemTask(task.getTaskType())) { // If system task
                     WorkflowSystemTask workflowSystemTask =
                             systemTaskRegistry.get(task.getTaskType());
+                    // The queue message is acked before the task executes, and the task row is
+                    // only moved past SCHEDULED after execution finishes. A persisted startTime
+                    // within the grace window therefore means the task is in flight on some
+                    // worker; repushing its message now would execute it a second time.
+                    long graceMillis = sweeperProperties.getStartedTaskRepairGraceMillis();
+                    if (graceMillis > 0
+                            && task.getStartTime() > 0
+                            && clock.millis() - task.getStartTime() < graceMillis) {
+                        return false;
+                    }
                     return workflowSystemTask.isAsync()
                             && (!workflowSystemTask.isAsyncComplete(task)
                                     || (workflowSystemTask.isAsyncComplete(task)

--- a/core/src/main/java/org/conductoross/conductor/core/execution/WorkflowSweeper.java
+++ b/core/src/main/java/org/conductoross/conductor/core/execution/WorkflowSweeper.java
@@ -68,6 +68,7 @@ public class WorkflowSweeper extends LifecycleAwareComponent {
     private final ExecutionLockService executionLockService;
     private final Clock clock = Clock.systemDefaultZone();
     private AtomicBoolean stop = new AtomicBoolean(false);
+    private final Predicate<TaskModel> isTaskRepairable;
 
     public WorkflowSweeper(
             @Qualifier(SWEEPER_EXECUTOR_NAME) Executor sweeperExecutor,
@@ -89,45 +90,44 @@ public class WorkflowSweeper extends LifecycleAwareComponent {
         this.systemTaskRegistry = systemTaskRegistry;
         this.objectMapper = objectMapper;
         this.executionLockService = executionLockService;
+        /*
+        For system task -> Verify the task isAsync() and not isAsyncComplete() or isAsyncComplete() in SCHEDULED state,
+        and in SCHEDULED or IN_PROGRESS state. (Example: SUB_WORKFLOW tasks in SCHEDULED state)
+        For simple task -> Verify the task is in SCHEDULED state.
+        */
+        this.isTaskRepairable =
+                task -> {
+                    if (systemTaskRegistry.isSystemTask(task.getTaskType())) { // If system task
+                        WorkflowSystemTask workflowSystemTask =
+                                systemTaskRegistry.get(task.getTaskType());
+                        // The queue message is acked before the task executes, and the task row is
+                        // only moved past SCHEDULED after execution finishes. A persisted startTime
+                        // within the grace window therefore means the task is in flight on some
+                        // worker; repushing its message now would execute it a second time.
+                        long graceMillis = sweeperProperties.getStartedTaskRepairGraceMillis();
+                        if (graceMillis > 0
+                                && task.getStartTime() > 0
+                                && clock.millis() - task.getStartTime() < graceMillis) {
+                            return false;
+                        }
+                        return workflowSystemTask.isAsync()
+                                && (!workflowSystemTask.isAsyncComplete(task)
+                                        || (workflowSystemTask.isAsyncComplete(task)
+                                                && task.getStatus() == TaskModel.Status.SCHEDULED))
+                                && (task.getStatus() == TaskModel.Status.IN_PROGRESS
+                                        || task.getStatus() == TaskModel.Status.SCHEDULED);
+                    } else { // Else if simple task or wait task
+                        return (task.getStatus() == TaskModel.Status.SCHEDULED
+                                || (!task.getStatus().isTerminal()
+                                        && task.getWaitTimeout() > 0
+                                        && (clock.millis() - task.getWaitTimeout() > 1000)));
+                    }
+                };
         log.info("Initializing sweeper with {} threads", properties.getSweeperThreadCount());
         for (int i = 0; i < properties.getSweeperThreadCount(); i++) {
             sweeperExecutor.execute(this::pollAndSweep);
         }
     }
-
-    /*
-    For system task -> Verify the task isAsync() and not isAsyncComplete() or isAsyncComplete() in SCHEDULED state,
-    and in SCHEDULED or IN_PROGRESS state. (Example: SUB_WORKFLOW tasks in SCHEDULED state)
-    For simple task -> Verify the task is in SCHEDULED state.
-    */
-    private final Predicate<TaskModel> isTaskRepairable =
-            task -> {
-                if (systemTaskRegistry.isSystemTask(task.getTaskType())) { // If system task
-                    WorkflowSystemTask workflowSystemTask =
-                            systemTaskRegistry.get(task.getTaskType());
-                    // The queue message is acked before the task executes, and the task row is
-                    // only moved past SCHEDULED after execution finishes. A persisted startTime
-                    // within the grace window therefore means the task is in flight on some
-                    // worker; repushing its message now would execute it a second time.
-                    long graceMillis = sweeperProperties.getStartedTaskRepairGraceMillis();
-                    if (graceMillis > 0
-                            && task.getStartTime() > 0
-                            && clock.millis() - task.getStartTime() < graceMillis) {
-                        return false;
-                    }
-                    return workflowSystemTask.isAsync()
-                            && (!workflowSystemTask.isAsyncComplete(task)
-                                    || (workflowSystemTask.isAsyncComplete(task)
-                                            && task.getStatus() == TaskModel.Status.SCHEDULED))
-                            && (task.getStatus() == TaskModel.Status.IN_PROGRESS
-                                    || task.getStatus() == TaskModel.Status.SCHEDULED);
-                } else { // Else if simple task or wait task
-                    return (task.getStatus() == TaskModel.Status.SCHEDULED
-                            || (!task.getStatus().isTerminal()
-                                    && task.getWaitTimeout() > 0
-                                    && (clock.millis() - task.getWaitTimeout() > 1000)));
-                }
-            };
 
     private void pollAndSweep() {
         try {

--- a/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
@@ -249,7 +249,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         then:
         1 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
-        1 * executionDAOFacade.updateTask(task)
+        2 * executionDAOFacade.updateTask(task) // 1st call persists the start marker, 2nd the result
         1 * queueDAO.postpone(queueName, taskId, task.workflowPriority, properties.systemTaskWorkerCallbackDuration.seconds)
         1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.IN_PROGRESS }
 
@@ -277,7 +277,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         then:
         1 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
-        1 * executionDAOFacade.updateTask(task)
+        2 * executionDAOFacade.updateTask(task) // 1st call persists the start marker, 2nd the result
 
         1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.COMPLETED }
         1 * queueDAO.remove(queueName, taskId)
@@ -303,7 +303,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         then:
         1 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
-        1 * executionDAOFacade.updateTask(task)
+        2 * executionDAOFacade.updateTask(task) // 1st call persists the start marker, 2nd the result
 
         // simulating a "start" failure that happens after the Task object is modified
         // the modification will be persisted
@@ -335,7 +335,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         then:
         1 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
-        1 * executionDAOFacade.updateTask(task) // 1st call for pollCount, 2nd call for status update
+        2 * executionDAOFacade.updateTask(task) // 1st call persists the start marker, 2nd the result
 
         1 * workflowSystemTask.isAsyncComplete(task) >> true
         1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.IN_PROGRESS }
@@ -434,6 +434,60 @@ class AsyncSystemTaskExecutorTest extends Specification {
         seenDuringStart == resolved
         // ...and afterwards the literal is restored for persistence
         task.getInputData() == literal
+    }
+
+    def "start marker is persisted before the system task starts and with literal input"() {
+        given:
+        String workflowId = "workflowId"
+        String taskId = "taskId"
+        def literal = [pwd: '${workflow.secrets.DB_PASSWORD}'] as Map
+        TaskModel task = new TaskModel(taskType: "type1", status: TaskModel.Status.SCHEDULED, taskId: taskId,
+                workflowInstanceId: workflowId, taskDefName: "taskDefName", workflowPriority: 10)
+        task.setInputData(literal)
+        WorkflowModel workflow = new WorkflowModel(workflowId: workflowId, status: WorkflowModel.Status.RUNNING)
+        workflowSystemTask.getEvaluationOffset(task, 1) >> Optional.empty()
+
+        when:
+        executor.execute(workflowSystemTask, taskId)
+
+        then:
+        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
+
+        then: // the start marker write: before start(), still SCHEDULED, unsubstituted input
+        1 * executionDAOFacade.updateTask(task) >> { TaskModel t ->
+            assert t.status == TaskModel.Status.SCHEDULED
+            assert t.startTime != 0
+            assert t.pollCount == 1
+            assert t.getInputData() == literal
+        }
+
+        then:
+        1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.IN_PROGRESS }
+
+        then: // the result write
+        1 * executionDAOFacade.updateTask(task)
+    }
+
+    def "start marker persistence failure does not prevent the system task from running"() {
+        given:
+        String workflowId = "workflowId"
+        String taskId = "taskId"
+        TaskModel task = new TaskModel(taskType: "type1", status: TaskModel.Status.SCHEDULED, taskId: taskId,
+                workflowInstanceId: workflowId, taskDefName: "taskDefName", workflowPriority: 10)
+        WorkflowModel workflow = new WorkflowModel(workflowId: workflowId, status: WorkflowModel.Status.RUNNING)
+        workflowSystemTask.getEvaluationOffset(task, 1) >> Optional.empty()
+
+        when:
+        executor.execute(workflowSystemTask, taskId)
+
+        then:
+        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
+        2 * executionDAOFacade.updateTask(task) >> { throw new RuntimeException("db down") } >> null
+        1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.IN_PROGRESS }
+
+        task.status == TaskModel.Status.IN_PROGRESS
     }
 
 }

--- a/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
@@ -469,7 +469,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         1 * executionDAOFacade.updateTask(task)
     }
 
-    def "start marker persistence failure does not prevent the system task from running"() {
+    def "start marker persistence failure aborts execution and is handled by the outer catch"() {
         given:
         String workflowId = "workflowId"
         String taskId = "taskId"
@@ -484,10 +484,11 @@ class AsyncSystemTaskExecutorTest extends Specification {
         then:
         1 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
+        // marker write throws; start() never runs; the finally block still persists the task
         2 * executionDAOFacade.updateTask(task) >> { throw new RuntimeException("db down") } >> null
-        1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.IN_PROGRESS }
+        0 * workflowSystemTask.start(workflow, task, workflowExecutor)
 
-        task.status == TaskModel.Status.IN_PROGRESS
+        task.status == TaskModel.Status.SCHEDULED
     }
 
 }

--- a/core/src/test/java/org/conductoross/conductor/core/execution/WorkflowSweeperTest.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/WorkflowSweeperTest.java
@@ -151,6 +151,78 @@ public class WorkflowSweeperTest {
     }
 
     @Test
+    public void sweepDoesNotRepushSystemTaskWithinStartedGracePeriod() {
+        TaskModel httpTask = newTask("http-task", "HTTP", TaskModel.Status.SCHEDULED);
+        httpTask.setStartTime(System.currentTimeMillis() - 5_000);
+        WorkflowModel workflow = newWorkflow(List.of(httpTask));
+
+        WorkflowSystemTask workflowSystemTask = mock(WorkflowSystemTask.class);
+        when(executionLockService.acquireLock(WORKFLOW_ID)).thenReturn(true);
+        when(workflowExecutor.getWorkflow(WORKFLOW_ID, true)).thenReturn(workflow);
+        when(workflowExecutor.decide(WORKFLOW_ID)).thenReturn(workflow);
+        when(systemTaskRegistry.isSystemTask("HTTP")).thenReturn(true);
+        when(systemTaskRegistry.get("HTTP")).thenReturn(workflowSystemTask);
+        when(workflowSystemTask.isAsync()).thenReturn(true);
+        when(workflowSystemTask.isAsyncComplete(httpTask)).thenReturn(false);
+        when(sweeperProperties.getStartedTaskRepairGraceMillis()).thenReturn(60_000L);
+
+        workflowSweeper.sweep(WORKFLOW_ID);
+
+        verify(queueDAO, never()).push(anyString(), anyString(), anyLong());
+        verify(executionLockService).releaseLock(WORKFLOW_ID);
+    }
+
+    @Test
+    public void sweepRepushesSystemTaskStartedBeyondGracePeriod() {
+        TaskModel httpTask = newTask("http-task", "HTTP", TaskModel.Status.SCHEDULED);
+        httpTask.setStartTime(System.currentTimeMillis() - 120_000);
+        httpTask.setCallbackAfterSeconds(3L);
+        WorkflowModel workflow = newWorkflow(List.of(httpTask));
+
+        WorkflowSystemTask workflowSystemTask = mock(WorkflowSystemTask.class);
+        when(executionLockService.acquireLock(WORKFLOW_ID)).thenReturn(true);
+        when(workflowExecutor.getWorkflow(WORKFLOW_ID, true)).thenReturn(workflow);
+        when(workflowExecutor.decide(WORKFLOW_ID)).thenReturn(workflow);
+        when(systemTaskRegistry.isSystemTask("HTTP")).thenReturn(true);
+        when(systemTaskRegistry.get("HTTP")).thenReturn(workflowSystemTask);
+        when(workflowSystemTask.isAsync()).thenReturn(true);
+        when(workflowSystemTask.isAsyncComplete(httpTask)).thenReturn(false);
+        when(sweeperProperties.getStartedTaskRepairGraceMillis()).thenReturn(60_000L);
+        when(queueDAO.containsMessage("HTTP", httpTask.getTaskId())).thenReturn(false);
+
+        workflowSweeper.sweep(WORKFLOW_ID);
+
+        verify(queueDAO, times(1))
+                .push("HTTP", httpTask.getTaskId(), httpTask.getCallbackAfterSeconds());
+        verify(executionLockService).releaseLock(WORKFLOW_ID);
+    }
+
+    @Test
+    public void sweepRepushesRecentlyStartedSystemTaskWhenGraceDisabled() {
+        TaskModel httpTask = newTask("http-task", "HTTP", TaskModel.Status.SCHEDULED);
+        httpTask.setStartTime(System.currentTimeMillis() - 5_000);
+        httpTask.setCallbackAfterSeconds(3L);
+        WorkflowModel workflow = newWorkflow(List.of(httpTask));
+
+        WorkflowSystemTask workflowSystemTask = mock(WorkflowSystemTask.class);
+        when(executionLockService.acquireLock(WORKFLOW_ID)).thenReturn(true);
+        when(workflowExecutor.getWorkflow(WORKFLOW_ID, true)).thenReturn(workflow);
+        when(workflowExecutor.decide(WORKFLOW_ID)).thenReturn(workflow);
+        when(systemTaskRegistry.isSystemTask("HTTP")).thenReturn(true);
+        when(systemTaskRegistry.get("HTTP")).thenReturn(workflowSystemTask);
+        when(workflowSystemTask.isAsync()).thenReturn(true);
+        when(workflowSystemTask.isAsyncComplete(httpTask)).thenReturn(false);
+        when(sweeperProperties.getStartedTaskRepairGraceMillis()).thenReturn(0L);
+        when(queueDAO.containsMessage("HTTP", httpTask.getTaskId())).thenReturn(false);
+
+        workflowSweeper.sweep(WORKFLOW_ID);
+
+        verify(queueDAO, times(1))
+                .push("HTTP", httpTask.getTaskId(), httpTask.getCallbackAfterSeconds());
+        verify(executionLockService).releaseLock(WORKFLOW_ID);
+    }
+
+    @Test
     public void sweepRepairsSubWorkflowTaskWhenSubWorkflowIsTerminal() {
         TaskModel subWorkflowTask =
                 newTask(


### PR DESCRIPTION
Queue message is acked before AsyncSystemTaskExecutor runs the side effect (HTTP call etc.), and task row only updates after it returns. During that window the task looks orphaned (SCHEDULED, no queue message), so the sweeper repushes it and a second worker re-executes it. Persist startTime before start() runs, and have the sweeper skip repair while startTime is within a grace window (SweeperProperties#startedTaskRepairGraceMillis, default 60s, 0 disables).

Pull Request type
----
- [X] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_

Queue message is acked before `AsyncSystemTaskExecutor` runs the side effect (HTTP call etc.), and task row only updates after it returns. During that window the task looks orphaned (SCHEDULED, no queue message), so the sweeper repushes it and a second worker re-executes it.

This PR persists `startTime` before `start()` runs, and has the sweeper skip repair while `startTime` is within a grace window (`SweeperProperties#startedTaskRepairGraceMillis`, default 60s, 0 disables).

Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_

Want it pushed to PR description via gh, or just keep as draft file?
