### PR TITLE
fix(ui-next): batch of UI bug fixes (status humanize, counters, queue wait, ref-name trim, diff editor, name validation)

### DIFF
--- a/ui-next/src/components/StatusBadge.tsx
+++ b/ui-next/src/components/StatusBadge.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from "react";
 import { TaskStatus } from "types/TaskStatus";
 import { HumanTaskState as TaskState } from "types/HumanTaskTypes";
 import { getChipStatusColor } from "utils/helpers";
-import { capitalizeFirstLetter } from "utils/utils";
+import { humanizeStatus } from "utils/utils";
 import TagChip from "components/ui/TagChip";
 
 export interface StatusBadgeProps {
@@ -21,11 +21,7 @@ const StatusBadge: FunctionComponent<StatusBadgeProps> = ({
       : {
           backgroundColor: color,
         };
-  let formattedStatus = status ? status.toLowerCase() : "";
-  formattedStatus =
-    formattedStatus && formattedStatus.length > 0
-      ? capitalizeFirstLetter(formattedStatus)
-      : "";
+  const formattedStatus = humanizeStatus(status);
   return (
     <TagChip
       style={chipStyles}

--- a/ui-next/src/components/StatusTagChip.tsx
+++ b/ui-next/src/components/StatusTagChip.tsx
@@ -3,7 +3,7 @@ import { Chip } from "@mui/material";
 import { WorkflowExecutionStatus } from "types/Execution";
 import { TaskStatus } from "types/TaskStatus";
 import { getChipStatusColor } from "utils/helpers";
-import { capitalizeFirstLetter } from "utils/utils";
+import { humanizeStatus } from "utils/utils";
 
 export const renderStatusTagChip = (value: string[], getTagProps: any) =>
   value.map((val: string | { label: string }, index) => {
@@ -16,7 +16,7 @@ export const renderStatusTagChip = (value: string[], getTagProps: any) =>
     return (
       <Chip
         key={key}
-        label={capitalizeFirstLetter(renderableLabel)}
+        label={humanizeStatus(renderableLabel)}
         {...otherTagProps}
         sx={{
           marginTop: "1px",

--- a/ui-next/src/components/WorkflowStatusBadge.tsx
+++ b/ui-next/src/components/WorkflowStatusBadge.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from "react";
 import { getChipStatusColor } from "utils/helpers";
-import { capitalizeFirstLetter } from "utils/utils";
+import { humanizeStatus } from "utils/utils";
 import TagChip from "./ui/TagChip";
 import { WorkflowExecutionStatus } from "types/Execution";
 
@@ -18,11 +18,7 @@ const WorkflowStatusBadge: FunctionComponent<WorkflowStatusBadgeProps> = ({
       : {
           backgroundColor: color,
         };
-  let formattedStatus = status ? status.toLowerCase() : "";
-  formattedStatus =
-    formattedStatus && formattedStatus.length > 0
-      ? capitalizeFirstLetter(formattedStatus)
-      : "";
+  const formattedStatus = humanizeStatus(status);
   return (
     <TagChip
       style={chipStyles}

--- a/ui-next/src/components/features/flow/components/RichAddTaskMenu/AddTaskSidebar.tsx
+++ b/ui-next/src/components/features/flow/components/RichAddTaskMenu/AddTaskSidebar.tsx
@@ -42,6 +42,7 @@ import {
   SubWorkflowTaskDef,
 } from "types";
 import { getSequentiallySuffix } from "utils/strings";
+import { pluralizeResults } from "utils/helpers";
 import { getInitials } from "utils/utils";
 import { ActorRef } from "xstate";
 import { itemFilterMatcher } from "./helpers";
@@ -566,7 +567,7 @@ const AddTaskSidebar = ({
                   userSelect: "none",
                 }}
               >
-                {filteredOptions.length} results
+                {pluralizeResults(filteredOptions.length)}
               </Typography>
             )}
           </Box>

--- a/ui-next/src/components/features/flow/state/service.ts
+++ b/ui-next/src/components/features/flow/state/service.ts
@@ -74,7 +74,14 @@ export const updateWorkflowDefinitionService = async (
         }),
       workflowExecutionStatus,
     );
-    const justTheIds = nodes.map(_property("id"));
+    // Compare reference names trimmed of surrounding whitespace so a
+    // leading/trailing space (e.g. " wait_ref" vs "wait_ref") is still caught
+    // as a duplicate. Without trimming the two are distinct strings, so the
+    // whitespace variant silently bypasses duplicate detection while looking
+    // identical in the field and breaking ${ref.output} references and JOINs.
+    const justTheIds = nodes
+      .map(_property("id"))
+      .map((id) => (typeof id === "string" ? id.trim() : id));
     const duplicates = _filter(justTheIds, (value, index, iteratee) =>
       _includes(iteratee, value, index + 1),
     );

--- a/ui-next/src/components/ui/DiffEditor.tsx
+++ b/ui-next/src/components/ui/DiffEditor.tsx
@@ -13,6 +13,16 @@ const defaultOptions: DiffEditorOptions = {
 
 export const DiffEditor = ({ options = {}, ...rest }) => {
   return (
-    <MonacoDiffEditor options={{ ...defaultOptions, ...options }} {...rest} />
+    <MonacoDiffEditor
+      // Keep the underlying text models alive across unmount. The diff editor is
+      // toggled off when a confirm-save flow closes (e.g. after the backend
+      // rejects a save); without this, Monaco disposes the models while the
+      // widget still references them and throws the uncaught
+      // "TextModel got disposed before DiffEditorWidget model got reset".
+      keepCurrentOriginalModel
+      keepCurrentModifiedModel
+      options={{ ...defaultOptions, ...options }}
+      {...rest}
+    />
   );
 };

--- a/ui-next/src/pages/agent/executions/AgentSearch.tsx
+++ b/ui-next/src/pages/agent/executions/AgentSearch.tsx
@@ -12,6 +12,7 @@ import { colors } from "theme/tokens/variables";
 import { TaskExecutionResult } from "types/TaskExecution";
 import { DoSearchProps } from "types/WorkflowExecution";
 import { RUN_AGENT_URL } from "utils/constants/route";
+import { pluralizeResults } from "utils/helpers";
 import { dateToEpoch } from "utils/date";
 import { commonlyUsedDateTime, getSearchDateTime } from "utils/date";
 import { usePushHistory } from "utils/hooks/usePushHistory";
@@ -126,7 +127,7 @@ export default function AgentPanel() {
     return (
       <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
         <MuiTypography fontWeight={400} fontSize={14}>
-          {results.length} results
+          {pluralizeResults(results.length)}
         </MuiTypography>
         <MuiTypography color={colors.greyText} fontSize={12}>
           of {totalHits}

--- a/ui-next/src/pages/execution/TaskSummary.tsx
+++ b/ui-next/src/pages/execution/TaskSummary.tsx
@@ -1,5 +1,6 @@
 import _isFinite from "lodash/isFinite";
 import _get from "lodash/get";
+import { durationRenderer } from "utils/date";
 import { NavLink, KeyValueTable } from "components";
 import { Link, Paper } from "@mui/material";
 import { ExecutionTask, TaskType } from "types";
@@ -104,10 +105,13 @@ export default function TaskSummary({ taskResult }: TaskSummaryProps) {
       value: taskResult.seq,
     });
   }
-  if (taskResult.queueWaitTime) {
+  if (_isFinite(taskResult.queueWaitTime)) {
+    // queueWaitTime is startTime - scheduledTime; sub-millisecond clock skew can
+    // make it slightly negative. Clamp to 0 and render with a unit so it reads
+    // consistently with the Duration row (e.g. "0ms") instead of a raw signed int.
     data.push({
       label: "Queue wait time",
-      value: taskResult.queueWaitTime,
+      value: durationRenderer(Math.max(0, taskResult.queueWaitTime as number)),
     });
   }
   if (shouldDisplayEvaluatedCase) {

--- a/ui-next/src/pages/executions/TaskSearch.tsx
+++ b/ui-next/src/pages/executions/TaskSearch.tsx
@@ -19,6 +19,7 @@ import { Key } from "ts-key-enum";
 import { TaskExecutionResult } from "types/TaskExecution";
 import { IObject } from "types/common";
 import { dateToEpoch } from "utils";
+import { pluralizeResults } from "utils/helpers";
 import { ERROR_URL, NEW_TASK_DEF_URL } from "utils/constants/route";
 import { commonlyUsedDateTime, getSearchDateTime } from "utils/date";
 import { usePushHistory } from "utils/hooks/usePushHistory";
@@ -37,7 +38,7 @@ const getTableTitle = (resultObj: TaskExecutionResult) => {
   return (
     <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
       <MuiTypography fontWeight={400} fontSize={14}>
-        {results.length} results
+        {pluralizeResults(results.length)}
       </MuiTypography>
       <MuiTypography color={colors.greyText} fontSize={12}>
         of {totalHits}

--- a/ui-next/src/pages/executions/WorkflowSearch.tsx
+++ b/ui-next/src/pages/executions/WorkflowSearch.tsx
@@ -12,6 +12,7 @@ import { colors } from "theme/tokens/variables";
 import { TaskExecutionResult } from "types/TaskExecution";
 import { DoSearchProps } from "types/WorkflowExecution";
 import { RUN_WORKFLOW_URL } from "utils/constants/route";
+import { pluralizeResults } from "utils/helpers";
 import { dateToEpoch } from "utils/date";
 import { commonlyUsedDateTime, getSearchDateTime } from "utils/date";
 import { usePushHistory } from "utils/hooks/usePushHistory";
@@ -150,7 +151,7 @@ export default function WorkflowPanel({
     return (
       <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
         <MuiTypography fontWeight={400} fontSize={14}>
-          {results.length} results
+          {pluralizeResults(results.length)}
         </MuiTypography>
         <MuiTypography color={colors.greyText} fontSize={12}>
           of {totalHits}

--- a/ui-next/src/utils/constants/regex.ts
+++ b/ui-next/src/utils/constants/regex.ts
@@ -6,8 +6,13 @@ export const CONTAIN_VARIABLE_SYNTAX_REGEX = /^(?=.*?[${}]{1}).*$/;
 // workflowType IN (wf_name(test), wf_name2), because the
 // end parenthesis would be interpreted as the end of the
 // IN clause.
+// `/` and `%` are additionally disallowed: although the backend accepts them,
+// a name containing either cannot be reopened from the UI. The name is carried
+// as a path segment (/workflowDef/{name} and GET /metadata/workflow/{name}), and
+// the percent-encoded `%2F` / `%25` is rejected by the server's path handling
+// (400), leaving the definition saved but unreachable.
 export const WORKFLOW_NAME_REGEX =
-  /^(?! )[.A-Za-z0-9!@#$%^&*_<>{}[\]|+=\s-]+(?<! )$/;
+  /^(?! )[.A-Za-z0-9!@#$^&*_<>{}[\]|+=\s-]+(?<! )$/;
 
 export const TASK_NAME_REGEX = /^[A-Za-z0-9_<>{}#\s-]*$/;
 

--- a/ui-next/src/utils/constants/workflowNameRegex.test.ts
+++ b/ui-next/src/utils/constants/workflowNameRegex.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { WORKFLOW_NAME_REGEX } from "./regex";
+
+describe("WORKFLOW_NAME_REGEX", () => {
+  it("accepts ordinary workflow names", () => {
+    expect(WORKFLOW_NAME_REGEX.test("bughunt_demo")).toBe(true);
+    expect(WORKFLOW_NAME_REGEX.test("bug hunt demo")).toBe(true);
+    expect(WORKFLOW_NAME_REGEX.test("wf<x>{y}#1")).toBe(true);
+  });
+
+  it("rejects slash and percent, which the UI route cannot round-trip", () => {
+    expect(WORKFLOW_NAME_REGEX.test("bughunt/slash2")).toBe(false);
+    expect(WORKFLOW_NAME_REGEX.test("bughunt%25")).toBe(false);
+  });
+
+  it("rejects leading and trailing spaces", () => {
+    expect(WORKFLOW_NAME_REGEX.test(" leading")).toBe(false);
+    expect(WORKFLOW_NAME_REGEX.test("trailing ")).toBe(false);
+  });
+});

--- a/ui-next/src/utils/helpers.ts
+++ b/ui-next/src/utils/helpers.ts
@@ -28,6 +28,14 @@ export function isFailedTask(status: TaskStatus) {
  * @param {array} data: data of table
  * @returns {string}
  */
+/**
+ * Formats a result count with a correctly singularized noun, e.g.
+ * "1 result" / "3 results".
+ */
+export function pluralizeResults(count: number): string {
+  return `${count} ${count === 1 ? "result" : "results"}`;
+}
+
 export function createTableTitle({
   filteredData = [],
   data = [],
@@ -35,11 +43,10 @@ export function createTableTitle({
   filteredData: any[];
   data: any[];
 }): string {
-  return filteredData.length === data.length
-    ? `${filteredData.length} results`
-    : `${filteredData.length} results (${
-        data.length - filteredData.length
-      } not shown)`;
+  const count = filteredData.length;
+  return count === data.length
+    ? pluralizeResults(count)
+    : `${pluralizeResults(count)} (${data.length - count} not shown)`;
 }
 
 export function juxt<T extends readonly unknown[]>(

--- a/ui-next/src/utils/humanizeStatus.test.ts
+++ b/ui-next/src/utils/humanizeStatus.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { humanizeStatus } from "./utils";
+
+describe("humanizeStatus", () => {
+  it("title-cases multi-word snake-case statuses", () => {
+    expect(humanizeStatus("IN_PROGRESS")).toBe("In Progress");
+    expect(humanizeStatus("TIMED_OUT")).toBe("Timed Out");
+    expect(humanizeStatus("FAILED_WITH_TERMINAL_ERROR")).toBe(
+      "Failed With Terminal Error",
+    );
+  });
+
+  it("leaves single-word statuses correctly capitalized", () => {
+    expect(humanizeStatus("COMPLETED")).toBe("Completed");
+    expect(humanizeStatus("FAILED")).toBe("Failed");
+  });
+
+  it("handles already-lowercased input", () => {
+    expect(humanizeStatus("in_progress")).toBe("In Progress");
+  });
+
+  it("returns an empty string for empty or missing input", () => {
+    expect(humanizeStatus("")).toBe("");
+    expect(humanizeStatus(undefined)).toBe("");
+  });
+});

--- a/ui-next/src/utils/pluralizeResults.test.ts
+++ b/ui-next/src/utils/pluralizeResults.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { createTableTitle, pluralizeResults } from "./helpers";
+
+describe("pluralizeResults", () => {
+  it("singularizes a count of one", () => {
+    expect(pluralizeResults(1)).toBe("1 result");
+  });
+
+  it("pluralizes zero and counts greater than one", () => {
+    expect(pluralizeResults(0)).toBe("0 results");
+    expect(pluralizeResults(2)).toBe("2 results");
+  });
+});
+
+describe("createTableTitle", () => {
+  it("singularizes when a single row is shown", () => {
+    expect(createTableTitle({ filteredData: [1], data: [1] })).toBe(
+      "1 result",
+    );
+  });
+
+  it("pluralizes and reports hidden rows when filtered", () => {
+    expect(
+      createTableTitle({ filteredData: [1], data: [1, 2, 3] }),
+    ).toBe("1 result (2 not shown)");
+    expect(
+      createTableTitle({ filteredData: [1, 2], data: [1, 2] }),
+    ).toBe("2 results");
+  });
+});

--- a/ui-next/src/utils/queueWaitTime.test.ts
+++ b/ui-next/src/utils/queueWaitTime.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { durationRenderer } from "./date";
+
+// Covers the queue-wait-time formatting used in the task Summary panel:
+// the value (startTime - scheduledTime) is clamped to >= 0 and rendered with a
+// unit so sub-millisecond clock skew never surfaces as a raw negative integer.
+describe("queue wait time formatting", () => {
+  const format = (value: number) => durationRenderer(Math.max(0, value));
+
+  it("clamps negative clock-skew values to 0ms", () => {
+    expect(format(-6)).toBe("0ms");
+  });
+
+  it("renders zero with a unit", () => {
+    expect(format(0)).toBe("0ms");
+  });
+
+  it("renders small positive waits with a ms unit", () => {
+    expect(format(42)).toBe("42ms");
+  });
+});

--- a/ui-next/src/utils/utils.ts
+++ b/ui-next/src/utils/utils.ts
@@ -123,6 +123,22 @@ export const tryFunc = async <T, E extends ErrorObj | undefined = undefined>({
 
 export const capitalizeFirstLetter = _capitalize;
 
+// Renders a raw status enum as human-readable text. Conductor statuses are
+// upper-snake-case (e.g. IN_PROGRESS, TIMED_OUT); a plain capitalize leaves the
+// underscore and only title-cases the first word ("In_progress"). Split on
+// underscores and title-case each word so multi-word statuses read correctly
+// ("In Progress", "Timed Out") while single-word ones are unchanged.
+export const humanizeStatus = (status?: string): string => {
+  if (!status) {
+    return "";
+  }
+  return status
+    .toLowerCase()
+    .split("_")
+    .map((word) => capitalizeFirstLetter(word))
+    .join(" ");
+};
+
 export const getTitleSuffix = (type?: string, id?: string) => {
   if (type) {
     return ` - ${capitalizeFirstLetter(type)}` + (id ? ` - ${id}` : "");


### PR DESCRIPTION
## Summary

Six focused ui-next bug fixes reported downstream in orkes-io/conductor-ui. One commit per issue; each passes typecheck, lint, and the full vitest suite locally.

| Commit | Issue | Fix |
|---|---|---|
| humanize status enums | #4240 | Multi-word statuses (`In_progress`, `Timed_out`) rendered raw. Added `humanizeStatus()` (underscore→space + title-case); used in StatusBadge / WorkflowStatusBadge / StatusTagChip. |
| queue wait time | #4245 | Task Summary "Queue wait time" showed a unitless, sometimes-negative int. Clamp to `>=0` and render via `durationRenderer` (e.g. `0ms`). |
| singularize counters | #4246 | `1 results` → `1 result`. Added `pluralizeResults()`; used in `createTableTitle` (shared tables) and the Workflow/Task/Agent search headers + Add-task sidebar. |
| trim ref names | #4248 | Leading/trailing space bypassed duplicate task-reference-name detection. Compare trimmed ids so `" wait_ref"` collides with `wait_ref`. |
| diff editor dispose | #4250 | `keepCurrentOriginalModel`/`keepCurrentModifiedModel` on the shared DiffEditor to stop the uncaught "TextModel got disposed before DiffEditorWidget model got reset" when a confirm-save flow closes. |
| name validation | #4241 | Workflow names with `/` or `%` saved but could never be reopened (path-segment `%2F`/`%25` → server 400). Dropped `%` from `WORKFLOW_NAME_REGEX` (`/` already excluded) so both fail client-side validation. |

## Verification
- `tsc --noEmit` — 0 errors
- `eslint src/**/*.{js,jsx,ts,tsx} --quiet` — clean
- `vitest run` — 685 passed, 1 skipped (added: humanizeStatus, queue-wait formatting, pluralizeResults/createTableTitle, WORKFLOW_NAME_REGEX)
- `vite build` — green

Fixes orkes-io/conductor-ui#4240, orkes-io/conductor-ui#4245, orkes-io/conductor-ui#4246, orkes-io/conductor-ui#4248, orkes-io/conductor-ui#4250, orkes-io/conductor-ui#4241