### PR TITLE
ci: run python SDK agent e2e against a SQLite server built from source

### DIFF
--- a/.github/agent-e2e/known-failures-python.json
+++ b/.github/agent-e2e/known-failures-python.json
@@ -1,0 +1,4 @@
+{
+  "_README": "conductor-oss known failures for the agent python e2e suite (bundle: conductor-ai-e2e-python-*, from conductor-oss/python-sdk), consumed by known_failures_plugin.py via E2E_KNOWN_FAILURES. Each key is a pytest node-id (or a '<file>::<Class>::<test>' suffix); the value is the reason + a tracking link. The suite is expected GREEN against the SQLite server built from this repo, so this list is EMPTY. Add an entry only for a genuine, tracked, deterministic failure while its fix is in flight; a key that matches nothing is a harmless no-op (the test still runs and the gate still catches a real break), and a fixed bug turns its test XPASS — remove the entry then. Do NOT list flaky tests (those are handled by rerun).",
+  "_HOWTO": "Reconcile from the run's results/junit-e2e.xml. Example entry: \"test_suite4_mcp_tools.py::TestSuite4McpTools::test_mcp_lifecycle\": \"reason — conductor-oss/conductor#NNNN\""
+}

--- a/.github/agent-e2e/known_failures_plugin.py
+++ b/.github/agent-e2e/known_failures_plugin.py
@@ -1,0 +1,62 @@
+"""Known-failure xfail loader for the agent (conductor-ai) python e2e suite.
+
+The e2e suite is shared: the SAME tests (this repo's python SDK e2e, shipped as the
+`conductor-ai-e2e-python-*` bundle from conductor-oss/python-sdk) run against multiple
+targets. A test can be a known failure on one target and pass on another, so skip lists are
+kept per target and selected via the E2E_KNOWN_FAILURES env var. This file is the loader; the
+conductor-oss list lives in known-failures-python.json (empty when the suite is green).
+
+It runs as an external pytest plugin (`-p known_failures_plugin`) so it composes with the
+downloaded bundle's own conftest WITHOUT modifying the bundle.
+
+Point E2E_KNOWN_FAILURES at a JSON object mapping a test node-id (or a "<file>::<test>" suffix
+of one) to a human-readable reason. Matched tests are marked xfail(strict=False, run=True):
+they still RUN, a failure reports as XFAIL (green), and a fix XPASSes — the signal to delete
+the entry. Keys that match nothing are harmless no-ops (the test runs and the gate still
+catches a real break), so a stale entry can never silently hide a regression. Keys beginning
+with "_" (e.g. "_README") are treated as comments and ignored.
+"""
+
+import json
+import os
+
+import pytest
+
+
+def _load_known_failures():
+    path = os.environ.get("E2E_KNOWN_FAILURES")
+    if not path or not os.path.exists(path):
+        return {}
+    with open(path) as f:
+        data = json.load(f)
+    return {k: v for k, v in data.items() if not k.startswith("_")}
+
+
+def _matches(nodeid, suffix):
+    # The suite appends an xdist loadgroup label as "@<group>" to some node-ids
+    # (e.g. test_mcp_lifecycle@credentials). Match against both the raw node-id and
+    # the label-stripped base so entries can be written either way.
+    for nid in (nodeid, nodeid.split("@", 1)[0]):
+        for suf in (suffix, suffix.split("@", 1)[0]):
+            if nid == suf or nid.endswith("::" + suf) or nid.endswith(suf):
+                return True
+    return False
+
+
+def pytest_collection_modifyitems(config, items):
+    known = _load_known_failures()
+    if not known:
+        return
+    matched = 0
+    for item in items:
+        for suffix, reason in known.items():
+            if _matches(item.nodeid, suffix):
+                item.add_marker(pytest.mark.xfail(reason=reason, strict=False, run=True))
+                matched += 1
+                break
+    reporter = config.pluginmanager.get_plugin("terminalreporter")
+    if reporter is not None:
+        reporter.write_line(
+            f"[known-failures] xfail-marked {matched} item(s) from "
+            f"{os.environ.get('E2E_KNOWN_FAILURES')}"
+        )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       heavy-persistence: ${{ steps.filter.outputs.heavy-persistence }}
+      agent: ${{ steps.filter.outputs.agent }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -61,6 +62,14 @@ jobs:
               - 'os-persistence-v3/**'
               - 'scheduler/cassandra-persistence/**'
               - 'scheduler/mysql-persistence/**'
+            agent:
+              - 'ai/**'
+              - 'conductor-agentspan/**'
+              - 'server/**'
+              - 'core/**'
+              - 'sqlite-persistence/**'
+              - '.github/agent-e2e/**'
+              - '.github/workflows/ci.yml'
 
   build:
     runs-on: ubuntu-latest
@@ -404,3 +413,106 @@ jobs:
 
       - name: Build UI
         run: NODE_OPTIONS=--max-old-space-size=4096 pnpm build
+
+  # Boots the conductor server built from THIS commit in SQLite mode (the default — no external
+  # DB) and runs the released python SDK agent e2e suite against it, so a server change can't
+  # silently break the SDK before a release. The suite + bundle come from conductor-oss/python-sdk
+  # (conductor-ai-e2e-python-<version>); the server auto-configures the openai provider from
+  # OPENAI_API_KEY (conductor.ai.openai.api-key), so no manual integration setup is needed.
+  # Known failures (none today) are xfail-ed via .github/agent-e2e/ so the lane can gate while
+  # any future gap is fixed. Runs on push/dispatch, and on PRs that touch agent-relevant paths.
+  python-sdk-e2e:
+    name: Python SDK E2E (SQLite)
+    needs: detect-changes
+    if: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.agent == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    env:
+      # Pinned python-sdk release bundle (conductor-python[agents] resolves to the same version).
+      # python-sdk release tags carry no `v` prefix. Bump deliberately.
+      CONDUCTOR_PY_E2E_BUNDLE_VERSION: "2.0.0-rc2"
+      AGENTSPAN_SERVER_URL: http://localhost:8080/api
+      AGENTSPAN_LLM_MODEL: openai/gpt-4o-mini
+      MCP_TESTKIT_URL: http://localhost:3001
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      E2E_KNOWN_FAILURES: ${{ github.workspace }}/.github/agent-e2e/known-failures-python.json
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Zulu JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: "21"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build server boot jar
+        run: ./gradlew :conductor-server:bootJar -x test --no-daemon
+
+      - name: Start mcp-testkit (best effort)
+        run: |
+          python -m pip install --quiet mcp-testkit || { echo "::warning::mcp-testkit install failed — MCP suites will skip"; exit 0; }
+          nohup mcp-testkit --transport http --port 3001 > mcp-testkit.log 2>&1 &
+          for i in $(seq 1 15); do curl -sf http://localhost:3001/ >/dev/null 2>&1 && break; sleep 1; done
+          echo "mcp-testkit started (or unavailable; suites skip gracefully)"
+
+      - name: Start conductor server (SQLite)
+        run: |
+          JAR="$(ls server/build/libs/conductor-server-*-boot.jar | head -1)"
+          echo "booting $JAR"
+          nohup java -jar "$JAR" --server.port=8080 > conductor-server.log 2>&1 &
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:8080/health >/dev/null 2>&1; then
+              echo "server healthy after ~$((i * 3))s"; break
+            fi
+            if [ "$i" -eq 60 ]; then echo "::error::server failed to become healthy within 180s"; tail -100 conductor-server.log; exit 1; fi
+            sleep 3
+          done
+
+      - name: Fetch python e2e bundle
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          V="${CONDUCTOR_PY_E2E_BUNDLE_VERSION}"
+          NAME="conductor-ai-e2e-python-${V}"
+          gh release download "${V}" --repo conductor-oss/python-sdk \
+            --pattern "${NAME}.tar.gz" --pattern "${NAME}.tar.gz.sha256" --dir .
+          echo "$(cat "${NAME}.tar.gz.sha256")  ${NAME}.tar.gz" | sha256sum -c -
+          tar -xzf "${NAME}.tar.gz"
+          echo "BUNDLE_DIR=${NAME}" >> "$GITHUB_ENV"
+
+      # `run.sh` forwards extra args to pytest, so `-p known_failures_plugin` loads the
+      # orkes-style xfail plugin (found via PYTHONPATH) without editing the bundle. Gating:
+      # a genuine failure fails the job; entries in known-failures-python.json (none today)
+      # are xfail-ed green.
+      - name: Run python e2e (SQLite; known failures xfail-ed)
+        env:
+          PYTHONPATH: ${{ github.workspace }}/.github/agent-e2e
+        working-directory: ${{ env.BUNDLE_DIR }}
+        run: bash run.sh -p known_failures_plugin
+
+      - name: Publish test report
+        if: always()
+        uses: mikepenz/action-junit-report@v4
+        with:
+          report_paths: "${{ env.BUNDLE_DIR }}/results/junit-e2e.xml"
+          check_name: "Python SDK E2E (SQLite)"
+          fail_on_failure: false
+          require_tests: false
+
+      - name: Upload results + server log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-sdk-e2e-results
+          path: |
+            ${{ env.BUNDLE_DIR }}/results/**
+            conductor-server.log
+            mcp-testkit.log
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
## What

Adds a gating **`python-sdk-e2e`** job to CI that boots the conductor server **built from this commit** in **SQLite mode** (the default persistence — no external DB) and runs the released **python SDK agent e2e** suite against it. This catches server changes that would break the SDK end-to-end **before a release**.

## Why

Today nothing in this repo's CI exercises the agent SDK against a from-source server. The python SDK ships an e2e suite (`conductor-oss/python-sdk`, released as the `conductor-ai-e2e-python-*` bundle); wiring it here means a server-side regression in the agent surface (LLM chat/complete, tools, MCP, guardrails, scheduling, …) fails CI instead of surfacing after release.

## How

- **From-source server, SQLite:** builds `:conductor-server:bootJar` and boots it on `:8080`. SQLite is the default (`conductor.db.type=sqlite` / `queue.type=sqlite` / `indexing.type=sqlite`), so no Postgres/Redis/ES services are needed.
- **openai auto-config:** the server reads `conductor.ai.openai.api-key=${OPENAI_API_KEY:}`, so setting the env var is enough — no manual integration registration.
- **Bundle:** fetches the pinned `conductor-ai-e2e-python-2.0.0-rc2` bundle from `conductor-oss/python-sdk` at runtime, sha256-verified; `run.sh` installs `conductor-python[agents]==<version>` and runs the full suite.
- **Skip support (green today):** known failures are xfail-ed via an external pytest plugin (`.github/agent-e2e/known_failures_plugin.py`, loaded with `-p known_failures_plugin`) reading a per-repo list (`.github/agent-e2e/known-failures-python.json`). The suite is green against this server, so the list is **empty** — the mechanism stays so the lane can gate while any future gap is fixed (a fix XPASSes; a stale/mismatched entry is a harmless no-op that can't hide a regression).
- **Cost control:** runs on push/dispatch, and on PRs only when agent-relevant paths change (`ai/`, `conductor-agentspan/`, `server/`, `core/`, `sqlite-persistence/`, the workflow) via a `detect-changes` `agent` filter — so unrelated PRs don't spend LLM budget.

## ⚠️ Requires a repo secret

The job needs **`OPENAI_API_KEY`** (and optionally `ANTHROPIC_API_KEY`) configured as a repository/organization secret. GitHub does **not** pass secrets to fork PRs, so this job can only run with real LLM calls on branches in this repo (or once the secret is available) — a maintainer should validate it on a branch. The bundle version pin (`2.0.0-rc2`) should be bumped deliberately as new python-sdk releases cut their e2e bundles.

