### PR TITLE
fix(scheduler): return 404 from GET /schedules/{name} when the schedule does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 
 ### Breaking Changes
+- **`GET /api/scheduler/schedules/{name}` now returns 404 for an unknown schedule**
+  - Previously returned `200 OK` with an empty body when the schedule did not exist
+  - Now returns `404 Not Found` with the standard error body, matching every other not-found
+    response in the API (including this same resource's `pause`/`resume` of a missing schedule)
+  - If your integration checks for an empty body to detect a missing schedule, switch to
+    handling the `404` status instead
 - **JavaScript Evaluator Migration from Nashorn to GraalJS**
   - Minimum Java version is now **Java 17** (previously Java 11+)
   - Nashorn JavaScript engine (deprecated in Java 11, removed in Java 15) replaced with GraalJS

--- a/scheduler/core/src/main/java/io/orkes/conductor/scheduler/service/SchedulerService.java
+++ b/scheduler/core/src/main/java/io/orkes/conductor/scheduler/service/SchedulerService.java
@@ -1106,7 +1106,11 @@ public class SchedulerService extends LifecycleAwareComponent {
     }
 
     public WorkflowSchedule getSchedule(String name) {
-        return schedulerDAO.findScheduleByName(name);
+        WorkflowScheduleModel schedule = schedulerDAO.findScheduleByName(name);
+        if (schedule == null) {
+            throw new NotFoundException("Schedule '%s' not found".formatted(name));
+        }
+        return schedule;
     }
 
     public List<WorkflowScheduleModel> getAllSchedules(String workflowName) {

--- a/scheduler/core/src/test/java/io/orkes/conductor/scheduler/service/SchedulerServiceTest.java
+++ b/scheduler/core/src/test/java/io/orkes/conductor/scheduler/service/SchedulerServiceTest.java
@@ -150,6 +150,29 @@ class SchedulerServiceTest {
     }
 
     @Test
+    @DisplayName("getSchedule returns the schedule when it exists")
+    void getScheduleReturnsExistingSchedule() {
+        WorkflowSchedule ws = new WorkflowSchedule();
+        ws.setName("existing");
+        ws.setCronExpression("* * * * * ?");
+        schedulerDAO.updateSchedule(WorkflowScheduleModel.from(ws));
+
+        SchedulerService service = createService(Mockito.mock(SchedulerTimeProvider.class));
+
+        assertEquals("existing", service.getSchedule("existing").getName());
+    }
+
+    @Test
+    @DisplayName("getSchedule throws NotFoundException when the schedule does not exist")
+    void getScheduleThrowsNotFoundWhenMissing() {
+        SchedulerService service = createService(Mockito.mock(SchedulerTimeProvider.class));
+
+        NotFoundException ex =
+                assertThrows(NotFoundException.class, () -> service.getSchedule("does-not-exist"));
+        assertEquals("Schedule 'does-not-exist' not found", ex.getMessage());
+    }
+
+    @Test
     @DisplayName("getEffectiveCronSchedules wraps legacy single cronExpression")
     void effectiveCronSchedulesWrapsLegacyCronExpression() {
         WorkflowSchedule ws = new WorkflowSchedule();


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_

- `GET /schedules/{name}` returned `200` with an empty body for a missing schedule — every other
  not-found in this API (e.g. `pause`/`resume` of a missing schedule) returns `404`
- `SchedulerService.getSchedule` now throws `NotFoundException` on a miss instead of returning
  null; `SchedulerResource` is unchanged, just delegates and returns whatever the service gives it

Issue #

Alternatives considered
----

- Leave the empty-200 contract as-is — rejected, inconsistent with every other not-found on this
  resource and forces clients to special-case this one endpoint
