### PR TITLE
Add poll-worker execution mode for @WorkerTask annotated workers (orkes-conductor execution-model convergence)

### DIFF
--- a/core/src/main/java/org/conductoross/conductor/core/execution/tasks/annotated/AnnotatedWorkerPollingHost.java
+++ b/core/src/main/java/org/conductoross/conductor/core/execution/tasks/annotated/AnnotatedWorkerPollingHost.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.Lazy;
@@ -70,20 +71,32 @@ public class AnnotatedWorkerPollingHost implements SmartLifecycle {
 
     static final int DEFAULT_RETRY_COUNT = 3;
 
+    /**
+     * When false, the server only schedules/queues annotated task types (and still auto-registers
+     * their task defs); execution is left entirely to external workers polling the task API — e.g.
+     * a standalone workers process built from the same @WorkerTask beans and the conductor client,
+     * which is exactly orkes-conductor's independently-scalable workers topology.
+     */
+    public static final String POLLING_ENABLED_PROPERTY =
+            "conductor.annotated-workers.polling-host.enabled";
+
     private final WorkerTaskAnnotationScanner scanner;
     private final ExecutionService executionService;
     private final MetadataDAO metadataDAO;
     private final String workerId;
+    private final boolean pollingEnabled;
     private final AtomicBoolean running = new AtomicBoolean(false);
     private ScheduledExecutorService pollerPool;
 
     public AnnotatedWorkerPollingHost(
             WorkerTaskAnnotationScanner scanner,
             @Lazy ExecutionService executionService,
-            @Lazy MetadataDAO metadataDAO) {
+            @Lazy MetadataDAO metadataDAO,
+            @Value("${" + POLLING_ENABLED_PROPERTY + ":true}") boolean pollingEnabled) {
         this.scanner = scanner;
         this.executionService = executionService;
         this.metadataDAO = metadataDAO;
+        this.pollingEnabled = pollingEnabled;
         this.workerId = Utils.getServerId() + "-annotated-poll-worker";
     }
 
@@ -99,6 +112,15 @@ public class AnnotatedWorkerPollingHost implements SmartLifecycle {
         }
 
         workers.forEach(worker -> registerTaskDefIfAbsent(worker.getTaskType()));
+
+        if (!pollingEnabled) {
+            log.info(
+                    "In-process polling disabled ({}=false); {} annotated task type(s) are queued"
+                            + " for external workers polling the task API",
+                    POLLING_ENABLED_PROPERTY,
+                    workers.size());
+            return;
+        }
 
         int totalThreads =
                 workers.stream().mapToInt(w -> Math.max(1, w.getAnnotation().threadCount())).sum();

--- a/core/src/main/java/org/conductoross/conductor/core/execution/tasks/annotated/AnnotatedWorkerPollingHost.java
+++ b/core/src/main/java/org/conductoross/conductor/core/execution/tasks/annotated/AnnotatedWorkerPollingHost.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.core.execution.tasks.annotated;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.common.metadata.tasks.TaskResult;
+import com.netflix.conductor.core.utils.Utils;
+import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.model.TaskModel;
+import com.netflix.conductor.model.WorkflowModel;
+import com.netflix.conductor.sdk.workflow.task.WorkerTask;
+import com.netflix.conductor.service.ExecutionService;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Executes @WorkerTask annotated methods through the standard worker poll/update path instead of
+ * the async system-task machinery. Active only when {@code conductor.annotated-workers.mode} is
+ * {@code poll-worker}.
+ *
+ * <p>Execution model (identical to a remote SDK worker, minus the HTTP hop — this host calls the
+ * same {@link ExecutionService} the task API endpoints delegate to):
+ *
+ * <ol>
+ *   <li>{@link ExecutionService#poll} pops the queue message, moves the task to IN_PROGRESS,
+ *       persists it, and ACKS (removes) the message — the queue's redelivery sweep can never
+ *       redeliver a task that is being executed.
+ *   <li>The annotated method is invoked via the same {@link AnnotatedWorkflowSystemTask} adapter
+ *       used in system-task mode (same parameter/result mapping, TaskContext, and exception
+ *       semantics).
+ *   <li>{@link ExecutionService#updateTask} reports the result; the decider advances the workflow.
+ * </ol>
+ *
+ * <p>Recovery: if the JVM dies mid-invocation, the task sits IN_PROGRESS until the decider's
+ * response timeout ({@code responseTimeoutSeconds} on the task def, auto-registered by this host
+ * when absent) times it out and schedules a retry per the def's retry policy.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(
+        name = WorkerTaskAnnotationScanner.MODE_PROPERTY,
+        havingValue = WorkerTaskAnnotationScanner.MODE_POLL_WORKER)
+public class AnnotatedWorkerPollingHost implements SmartLifecycle {
+
+    /** Defaults applied when a task type has no registered TaskDef. */
+    static final long DEFAULT_RESPONSE_TIMEOUT_SECONDS = 3600;
+
+    static final int DEFAULT_RETRY_COUNT = 3;
+
+    private final WorkerTaskAnnotationScanner scanner;
+    private final ExecutionService executionService;
+    private final MetadataDAO metadataDAO;
+    private final String workerId;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private ScheduledExecutorService pollerPool;
+
+    public AnnotatedWorkerPollingHost(
+            WorkerTaskAnnotationScanner scanner,
+            @Lazy ExecutionService executionService,
+            @Lazy MetadataDAO metadataDAO) {
+        this.scanner = scanner;
+        this.executionService = executionService;
+        this.metadataDAO = metadataDAO;
+        this.workerId = Utils.getServerId() + "-annotated-poll-worker";
+    }
+
+    @Override
+    public void start() {
+        if (!running.compareAndSet(false, true)) {
+            return;
+        }
+        var workers = scanner.getDiscoveredWorkers();
+        if (workers.isEmpty()) {
+            log.info("No @WorkerTask annotated workers discovered; polling host idle");
+            return;
+        }
+
+        workers.forEach(worker -> registerTaskDefIfAbsent(worker.getTaskType()));
+
+        int totalThreads =
+                workers.stream().mapToInt(w -> Math.max(1, w.getAnnotation().threadCount())).sum();
+        AtomicInteger threadCounter = new AtomicInteger();
+        pollerPool =
+                Executors.newScheduledThreadPool(
+                        totalThreads,
+                        runnable -> {
+                            Thread thread = new Thread(runnable);
+                            thread.setName(
+                                    "annotated-poll-worker-" + threadCounter.incrementAndGet());
+                            thread.setDaemon(true);
+                            return thread;
+                        });
+
+        for (AnnotatedWorkflowSystemTask worker : workers) {
+            WorkerTask annotation = worker.getAnnotation();
+            int threads = Math.max(1, annotation.threadCount());
+            long pollingIntervalMs = Math.max(1, annotation.pollingInterval());
+            for (int i = 0; i < threads; i++) {
+                pollerPool.scheduleWithFixedDelay(
+                        () -> pollAndExecute(worker),
+                        pollingIntervalMs,
+                        pollingIntervalMs,
+                        TimeUnit.MILLISECONDS);
+            }
+            log.info(
+                    "Polling annotated task type {} with {} thread(s) every {}ms",
+                    worker.getTaskType(),
+                    threads,
+                    pollingIntervalMs);
+        }
+    }
+
+    void pollAndExecute(AnnotatedWorkflowSystemTask worker) {
+        if (!running.get()) {
+            return;
+        }
+        try {
+            String domain =
+                    StringUtils.isBlank(worker.getAnnotation().domain())
+                            ? null
+                            : worker.getAnnotation().domain();
+            Task polled = executionService.poll(worker.getTaskType(), workerId, domain);
+            if (polled == null) {
+                return;
+            }
+            execute(worker, polled);
+        } catch (Exception e) {
+            log.error("Error in poll loop for annotated task type {}", worker.getTaskType(), e);
+        }
+    }
+
+    private void execute(AnnotatedWorkflowSystemTask worker, Task polled) {
+        TaskModel shim = toTaskModel(polled);
+        WorkflowModel workflowShim = new WorkflowModel();
+        workflowShim.setWorkflowId(polled.getWorkflowInstanceId());
+
+        // Same adapter as system-task mode: parameter mapping, TaskContext lifecycle, result
+        // mapping, and NonRetryableException -> FAILED_WITH_TERMINAL_ERROR semantics.
+        worker.execute(workflowShim, shim, null);
+
+        TaskResult result = new TaskResult();
+        result.setWorkflowInstanceId(polled.getWorkflowInstanceId());
+        result.setTaskId(polled.getTaskId());
+        result.setWorkerId(workerId);
+        result.setStatus(toTaskResultStatus(shim.getStatus()));
+        result.setReasonForIncompletion(shim.getReasonForIncompletion());
+        result.setCallbackAfterSeconds(shim.getCallbackAfterSeconds());
+        result.getOutputData().putAll(shim.getOutputData());
+
+        executionService.updateTask(result);
+    }
+
+    private TaskModel toTaskModel(Task polled) {
+        TaskModel task = new TaskModel();
+        task.setTaskId(polled.getTaskId());
+        task.setTaskType(polled.getTaskType());
+        task.setTaskDefName(polled.getTaskDefName());
+        task.setReferenceTaskName(polled.getReferenceTaskName());
+        task.setWorkflowInstanceId(polled.getWorkflowInstanceId());
+        task.setWorkflowType(polled.getWorkflowType());
+        task.setCorrelationId(polled.getCorrelationId());
+        task.setStatus(TaskModel.Status.IN_PROGRESS);
+        task.setRetryCount(polled.getRetryCount());
+        task.setPollCount(polled.getPollCount());
+        task.setWorkerId(workerId);
+        task.setScheduledTime(polled.getScheduledTime());
+        task.setStartTime(polled.getStartTime());
+        task.setCallbackAfterSeconds(0);
+        task.setWorkflowPriority(polled.getWorkflowPriority());
+        // The polled Task carries the substituted-secrets input; use it verbatim.
+        if (polled.getInputData() != null) {
+            task.setInputData(new java.util.HashMap<>(polled.getInputData()));
+        }
+        return task;
+    }
+
+    private TaskResult.Status toTaskResultStatus(TaskModel.Status status) {
+        if (status == null) {
+            return TaskResult.Status.COMPLETED;
+        }
+        return switch (status) {
+            case FAILED -> TaskResult.Status.FAILED;
+            case FAILED_WITH_TERMINAL_ERROR -> TaskResult.Status.FAILED_WITH_TERMINAL_ERROR;
+            case IN_PROGRESS -> TaskResult.Status.IN_PROGRESS;
+            case CANCELED -> TaskResult.Status.CANCELED;
+            default -> TaskResult.Status.COMPLETED;
+        };
+    }
+
+    /**
+     * On the poll path the task def is the recovery mechanism ({@code responseTimeoutSeconds}
+     * drives the decider's retry of a dead worker), so every annotated task type must have one.
+     * Mirrors orkes-conductor's workers-side def registration.
+     */
+    void registerTaskDefIfAbsent(String taskType) {
+        try {
+            if (metadataDAO.getTaskDef(taskType) != null) {
+                return;
+            }
+            TaskDef taskDef = new TaskDef();
+            taskDef.setName(taskType);
+            taskDef.setDescription("Auto-registered for @WorkerTask " + taskType);
+            taskDef.setOwnerEmail("annotated-workers@conductor-oss.org");
+            taskDef.setResponseTimeoutSeconds(DEFAULT_RESPONSE_TIMEOUT_SECONDS);
+            taskDef.setRetryCount(DEFAULT_RETRY_COUNT);
+            taskDef.setRetryLogic(TaskDef.RetryLogic.EXPONENTIAL_BACKOFF);
+            taskDef.setRetryDelaySeconds(2);
+            taskDef.setBackoffScaleFactor(2);
+            taskDef.setTimeoutSeconds(0);
+            metadataDAO.createTaskDef(taskDef);
+            log.info("Auto-registered task def for annotated task type {}", taskType);
+        } catch (Exception e) {
+            log.warn("Unable to auto-register task def for {}", taskType, e);
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (!running.compareAndSet(true, false)) {
+            return;
+        }
+        if (pollerPool != null) {
+            pollerPool.shutdownNow();
+        }
+        log.info("Annotated worker polling host stopped");
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running.get();
+    }
+}

--- a/core/src/main/java/org/conductoross/conductor/core/execution/tasks/annotated/WorkerTaskAnnotationScanner.java
+++ b/core/src/main/java/org/conductoross/conductor/core/execution/tasks/annotated/WorkerTaskAnnotationScanner.java
@@ -13,6 +13,7 @@
 package org.conductoross.conductor.core.execution.tasks.annotated;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -36,30 +38,53 @@ import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.sdk.workflow.task.WorkerTask;
 
 /**
- * Spring component that scans for @WorkerTask annotated methods in Spring beans and adds them to
- * the existing asyncSystemTasks collection and taskMappersByTaskType map.
+ * Spring component that scans for @WorkerTask annotated methods in Spring beans.
+ *
+ * <p>Two execution modes, selected by {@code conductor.annotated-workers.mode}:
+ *
+ * <ul>
+ *   <li>{@code system-task} (default) — each annotated method is registered as an async system task
+ *       (added to the asyncSystemTasks collection) and executed in-engine by the system-task-worker
+ *       machinery. This is the historical behavior.
+ *   <li>{@code poll-worker} — annotated task types are NOT registered as system tasks, so the
+ *       decider queues them like any worker task, and {@link AnnotatedWorkerPollingHost} executes
+ *       them through the standard poll/update path ({@code ExecutionService.poll} acks the queue
+ *       message and moves the task to IN_PROGRESS before the method runs; recovery is the decider's
+ *       task-def response timeout). This is the same execution model orkes-conductor uses for these
+ *       task types, with in-process pollers instead of a remote workers process.
+ * </ul>
+ *
+ * <p>In both modes a TaskMapper is registered per task type so the decider can schedule it.
  */
 @Component
 public class WorkerTaskAnnotationScanner implements InitializingBean {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WorkerTaskAnnotationScanner.class);
 
+    public static final String MODE_PROPERTY = "conductor.annotated-workers.mode";
+    public static final String MODE_SYSTEM_TASK = "system-task";
+    public static final String MODE_POLL_WORKER = "poll-worker";
+
     private final List<AnnotatedSystemTaskWorker> annotatedSystemTaskWorkers;
     private final Set<WorkflowSystemTask> asyncSystemTasks;
     private final Map<String, TaskMapper> taskMappers = new HashMap<>();
+    private final List<AnnotatedWorkflowSystemTask> discoveredWorkers = new ArrayList<>();
     private final ParametersUtils parametersUtils;
     private final MetadataDAO metadataDAO;
+    private final String mode;
 
     public WorkerTaskAnnotationScanner(
             List<AnnotatedSystemTaskWorker> annotatedSystemTaskWorkers,
             @Qualifier(SystemTaskRegistry.ASYNC_SYSTEM_TASKS_QUALIFIER)
                     Set<WorkflowSystemTask> asyncSystemTasks,
             @Lazy ParametersUtils parametersUtils,
-            @Lazy MetadataDAO metadataDAO) {
+            @Lazy MetadataDAO metadataDAO,
+            @Value("${" + MODE_PROPERTY + ":" + MODE_SYSTEM_TASK + "}") String mode) {
         this.annotatedSystemTaskWorkers = annotatedSystemTaskWorkers;
         this.asyncSystemTasks = asyncSystemTasks;
         this.parametersUtils = parametersUtils;
         this.metadataDAO = metadataDAO;
+        this.mode = mode;
     }
 
     /**
@@ -95,9 +120,18 @@ public class WorkerTaskAnnotationScanner implements InitializingBean {
 
                         AnnotatedWorkflowSystemTask task =
                                 new AnnotatedWorkflowSystemTask(taskType, method, bean, annotation);
+                        discoveredWorkers.add(task);
 
-                        // Add to existing asyncSystemTasks collection
-                        asyncSystemTasks.add(task);
+                        if (MODE_POLL_WORKER.equals(mode)) {
+                            // Not a system task: the decider queues this type like any worker
+                            // task and AnnotatedWorkerPollingHost executes it via poll/update.
+                            LOGGER.info(
+                                    "Annotated task type {} registered for poll-worker execution",
+                                    taskType);
+                        } else {
+                            // Add to existing asyncSystemTasks collection
+                            asyncSystemTasks.add(task);
+                        }
 
                         // Register a TaskMapper for this task type so DeciderService can find it
                         AnnotatedSystemTaskMapper mapper =
@@ -131,5 +165,10 @@ public class WorkerTaskAnnotationScanner implements InitializingBean {
     @Bean
     public Map<String, TaskMapper> annotatedTaskSystems() {
         return taskMappers;
+    }
+
+    /** The annotated worker adapters discovered by the scan, regardless of mode. */
+    public List<AnnotatedWorkflowSystemTask> getDiscoveredWorkers() {
+        return List.copyOf(discoveredWorkers);
     }
 }

--- a/core/src/test/java/org/conductoross/conductor/core/execution/tasks/annotated/TestAnnotatedSystemTaskIntegration.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/tasks/annotated/TestAnnotatedSystemTaskIntegration.java
@@ -91,7 +91,11 @@ public class TestAnnotatedSystemTaskIntegration {
                 ParametersUtils parametersUtils,
                 MetadataDAO metadataDAO) {
             return new WorkerTaskAnnotationScanner(
-                    workers, asyncSystemTasks, parametersUtils, metadataDAO);
+                    workers,
+                    asyncSystemTasks,
+                    parametersUtils,
+                    metadataDAO,
+                    WorkerTaskAnnotationScanner.MODE_SYSTEM_TASK);
         }
     }
 

--- a/core/src/test/java/org/conductoross/conductor/core/execution/tasks/annotated/TestAnnotatedWorkerPollingHost.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/tasks/annotated/TestAnnotatedWorkerPollingHost.java
@@ -87,7 +87,7 @@ public class TestAnnotatedWorkerPollingHost {
                         mock(ParametersUtils.class),
                         metadataDAO,
                         WorkerTaskAnnotationScanner.MODE_POLL_WORKER);
-        host = new AnnotatedWorkerPollingHost(scanner, executionService, metadataDAO);
+        host = new AnnotatedWorkerPollingHost(scanner, executionService, metadataDAO, true);
         // pollAndExecute is guarded by the running flag
         setRunning();
     }
@@ -222,6 +222,31 @@ public class TestAnnotatedWorkerPollingHost {
         assertFalse(
                 "task mappers must still be registered for the decider",
                 pollScanner.annotatedTaskSystems().isEmpty());
+    }
+
+    @Test
+    public void testDisabledPollingHostRegistersDefsButStartsNoPollers() throws Exception {
+        Set<WorkflowSystemTask> asyncSystemTasks = new HashSet<>();
+        WorkerTaskAnnotationScanner pollScanner =
+                new WorkerTaskAnnotationScanner(
+                        List.of(new ScannedPollBean()),
+                        asyncSystemTasks,
+                        mock(ParametersUtils.class),
+                        metadataDAO,
+                        WorkerTaskAnnotationScanner.MODE_POLL_WORKER);
+        pollScanner.afterPropertiesSet();
+        when(metadataDAO.getTaskDef("scanned_poll_task")).thenReturn(null);
+
+        AnnotatedWorkerPollingHost disabledHost =
+                new AnnotatedWorkerPollingHost(pollScanner, executionService, metadataDAO, false);
+        disabledHost.start();
+
+        // Task def is still registered server-side for external workers...
+        verify(metadataDAO).createTaskDef(any(TaskDef.class));
+        // ...but no in-process poller pool is created.
+        var poolField = AnnotatedWorkerPollingHost.class.getDeclaredField("pollerPool");
+        poolField.setAccessible(true);
+        assertNull(poolField.get(disabledHost));
     }
 
     @Test

--- a/core/src/test/java/org/conductoross/conductor/core/execution/tasks/annotated/TestAnnotatedWorkerPollingHost.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/tasks/annotated/TestAnnotatedWorkerPollingHost.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.core.execution.tasks.annotated;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.conductoross.conductor.core.execution.tasks.AnnotatedSystemTaskWorker;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.common.metadata.tasks.TaskResult;
+import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
+import com.netflix.conductor.core.utils.ParametersUtils;
+import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.sdk.workflow.executor.task.NonRetryableException;
+import com.netflix.conductor.sdk.workflow.task.InputParam;
+import com.netflix.conductor.sdk.workflow.task.WorkerTask;
+import com.netflix.conductor.service.ExecutionService;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestAnnotatedWorkerPollingHost {
+
+    private ExecutionService executionService;
+    private MetadataDAO metadataDAO;
+    private WorkerTaskAnnotationScanner scanner;
+    private AnnotatedWorkerPollingHost host;
+
+    static class PollWorkerBean implements AnnotatedSystemTaskWorker {
+        public Map<String, Object> successTask(@InputParam("input") String input) {
+            return Map.of("output", "processed: " + input);
+        }
+
+        public void throwsException(@InputParam("input") String input) {
+            throw new RuntimeException("worker blew up");
+        }
+
+        public void throwsNonRetryable(@InputParam("input") String input) {
+            throw new NonRetryableException("terminal failure");
+        }
+    }
+
+    /** Bean with a real @WorkerTask annotation, for scanner-mode tests. */
+    static class ScannedPollBean implements AnnotatedSystemTaskWorker {
+        @WorkerTask("scanned_poll_task")
+        public Map<String, Object> doWork(@InputParam("input") String input) {
+            return Map.of("output", input);
+        }
+    }
+
+    @Before
+    public void setUp() {
+        executionService = mock(ExecutionService.class);
+        metadataDAO = mock(MetadataDAO.class);
+        Set<WorkflowSystemTask> asyncSystemTasks = new HashSet<>();
+        scanner =
+                new WorkerTaskAnnotationScanner(
+                        List.of(),
+                        asyncSystemTasks,
+                        mock(ParametersUtils.class),
+                        metadataDAO,
+                        WorkerTaskAnnotationScanner.MODE_POLL_WORKER);
+        host = new AnnotatedWorkerPollingHost(scanner, executionService, metadataDAO);
+        // pollAndExecute is guarded by the running flag
+        setRunning();
+    }
+
+    private void setRunning() {
+        try {
+            var field = AnnotatedWorkerPollingHost.class.getDeclaredField("running");
+            field.setAccessible(true);
+            ((java.util.concurrent.atomic.AtomicBoolean) field.get(host)).set(true);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private AnnotatedWorkflowSystemTask adapter(String taskType, String methodName)
+            throws Exception {
+        Method method = PollWorkerBean.class.getMethod(methodName, String.class);
+        WorkerTask annotation = Mockito.mock(WorkerTask.class);
+        Mockito.when(annotation.value()).thenReturn(taskType);
+        Mockito.when(annotation.threadCount()).thenReturn(1);
+        Mockito.when(annotation.pollingInterval()).thenReturn(100);
+        Mockito.when(annotation.domain()).thenReturn("");
+        return new AnnotatedWorkflowSystemTask(taskType, method, new PollWorkerBean(), annotation);
+    }
+
+    private Task polledTask(String taskType, Map<String, Object> input) {
+        Task task = new Task();
+        task.setTaskId("task-1");
+        task.setTaskType(taskType);
+        task.setTaskDefName(taskType);
+        task.setWorkflowInstanceId("wf-1");
+        task.setStatus(Task.Status.IN_PROGRESS);
+        task.setInputData(new HashMap<>(input));
+        return task;
+    }
+
+    @Test
+    public void testPollExecuteUpdateCompletes() throws Exception {
+        AnnotatedWorkflowSystemTask worker = adapter("poll_task", "successTask");
+        when(executionService.poll(eq("poll_task"), anyString(), isNull()))
+                .thenReturn(polledTask("poll_task", Map.of("input", "hello")));
+
+        host.pollAndExecute(worker);
+
+        ArgumentCaptor<TaskResult> captor = ArgumentCaptor.forClass(TaskResult.class);
+        verify(executionService).updateTask(captor.capture());
+        TaskResult result = captor.getValue();
+        assertEquals(TaskResult.Status.COMPLETED, result.getStatus());
+        assertEquals("task-1", result.getTaskId());
+        assertEquals("wf-1", result.getWorkflowInstanceId());
+        assertEquals("processed: hello", result.getOutputData().get("output"));
+    }
+
+    @Test
+    public void testWorkerExceptionReportsFailed() throws Exception {
+        AnnotatedWorkflowSystemTask worker = adapter("failing_task", "throwsException");
+        when(executionService.poll(eq("failing_task"), anyString(), isNull()))
+                .thenReturn(polledTask("failing_task", Map.of("input", "x")));
+
+        host.pollAndExecute(worker);
+
+        ArgumentCaptor<TaskResult> captor = ArgumentCaptor.forClass(TaskResult.class);
+        verify(executionService).updateTask(captor.capture());
+        assertEquals(TaskResult.Status.FAILED, captor.getValue().getStatus());
+        assertTrue(captor.getValue().getReasonForIncompletion().contains("worker blew up"));
+    }
+
+    @Test
+    public void testNonRetryableExceptionReportsTerminalFailure() throws Exception {
+        AnnotatedWorkflowSystemTask worker = adapter("terminal_task", "throwsNonRetryable");
+        when(executionService.poll(eq("terminal_task"), anyString(), isNull()))
+                .thenReturn(polledTask("terminal_task", Map.of("input", "x")));
+
+        host.pollAndExecute(worker);
+
+        ArgumentCaptor<TaskResult> captor = ArgumentCaptor.forClass(TaskResult.class);
+        verify(executionService).updateTask(captor.capture());
+        assertEquals(TaskResult.Status.FAILED_WITH_TERMINAL_ERROR, captor.getValue().getStatus());
+    }
+
+    @Test
+    public void testEmptyPollDoesNothing() throws Exception {
+        AnnotatedWorkflowSystemTask worker = adapter("idle_task", "successTask");
+        when(executionService.poll(eq("idle_task"), anyString(), isNull())).thenReturn(null);
+
+        host.pollAndExecute(worker);
+
+        verify(executionService, never()).updateTask(any(TaskResult.class));
+    }
+
+    @Test
+    public void testTaskDefAutoRegisteredWhenAbsent() {
+        when(metadataDAO.getTaskDef("new_task")).thenReturn(null);
+
+        host.registerTaskDefIfAbsent("new_task");
+
+        ArgumentCaptor<TaskDef> captor = ArgumentCaptor.forClass(TaskDef.class);
+        verify(metadataDAO).createTaskDef(captor.capture());
+        TaskDef def = captor.getValue();
+        assertEquals("new_task", def.getName());
+        assertEquals(
+                AnnotatedWorkerPollingHost.DEFAULT_RESPONSE_TIMEOUT_SECONDS,
+                def.getResponseTimeoutSeconds());
+        assertEquals(AnnotatedWorkerPollingHost.DEFAULT_RETRY_COUNT, def.getRetryCount());
+    }
+
+    @Test
+    public void testTaskDefNotOverwrittenWhenPresent() {
+        when(metadataDAO.getTaskDef("existing_task")).thenReturn(new TaskDef("existing_task"));
+
+        host.registerTaskDefIfAbsent("existing_task");
+
+        verify(metadataDAO, never()).createTaskDef(any());
+    }
+
+    @Test
+    public void testPollWorkerModeDoesNotRegisterSystemTasks() {
+        Set<WorkflowSystemTask> asyncSystemTasks = new HashSet<>();
+        WorkerTaskAnnotationScanner pollScanner =
+                new WorkerTaskAnnotationScanner(
+                        List.of(new ScannedPollBean()),
+                        asyncSystemTasks,
+                        mock(ParametersUtils.class),
+                        metadataDAO,
+                        WorkerTaskAnnotationScanner.MODE_POLL_WORKER);
+        pollScanner.afterPropertiesSet();
+
+        assertTrue("poll-worker mode must not register system tasks", asyncSystemTasks.isEmpty());
+        assertFalse(
+                "workers must still be discovered for the polling host",
+                pollScanner.getDiscoveredWorkers().isEmpty());
+        assertFalse(
+                "task mappers must still be registered for the decider",
+                pollScanner.annotatedTaskSystems().isEmpty());
+    }
+
+    @Test
+    public void testSystemTaskModeStillRegistersSystemTasks() {
+        Set<WorkflowSystemTask> asyncSystemTasks = new HashSet<>();
+        WorkerTaskAnnotationScanner systemScanner =
+                new WorkerTaskAnnotationScanner(
+                        List.of(new ScannedPollBean()),
+                        asyncSystemTasks,
+                        mock(ParametersUtils.class),
+                        metadataDAO,
+                        WorkerTaskAnnotationScanner.MODE_SYSTEM_TASK);
+        systemScanner.afterPropertiesSet();
+
+        assertFalse(
+                "system-task mode keeps the historical registration", asyncSystemTasks.isEmpty());
+    }
+}

--- a/docs/design/2026-07-17-annotated-workers-poll-mode.md
+++ b/docs/design/2026-07-17-annotated-workers-poll-mode.md
@@ -94,6 +94,22 @@ their HTTP `TaskClient`; both repos share everything above the seam. (A
 loopback-HTTP fallback config is nearly free and gives an orkes-identical
 topology for anyone running OSS workers out-of-process.)
 
+## Scaling topologies
+
+Because poll-worker mode routes annotated types through the standard task API
+path, all three topologies work with the same beans and no further code:
+
+1. **Single binary** (default): the in-process host polls. Scales with server
+   replicas — polling is competitive over the shared queue, so N servers ×
+   `threadCount` pollers execute safely in parallel.
+2. **Server + external workers**: external worker processes (conductor-client
+   + the same `@WorkerTask` beans, i.e. orkes' workers-app assembly) poll the
+   task API alongside the in-process host.
+3. **Fully external / independently scalable** (orkes-exact):
+   `conductor.annotated-workers.polling-host.enabled=false` — the server only
+   schedules, queues, and auto-registers task defs; standalone worker jars own
+   all execution and scale independently of the server fleet.
+
 ## Known deltas to resolve before flipping the default
 
 - **Poll latency**: system tasks fire ~ms after `decide()`; pollers add

--- a/docs/design/2026-07-17-annotated-workers-poll-mode.md
+++ b/docs/design/2026-07-17-annotated-workers-poll-mode.md
@@ -1,0 +1,129 @@
+# Annotated workers: poll-worker mode (convergence with orkes-conductor)
+
+**Status: implemented** (`conductor.annotated-workers.mode=poll-worker`, default
+`system-task`) — written so OSS and orkes-conductor converge on one mechanism.
+
+## Where the two repos stand today
+
+The `@WorkerTask` worker beans are already shared code: orkes-conductor's
+workers process depends on this repo's `conductor-ai` jar and component-scans
+`org.conductoross`, so **our `LLMWorkers` (`ai/.../LLMWorkers.java:126`,
+`@WorkerTask("LLM_CHAT_COMPLETE")`) is the class executing LLM calls in orkes
+production**, with `OrkesLLM extends LLMs` injected as the `@Primary` provider.
+The divergence is exactly one decision — which runtime discovers the
+annotation:
+
+| | Discovery runtime | Execution model |
+|---|---|---|
+| orkes-conductor | `ConductorWorkerAutoConfiguration` (`org.conductoross:conductor-client-spring`) in a separate workers process | SDK pollers via `TaskClient` HTTP → ack at poll → `IN_PROGRESS` → decider def-timeout recovery |
+| conductor-oss | `WorkerTaskAnnotationScanner` in the server | in-engine async system task → blocking `start()` → queue redelivery (made safe by the #1321 execution lease) |
+
+Everything below the annotation (worker methods, `LLMs` provider layer,
+`TaskContext`, `NonRetryableException`) is identical. Everything above the
+`TaskClient` seam (poller machinery, `@WorkerTask` scanning) is identical.
+Only the hosting differs.
+
+## Target architecture
+
+`conductor.annotated-workers.mode = system-task | poll-worker` (default
+`system-task` until parity is proven).
+
+```mermaid
+flowchart LR
+    subgraph shared [Shared classes - both repos]
+        W["@WorkerTask beans<br/>(LLMWorkers, MCPWorkers, ...)"]
+        R[WorkerTaskDefRegistrar]
+        I[InternalTaskRegistry]
+    end
+    subgraph runtime [Discovery runtime - per mode]
+        S[WorkerTaskAnnotationScanner<br/>system-task mode]
+        P[ConductorWorkerAutoConfiguration<br/>poll-worker mode]
+    end
+    subgraph seam [TaskClient seam]
+        L[LocalTaskClient<br/>in-process, OSS single binary]
+        H[HTTP TaskClient<br/>orkes workers process]
+    end
+    W --> S
+    W --> P
+    P --> L
+    P --> H
+```
+
+## The pieces
+
+### 1. `WorkerTaskDefRegistrar` (shared; do this first, useful regardless)
+
+Scan `@WorkerTask` beans and register a `TaskDef` per task type
+(`responseTimeoutSeconds`, `retryCount`, thread/poll config from the
+annotation) when none exists — the OSS port of orkes'
+`OrkesConductorWorkersApplication.wireupTaskDefinitions()` +
+`RemoteWorker.getTaskDef()`. Home: the `ai` module or a small new
+`conductor-annotated-workers` module orkes already imports.
+
+- In system-task mode this **also fixes the #1321 lease-value gap**: every
+  annotated type gets a registered def with a real `responseTimeoutSeconds`,
+  so `MetadataMapperService.java:123` populates it into any workflow and
+  `getExecutionLease` always has a number (multi-agent compiled tasks
+  included).
+- Orkes convergence: they delete `wireupTaskDefinitions()` and use this class.
+
+### 2. `InternalTaskRegistry` (upstream from orkes into core)
+
+Orkes' `oss-core/.../InternalTaskRegistry.java` marks worker-executed types
+(`LLM_CHAT_COMPLETE`, `HTTP_POLL`, ...) as "internal" so domain routing skips
+them and UX treats them as built-ins. Upstreaming the class (same package,
+same name) into this repo's core means orkes drops a vendored file on their
+next rebase, and OSS has the classification hook poll-worker mode needs.
+
+### 3. Poll-worker mode wiring
+
+- Scanner behavior per mode: `system-task` → today's path (register system
+  tasks + mappers, executor lease protects blocking calls); `poll-worker` →
+  register **nothing** with `SystemTaskRegistry` (the decider then queues
+  these types for polling like any worker task), run only the def registrar.
+- Worker host: reuse `org.conductoross:conductor-client-spring`'s
+  `ConductorWorkerAutoConfiguration` verbatim — it only needs a `TaskClient`
+  bean and finds the `@WorkerTask` beans already in the context.
+
+### 4. `LocalTaskClient` (the only genuinely new code)
+
+A `TaskClient` implementation backed by the in-process `TaskService` /
+`ExecutionService` beans (batch poll, update, ack) instead of HTTP. This keeps
+OSS single-binary while running the *identical* poller machinery. Orkes keeps
+their HTTP `TaskClient`; both repos share everything above the seam. (A
+loopback-HTTP fallback config is nearly free and gives an orkes-identical
+topology for anyone running OSS workers out-of-process.)
+
+## Known deltas to resolve before flipping the default
+
+- **Poll latency**: system tasks fire ~ms after `decide()`; pollers add
+  `pollingInterval` per task. Agent loops run many tasks per turn — measure a
+  real chat turn; tune `@WorkerTask(pollingInterval)` or batch-poll settings.
+- **Cancellation**: `AnnotatedTaskCancellationHandler` hooks the system task's
+  engine-side `cancel()` (A2A relies on it). Poll workers get no cancel
+  callback — needs a poll-side check (task state watch) or accepted loss.
+- **Retry semantics**: with real defs registered, decider response-timeout
+  retries apply — correct for idempotent-billing-aware workers, but review
+  `retryCount` per task type (a paid LLM call retry is a real cost decision).
+- **Metrics/ops**: worker-poller metrics replace system-task metrics;
+  dashboards and alerting change shape.
+
+## Phasing
+
+1. **Now-ish (small, standalone value)**: `WorkerTaskDefRegistrar` +
+   upstream `InternalTaskRegistry`. Fixes the lease-value gap; gives orkes two
+   deletions on next rebase.
+2. **Poll-worker mode behind the flag**: `LocalTaskClient` + scanner mode
+   switch + client-spring dependency. Default stays `system-task`.
+3. **Parity validation**: latency benchmark on an agent chat turn,
+   cancellation story, soak in e2e-testing.
+4. **Flip default**; deprecate `AnnotatedWorkflowSystemTask`. The #1321
+   execution lease stays (it protects `HttpTask` and any straggler blocking
+   system task); it simply stops being load-bearing for LLM tasks.
+
+## Convergence end-state
+
+Orkes' workers app reduces to: OSS worker-host config + HTTP `TaskClient` +
+`@Primary` provider overrides (`OrkesLLM`) + their enterprise-only workers.
+Every mechanism class — beans, registrar, registry, poller wiring — is the
+same class from the same jar in both repos.

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/AnnotatedWorkerPollModeSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/AnnotatedWorkerPollModeSpec.groovy
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.test.integration
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.test.context.TestPropertySource
+
+import com.netflix.conductor.common.metadata.tasks.Task
+import com.netflix.conductor.common.run.Workflow
+import com.netflix.conductor.core.execution.tasks.SystemTaskRegistry
+import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask
+import com.netflix.conductor.dao.QueueDAO
+import com.netflix.conductor.test.base.AbstractSpecification
+import com.netflix.conductor.test.utils.ControllableWorker
+
+import spock.util.concurrent.PollingConditions
+
+/**
+ * E2E verification of {@code conductor.annotated-workers.mode=poll-worker}: annotated
+ * worker tasks execute through the standard worker poll/update path (the same execution model
+ * orkes-conductor uses for these task types) instead of the async system-task machinery.
+ *
+ * <p>Proves two things against the REAL scheduling, queue (redis), poller, and decider:
+ *
+ * <ul>
+ *   <li>Polling works end-to-end: the workflow completes with the worker's output, the task is
+ *       claimed by a poll-worker thread, and the task type is NOT registered as a system task.
+ *   <li>The #1321 duplicate-execution scenario is structurally impossible: the poll ACKs
+ *       (removes) the queue message before the blocking method runs, so there is nothing for the
+ *       redelivery machinery to redeliver mid-execution — the operation runs EXACTLY ONCE.
+ * </ul>
+ */
+@TestPropertySource(properties = [
+        "conductor.annotated-workers.mode=poll-worker"
+])
+class AnnotatedWorkerPollModeSpec extends AbstractSpecification {
+
+    @Autowired
+    QueueDAO queueDAO
+
+    @Autowired
+    ControllableWorker controllableWorker
+
+    @Autowired
+    @Qualifier(SystemTaskRegistry.ASYNC_SYSTEM_TASKS_QUALIFIER)
+    Set<WorkflowSystemTask> asyncSystemTasks
+
+    static final String WF = 'controllable_async_system_task_wf'
+    static final String QUEUE = ControllableWorker.TASK_TYPE
+
+    def poll = new PollingConditions(timeout: 20, delay: 0.2)
+
+    def setup() {
+        controllableWorker.reset()
+        workflowTestUtil.registerWorkflows('controllable_async_system_task_workflow.json')
+    }
+
+    def "annotated worker task executes through the poll path and completes the workflow"() {
+        expect: "in poll-worker mode the annotated type is NOT registered as a system task"
+        asyncSystemTasks.find { it.taskType == QUEUE } == null
+
+        and: "a task def was auto-registered with poll-path recovery settings"
+        def taskDef = metadataService.getTaskDef(QUEUE)
+        taskDef.responseTimeoutSeconds == 3600
+        taskDef.retryCount == 3
+
+        when: "a workflow with the annotated task is started (worker not armed: returns immediately)"
+        def workflowId = startWorkflow(WF, 1, 'pollmode_' + UUID.randomUUID(), [:], null)
+
+        then: "a poll-worker thread claims and executes it and the workflow completes"
+        poll.eventually {
+            def wf = workflowExecutionService.getExecutionStatus(workflowId, true)
+            assert wf.status == Workflow.WorkflowStatus.COMPLETED
+            assert wf.tasks.size() == 1
+            assert wf.tasks[0].taskType == QUEUE
+            assert wf.tasks[0].status == Task.Status.COMPLETED
+            assert wf.tasks[0].workerId?.contains('annotated-poll-worker')
+            assert wf.output['taskOutput'] == 1
+        }
+        controllableWorker.invocations.get() == 1
+    }
+
+    def "blocking execution cannot be redelivered mid-flight - poll acked the queue message"() {
+        given: "the worker is armed to block during its invocation (the long provider call)"
+        controllableWorker.enteredRun = new CountDownLatch(1)
+        controllableWorker.release = new CountDownLatch(1)
+
+        when: "the workflow is started"
+        def workflowId = startWorkflow(WF, 1, 'pollmode1321_' + UUID.randomUUID(), [:], null)
+
+        then: "a poll-worker thread entered the method and is blocking"
+        controllableWorker.enteredRun.await(15, TimeUnit.SECONDS)
+
+        and: "the task was claimed at poll time: IN_PROGRESS before the method completed"
+        poll.eventually {
+            def wf = workflowExecutionService.getExecutionStatus(workflowId, true)
+            assert wf.tasks[0].status == Task.Status.IN_PROGRESS
+            assert wf.tasks[0].workerId?.contains('annotated-poll-worker')
+        }
+
+        when: "the redelivery machinery gets every chance to redeliver mid-execution"
+        queueDAO.processUnacks(QUEUE)
+        Thread.sleep(1500)
+        List<String> redelivered = queueDAO.pop(QUEUE, 1, 300)
+
+        then: "nothing to redeliver - the poll ACKED (removed) the message before execution"
+        redelivered == null || redelivered.isEmpty()
+        controllableWorker.invocations.get() == 1
+
+        when: "the blocked call finally finishes"
+        controllableWorker.release.countDown()
+
+        then: "the workflow completes normally with exactly one invocation"
+        poll.eventually {
+            def wf = workflowExecutionService.getExecutionStatus(workflowId, true)
+            assert wf.status == Workflow.WorkflowStatus.COMPLETED
+        }
+        controllableWorker.invocations.get() == 1
+    }
+}

--- a/test-harness/src/test/java/com/netflix/conductor/test/utils/ControllableWorker.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/utils/ControllableWorker.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.test.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.conductoross.conductor.core.execution.tasks.AnnotatedSystemTaskWorker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.netflix.conductor.sdk.workflow.task.WorkerTask;
+
+/**
+ * A test-only annotated system-task worker whose {@link #run} blocks under external control (via
+ * latches) and counts how many times it is invoked. It stands in for a long-running provider call
+ * (e.g. an agent-loop LLM_CHAT_COMPLETE turn) and is registered through the real
+ * WorkerTaskAnnotationScanner / AnnotatedWorkflowSystemTask production path, reproducing the
+ * mechanism behind issue #1321 (async system task running longer than the queue unack window
+ * executed twice).
+ */
+@Component
+public class ControllableWorker implements AnnotatedSystemTaskWorker {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ControllableWorker.class);
+
+    public static final String TASK_TYPE = "CONTROLLABLE_SYS_TASK";
+
+    /** Total number of times {@link #run} has been entered since the last {@link #reset}. */
+    public final AtomicInteger invocations = new AtomicInteger(0);
+
+    /** Counted down each time a {@link #run} invocation is entered (before it blocks). */
+    public volatile CountDownLatch enteredRun;
+
+    /** Every {@link #run} invocation blocks on this latch, simulating the provider call. */
+    public volatile CountDownLatch release;
+
+    /** Reset all control state; call from a spec's setup() before driving a scenario. */
+    public void reset() {
+        invocations.set(0);
+        enteredRun = null;
+        release = null;
+    }
+
+    @WorkerTask(TASK_TYPE)
+    public Map<String, Object> run() throws InterruptedException {
+        int attempt = invocations.incrementAndGet();
+        LOGGER.info("ControllableWorker.run invocation #{}", attempt);
+        if (enteredRun != null) {
+            enteredRun.countDown();
+        }
+        if (release != null) {
+            // Bounded to keep the test fast even if something goes wrong.
+            release.await(30, TimeUnit.SECONDS);
+        }
+        Map<String, Object> output = new HashMap<>();
+        output.put("attempt", attempt);
+        return output;
+    }
+}

--- a/test-harness/src/test/resources/controllable_async_system_task_workflow.json
+++ b/test-harness/src/test/resources/controllable_async_system_task_workflow.json
@@ -1,0 +1,26 @@
+{
+  "name": "controllable_async_system_task_wf",
+  "description": "workflow with a single controllable async system task (issues #1321/#1322)",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "controllable_task",
+      "taskReferenceName": "controllable_ref",
+      "inputParameters": {},
+      "type": "CONTROLLABLE_SYS_TASK",
+      "startDelay": 0,
+      "optional": false,
+      "asyncComplete": false
+    }
+  ],
+  "inputParameters": [],
+  "outputParameters": {
+    "taskOutput": "${controllable_ref.output.attempt}"
+  },
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false,
+  "timeoutPolicy": "ALERT_ONLY",
+  "timeoutSeconds": 0,
+  "ownerEmail": "test@harness.com"
+}


### PR DESCRIPTION
## Summary

Adds an opt-in execution mode for `@WorkerTask` annotated workers: **`conductor.annotated-workers.mode=poll-worker`** executes them through the standard worker **poll/update path** instead of the async system-task machinery. This is the execution model orkes-conductor uses in production for these exact task types (its workers process runs this repo's `LLMWorkers` et al. via SDK pollers against the task API); this PR provides the same model in-process, so OSS stays single-binary. Default is `system-task` — **behavior is byte-identical to main unless the flag is set**.

Design doc with the full convergence rationale: [`docs/design/2026-07-17-annotated-workers-poll-mode.md`](docs/design/2026-07-17-annotated-workers-poll-mode.md).

## Why

Annotated workers (`LLM_CHAT_COMPLETE` et al.) run blocking provider calls. On the system-task path they execute inside `start()` with the task still `SCHEDULED` and the queue message popped-but-unacked; any call outlasting the queue's redelivery window (redis: 30s, sqlite/postgres/mysql: ~60s) is redelivered and executed twice — duplicate paid LLM calls (#1321). On the poll path this is **structurally impossible**: `ExecutionService.poll` acks (removes) the queue message and persists `IN_PROGRESS` *before* the method runs. Recovery for a dead worker is the decider's def-aware `responseTimeoutSeconds` — the mechanism worker tasks have always used.

## What changed

- **`WorkerTaskAnnotationScanner`** — in poll-worker mode, annotated types are not registered as system tasks, so the decider queues them like any worker task. A `TaskMapper` per type is still registered in both modes. Discovered adapters are exposed for the polling host.
- **`AnnotatedWorkerPollingHost`** (new, `@ConditionalOnProperty` poll-worker) — per-`@WorkerTask` pollers (`threadCount`/`pollingInterval`/`domain` from the annotation) drive `ExecutionService.poll` → invoke via the **same `AnnotatedWorkflowSystemTask` adapter** used in system-task mode (identical parameter/result mapping, `TaskContext`, `NonRetryableException` → `FAILED_WITH_TERMINAL_ERROR`) → `ExecutionService.updateTask`. This is the same server-side machinery remote SDK workers hit through the task API, minus the HTTP hop.
- **Task-def auto-registration** — on the poll path the def is the recovery policy, so the host registers a def per annotated type when absent (`responseTimeoutSeconds=3600`, `retryCount=3`, exponential backoff), mirroring orkes-conductor's workers-side `wireupTaskDefinitions()`.

No existing execution paths are touched: no changes to `AsyncSystemTaskExecutor`, `SystemTaskWorker`, `DeciderService`, or any queue implementation.

## E2E proof (`AnnotatedWorkerPollModeSpec`, real redis queue via testcontainers)

1. **Polling works end-to-end**: a workflow with an annotated task completes with the worker's output; the task is claimed by an `annotated-poll-worker` thread; the type is verifiably absent from the system-task registry; the auto-registered def carries the recovery settings.
2. **Exactly-once under a blocked invocation**: the worker blocks mid-"provider call" (latch-controlled); the task is `IN_PROGRESS` and the queue message already acked; `processUnacks` + a direct `pop` confirm there is **nothing to redeliver**; after release the workflow completes with `invocations == 1`.

Both pass (`tests=2, failures=0`), plus unit tests for the host (poll→execute→update, FAILED/terminal-error mapping, empty poll, def registration) and scanner mode behavior.

Regression: full `:conductor-core:test` green; default-mode harness specs (`SystemTaskSpec`, `SimpleWorkflowSpec`) green.

## Relationship to #1335

#1335 fixes #1321 *on* the system-task path (execution lease). This PR provides the alternative/long-term execution model that sidesteps that path entirely for annotated workers, and converges OSS with orkes-conductor's architecture (same annotation, same worker beans, same server mechanism — only the poller transport differs). The two are complementary: the lease protects system-task mode and `HttpTask`; poll-worker mode is the opt-in future default.

## Scaling topologies

Poll-worker mode routes annotated types through the standard task API path, so all three deployment shapes work with the same `@WorkerTask` beans:

1. **Single binary** (default): the in-process host polls; scales with server replicas (competitive polling over the shared queue).
2. **Server + external workers**: external worker processes (conductor-client + the same beans — orkes' workers-app assembly) poll the task API alongside the in-process host.
3. **Fully external, independently scalable** (orkes-exact): `conductor.annotated-workers.polling-host.enabled=false` — the server only schedules, queues, and auto-registers task defs; standalone worker jars own all execution and scale independently of the server fleet.

## Known deltas (documented in the design doc)

- Poll latency (`pollingInterval`, default 100ms per the annotation) replaces near-instant system-task dispatch — tune per task type for agent loops.
- `AnnotatedTaskCancellationHandler` (engine-side `cancel()`) has no poll-side callback yet; in-flight invocations run to completion on workflow termination.
- Decider response-timeout retries now apply to annotated tasks in poll mode (def `retryCount=3` default) — review per task type where a retry has billing cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

