### PR TITLE
feat(files): enforce workflow-scoped file transfers

### DIFF
--- a/awss3-storage/src/main/java/org/conductoross/conductor/s3/storage/S3FileStorage.java
+++ b/awss3-storage/src/main/java/org/conductoross/conductor/s3/storage/S3FileStorage.java
@@ -132,4 +132,14 @@ public class S3FileStorage implements FileStorage {
                         .multipartUpload(CompletedMultipartUpload.builder().parts(parts).build())
                         .build());
     }
+
+    @Override
+    public void abortMultipartUpload(String storagePath, String uploadId) {
+        s3Client.abortMultipartUpload(
+                AbortMultipartUploadRequest.builder()
+                        .bucket(bucketName)
+                        .key(storagePath)
+                        .uploadId(uploadId)
+                        .build());
+    }
 }

--- a/common/src/main/java/org/conductoross/conductor/model/file/FileDownloadUrlResponse.java
+++ b/common/src/main/java/org/conductoross/conductor/model/file/FileDownloadUrlResponse.java
@@ -14,7 +14,10 @@ package org.conductoross.conductor.model.file;
 
 import java.util.Objects;
 
-/** Response to {@code GET /api/files/{fileId}/download-url}. Requires status {@code UPLOADED}. */
+/**
+ * Response to {@code GET /api/files/{workflowId}/{fileId}/download-url}. Requires status {@code
+ * UPLOADED}.
+ */
 public class FileDownloadUrlResponse {
 
     private String fileHandleId;

--- a/common/src/main/java/org/conductoross/conductor/model/file/FileHandle.java
+++ b/common/src/main/java/org/conductoross/conductor/model/file/FileHandle.java
@@ -15,7 +15,7 @@ package org.conductoross.conductor.model.file;
 import java.util.Objects;
 
 /**
- * File-metadata DTO returned by {@code GET /api/files/{fileId}}. Does not expose the
+ * File-metadata DTO returned by {@code GET /api/files/{workflowId}/{fileId}}. Does not expose the
  * server-internal {@code storagePath}.
  */
 public class FileHandle {
@@ -26,6 +26,9 @@ public class FileHandle {
     private String fileName;
 
     private String contentType;
+
+    /** Actual byte size reported by the storage backend after upload completion. */
+    private long fileSize;
 
     private String contentHash;
 
@@ -63,6 +66,14 @@ public class FileHandle {
 
     public void setContentType(String contentType) {
         this.contentType = contentType;
+    }
+
+    public long getFileSize() {
+        return fileSize;
+    }
+
+    public void setFileSize(long fileSize) {
+        this.fileSize = fileSize;
     }
 
     public String getContentHash() {
@@ -128,6 +139,7 @@ public class FileHandle {
         return Objects.equals(fileHandleId, that.fileHandleId)
                 && Objects.equals(fileName, that.fileName)
                 && Objects.equals(contentType, that.contentType)
+                && fileSize == that.fileSize
                 && Objects.equals(contentHash, that.contentHash)
                 && storageType == that.storageType
                 && uploadStatus == that.uploadStatus;
@@ -136,7 +148,13 @@ public class FileHandle {
     @Override
     public int hashCode() {
         return Objects.hash(
-                fileHandleId, fileName, contentType, contentHash, storageType, uploadStatus);
+                fileHandleId,
+                fileName,
+                contentType,
+                fileSize,
+                contentHash,
+                storageType,
+                uploadStatus);
     }
 
     @Override

--- a/common/src/main/java/org/conductoross/conductor/model/file/FileUploadCompleteResponse.java
+++ b/common/src/main/java/org/conductoross/conductor/model/file/FileUploadCompleteResponse.java
@@ -15,8 +15,8 @@ package org.conductoross.conductor.model.file;
 import java.util.Objects;
 
 /**
- * Response to {@code POST /api/files/{fileId}/upload-complete}. {@code contentHash} is the
- * backend-reported hash, or {@code null} for backends that do not expose one.
+ * Response to {@code POST /api/files/{workflowId}/{fileId}/upload-complete}. {@code contentHash} is
+ * the backend-reported hash, or {@code null} for backends that do not expose one.
  */
 public class FileUploadCompleteResponse {
 

--- a/common/src/main/java/org/conductoross/conductor/model/file/FileUploadResponse.java
+++ b/common/src/main/java/org/conductoross/conductor/model/file/FileUploadResponse.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 /**
  * Response to {@code POST /api/files}. Carries the new {@code fileHandleId} plus a presigned upload
  * URL and its expiry. Status is {@code UPLOADING}; client confirms via {@code POST
- * /api/files/{fileId}/upload-complete}.
+ * /api/files/{workflowId}/{fileId}/upload-complete}.
  */
 public class FileUploadResponse {
 

--- a/common/src/main/java/org/conductoross/conductor/model/file/FileUploadUrlResponse.java
+++ b/common/src/main/java/org/conductoross/conductor/model/file/FileUploadUrlResponse.java
@@ -15,7 +15,8 @@ package org.conductoross.conductor.model.file;
 import java.util.Objects;
 
 /**
- * Response to {@code GET /api/files/{fileId}/upload-url} — fresh presigned upload URL for retry.
+ * Response to {@code GET /api/files/{workflowId}/{fileId}/upload-url} — fresh presigned upload URL
+ * for retry.
  */
 public class FileUploadUrlResponse {
 

--- a/common/src/main/java/org/conductoross/conductor/model/file/MultipartCompleteRequest.java
+++ b/common/src/main/java/org/conductoross/conductor/model/file/MultipartCompleteRequest.java
@@ -16,8 +16,8 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Payload for {@code POST /api/files/{fileId}/multipart/{uploadId}/complete}. {@code partETags} is
- * the ordered list of ETags (or backend equivalents) from each part upload.
+ * Payload for {@code POST /api/files/{workflowId}/{fileId}/multipart/{uploadId}/complete}. {@code
+ * partETags} is the ordered list of ETags (or backend equivalents) from each part upload.
  */
 public class MultipartCompleteRequest {
 

--- a/common/src/main/java/org/conductoross/conductor/model/file/MultipartInitResponse.java
+++ b/common/src/main/java/org/conductoross/conductor/model/file/MultipartInitResponse.java
@@ -14,7 +14,10 @@ package org.conductoross.conductor.model.file;
 
 import java.util.Objects;
 
-/** Response to {@code POST /api/files/{fileId}/multipart} — initiates a multipart upload. */
+/**
+ * Response to {@code POST /api/files/{workflowId}/{fileId}/multipart} — initiates a multipart
+ * upload.
+ */
 public class MultipartInitResponse {
 
     private String fileHandleId;

--- a/core/src/main/java/org/conductoross/conductor/core/storage/FileStorage.java
+++ b/core/src/main/java/org/conductoross/conductor/core/storage/FileStorage.java
@@ -44,15 +44,12 @@ public interface FileStorage {
      */
     StorageFileInfo getStorageFileInfo(String storagePath);
 
-    /**
-     * Starts a backend-native multipart upload. Returns the backend's upload ID (S3 {@code
-     * UploadId}, GCS resumable session ID, etc.).
-     */
+    /** Starts a backend-native multipart upload and returns its backend-specific upload ID. */
     String initiateMultipartUpload(String storagePath);
 
     /**
-     * Returns a presigned URL for a single part of an S3 multipart upload. Not called for GCS/Azure
-     * — those reuse the resumable URL from {@link #initiateMultipartUpload}.
+     * Returns a signed URL for one multipart part. Provider-specific query parameters may be added
+     * by the transfer client after this URL is issued.
      *
      * @param partNumber 1-based part number
      */
@@ -62,7 +59,13 @@ public interface FileStorage {
     /**
      * Finalizes a multipart upload.
      *
-     * @param partETags ordered list of ETags returned by each part upload
+     * @param partETags ordered provider completion tokens, such as S3 ETags or Azure block IDs
      */
     void completeMultipartUpload(String storagePath, String uploadId, List<String> partETags);
+
+    /**
+     * Cancels a multipart upload when the backend exposes an explicit abort operation. Backends
+     * whose uncommitted parts expire automatically can use this default no-op.
+     */
+    default void abortMultipartUpload(String storagePath, String uploadId) {}
 }

--- a/core/src/main/java/org/conductoross/conductor/core/storage/FileStorageService.java
+++ b/core/src/main/java/org/conductoross/conductor/core/storage/FileStorageService.java
@@ -18,7 +18,7 @@ import org.conductoross.conductor.model.file.*;
 import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 /**
@@ -40,14 +40,14 @@ public interface FileStorageService {
      */
     FileUploadResponse createFile(@NotNull @Valid FileUploadRequest request);
 
-    /** Issues a fresh presigned upload URL for retry when the original has expired. */
-    FileUploadUrlResponse getUploadUrl(@NotEmpty String fileId);
+    /** Issues a fresh presigned upload URL when the exact owning workflow requests it. */
+    FileUploadUrlResponse getUploadUrl(@NotBlank String workflowId, @NotBlank String fileId);
 
     /**
      * Verifies the object is present on the backend, reads and persists {@code contentHash} and
      * actual size, transitions the record to {@code UPLOADED}.
      */
-    FileUploadCompleteResponse confirmUpload(@NotEmpty String fileId);
+    FileUploadCompleteResponse confirmUpload(@NotBlank String workflowId, @NotBlank String fileId);
 
     /**
      * Issues a presigned download URL. Requires status {@code UPLOADED}.
@@ -63,17 +63,21 @@ public interface FileStorageService {
      * @throws com.netflix.conductor.core.exception.AccessForbiddenException if the caller is not in
      *     the file's workflow family
      */
-    FileDownloadUrlResponse getDownloadUrl(@NotEmpty String fileId, @NotNull String workflowId);
+    FileDownloadUrlResponse getDownloadUrl(@NotBlank String workflowId, @NotBlank String fileId);
 
-    /** Returns full file metadata. The server-internal {@code storagePath} is not exposed. */
-    FileHandle getFileMetadata(@NotEmpty String fileId);
+    /**
+     * Returns file metadata to a member of the owning workflow's family. The server-internal {@code
+     * storagePath} is not exposed.
+     */
+    FileHandle getFileMetadata(@NotBlank String workflowId, @NotBlank String fileId);
 
     /**
      * Starts a backend-native multipart upload. Returns the backend upload ID, recommended part
      * size, and — for GCS/Azure — a resumable session URL. For S3 the response URL is {@code null}
      * and per-part URLs are obtained via {@link #getPartUploadUrl}.
      */
-    MultipartInitResponse initiateMultipartUpload(@NotEmpty String fileId);
+    MultipartInitResponse initiateMultipartUpload(
+            @NotBlank String workflowId, @NotBlank String fileId);
 
     /**
      * Issues a presigned URL for a single S3 multipart part. Not used for GCS/Azure.
@@ -81,7 +85,10 @@ public interface FileStorageService {
      * @param partNumber 1-based part number
      */
     FileUploadUrlResponse getPartUploadUrl(
-            @NotEmpty String fileId, @NotEmpty String uploadId, int partNumber);
+            @NotBlank String workflowId,
+            @NotBlank String fileId,
+            @NotBlank String uploadId,
+            int partNumber);
 
     /**
      * Finalizes a multipart upload and transitions the record to {@code UPLOADED}, persisting the
@@ -90,5 +97,12 @@ public interface FileStorageService {
      * @param partETags ordered ETags (or backend equivalents) from each part upload
      */
     FileUploadCompleteResponse completeMultipartUpload(
-            @NotEmpty String fileId, @NotEmpty String uploadId, @NotNull List<String> partETags);
+            @NotBlank String workflowId,
+            @NotBlank String fileId,
+            @NotBlank String uploadId,
+            @NotNull List<String> partETags);
+
+    /** Best-effort cancellation of a multipart session by the exact owning workflow. */
+    void abortMultipartUpload(
+            @NotBlank String workflowId, @NotBlank String fileId, @NotBlank String uploadId);
 }

--- a/core/src/main/java/org/conductoross/conductor/core/storage/FileStorageServiceImpl.java
+++ b/core/src/main/java/org/conductoross/conductor/core/storage/FileStorageServiceImpl.java
@@ -80,8 +80,8 @@ public class FileStorageServiceImpl implements FileStorageService {
     }
 
     @Override
-    public FileUploadUrlResponse getUploadUrl(String fileId) {
-        FileModel model = getFileModelOrThrow(fileId);
+    public FileUploadUrlResponse getUploadUrl(String workflowId, String fileId) {
+        FileModel model = getOwnedFile(workflowId, fileId);
         String uploadUrl =
                 fileStorage.generateUploadUrl(
                         model.getStoragePath(), properties.getSignedUrlExpiration());
@@ -95,8 +95,8 @@ public class FileStorageServiceImpl implements FileStorageService {
     }
 
     @Override
-    public FileUploadCompleteResponse confirmUpload(String fileId) {
-        FileModel model = getFileModelOrThrow(fileId);
+    public FileUploadCompleteResponse confirmUpload(String workflowId, String fileId) {
+        FileModel model = getOwnedFile(workflowId, fileId);
         if (model.getUploadStatus() == FileUploadStatus.UPLOADED) {
             throw new ConflictException("File already uploaded: " + fileId);
         }
@@ -117,8 +117,12 @@ public class FileStorageServiceImpl implements FileStorageService {
     }
 
     @Override
-    public FileDownloadUrlResponse getDownloadUrl(String fileId, String workflowId) {
-        FileModel model = getFileModel(fileId, workflowId);
+    public FileDownloadUrlResponse getDownloadUrl(String workflowId, String fileId) {
+        FileModel model = getFamilyAccessibleFile(workflowId, fileId);
+        if (model.getUploadStatus() != FileUploadStatus.UPLOADED) {
+            throw new IllegalArgumentException(
+                    "File not yet uploaded: " + fileId + ", status=" + model.getUploadStatus());
+        }
         String downloadUrl =
                 fileStorage.generateDownloadUrl(
                         model.getStoragePath(), properties.getSignedUrlExpiration());
@@ -132,14 +136,14 @@ public class FileStorageServiceImpl implements FileStorageService {
     }
 
     @Override
-    public FileHandle getFileMetadata(String fileId) {
-        FileModel model = getFileModelOrThrow(fileId);
+    public FileHandle getFileMetadata(String workflowId, String fileId) {
+        FileModel model = getFamilyAccessibleFile(workflowId, fileId);
         return FileModelConverter.toFileHandle(model);
     }
 
     @Override
-    public MultipartInitResponse initiateMultipartUpload(String fileId) {
-        FileModel model = getFileModelOrThrow(fileId);
+    public MultipartInitResponse initiateMultipartUpload(String workflowId, String fileId) {
+        FileModel model = getOwnedFile(workflowId, fileId);
         String uploadId = fileStorage.initiateMultipartUpload(model.getStoragePath());
 
         MultipartInitResponse response = new MultipartInitResponse();
@@ -149,8 +153,9 @@ public class FileStorageServiceImpl implements FileStorageService {
     }
 
     @Override
-    public FileUploadUrlResponse getPartUploadUrl(String fileId, String uploadId, int partNumber) {
-        FileModel model = getFileModelOrThrow(fileId);
+    public FileUploadUrlResponse getPartUploadUrl(
+            String workflowId, String fileId, String uploadId, int partNumber) {
+        FileModel model = getOwnedFile(workflowId, fileId);
         String url =
                 fileStorage.generatePartUploadUrl(
                         model.getStoragePath(),
@@ -168,8 +173,8 @@ public class FileStorageServiceImpl implements FileStorageService {
 
     @Override
     public FileUploadCompleteResponse completeMultipartUpload(
-            String fileId, String uploadId, List<String> partETags) {
-        FileModel model = getFileModelOrThrow(fileId);
+            String workflowId, String fileId, String uploadId, List<String> partETags) {
+        FileModel model = getOwnedFile(workflowId, fileId);
         fileStorage.completeMultipartUpload(model.getStoragePath(), uploadId, partETags);
 
         StorageFileInfo info = fileStorage.getStorageFileInfo(model.getStoragePath());
@@ -188,22 +193,33 @@ public class FileStorageServiceImpl implements FileStorageService {
         return response;
     }
 
-    private @NonNull FileModel getFileModel(String fileId, String workflowId) {
-        FileModel model = getFileModelOrThrow(fileId);
-        if (model.getUploadStatus() != FileUploadStatus.UPLOADED) {
-            throw new IllegalArgumentException(
-                    "File not yet uploaded: " + fileId + ", status=" + model.getUploadStatus());
-        }
+    @Override
+    public void abortMultipartUpload(String workflowId, String fileId, String uploadId) {
+        FileModel model = getOwnedFile(workflowId, fileId);
+        fileStorage.abortMultipartUpload(model.getStoragePath(), uploadId);
+    }
 
+    /** Upload state may only be mutated by the workflow that created the file record. */
+    private @NonNull FileModel getOwnedFile(String workflowId, String fileId) {
+        FileModel model = getFileModelOrThrow(fileId);
+        if (workflowId == null
+                || workflowId.isBlank()
+                || !workflowId.equals(model.getWorkflowId())) {
+            throw new AccessForbiddenException("Workflow does not own file: " + fileId);
+        }
+        return model;
+    }
+
+    /** Downloads and metadata are visible to the owning workflow's full workflow family. */
+    private @NonNull FileModel getFamilyAccessibleFile(String workflowId, String fileId) {
+        FileModel model = getFileModelOrThrow(fileId);
         if (model.getWorkflowId() == null || model.getWorkflowId().isBlank()) {
             throw new AccessForbiddenException("File has no workflowId: " + fileId);
         }
 
         Set<String> family = workflowFamilyResolver.getFamily(workflowId);
         if (!family.contains(model.getWorkflowId())) {
-            throw new AccessForbiddenException(
-                    "workflowId %s is not in the workflow family of file %s"
-                            .formatted(workflowId, fileId));
+            throw new AccessForbiddenException("Workflow cannot access file: " + fileId);
         }
         return model;
     }

--- a/core/src/main/java/org/conductoross/conductor/core/storage/converter/FileModelConverter.java
+++ b/core/src/main/java/org/conductoross/conductor/core/storage/converter/FileModelConverter.java
@@ -45,6 +45,7 @@ public class FileModelConverter {
         handle.setFileHandleId(FileIdToFileHandleIdConverter.toFileHandleId(model.getFileId()));
         handle.setFileName(model.getFileName());
         handle.setContentType(model.getContentType());
+        handle.setFileSize(model.getStorageContentSize());
         handle.setContentHash(model.getStorageContentHash());
         handle.setStorageType(model.getStorageType());
         handle.setUploadStatus(model.getUploadStatus());

--- a/core/src/test/java/org/conductoross/conductor/core/storage/FileStorageServiceImplTest.java
+++ b/core/src/test/java/org/conductoross/conductor/core/storage/FileStorageServiceImplTest.java
@@ -77,7 +77,7 @@ public class FileStorageServiceImplTest {
     @Test
     public void testGetUploadUrl() {
         String fileId = createTestFileId();
-        FileUploadUrlResponse response = service.getUploadUrl(fileId);
+        FileUploadUrlResponse response = service.getUploadUrl(WORKFLOW_ID, fileId);
 
         assertEquals(
                 FileIdToFileHandleIdConverter.toFileHandleId(fileId), response.getFileHandleId());
@@ -87,7 +87,7 @@ public class FileStorageServiceImplTest {
 
     @Test(expected = NotFoundException.class)
     public void testGetUploadUrlNotFound() {
-        service.getUploadUrl("nonexistent");
+        service.getUploadUrl(WORKFLOW_ID, "nonexistent");
     }
 
     @Test
@@ -95,7 +95,7 @@ public class FileStorageServiceImplTest {
         String fileId = createTestFileId();
         simulateFileOnStorage(fileId);
 
-        FileUploadCompleteResponse response = service.confirmUpload(fileId);
+        FileUploadCompleteResponse response = service.confirmUpload(WORKFLOW_ID, fileId);
 
         assertEquals(
                 FileIdToFileHandleIdConverter.toFileHandleId(fileId), response.getFileHandleId());
@@ -107,23 +107,23 @@ public class FileStorageServiceImplTest {
         String fileId = createTestFileId();
         simulateFileOnStorage(fileId);
 
-        service.confirmUpload(fileId);
-        service.confirmUpload(fileId);
+        service.confirmUpload(WORKFLOW_ID, fileId);
+        service.confirmUpload(WORKFLOW_ID, fileId);
     }
 
     @Test(expected = NonTransientException.class)
     public void testConfirmUploadFileNotOnStorage() {
         String fileId = createTestFileId();
-        service.confirmUpload(fileId);
+        service.confirmUpload(WORKFLOW_ID, fileId);
     }
 
     @Test
     public void testGetDownloadUrl() {
         String fileId = createTestFileId();
         simulateFileOnStorage(fileId);
-        service.confirmUpload(fileId);
+        service.confirmUpload(WORKFLOW_ID, fileId);
 
-        FileDownloadUrlResponse response = service.getDownloadUrl(fileId, WORKFLOW_ID);
+        FileDownloadUrlResponse response = service.getDownloadUrl(WORKFLOW_ID, fileId);
 
         assertEquals(
                 FileIdToFileHandleIdConverter.toFileHandleId(fileId), response.getFileHandleId());
@@ -134,7 +134,7 @@ public class FileStorageServiceImplTest {
     @Test(expected = IllegalArgumentException.class)
     public void testGetDownloadUrlNotUploaded() {
         String fileId = createTestFileId();
-        service.getDownloadUrl(fileId, WORKFLOW_ID);
+        service.getDownloadUrl(WORKFLOW_ID, fileId);
     }
 
     // ── Upload enforcement ────────────────────────────────────────────────────
@@ -157,16 +157,16 @@ public class FileStorageServiceImplTest {
         fileMetadataDAO.createFileMetadata(model);
         fileStorage.putFile(model.getStoragePath(), new byte[] {1});
 
-        service.getDownloadUrl(fileId, WORKFLOW_ID);
+        service.getDownloadUrl(WORKFLOW_ID, fileId);
     }
 
     @Test(expected = AccessForbiddenException.class)
     public void testDownloadForbiddenWhenCallerNotInFamily() {
         String fileId = createTestFileId();
         simulateFileOnStorage(fileId);
-        service.confirmUpload(fileId);
+        service.confirmUpload(WORKFLOW_ID, fileId);
 
-        service.getDownloadUrl(fileId, "unrelated-workflow");
+        service.getDownloadUrl("unrelated-workflow", fileId);
     }
 
     @Test
@@ -174,9 +174,9 @@ public class FileStorageServiceImplTest {
         // StubWorkflowFamilyResolver includes WORKFLOW_ID in the family
         String fileId = createTestFileId();
         simulateFileOnStorage(fileId);
-        service.confirmUpload(fileId);
+        service.confirmUpload(WORKFLOW_ID, fileId);
 
-        FileDownloadUrlResponse response = service.getDownloadUrl(fileId, WORKFLOW_ID);
+        FileDownloadUrlResponse response = service.getDownloadUrl(WORKFLOW_ID, fileId);
         assertNotNull(response.getDownloadUrl());
     }
 
@@ -197,9 +197,9 @@ public class FileStorageServiceImplTest {
                 svc.createFile(newRequestWithWorkflow("parent-file.bin", parentId));
         String fileId = FileIdToFileHandleIdConverter.toFileId(created.getFileHandleId());
         simulateFileOnStorage(fileId);
-        svc.confirmUpload(fileId);
+        svc.confirmUpload(parentId, fileId);
 
-        FileDownloadUrlResponse response = svc.getDownloadUrl(fileId, childId);
+        FileDownloadUrlResponse response = svc.getDownloadUrl(childId, fileId);
         assertNotNull(response.getDownloadUrl());
     }
 
@@ -220,33 +220,36 @@ public class FileStorageServiceImplTest {
                 svc.createFile(newRequestWithWorkflow("child-file.bin", childId));
         String fileId = FileIdToFileHandleIdConverter.toFileId(created.getFileHandleId());
         simulateFileOnStorage(fileId);
-        svc.confirmUpload(fileId);
+        svc.confirmUpload(childId, fileId);
 
-        FileDownloadUrlResponse response = svc.getDownloadUrl(fileId, parentId);
+        FileDownloadUrlResponse response = svc.getDownloadUrl(parentId, fileId);
         assertNotNull(response.getDownloadUrl());
     }
 
     @Test
     public void testGetFileMetadata() {
         String fileId = createTestFileId();
+        simulateFileOnStorage(fileId);
+        service.confirmUpload(WORKFLOW_ID, fileId);
 
-        FileHandle handle = service.getFileMetadata(fileId);
+        FileHandle handle = service.getFileMetadata(WORKFLOW_ID, fileId);
 
         assertEquals(
                 FileIdToFileHandleIdConverter.toFileHandleId(fileId), handle.getFileHandleId());
         assertEquals("report.pdf", handle.getFileName());
         assertEquals(StorageType.LOCAL, handle.getStorageType());
+        assertEquals(3L, handle.getFileSize());
     }
 
     @Test(expected = NotFoundException.class)
     public void testGetFileMetadataNotFound() {
-        service.getFileMetadata("nonexistent");
+        service.getFileMetadata(WORKFLOW_ID, "nonexistent");
     }
 
     @Test
     public void testInitiateMultipartUpload() {
         String fileId = createTestFileId();
-        MultipartInitResponse response = service.initiateMultipartUpload(fileId);
+        MultipartInitResponse response = service.initiateMultipartUpload(WORKFLOW_ID, fileId);
 
         assertEquals(
                 FileIdToFileHandleIdConverter.toFileHandleId(fileId), response.getFileHandleId());
@@ -256,7 +259,8 @@ public class FileStorageServiceImplTest {
     @Test
     public void testGetPartUploadUrl() {
         String fileId = createTestFileId();
-        FileUploadUrlResponse response = service.getPartUploadUrl(fileId, "upload-123", 1);
+        FileUploadUrlResponse response =
+                service.getPartUploadUrl(WORKFLOW_ID, fileId, "upload-123", 1);
 
         assertEquals(
                 FileIdToFileHandleIdConverter.toFileHandleId(fileId), response.getFileHandleId());
@@ -268,11 +272,68 @@ public class FileStorageServiceImplTest {
     public void testCompleteMultipartUpload() {
         String fileId = createTestFileId();
         FileUploadCompleteResponse response =
-                service.completeMultipartUpload(fileId, "upload-123", List.of("etag1", "etag2"));
+                service.completeMultipartUpload(
+                        WORKFLOW_ID, fileId, "upload-123", List.of("etag1", "etag2"));
 
         assertEquals(
                 FileIdToFileHandleIdConverter.toFileHandleId(fileId), response.getFileHandleId());
         assertEquals(FileUploadStatus.UPLOADED, response.getUploadStatus());
+    }
+
+    @Test(expected = AccessForbiddenException.class)
+    public void testUploadUrlRequiresExactOwner() {
+        String fileId = createTestFileId();
+        service.getUploadUrl("unrelated-workflow", fileId);
+    }
+
+    @Test(expected = AccessForbiddenException.class)
+    public void testUploadMutationRejectsWorkflowFamilyMember() {
+        String parentId = "wf-parent";
+        String childId = "wf-child";
+        FileStorageServiceImpl svc =
+                new FileStorageServiceImpl(
+                        fileStorage,
+                        fileMetadataDAO,
+                        properties,
+                        wfId -> Set.of(parentId, childId));
+        FileUploadResponse created =
+                svc.createFile(newRequestWithWorkflow("parent-file.bin", parentId));
+        String fileId = FileIdToFileHandleIdConverter.toFileId(created.getFileHandleId());
+
+        svc.initiateMultipartUpload(childId, fileId);
+    }
+
+    @Test(expected = AccessForbiddenException.class)
+    public void testMetadataRejectsUnrelatedWorkflow() {
+        String fileId = createTestFileId();
+        service.getFileMetadata("unrelated-workflow", fileId);
+    }
+
+    @Test
+    public void testMetadataAllowsWorkflowFamilyMember() {
+        String parentId = "wf-parent";
+        String childId = "wf-child";
+        FileStorageServiceImpl svc =
+                new FileStorageServiceImpl(
+                        fileStorage,
+                        fileMetadataDAO,
+                        properties,
+                        wfId -> Set.of(parentId, childId));
+        FileUploadResponse created =
+                svc.createFile(newRequestWithWorkflow("parent-file.bin", parentId));
+        String fileId = FileIdToFileHandleIdConverter.toFileId(created.getFileHandleId());
+
+        assertNotNull(svc.getFileMetadata(childId, fileId));
+    }
+
+    @Test
+    public void testAbortMultipartUpload() {
+        String fileId = createTestFileId();
+        String storagePath = fileMetadataDAO.getFileMetadata(fileId).getStoragePath();
+
+        service.abortMultipartUpload(WORKFLOW_ID, fileId, "upload-123");
+
+        assertTrue(fileStorage.wasMultipartUploadAborted(storagePath, "upload-123"));
     }
 
     private String createTestFileId() {

--- a/core/src/test/java/org/conductoross/conductor/core/storage/StubFileStorage.java
+++ b/core/src/test/java/org/conductoross/conductor/core/storage/StubFileStorage.java
@@ -22,6 +22,7 @@ import org.conductoross.conductor.model.file.StorageType;
 public class StubFileStorage implements FileStorage {
 
     private final Map<String, byte[]> files = new ConcurrentHashMap<>();
+    private final Map<String, String> abortedUploads = new ConcurrentHashMap<>();
 
     @Override
     public StorageType getStorageType() {
@@ -68,7 +69,16 @@ public class StubFileStorage implements FileStorage {
         files.putIfAbsent(storagePath, new byte[0]);
     }
 
+    @Override
+    public void abortMultipartUpload(String storagePath, String uploadId) {
+        abortedUploads.put(storagePath, uploadId);
+    }
+
     public void putFile(String storagePath, byte[] data) {
         files.put(storagePath, data);
+    }
+
+    public boolean wasMultipartUploadAborted(String storagePath, String uploadId) {
+        return uploadId.equals(abortedUploads.get(storagePath));
     }
 }

--- a/core/src/test/java/org/conductoross/conductor/core/storage/converter/FileModelConverterTest.java
+++ b/core/src/test/java/org/conductoross/conductor/core/storage/converter/FileModelConverterTest.java
@@ -52,6 +52,7 @@ public class FileModelConverterTest {
         model.setFileId("abc");
         model.setFileName("doc.pdf");
         model.setContentType("application/pdf");
+        model.setStorageContentSize(4096);
         model.setStorageContentHash("hash123");
         model.setStorageType(StorageType.S3);
         model.setUploadStatus(FileUploadStatus.UPLOADED);
@@ -64,6 +65,7 @@ public class FileModelConverterTest {
 
         assertEquals(FileIdToFileHandleIdConverter.PREFIX + "abc", handle.getFileHandleId());
         assertEquals("doc.pdf", handle.getFileName());
+        assertEquals(4096, handle.getFileSize());
         assertEquals("hash123", handle.getContentHash());
         assertEquals(StorageType.S3, handle.getStorageType());
         assertEquals("wf-1", handle.getWorkflowId());

--- a/docs/design/file-storage.md
+++ b/docs/design/file-storage.md
@@ -1,0 +1,104 @@
+# File Storage Design
+
+## Status
+
+Implemented by the workflow-scoped File API in Conductor and `FileClient` in the Java SDK.
+
+## Goals
+
+- Keep binary payloads out of workflow JSON.
+- Make every file operation carry workflow context.
+- Represent files in workflow data as opaque `conductor://file/<id>` strings.
+- Transfer bytes directly to storage without proxying them through Conductor.
+- Support retryable, repeatable uploads and crash-safe downloads.
+- Keep provider protocol details out of worker code.
+
+## Non-goals
+
+- Smart file objects that the task runner discovers and uploads implicitly.
+- A public SDK storage-backend extension point.
+- Forwarding Conductor credentials to object storage.
+- Treating GCS signed PUT uploads as a resumable multipart protocol.
+
+## Components
+
+```text
+Worker
+  |
+  | FileClient + workflow ID + opaque handle
+  v
+Workflow-scoped File API
+  |
+  +--> FileStorageService --> FileMetadataDAO
+  |
+  +--> FileStorage --> signed URL / storage metadata / multipart mutation
+
+FileClient -- raw signed request --> S3, Azure Blob, GCS, or local filesystem
+```
+
+The server decides identity, ownership, storage location, URL lifetime, and upload state. `FileClient` orchestrates the workflow API and byte transfers. Package-private transfer adapters implement exactly one provider transfer attempt; they do not own retries or lifecycle state.
+
+## Public contract
+
+The file value passed through a workflow is always a string:
+
+```text
+conductor://file/<id>
+```
+
+Provider URLs, bucket paths, filenames, and SDK-specific objects are not part of this contract. This keeps workflow definitions portable across storage providers.
+
+Each call also carries a workflow ID. Upload creation and every upload mutation require the exact owner. Metadata and downloads accept a member of the owner's workflow family so parent and child workflows can exchange files.
+
+## Upload lifecycle
+
+```text
+create metadata (UPLOADING)
+  --> transfer bytes
+  --> complete and verify storage object
+  --> metadata (UPLOADED)
+```
+
+For streams, the client first buffers to a temporary path. This happens before creation so a local disk failure does not leave an orphaned server record, and it makes every retry repeatable. The caller owns the stream and remains responsible for closing it.
+
+The client selects multipart when `size > multipartThreshold` and the adapter supports it:
+
+```text
+initiate
+  --> get fresh URL + upload exact byte range for part 1
+  --> ...
+  --> get fresh URL + upload exact byte range for part N
+  --> complete ordered token list
+```
+
+If any multipart step fails, the client requests a best-effort abort. S3 has an explicit abort operation; Azure uncommitted blocks expire.
+
+## Provider rules
+
+| Provider | Whole-file rule | Multipart rule |
+|---|---|---|
+| S3 | Signed PUT. | Each part must return a non-blank `ETag`; ordered ETags complete the upload. |
+| Azure Blob | Signed PUT with `x-ms-blob-type: BlockBlob`. | Stable Base64 block IDs; part URLs add `comp=block&blockid=...`; ordered IDs are committed. |
+| GCS | Signed PUT. | Disabled until a real resumable protocol is implemented. |
+| Local | `file:` URL copy. | Not supported. |
+| Unknown | Generic HTTP(S) signed PUT/GET when the server supplies such a URL. | Not supported. |
+
+Range bodies use a positioned file channel and must emit exactly the requested length. A short read is a failure rather than a silently truncated part.
+
+## Retry and completion semantics
+
+Adapters make one attempt. `FileClient` retries only transient transport failures, throttling, expired signatures, and server errors. It asks Conductor for a new signed URL before each retry and preserves thread interruption.
+
+Completion can be ambiguous: storage may be committed even if the response is lost. After a completion error, the client reads workflow-scoped metadata. `UPLOADED` means the operation succeeded; otherwise normal retry rules apply.
+
+## Download lifecycle
+
+The client validates the destination before requesting a signed URL, downloads to a unique sibling `.part` file, and atomically replaces the requested path only after success. A failed transfer removes the temporary file and leaves an existing destination unchanged. Filesystems without atomic replacement support fail explicitly.
+
+## Signed URL security boundary
+
+Signed URLs are bearer credentials. They must not appear in exceptions or logs. Signed requests use a separate raw HTTP client with redirects disabled and no Conductor authentication, cookie jar, or application interceptors. The server API client and storage-transfer client therefore have separate trust boundaries.
+
+## Compatibility
+
+Workflow-scoped routes replace unscoped mutation and metadata routes. Smart SDK file types and automatic task-runner uploads are removed. Workers must exchange raw handle strings and invoke `FileClient` explicitly. Because the serialized workflow shape changed from an object to a string, mixed worker versions are not wire-compatible and require a coordinated rollout.

--- a/docs/documentation/advanced/file-storage.md
+++ b/docs/documentation/advanced/file-storage.md
@@ -1,96 +1,162 @@
 ---
-description: "File Storage — first-class support for binary file payloads in Conductor workflows, with pluggable backends (local, S3, Azure Blob, GCS)."
+description: "File Storage — workflow-scoped binary payloads backed by local storage, S3, Azure Blob, or GCS."
 ---
+
 # File Storage
 
 ## Context
 
-The file-storage feature lets workflows carry binary file payloads (images, video, archives, model artefacts) without stuffing them into JSON inputs and outputs. Files are uploaded directly to a configured backend via short-lived presigned URLs and tracked in Conductor by a metadata record. Workflow tasks pass a small `FileHandle`/`FileHandler` reference instead of the bytes themselves.
+File storage lets workflows carry images, video, archives, model artifacts, and other binary payloads without embedding bytes in JSON. Workflow inputs and outputs carry only an opaque string such as `conductor://file/<id>`.
 
-This is distinct from [External Payload Storage](externalpayloadstorage.md), which transparently offloads oversized JSON workflow/task payloads. File storage is for *user file content* that the workflow knowingly produces or consumes.
+Conductor owns the metadata and authorization decision. File bytes move directly between the SDK and a configured storage backend through short-lived signed URLs. This is distinct from [External Payload Storage](externalpayloadstorage.md), which transparently offloads oversized workflow and task JSON.
 
 ## Feature flag
-
-The entire feature — REST endpoints, service beans, DAOs — is gated by a single property:
 
 ```properties
 conductor.file-storage.enabled=true
 ```
 
-When `false` (the default) nothing registers and `/api/files/*` returns `404`.
+When `false` (the default), file-storage services and REST endpoints are not registered.
 
 ## Common properties
 
-`conductor.file-storage.*`:
-
-| Property | Description | default value |
-| --- | --- | --- |
-| conductor.file-storage.enabled | Master flag for the file-storage feature. | `false` |
-| conductor.file-storage.type | Backend selector: `local`, `s3`, `azure-blob`, `gcs`. | `local` |
-| conductor.file-storage.signed-url-expiration | TTL for presigned upload/download URLs. Spring `Duration`; bare numbers are seconds. | `60s` |
+| Property | Description | Default |
+|---|---|---|
+| `conductor.file-storage.enabled` | Enables file storage. | `false` |
+| `conductor.file-storage.type` | `local`, `s3`, `azure-blob`, or `gcs`. | `local` |
+| `conductor.file-storage.signed-url-expiration` | Signed upload/download URL TTL as a Spring `Duration`. Bare numbers are seconds. | `60s` |
 
 ## Backends
 
 ### Local (`type=local`)
 
-Server-local filesystem. Intended for development and single-node deployments only — does not scale horizontally and does not support multipart upload.
+Server-local filesystem for development and single-node deployments. It supports only `file:` URLs and single-request transfers.
 
-| Property | Description | default value |
-| --- | --- | --- |
-| conductor.file-storage.local.directory | Directory where files are written. | `${java.io.tmpdir}/conductor/files-uploaded` |
+| Property | Description | Default |
+|---|---|---|
+| `conductor.file-storage.local.directory` | Directory containing file objects. | `${java.io.tmpdir}/conductor/files-uploaded` |
 
 ### Amazon S3 (`type=s3`)
 
-Uses the default AWS credential provider chain (environment, instance profile, etc.).
+Uses the default AWS credential provider chain. The Java SDK supports single-request and multipart transfers. Multipart completion requires every part's S3 `ETag`; failed sessions are aborted on a best-effort basis.
 
-| Property | Description | default value |
-| --- | --- | --- |
-| conductor.file-storage.s3.bucket-name | S3 bucket where files are stored. | |
-| conductor.file-storage.s3.region | AWS region for the bucket. | `us-east-1` |
+| Property | Description | Default |
+|---|---|---|
+| `conductor.file-storage.s3.bucket-name` | Destination bucket. | — |
+| `conductor.file-storage.s3.region` | Bucket region. | `us-east-1` |
 
 ### Azure Blob (`type=azure-blob`)
 
-| Property | Description | default value |
-| --- | --- | --- |
-| conductor.file-storage.azure-blob.container-name | Azure Blob container where files are stored. | |
-| conductor.file-storage.azure-blob.connection-string | Account connection string. Required for SAS-signed URLs. | |
+The Java SDK sends `x-ms-blob-type: BlockBlob` for whole-file uploads. Multipart uses deterministic Base64 block IDs and commits the ordered block list. Uncommitted blocks expire, so abort is a server-side no-op.
+
+| Property | Description | Default |
+|---|---|---|
+| `conductor.file-storage.azure-blob.container-name` | Destination container. | — |
+| `conductor.file-storage.azure-blob.connection-string` | Account connection string used to create SAS URLs. | — |
 
 ### Google Cloud Storage (`type=gcs`)
 
-| Property | Description | default value |
-| --- | --- | --- |
-| conductor.file-storage.gcs.bucket-name | GCS bucket where files are stored. | |
-| conductor.file-storage.gcs.project-id | GCP project that owns the bucket. | |
-| conductor.file-storage.gcs.credentials-file | Path to a service-account JSON key file. Falls back to application default credentials if unset. | |
+The Java SDK intentionally uses single-request signed PUT uploads. GCS resumable upload is not exposed as multipart until the resumable protocol is implemented end to end.
 
-### Bring Your Own Storage (BYOS)
+| Property | Description | Default |
+|---|---|---|
+| `conductor.file-storage.gcs.bucket-name` | Destination bucket. | — |
+| `conductor.file-storage.gcs.project-id` | Project that owns the bucket. | — |
+| `conductor.file-storage.gcs.credentials-file` | Service-account JSON path; application default credentials are used when unset. | — |
 
-Implement `org.conductoross.conductor.core.storage.FileStorage` and register it as a Spring bean. The default service uses the bean that matches `conductor.file-storage.type`.
+### Bring Your Own Storage
 
-## Persistence
+Implement `org.conductoross.conductor.core.storage.FileStorage` and register a Spring bean for the configured storage type. This is a server extension point. Java SDK signed-transfer adapters are internal and are not a public application extension point.
 
-File metadata lives in the `file_metadata` table — `fileId`, `fileName`, `contentType`, `storagePath`, `uploadStatus`, `workflowId`, `taskId`, timestamps, plus storage-reported `contentHash` and `contentSize` after upload completes.
+## Persistence and layout
 
-Schemas are created by Flyway:
+File metadata stores the ID, original filename, content type, storage path, upload status, workflow/task ownership, timestamps, and the storage-reported hash and size after completion.
 
-| Backend | Migration |
-| --- | --- |
-| Postgres | `V15__file_metadata.sql` |
+| Database | Migration |
+|---|---|
+| PostgreSQL | `V15__file_metadata.sql` |
 | MySQL | `V9__file_metadata.sql` |
 | SQLite | `V3__file_metadata.sql` |
 
-Redis and Cassandra metadata DAOs are also provided.
+Redis and Cassandra metadata DAOs are also available. Objects use the same logical layout across providers:
 
-## Storage layout
+```text
+conductor/<workflowId>/<fileId>
+```
 
-Objects are written to `conductor/<workflowId>/<fileId>` inside the configured bucket / container / directory. Layout is the same across backends.
+## Authorization model
 
-## Access scope
+Each file has one owning workflow. Authorization is intentionally asymmetric:
 
-Download URLs are *workflow-family scoped*: the caller must supply a `workflowId` that resolves to the same workflow family (self, ancestors, or descendants in the sub-workflow tree) as the file's `workflowId`. Mismatches return `403 Forbidden`. There is no per-file size cap in this iteration.
+| Operation | Access rule |
+|---|---|
+| Create | The supplied workflow becomes the owner. |
+| Refresh upload URL, complete upload, initiate/upload/complete/abort multipart | Exact owner only. |
+| Metadata and download | Owner's workflow family: self, ancestors, and descendants. |
 
-## Worker usage
+This permits a parent and sub-workflow to exchange a handle while preventing either from mutating another execution's in-progress upload.
 
-Workers consume and produce files via the Java SDK's `FileHandler` type. See the [File handling](../clientsdks/java-sdk.md#file-handling) section of the Java SDK page and the [Media Transcoder](https://github.com/conductor-oss/file-storage-java-sdk/tree/main/examples/file-storage/media-transcoder) example.
+## Java worker usage
 
-For direct REST access (non-Java callers, custom clients), see the [File API reference](../api/files.md).
+Workers inject `FileClient`, accept and return handle strings, and call upload or download explicitly. The task runner does not scan worker inputs/outputs for file objects and does not upload automatically.
+
+```java
+public final class ResizeWorker {
+    private final FileClient files;
+
+    public ResizeWorker(FileClient files) {
+        this.files = files;
+    }
+
+    @WorkerTask("resize_image")
+    public @OutputParam("image") String resize(
+            @InputParam("image") String inputHandle,
+            @WorkflowInstanceIdInputParam String workflowId) throws IOException {
+        Path input = Files.createTempFile("image-", ".bin");
+        Path output = Files.createTempFile("resized-", ".png");
+        try {
+            files.download(workflowId, inputHandle, input);
+            resize(input, output);
+            return files.upload(
+                    workflowId,
+                    output,
+                    new FileUploadOptions().setContentType("image/png"));
+        } finally {
+            Files.deleteIfExists(input);
+            Files.deleteIfExists(output);
+        }
+    }
+}
+```
+
+See [Java SDK file handling](../clientsdks/java-sdk.md#file-handling) for every public upload/download form and the [File API](../api/files.md) for direct REST access.
+
+## Transfer behavior
+
+`FileClient` owns orchestration: request validation, file-record creation, retry policy, signed-URL refresh, automatic multipart selection, completion reconciliation, and cleanup. Internal provider adapters perform one signed transfer attempt.
+
+- Streams are buffered to a repeatable temporary file before the server record is created. A stream upload requires a filename, never closes the caller's stream, and removes the temporary file.
+- Files larger than the configured threshold use multipart only for S3 and Azure. GCS, local, and unknown HTTP(S) storage types use one request.
+- Downloads write to a unique sibling temporary file and atomically replace the destination only after a complete response.
+- Signed URL requests use a separate raw HTTP client with redirects disabled. Conductor authentication, cookies, and API interceptors are not forwarded.
+- Retries refresh signed URLs and stop when the thread is interrupted. Signed URLs are redacted from errors.
+
+The detailed component and lifecycle rationale is in [File Storage Design](../../design/file-storage.md).
+
+## Migration from smart file objects
+
+The current contract replaces `FileHandler`, `ManagedFileHandler`, `LocalFileHandler`, `FileUploader`, and `WorkflowFileClient` with explicit `FileClient` calls and raw handle strings.
+
+Old output:
+
+```json
+{"fileHandleId":"conductor://file/abc","fileName":"report.pdf","contentType":"application/pdf"}
+```
+
+Current output:
+
+```json
+"conductor://file/abc"
+```
+
+Mixed worker versions therefore produce incompatible workflow data shapes. Drain running workflows or coordinate the server and worker rollout before switching formats.

--- a/docs/documentation/api/files.md
+++ b/docs/documentation/api/files.md
@@ -1,31 +1,49 @@
 ---
-description: "Conductor File API — create, upload, download, and inspect file payloads. Includes single-shot and multipart presigned URL flows."
+description: "Conductor File API — create, upload, download, and inspect workflow-scoped file payloads."
 ---
 
 # File API
 
-The File API manages binary file payloads associated with workflow executions. All endpoints use the base path `/api/files` and are gated by `conductor.file-storage.enabled=true` — when the feature is disabled, every endpoint returns `404`. See [File Storage](../advanced/file-storage.md) for backend setup.
+The File API manages binary payloads associated with workflow executions. All endpoints use the base path `/api/files` and require `conductor.file-storage.enabled=true`. When the feature is disabled, the endpoints are not registered and return `404`. See [File Storage](../advanced/file-storage.md) for backend configuration.
 
-Path variables carry the bare `fileId` (a UUID assigned at creation). Request and response bodies carry the prefixed handle as `fileHandleId` (`conductor://file/<fileId>`); pass either form back in to subsequent calls — the server normalizes them.
+Conductor stores only metadata and returns short-lived signed URLs. Upload and download bytes travel directly between the caller and the configured storage backend.
 
-Download access is *workflow-family scoped*: callers must supply a `workflowId` that belongs to the same workflow family (self, ancestors, or descendants) as the file's owning workflow. Cross-family access returns `403 Forbidden`.
+## Handles and workflow scope
 
-## Create a File
+Files are opaque handle strings:
 
+```text
+conductor://file/<fileId>
 ```
+
+Workflow inputs and outputs should carry the complete handle string. REST path variables use the bare `fileId`; do not place the `conductor://file/` prefix in a path segment.
+
+Every operation has workflow context, with two authorization scopes:
+
+| Operation | Required workflow relationship |
+|---|---|
+| Create | The request's `workflowId` becomes the owner. |
+| Upload URL refresh, upload completion, and multipart mutations | Exact owning workflow. |
+| Metadata and download URL | Owning workflow or a member of its workflow family (self, ancestor, or descendant). |
+
+An unrelated workflow, or a family member attempting an upload mutation, receives `403 Forbidden`.
+
+## Single-request upload
+
+### 1. Create a file record
+
+```text
 POST /api/files
 ```
 
-Reserves a `fileId`, persists the metadata record, and returns a presigned upload URL. The file is created in `UPLOADING` status; the client must confirm completion via [Confirm Upload](#confirm-upload) once the bytes are uploaded.
-
-**Request body:**
+This creates an `UPLOADING` metadata record and returns the initial signed upload URL.
 
 | Field | Description | Required |
 |---|---|---|
-| `workflowId` | Workflow execution that owns this file. Used for download-access scoping. | Yes |
+| `workflowId` | Workflow execution that owns the file. | Yes |
 | `fileName` | Original file name. | No |
 | `contentType` | MIME type. | No |
-| `taskId` | Task that produced the file, if applicable. | No |
+| `taskId` | Task that produced the file. | No |
 
 ```shell
 curl -X POST 'http://localhost:8080/api/files' \
@@ -33,11 +51,12 @@ curl -X POST 'http://localhost:8080/api/files' \
   -d '{
     "workflowId": "3a5b8c2d-1234-5678-9abc-def012345678",
     "fileName": "input.mp4",
-    "contentType": "video/mp4"
+    "contentType": "video/mp4",
+    "taskId": "task-uuid-1"
   }'
 ```
 
-**Response** `201 Created`
+Response: `201 Created`
 
 ```json
 {
@@ -46,53 +65,57 @@ curl -X POST 'http://localhost:8080/api/files' \
   "contentType": "video/mp4",
   "storageType": "S3",
   "uploadStatus": "UPLOADING",
-  "uploadUrl": "https://bucket.s3.amazonaws.com/conductor/3a5b8c2d.../a1b2c3d4...?X-Amz-Signature=...",
+  "uploadUrl": "<signed-upload-url>",
   "uploadUrlExpiresAt": 1700000060000,
   "createdAt": 1700000000000
 }
 ```
 
-The client `PUT`s file bytes directly to `uploadUrl`, then calls [Confirm Upload](#confirm-upload).
+### 2. Upload the bytes
 
----
-
-## Get a Fresh Upload URL
-
-```
-GET /api/files/{fileId}/upload-url
-```
-
-Issues a new presigned upload URL — used to retry an upload after the original URL expired.
+Use the method and headers required by the selected provider. The returned URL is a credential: do not log it or attach Conductor authentication headers to it.
 
 ```shell
-curl 'http://localhost:8080/api/files/a1b2c3d4-5678-90ab-cdef-111111111111/upload-url'
+curl -X PUT --upload-file ./input.mp4 '<signed-upload-url>'
 ```
 
-**Response** `200 OK`
+Azure whole-blob uploads additionally require `x-ms-blob-type: BlockBlob`.
+
+### 3. Refresh an expired upload URL
+
+```text
+GET /api/files/{workflowId}/{fileId}/upload-url
+```
+
+Only the owning workflow can refresh the URL.
+
+```shell
+curl 'http://localhost:8080/api/files/3a5b8c2d-1234-5678-9abc-def012345678/a1b2c3d4-5678-90ab-cdef-111111111111/upload-url'
+```
+
+Response: `200 OK`
 
 ```json
 {
   "fileHandleId": "conductor://file/a1b2c3d4-5678-90ab-cdef-111111111111",
-  "uploadUrl": "https://bucket.s3.amazonaws.com/conductor/3a5b8c2d.../a1b2c3d4...?X-Amz-Signature=...",
+  "uploadUrl": "<fresh-signed-upload-url>",
   "expiresAt": 1700000060000
 }
 ```
 
----
+### 4. Confirm the upload
 
-## Confirm Upload
-
-```
-POST /api/files/{fileId}/upload-complete
+```text
+POST /api/files/{workflowId}/{fileId}/upload-complete
 ```
 
-Marks the upload as complete. The server probes the storage backend to verify the object exists, then transitions the record to `UPLOADED` and records the backend-reported content hash and size.
+The server verifies that the object exists, records the backend-reported hash and size, and changes the status to `UPLOADED`.
 
 ```shell
-curl -X POST 'http://localhost:8080/api/files/a1b2c3d4-5678-90ab-cdef-111111111111/upload-complete'
+curl -X POST 'http://localhost:8080/api/files/3a5b8c2d-1234-5678-9abc-def012345678/a1b2c3d4-5678-90ab-cdef-111111111111/upload-complete'
 ```
 
-**Response** `200 OK`
+Response: `200 OK`
 
 ```json
 {
@@ -102,60 +125,28 @@ curl -X POST 'http://localhost:8080/api/files/a1b2c3d4-5678-90ab-cdef-1111111111
 }
 ```
 
-`409 Conflict` if the file is already in `UPLOADED` status; `500 Internal Server Error` if the backend reports the object is missing.
+Completion returns `409 Conflict` if the file is already `UPLOADED`. Clients that lose the completion response should reconcile by reading workflow-scoped metadata before deciding whether to retry.
 
----
+## Read metadata
 
-## Get a Download URL
-
-```
-GET /api/files/{workflowId}/{fileId}/download-url
+```text
+GET /api/files/{workflowId}/{fileId}
 ```
 
-Issues a presigned download URL. The caller's `workflowId` must be in the same workflow family as the file's owning workflow.
-
-| Parameter | Description |
-|---|---|
-| `workflowId` | The caller's workflow ID, used for family-scope check. |
-| `fileId` | The file to download. |
+The owning workflow and its workflow family can read metadata. This endpoint can also return an `UPLOADING` record, which lets clients reconcile an ambiguous completion response.
 
 ```shell
-curl 'http://localhost:8080/api/files/3a5b8c2d-1234-5678-9abc-def012345678/a1b2c3d4-5678-90ab-cdef-111111111111/download-url'
+curl 'http://localhost:8080/api/files/3a5b8c2d-1234-5678-9abc-def012345678/a1b2c3d4-5678-90ab-cdef-111111111111'
 ```
 
-**Response** `200 OK`
-
-```json
-{
-  "fileHandleId": "conductor://file/a1b2c3d4-5678-90ab-cdef-111111111111",
-  "downloadUrl": "https://bucket.s3.amazonaws.com/conductor/3a5b8c2d.../a1b2c3d4...?X-Amz-Signature=...",
-  "expiresAt": 1700000060000
-}
-```
-
-`403 Forbidden` if the caller's workflow is not in the file's family. `400 Bad Request` if the file is not yet `UPLOADED`.
-
----
-
-## Get File Metadata
-
-```
-GET /api/files/{fileId}
-```
-
-Returns the file metadata record. Does not expose the server-internal storage path.
-
-```shell
-curl 'http://localhost:8080/api/files/a1b2c3d4-5678-90ab-cdef-111111111111'
-```
-
-**Response** `200 OK`
+Response: `200 OK`
 
 ```json
 {
   "fileHandleId": "conductor://file/a1b2c3d4-5678-90ab-cdef-111111111111",
   "fileName": "input.mp4",
   "contentType": "video/mp4",
+  "fileSize": 1048576,
   "contentHash": "d41d8cd98f00b204e9800998ecf8427e",
   "storageType": "S3",
   "uploadStatus": "UPLOADED",
@@ -166,91 +157,137 @@ curl 'http://localhost:8080/api/files/a1b2c3d4-5678-90ab-cdef-111111111111'
 }
 ```
 
----
+## Download
 
-## Multipart Upload
+### 1. Get a download URL
 
-Multipart is opt-in (typically for files above ~100 MB) and supported on `s3`, `azure-blob`, and `gcs` backends. The `local` backend does not support multipart.
-
-### Initiate Multipart
-
-```
-POST /api/files/{fileId}/multipart
+```text
+GET /api/files/{workflowId}/{fileId}/download-url
 ```
 
-Begins a multipart upload session. Returns a backend-specific `uploadId`. For GCS/Azure, `uploadUrl` is the resumable session URL clients upload parts to directly; for S3 it is `null` and clients fetch a per-part URL via [Get Part Upload URL](#get-part-upload-url).
+The file must be `UPLOADED`. The owning workflow or any workflow in its family can request the URL.
 
 ```shell
-curl -X POST 'http://localhost:8080/api/files/a1b2c3d4-5678-90ab-cdef-111111111111/multipart'
+curl 'http://localhost:8080/api/files/3a5b8c2d-1234-5678-9abc-def012345678/a1b2c3d4-5678-90ab-cdef-111111111111/download-url'
 ```
 
-**Response** `200 OK`
+Response: `200 OK`
 
 ```json
 {
   "fileHandleId": "conductor://file/a1b2c3d4-5678-90ab-cdef-111111111111",
-  "uploadId": "S3-multipart-upload-id-string",
-  "uploadUrl": null
-}
-```
-
-### Get Part Upload URL
-
-```
-GET /api/files/{fileId}/multipart/{uploadId}/part/{partNumber}
-```
-
-S3 only. Returns a presigned URL for uploading a single part. Part numbers start at `1`.
-
-```shell
-curl 'http://localhost:8080/api/files/a1b2c3d4-5678-90ab-cdef-111111111111/multipart/S3-multipart-upload-id-string/part/1'
-```
-
-**Response** `200 OK`
-
-```json
-{
-  "fileHandleId": "conductor://file/a1b2c3d4-5678-90ab-cdef-111111111111",
-  "uploadUrl": "https://bucket.s3.amazonaws.com/conductor/.../?partNumber=1&uploadId=...&X-Amz-Signature=...",
+  "downloadUrl": "<signed-download-url>",
   "expiresAt": 1700000060000
 }
 ```
 
-### Complete Multipart
-
-```
-POST /api/files/{fileId}/multipart/{uploadId}/complete
-```
-
-Finalizes the multipart upload and transitions the file to `UPLOADED`. The request body carries the ordered list of part ETags (or backend equivalents) from the part uploads.
+### 2. Download the bytes
 
 ```shell
-curl -X POST 'http://localhost:8080/api/files/a1b2c3d4-5678-90ab-cdef-111111111111/multipart/S3-multipart-upload-id-string/complete' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "partETags": ["\"etag-of-part-1\"", "\"etag-of-part-2\"", "\"etag-of-part-3\""]
-  }'
+curl --fail --output ./input.mp4 '<signed-download-url>'
 ```
 
-**Response** `200 OK`
+Do not attach Conductor authentication headers to the signed storage request. Application clients should download to a temporary file and atomically replace the destination only after a complete response; the Java SDK's `FileClient` does this automatically.
+
+## Multipart upload
+
+The Java SDK selects multipart automatically when a file exceeds its configured threshold and the storage adapter supports it. Application code should normally call `FileClient.upload(...)` instead of these endpoints directly.
+
+The supported completion token is provider-specific:
+
+| Provider | Part completion token |
+|---|---|
+| Amazon S3 | Required `ETag` response header from each part. |
+| Azure Blob | Stable Base64 block ID used for that part. |
+
+GCS and local storage use a single request in the Java SDK. GCS resumable upload is intentionally not presented as multipart until its protocol is implemented end to end.
+
+### 1. Initiate
+
+```text
+POST /api/files/{workflowId}/{fileId}/multipart
+```
+
+```shell
+curl -X POST 'http://localhost:8080/api/files/3a5b8c2d-1234-5678-9abc-def012345678/a1b2c3d4-5678-90ab-cdef-111111111111/multipart'
+```
+
+Response: `200 OK`
+
+```json
+{
+  "fileHandleId": "conductor://file/a1b2c3d4-5678-90ab-cdef-111111111111",
+  "uploadId": "backend-multipart-upload-id"
+}
+```
+
+### 2. Get a URL for each part
+
+```text
+GET /api/files/{workflowId}/{fileId}/multipart/{uploadId}/part/{partNumber}
+```
+
+Part numbers are 1-based. Request a fresh URL before each retry.
+
+```shell
+curl 'http://localhost:8080/api/files/3a5b8c2d-1234-5678-9abc-def012345678/a1b2c3d4-5678-90ab-cdef-111111111111/multipart/backend-multipart-upload-id/part/1'
+```
+
+Response: `200 OK`
+
+```json
+{
+  "fileHandleId": "conductor://file/a1b2c3d4-5678-90ab-cdef-111111111111",
+  "uploadUrl": "<signed-part-upload-url>",
+  "expiresAt": 1700000060000
+}
+```
+
+Upload exactly that part's byte range. For S3, retain the non-blank `ETag` response header. For Azure, use deterministic Base64 block IDs and append `comp=block&blockid=<encoded-block-id>` to the signed URL.
+
+### 3. Complete
+
+```text
+POST /api/files/{workflowId}/{fileId}/multipart/{uploadId}/complete
+```
+
+The `partETags` field is the ordered list of provider completion tokens: S3 ETags or Azure block IDs.
+
+```shell
+curl -X POST 'http://localhost:8080/api/files/3a5b8c2d-1234-5678-9abc-def012345678/a1b2c3d4-5678-90ab-cdef-111111111111/multipart/backend-multipart-upload-id/complete' \
+  -H 'Content-Type: application/json' \
+  -d '{"partETags":["part-token-1","part-token-2","part-token-3"]}'
+```
+
+Response: `200 OK`
 
 ```json
 {
   "fileHandleId": "conductor://file/a1b2c3d4-5678-90ab-cdef-111111111111",
   "uploadStatus": "UPLOADED",
-  "contentHash": "d41d8cd98f00b204e9800998ecf8427e"
+  "contentHash": "backend-reported-content-hash"
 }
 ```
 
----
+### Abort a failed session
+
+```text
+DELETE /api/files/{workflowId}/{fileId}/multipart/{uploadId}
+```
+
+```shell
+curl -X DELETE 'http://localhost:8080/api/files/3a5b8c2d-1234-5678-9abc-def012345678/a1b2c3d4-5678-90ab-cdef-111111111111/multipart/backend-multipart-upload-id'
+```
+
+Response: `204 No Content`. S3 aborts the backend session. Backends whose uncommitted blocks expire do not require an explicit provider operation.
 
 ## Errors
 
 | Status | Cause |
 |---|---|
-| `400 Bad Request` | Missing `workflowId` on create; download requested before file is `UPLOADED`. |
-| `403 Forbidden` | Caller's `workflowId` is not in the file's workflow family. |
-| `404 Not Found` | Unknown `fileId`, or `conductor.file-storage.enabled=false`. |
-| `409 Conflict` | Confirm-upload called on a file already in `UPLOADED` status. |
-| `413 Payload Too Large` | `FileStorageException` raised by a backend (e.g., upstream size enforcement). |
-| `500 Internal Server Error` | Backend reports object missing on confirm/complete; other transient/non-transient backend errors. |
+| `400 Bad Request` | Blank workflow ID, invalid request, or download requested before `UPLOADED`. |
+| `403 Forbidden` | Exact owner required for an upload mutation, or caller is outside the file's workflow family for read access. |
+| `404 Not Found` | Unknown `fileId`, or file storage is disabled. |
+| `409 Conflict` | Single-request completion called after the file is already `UPLOADED`. |
+| `413 Payload Too Large` | Backend or deployment size enforcement rejected the request. |
+| `500 Internal Server Error` | Storage completion or metadata verification failed. |

--- a/docs/documentation/clientsdks/java-sdk.md
+++ b/docs/documentation/clientsdks/java-sdk.md
@@ -376,52 +376,153 @@ workflowClient.restartWorkflow(workflowId, false);
 
 ## File handling
 
-For workflows that move binary file payloads, the SDK exposes `FileHandler` — a worker-facing reference to a file in the configured backend. Pass it as a worker input/output and the runtime handles upload, download, and the metadata roundtrip transparently. See [File Storage](../advanced/file-storage.md) for the operator-side configuration and [File API](../api/files.md) for the underlying REST surface.
+Binary workflow values are opaque `conductor://file/<id>` strings. Workers inject `org.conductoross.conductor.client.FileClient`, receive handle strings as task inputs, and publish handle strings as outputs. Upload and download are explicit; the task runner does not scan worker objects for files.
 
-The relevant types in `org.conductoross.conductor.sdk.file`:
-
-| Type | Use |
-|---|---|
-| `FileHandler` | Worker parameter type for files. Static `fromLocalFile(Path)` / `fromLocalFile(Path, contentType)` create a handle for a local file the worker is producing. |
-| `FileUploader` | Explicit upload API; obtained from `task.getFileUploader()` inside a `Worker` impl, or from `WorkflowFileClient` outside one. |
-| `FileUploadOptions` | Optional metadata: `contentType`, `fileName`, `taskId`, `multipart`. |
-
-**Worker that consumes a file:**
+Every operation requires the workflow ID:
 
 ```java
-public class TranscodeInput {
-    public FileHandler primary_video;
-    public String resolution;
-}
+public String upload(String workflowId, Path source);
 
-@WorkerTask("transcode_video")
-public @OutputParam("output_file") FileHandler transcode(TranscodeInput input) throws IOException {
-    Path transcoded = Files.createTempFile("transcoded-", ".mp4");
-    try (InputStream in = input.primary_video.getInputStream()) {
-        Files.write(transcoded, in.readAllBytes());
+public String upload(
+        String workflowId,
+        Path source,
+        FileUploadOptions options);
+
+public String upload(
+        String workflowId,
+        InputStream source,
+        FileUploadOptions options);
+
+public Path download(
+        String workflowId,
+        String fileHandleId,
+        Path destination);
+
+public FileMetadata getMetadata(
+        String workflowId,
+        String fileHandleId);
+```
+
+`FileUploadOptions` supports `fileName`, `contentType`, and optional producing `taskId`. Multipart is deliberately absent from the options: `FileClient` selects it automatically from the source size, configured threshold, and provider capability.
+
+### Upload a path with inferred filename
+
+```java
+Path report = Path.of("/work/monthly-report.pdf");
+String handle = fileClient.upload(workflowId, report);
+```
+
+The source must be a readable regular file. Its final path segment becomes the filename.
+
+### Upload a path with metadata
+
+```java
+String handle = fileClient.upload(
+        task.getWorkflowInstanceId(),
+        report,
+        new FileUploadOptions()
+                .setFileName("customer-report.pdf")
+                .setContentType("application/pdf")
+                .setTaskId(task.getTaskId()));
+```
+
+### Upload a stream
+
+```java
+FileUploadOptions options = new FileUploadOptions()
+        .setFileName("events.ndjson")
+        .setContentType("application/x-ndjson")
+        .setTaskId(task.getTaskId());
+
+try (InputStream source = eventStore.openExport()) {
+    String handle = fileClient.upload(task.getWorkflowInstanceId(), source, options);
+    // FileClient does not close source; this try-with-resources block owns it.
+}
+```
+
+A stream upload requires a safe filename. `FileClient` buffers the stream into a repeatable temporary path before creating the server record, removes the temporary file afterward, and never closes the caller-owned stream.
+
+### Read metadata
+
+```java
+FileMetadata metadata = fileClient.getMetadata(workflowId, handle);
+
+System.out.printf(
+        "%s: %s, %d bytes, status=%s%n",
+        metadata.getFileName(),
+        metadata.getContentType(),
+        metadata.getFileSize(),
+        metadata.getUploadStatus());
+```
+
+### Download to a path
+
+```java
+Path destination = Path.of("/work/input.pdf");
+Path downloaded = fileClient.download(workflowId, handle, destination);
+```
+
+The destination may be new or existing. The client downloads to a unique sibling temporary file and atomically replaces the destination only after the transfer succeeds. A failed download removes the temporary file and leaves an existing destination unchanged.
+
+### Pass a file between workers
+
+```java
+public final class RenderWorker implements Worker {
+    private final FileClient fileClient;
+
+    public RenderWorker(FileClient fileClient) {
+        this.fileClient = fileClient;
     }
-    return FileHandler.fromLocalFile(transcoded, "video/mp4");
+
+    @Override
+    public TaskResult execute(Task task) {
+        TaskResult result = new TaskResult(task);
+        Path source = null;
+        Path rendered = null;
+        try {
+            String workflowId = task.getWorkflowInstanceId();
+            String sourceHandle = (String) task.getInputData().get("source");
+            source = Files.createTempFile("source-", ".bin");
+            rendered = Files.createTempFile("rendered-", ".pdf");
+            fileClient.download(workflowId, sourceHandle, source);
+            render(source, rendered);
+
+            String renderedHandle = fileClient.upload(
+                    workflowId,
+                    rendered,
+                    new FileUploadOptions()
+                            .setContentType("application/pdf")
+                            .setTaskId(task.getTaskId()));
+
+            result.setStatus(TaskResult.Status.COMPLETED);
+            result.addOutputData("rendered", renderedHandle);
+        } catch (Exception e) {
+            result.setStatus(TaskResult.Status.FAILED);
+            result.setReasonForIncompletion(e.getMessage());
+        } finally {
+            deleteQuietly(source);
+            deleteQuietly(rendered);
+        }
+        return result;
+    }
 }
 ```
 
-`primary_video` is auto-resolved from the task input — the runtime downloads the file lazily on first read of `getInputStream()`. The returned `FileHandler` is auto-uploaded by the task runner before the task output is published, and the resulting `fileHandleId` is substituted into the output map so downstream tasks can consume it.
+The workflow maps `${render.output.rendered}` into the next task as a plain string. A parent or sub-workflow in the same workflow family can read metadata and download the handle. Only the exact owning workflow can refresh or complete its upload.
 
-**Explicit upload inside a `Worker` implementation:**
+### Automatic multipart and retries
 
-```java
-@Override
-public TaskResult execute(Task task) {
-    Path output = renderReport(task);
-    FileHandler handle = task.getFileUploader().upload(
-            output,
-            new FileUploadOptions().setContentType("application/pdf").setMultipart(true));
-    TaskResult result = new TaskResult(task);
-    result.getOutputData().put("report", handle);
-    return result;
-}
+Spring auto-configuration creates `FileClient` and reads these settings:
+
+```properties
+conductor.file-client.retry-count=3
+conductor.file-client.multipart-threshold=104857600
+conductor.file-client.multipart-part-size=10485760
 ```
 
-Use this form when you want to control upload timing (e.g., upload before the task's main work completes, or upload an `InputStream` that's not backed by a file). When `multipart=true` the SDK uses the multipart upload flow on backends that support it, falling back to single-shot otherwise.
+Files larger than the threshold use multipart for S3 and Azure Blob. GCS, local storage, and generic HTTP(S) signed URLs stay single-request. Before each retry the client obtains a fresh signed URL; it retries only transient I/O failures, throttling, expired signatures, and server errors, and stops when the thread is interrupted.
+
+See the runnable [Media Transcoder example](https://github.com/conductor-oss/java-sdk/tree/main/examples/file-storage/media-transcoder), [File Storage](../advanced/file-storage.md) for server configuration, and [File API](../api/files.md) for the REST contract.
 
 ---
 

--- a/e2e/src/test/java/io/conductor/e2e/filestorage/FileStorageE2ETest.java
+++ b/e2e/src/test/java/io/conductor/e2e/filestorage/FileStorageE2ETest.java
@@ -71,7 +71,7 @@ class FileStorageE2ETest {
                 client.execute(
                                 ConductorClientRequest.builder()
                                         .method(Method.GET)
-                                        .path("/files/" + fileId + "/upload-url")
+                                        .path("/files/wf-1/" + fileId + "/upload-url")
                                         .build(),
                                 MAP_TYPE)
                         .getData();
@@ -89,7 +89,7 @@ class FileStorageE2ETest {
                 client.execute(
                                 ConductorClientRequest.builder()
                                         .method(Method.GET)
-                                        .path("/files/" + fileId)
+                                        .path("/files/wf-1/" + fileId)
                                         .build(),
                                 MAP_TYPE)
                         .getData();
@@ -107,7 +107,7 @@ class FileStorageE2ETest {
             client.execute(
                     ConductorClientRequest.builder()
                             .method(Method.GET)
-                            .path("/files/nonexistent-file-id-" + UUID.randomUUID())
+                            .path("/files/wf-1/nonexistent-file-id-" + UUID.randomUUID())
                             .build(),
                     MAP_TYPE);
             fail("Expected 404");
@@ -128,7 +128,7 @@ class FileStorageE2ETest {
                 client.execute(
                                 ConductorClientRequest.builder()
                                         .method(Method.POST)
-                                        .path("/files/" + fileId + "/multipart")
+                                        .path("/files/wf-1/" + fileId + "/multipart")
                                         .build(),
                                 MAP_TYPE)
                         .getData();
@@ -176,7 +176,7 @@ class FileStorageE2ETest {
                 client.execute(
                                 ConductorClientRequest.builder()
                                         .method(Method.POST)
-                                        .path("/files/" + fileId + "/upload-complete")
+                                        .path("/files/wf-rt/" + fileId + "/upload-complete")
                                         .build(),
                                 MAP_TYPE)
                         .getData();
@@ -229,15 +229,13 @@ class FileStorageE2ETest {
         String fileId = fileIdFromResponse(created);
         String uploadUrl = created.get("uploadUrl").toString();
 
-        // File must be UPLOADED before the family check is reached;
-        // without this the server returns 400 (not yet uploaded) instead of 403.
         Path uploadPath = Path.of(URI.create(uploadUrl));
         Files.createDirectories(uploadPath.getParent());
         Files.write(uploadPath, new byte[64]);
         client.execute(
                 ConductorClientRequest.builder()
                         .method(Method.POST)
-                        .path("/files/" + fileId + "/upload-complete")
+                        .path("/files/wf-owner/" + fileId + "/upload-complete")
                         .build(),
                 MAP_TYPE);
 

--- a/rest/src/main/java/org/conductoross/conductor/controllers/FileResource.java
+++ b/rest/src/main/java/org/conductoross/conductor/controllers/FileResource.java
@@ -46,52 +46,69 @@ public class FileResource {
         return fileStorageService.createFile(request);
     }
 
-    @GetMapping("/{fileId}/upload-url")
+    @GetMapping("/{workflowId}/{fileId}/upload-url")
     @Operation(summary = "Get presigned upload URL")
-    public FileUploadUrlResponse getUploadUrl(@PathVariable("fileId") String fileId) {
-        return fileStorageService.getUploadUrl(fileId);
+    public FileUploadUrlResponse getUploadUrl(
+            @PathVariable("workflowId") String workflowId, @PathVariable("fileId") String fileId) {
+        return fileStorageService.getUploadUrl(workflowId, fileId);
     }
 
-    @PostMapping("/{fileId}/upload-complete")
+    @PostMapping("/{workflowId}/{fileId}/upload-complete")
     @Operation(summary = "Confirm file upload completion")
-    public FileUploadCompleteResponse confirmUpload(@PathVariable("fileId") String fileId) {
-        return fileStorageService.confirmUpload(fileId);
+    public FileUploadCompleteResponse confirmUpload(
+            @PathVariable("workflowId") String workflowId, @PathVariable("fileId") String fileId) {
+        return fileStorageService.confirmUpload(workflowId, fileId);
     }
 
     @GetMapping("/{workflowId}/{fileId}/download-url")
     @Operation(summary = "Get presigned download URL")
     public FileDownloadUrlResponse getDownloadUrl(
             @PathVariable("workflowId") String workflowId, @PathVariable("fileId") String fileId) {
-        return fileStorageService.getDownloadUrl(fileId, workflowId);
+        return fileStorageService.getDownloadUrl(workflowId, fileId);
     }
 
-    @GetMapping("/{fileId}")
+    @GetMapping("/{workflowId}/{fileId}")
     @Operation(summary = "Get file metadata")
-    public FileHandle getFileMetadata(@PathVariable("fileId") String fileId) {
-        return fileStorageService.getFileMetadata(fileId);
+    public FileHandle getFileMetadata(
+            @PathVariable("workflowId") String workflowId, @PathVariable("fileId") String fileId) {
+        return fileStorageService.getFileMetadata(workflowId, fileId);
     }
 
-    @PostMapping("/{fileId}/multipart")
+    @PostMapping("/{workflowId}/{fileId}/multipart")
     @Operation(summary = "Initiate multipart upload")
-    public MultipartInitResponse initiateMultipartUpload(@PathVariable("fileId") String fileId) {
-        return fileStorageService.initiateMultipartUpload(fileId);
+    public MultipartInitResponse initiateMultipartUpload(
+            @PathVariable("workflowId") String workflowId, @PathVariable("fileId") String fileId) {
+        return fileStorageService.initiateMultipartUpload(workflowId, fileId);
     }
 
-    @GetMapping("/{fileId}/multipart/{uploadId}/part/{partNumber}")
-    @Operation(summary = "Get presigned URL for a multipart part (S3 only)")
+    @GetMapping("/{workflowId}/{fileId}/multipart/{uploadId}/part/{partNumber}")
+    @Operation(summary = "Get a signed URL for a multipart part")
     public FileUploadUrlResponse getPartUploadUrl(
+            @PathVariable("workflowId") String workflowId,
             @PathVariable("fileId") String fileId,
             @PathVariable("uploadId") String uploadId,
             @PathVariable("partNumber") int partNumber) {
-        return fileStorageService.getPartUploadUrl(fileId, uploadId, partNumber);
+        return fileStorageService.getPartUploadUrl(workflowId, fileId, uploadId, partNumber);
     }
 
-    @PostMapping("/{fileId}/multipart/{uploadId}/complete")
+    @PostMapping("/{workflowId}/{fileId}/multipart/{uploadId}/complete")
     @Operation(summary = "Complete multipart upload")
     public FileUploadCompleteResponse completeMultipartUpload(
+            @PathVariable("workflowId") String workflowId,
             @PathVariable("fileId") String fileId,
             @PathVariable("uploadId") String uploadId,
             @RequestBody MultipartCompleteRequest request) {
-        return fileStorageService.completeMultipartUpload(fileId, uploadId, request.getPartETags());
+        return fileStorageService.completeMultipartUpload(
+                workflowId, fileId, uploadId, request.getPartETags());
+    }
+
+    @DeleteMapping("/{workflowId}/{fileId}/multipart/{uploadId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "Abort multipart upload")
+    public void abortMultipartUpload(
+            @PathVariable("workflowId") String workflowId,
+            @PathVariable("fileId") String fileId,
+            @PathVariable("uploadId") String uploadId) {
+        fileStorageService.abortMultipartUpload(workflowId, fileId, uploadId);
     }
 }

--- a/rest/src/test/java/org/conductoross/conductor/rest/controllers/FileResourceTest.java
+++ b/rest/src/test/java/org/conductoross/conductor/rest/controllers/FileResourceTest.java
@@ -27,6 +27,7 @@ public class FileResourceTest {
 
     private static final String FILE_ID = "abc";
     private static final String FILE_HANDLE_ID = FileIdToFileHandleIdConverter.PREFIX + FILE_ID;
+    private static final String WORKFLOW_ID = "wf-1";
 
     private FileStorageService fileStorageService;
     private FileResource fileResource;
@@ -55,9 +56,9 @@ public class FileResourceTest {
         FileUploadUrlResponse expected = new FileUploadUrlResponse();
         expected.setFileHandleId(FILE_HANDLE_ID);
         expected.setUploadUrl("https://s3/url");
-        when(fileStorageService.getUploadUrl(FILE_ID)).thenReturn(expected);
+        when(fileStorageService.getUploadUrl(WORKFLOW_ID, FILE_ID)).thenReturn(expected);
 
-        FileUploadUrlResponse result = fileResource.getUploadUrl(FILE_ID);
+        FileUploadUrlResponse result = fileResource.getUploadUrl(WORKFLOW_ID, FILE_ID);
         assertEquals("https://s3/url", result.getUploadUrl());
     }
 
@@ -65,9 +66,9 @@ public class FileResourceTest {
     public void testConfirmUpload() {
         FileUploadCompleteResponse expected = new FileUploadCompleteResponse();
         expected.setUploadStatus(FileUploadStatus.UPLOADED);
-        when(fileStorageService.confirmUpload(FILE_ID)).thenReturn(expected);
+        when(fileStorageService.confirmUpload(WORKFLOW_ID, FILE_ID)).thenReturn(expected);
 
-        FileUploadCompleteResponse result = fileResource.confirmUpload(FILE_ID);
+        FileUploadCompleteResponse result = fileResource.confirmUpload(WORKFLOW_ID, FILE_ID);
         assertEquals(FileUploadStatus.UPLOADED, result.getUploadStatus());
     }
 
@@ -75,9 +76,9 @@ public class FileResourceTest {
     public void testGetDownloadUrl() {
         FileDownloadUrlResponse expected = new FileDownloadUrlResponse();
         expected.setDownloadUrl("https://s3/download");
-        when(fileStorageService.getDownloadUrl(FILE_ID, "wf-1")).thenReturn(expected);
+        when(fileStorageService.getDownloadUrl(WORKFLOW_ID, FILE_ID)).thenReturn(expected);
 
-        FileDownloadUrlResponse result = fileResource.getDownloadUrl("wf-1", FILE_ID);
+        FileDownloadUrlResponse result = fileResource.getDownloadUrl(WORKFLOW_ID, FILE_ID);
         assertEquals("https://s3/download", result.getDownloadUrl());
     }
 
@@ -86,9 +87,9 @@ public class FileResourceTest {
         FileHandle expected = new FileHandle();
         expected.setFileHandleId(FILE_HANDLE_ID);
         expected.setFileName("test.pdf");
-        when(fileStorageService.getFileMetadata(FILE_ID)).thenReturn(expected);
+        when(fileStorageService.getFileMetadata(WORKFLOW_ID, FILE_ID)).thenReturn(expected);
 
-        FileHandle result = fileResource.getFileMetadata(FILE_ID);
+        FileHandle result = fileResource.getFileMetadata(WORKFLOW_ID, FILE_ID);
         assertEquals("test.pdf", result.getFileName());
     }
 
@@ -96,9 +97,9 @@ public class FileResourceTest {
     public void testInitiateMultipartUpload() {
         MultipartInitResponse expected = new MultipartInitResponse();
         expected.setUploadId("mp-123");
-        when(fileStorageService.initiateMultipartUpload(FILE_ID)).thenReturn(expected);
+        when(fileStorageService.initiateMultipartUpload(WORKFLOW_ID, FILE_ID)).thenReturn(expected);
 
-        MultipartInitResponse result = fileResource.initiateMultipartUpload(FILE_ID);
+        MultipartInitResponse result = fileResource.initiateMultipartUpload(WORKFLOW_ID, FILE_ID);
         assertEquals("mp-123", result.getUploadId());
     }
 
@@ -106,9 +107,11 @@ public class FileResourceTest {
     public void testGetPartUploadUrl() {
         FileUploadUrlResponse expected = new FileUploadUrlResponse();
         expected.setUploadUrl("https://s3/part/1");
-        when(fileStorageService.getPartUploadUrl(FILE_ID, "mp-123", 1)).thenReturn(expected);
+        when(fileStorageService.getPartUploadUrl(WORKFLOW_ID, FILE_ID, "mp-123", 1))
+                .thenReturn(expected);
 
-        FileUploadUrlResponse result = fileResource.getPartUploadUrl(FILE_ID, "mp-123", 1);
+        FileUploadUrlResponse result =
+                fileResource.getPartUploadUrl(WORKFLOW_ID, FILE_ID, "mp-123", 1);
         assertEquals("https://s3/part/1", result.getUploadUrl());
     }
 
@@ -119,11 +122,18 @@ public class FileResourceTest {
         FileUploadCompleteResponse expected = new FileUploadCompleteResponse();
         expected.setUploadStatus(FileUploadStatus.UPLOADED);
         when(fileStorageService.completeMultipartUpload(
-                        FILE_ID, "mp-123", List.of("etag1", "etag2")))
+                        WORKFLOW_ID, FILE_ID, "mp-123", List.of("etag1", "etag2")))
                 .thenReturn(expected);
 
         FileUploadCompleteResponse result =
-                fileResource.completeMultipartUpload(FILE_ID, "mp-123", request);
+                fileResource.completeMultipartUpload(WORKFLOW_ID, FILE_ID, "mp-123", request);
         assertEquals(FileUploadStatus.UPLOADED, result.getUploadStatus());
+    }
+
+    @Test
+    public void testAbortMultipartUpload() {
+        fileResource.abortMultipartUpload(WORKFLOW_ID, FILE_ID, "mp-123");
+
+        verify(fileStorageService).abortMultipartUpload(WORKFLOW_ID, FILE_ID, "mp-123");
     }
 }

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/AbstractFileStorageIntegrationTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/AbstractFileStorageIntegrationTest.java
@@ -42,6 +42,8 @@ import com.netflix.conductor.ConductorTestApp;
         })
 public abstract class AbstractFileStorageIntegrationTest {
 
+    protected static final String WORKFLOW_ID = "wf-test";
+
     @SuppressWarnings("resource")
     private static final GenericContainer<?> REDIS =
             new GenericContainer<>(DockerImageName.parse("redis:6.2-alpine"))
@@ -73,7 +75,7 @@ public abstract class AbstractFileStorageIntegrationTest {
         FileUploadRequest req = new FileUploadRequest();
         req.setFileName(name);
         req.setContentType(contentType);
-        req.setWorkflowId("wf-test");
+        req.setWorkflowId(WORKFLOW_ID);
         return req;
     }
 }

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/AzureBlobFileStorageIntegrationTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/AzureBlobFileStorageIntegrationTest.java
@@ -88,7 +88,8 @@ class AzureBlobFileStorageIntegrationTest extends AbstractFileStorageIntegration
     @Test
     void getMetadataForUnknownFileThrowsNotFoundException() {
         assertThrows(
-                NotFoundException.class, () -> fileStorageService.getFileMetadata("nonexistent"));
+                NotFoundException.class,
+                () -> fileStorageService.getFileMetadata(WORKFLOW_ID, "nonexistent"));
     }
 
     @Test
@@ -100,7 +101,7 @@ class AzureBlobFileStorageIntegrationTest extends AbstractFileStorageIntegration
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> fileStorageService.getDownloadUrl(fileId, "wf-test"));
+                () -> fileStorageService.getDownloadUrl(WORKFLOW_ID, fileId));
     }
 
     @Test
@@ -112,8 +113,9 @@ class AzureBlobFileStorageIntegrationTest extends AbstractFileStorageIntegration
 
         putToSasUrl(created.getUploadUrl(), payload);
 
-        FileUploadCompleteResponse confirmed = fileStorageService.confirmUpload(fileId);
-        FileDownloadUrlResponse download = fileStorageService.getDownloadUrl(fileId, "wf-test");
+        FileUploadCompleteResponse confirmed =
+                fileStorageService.confirmUpload(WORKFLOW_ID, fileId);
+        FileDownloadUrlResponse download = fileStorageService.getDownloadUrl(WORKFLOW_ID, fileId);
         byte[] fetched = getFromSasUrl(download.getDownloadUrl());
 
         assertEquals(FileUploadStatus.UPLOADED, confirmed.getUploadStatus());

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/FileStorageIntegrationTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/FileStorageIntegrationTest.java
@@ -62,7 +62,7 @@ class FileStorageIntegrationTest extends AbstractFileStorageIntegrationTest {
                 fileStorageService.createFile(newRequest("doc.pdf", "application/pdf"));
         String fileId = FileIdToFileHandleIdConverter.toFileId(created.getFileHandleId());
 
-        FileHandle handle = fileStorageService.getFileMetadata(fileId);
+        FileHandle handle = fileStorageService.getFileMetadata(WORKFLOW_ID, fileId);
 
         assertEquals(created.getFileHandleId(), handle.getFileHandleId());
         assertEquals("doc.pdf", handle.getFileName());
@@ -72,7 +72,8 @@ class FileStorageIntegrationTest extends AbstractFileStorageIntegrationTest {
     @Test
     void getMetadataForUnknownFileThrowsNotFoundException() {
         assertThrows(
-                NotFoundException.class, () -> fileStorageService.getFileMetadata("nonexistent"));
+                NotFoundException.class,
+                () -> fileStorageService.getFileMetadata(WORKFLOW_ID, "nonexistent"));
     }
 
     @Test
@@ -84,7 +85,7 @@ class FileStorageIntegrationTest extends AbstractFileStorageIntegrationTest {
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> fileStorageService.getDownloadUrl(fileId, "wf-test"));
+                () -> fileStorageService.getDownloadUrl(WORKFLOW_ID, fileId));
     }
 
     @Test
@@ -97,8 +98,9 @@ class FileStorageIntegrationTest extends AbstractFileStorageIntegrationTest {
         Files.createDirectories(storagePath.getParent());
         Files.writeString(storagePath, "hello");
 
-        FileUploadCompleteResponse confirmed = fileStorageService.confirmUpload(fileId);
-        FileDownloadUrlResponse download = fileStorageService.getDownloadUrl(fileId, "wf-test");
+        FileUploadCompleteResponse confirmed =
+                fileStorageService.confirmUpload(WORKFLOW_ID, fileId);
+        FileDownloadUrlResponse download = fileStorageService.getDownloadUrl(WORKFLOW_ID, fileId);
 
         assertEquals(FileUploadStatus.UPLOADED, confirmed.getUploadStatus());
         assertNotNull(download.getDownloadUrl());
@@ -110,10 +112,13 @@ class FileStorageIntegrationTest extends AbstractFileStorageIntegrationTest {
                 fileStorageService.createFile(newRequest("large.bin", "application/octet-stream"));
         String fileId = FileIdToFileHandleIdConverter.toFileId(created.getFileHandleId());
 
-        MultipartInitResponse init = fileStorageService.initiateMultipartUpload(fileId);
+        MultipartInitResponse init =
+                fileStorageService.initiateMultipartUpload(WORKFLOW_ID, fileId);
 
         assertNotNull(init.getUploadId());
         assertNotNull(
-                fileStorageService.getPartUploadUrl(fileId, init.getUploadId(), 1).getUploadUrl());
+                fileStorageService
+                        .getPartUploadUrl(WORKFLOW_ID, fileId, init.getUploadId(), 1)
+                        .getUploadUrl());
     }
 }

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/GcsFileStorageIntegrationTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/GcsFileStorageIntegrationTest.java
@@ -94,7 +94,8 @@ class GcsFileStorageIntegrationTest extends AbstractFileStorageIntegrationTest {
     @Test
     void getMetadataForUnknownFileThrowsNotFoundException() {
         assertThrows(
-                NotFoundException.class, () -> fileStorageService.getFileMetadata("nonexistent"));
+                NotFoundException.class,
+                () -> fileStorageService.getFileMetadata(WORKFLOW_ID, "nonexistent"));
     }
 
     @Test
@@ -106,7 +107,7 @@ class GcsFileStorageIntegrationTest extends AbstractFileStorageIntegrationTest {
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> fileStorageService.getDownloadUrl(fileId, "wf-test"));
+                () -> fileStorageService.getDownloadUrl(WORKFLOW_ID, fileId));
     }
 
     @Test
@@ -123,8 +124,9 @@ class GcsFileStorageIntegrationTest extends AbstractFileStorageIntegrationTest {
         // finds the object in the bucket.
         TEST_STORAGE.create(BlobInfo.newBuilder(BlobId.of(BUCKET, storagePath)).build(), payload);
 
-        FileUploadCompleteResponse confirmed = fileStorageService.confirmUpload(fileId);
-        FileDownloadUrlResponse download = fileStorageService.getDownloadUrl(fileId, "wf-test");
+        FileUploadCompleteResponse confirmed =
+                fileStorageService.confirmUpload(WORKFLOW_ID, fileId);
+        FileDownloadUrlResponse download = fileStorageService.getDownloadUrl(WORKFLOW_ID, fileId);
 
         assertEquals(FileUploadStatus.UPLOADED, confirmed.getUploadStatus());
         assertNotNull(download.getDownloadUrl());

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/S3FileStorageIntegrationTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/S3FileStorageIntegrationTest.java
@@ -101,7 +101,8 @@ class S3FileStorageIntegrationTest extends AbstractFileStorageIntegrationTest {
     @Test
     void getMetadataForUnknownFileThrowsNotFoundException() {
         assertThrows(
-                NotFoundException.class, () -> fileStorageService.getFileMetadata("nonexistent"));
+                NotFoundException.class,
+                () -> fileStorageService.getFileMetadata(WORKFLOW_ID, "nonexistent"));
     }
 
     @Test
@@ -113,7 +114,7 @@ class S3FileStorageIntegrationTest extends AbstractFileStorageIntegrationTest {
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> fileStorageService.getDownloadUrl(fileId, "wf-test"));
+                () -> fileStorageService.getDownloadUrl(WORKFLOW_ID, fileId));
     }
 
     @Test
@@ -125,8 +126,9 @@ class S3FileStorageIntegrationTest extends AbstractFileStorageIntegrationTest {
 
         putToPresignedUrl(created.getUploadUrl(), payload);
 
-        FileUploadCompleteResponse confirmed = fileStorageService.confirmUpload(fileId);
-        FileDownloadUrlResponse download = fileStorageService.getDownloadUrl(fileId, "wf-test");
+        FileUploadCompleteResponse confirmed =
+                fileStorageService.confirmUpload(WORKFLOW_ID, fileId);
+        FileDownloadUrlResponse download = fileStorageService.getDownloadUrl(WORKFLOW_ID, fileId);
         byte[] fetched = getFromPresignedUrl(download.getDownloadUrl());
 
         assertEquals(FileUploadStatus.UPLOADED, confirmed.getUploadStatus());


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

Makes file operations workflow-aware end to end:

- scopes upload URL refresh, completion, metadata, and multipart routes by workflow ID
- requires the exact owning workflow for upload mutations
- allows workflow-family access for metadata and downloads
- adds best-effort multipart abort, including native S3 abort
- returns the storage-reported `fileSize` in metadata
- updates REST, service, integration, and E2E coverage
- replaces stale file-storage API/architecture/Java SDK documentation

Breaking change: the previous unscoped mutation and metadata routes are removed. Clients must pass workflow context on every operation.

Issue #

Tests
----

- `./gradlew :conductor-core:test --tests org.conductoross.conductor.core.storage.converter.FileModelConverterTest --tests org.conductoross.conductor.core.storage.FileStorageServiceImplTest :conductor-rest:test --tests org.conductoross.conductor.rest.controllers.FileResourceTest -x :conductor-ai:compileJava`
- `./gradlew :conductor-common:spotlessJavaApply :conductor-core:spotlessJavaApply :conductor-rest:spotlessJavaApply :conductor-awss3-storage:spotlessJavaApply :conductor-e2e:spotlessJavaApply :conductor-test-harness:spotlessJavaApply`
- live local-storage E2E on port 8080: media-transcode workflow completed and metadata returned correct byte sizes

Alternatives considered
----

Keeping unscoped routes or trusting a supplied file handle alone would leave upload mutations detached from ownership. Proxying file bytes through Conductor was also rejected; signed URLs retain the direct-to-storage data path.