### PR TITLE
fix(ui-next): Don't run playwright in Build UI CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,28 +405,16 @@ jobs:
       - name: Build UI
         run: NODE_OPTIONS=--max-old-space-size=4096 pnpm build
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v5
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-chromium-${{ hashFiles('ui-next/pnpm-lock.yaml') }}
-
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium
-
-      - name: Install Playwright browser deps (cached)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
       - name: Run Playwright E2E Tests
-        run: pnpm test:e2e
+        run: docker compose -f docker-compose.snapshots.yml run --rm playwright
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: playwright-report
-          path: ui-next/playwright-report
+          path: ui-next/playwright-snapshots-report/
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,17 +404,3 @@ jobs:
 
       - name: Build UI
         run: NODE_OPTIONS=--max-old-space-size=4096 pnpm build
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Run Playwright E2E Tests
-        run: docker compose -f docker-compose.snapshots.yml run --rm playwright
-
-      - name: Upload Playwright report
-        uses: actions/upload-artifact@v7
-        if: failure()
-        with:
-          name: playwright-report
-          path: ui-next/playwright-snapshots-report/
-          retention-days: 7

--- a/ui-next/e2e/workflow-execution-search-filters.spec.ts
+++ b/ui-next/e2e/workflow-execution-search-filters.spec.ts
@@ -17,6 +17,7 @@ import { mockCommonApis } from "./helpers/mockApi";
 
 const SCREENSHOT_CONFIG = {
   maxDiffPixelRatio: 0.03,
+  maxDiffPixels: 1500,
 };
 
 const VIEWPORTS = [

--- a/ui-next/e2e/workflow-execution-search-filters.spec.ts
+++ b/ui-next/e2e/workflow-execution-search-filters.spec.ts
@@ -17,7 +17,6 @@ import { mockCommonApis } from "./helpers/mockApi";
 
 const SCREENSHOT_CONFIG = {
   maxDiffPixelRatio: 0.03,
-  maxDiffPixels: 1500,
 };
 
 const VIEWPORTS = [


### PR DESCRIPTION
## Summary

Removes Playwright E2E tests from the `build-ui` job in `ci.yml`.

Fixes #1344, fixes #1345.

## Why

`ui-next-ci.yml` (`E2E Mocked` job) and `ui-next-integration-ci.yml` already run Playwright tests — in Docker — whenever `ui-next/**` files change on a PR targeting `main` or a push to `main`. Running them again natively in `build-ui` was redundant and caused spurious failures due to rendering differences between the Docker snapshot environment and the native GitHub Actions runner.

Note: if UI tests should run on _any_ push to `main` (not just when `ui-next/**` changes), the `paths` filters in `ui-next-ci.yml` and `ui-next-integration-ci.yml` would need to be removed. That's a separate decision.

## Change

Deleted from `build-ui` in `ci.yml`:
- Cache Playwright browsers
- Install Playwright browsers
- Install Playwright browser deps (cached)
- Run Playwright E2E Tests
- Upload Playwright report
