### PR TITLE
feat(core): poll-worker execution mode for annotated @WorkerTask tasks

### DIFF
--- a/core/src/main/java/org/conductoross/conductor/core/execution/tasks/annotated/AnnotatedPollWorkerCoordinator.java
+++ b/core/src/main/java/org/conductoross/conductor/core/execution/tasks/annotated/AnnotatedPollWorkerCoordinator.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.core.execution.tasks.annotated;
+
+import java.lang.reflect.InvocationTargetException;
+import java.net.InetAddress;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.stereotype.Component;
+
+import com.netflix.conductor.common.metadata.tasks.Task;
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.common.metadata.tasks.TaskResult;
+import com.netflix.conductor.core.dal.ExecutionDAOFacade;
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.model.TaskModel;
+import com.netflix.conductor.sdk.workflow.executor.task.NonRetryableException;
+import com.netflix.conductor.sdk.workflow.executor.task.TaskContext;
+import com.netflix.conductor.service.ExecutionService;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Executes {@code @WorkerTask} annotated methods through the standard worker-task contract when
+ * {@code conductor.annotated-workers.mode=poll-worker}.
+ *
+ * <p>Instead of registering annotated methods as async system tasks (whose blocking {@code start()}
+ * holds an unacked queue message and is re-executed when the unack window elapses — see issue
+ * #1321), each method is polled and executed exactly like a remote custom worker:
+ *
+ * <ul>
+ *   <li>{@link ExecutionService#poll} claims the task: IN_PROGRESS + workerId are persisted and the
+ *       queue message is ACKed <b>before</b> the method runs, so redelivery of an in-flight task is
+ *       structurally impossible.
+ *   <li>Liveness is governed by the task def's {@code responseTimeoutSeconds}; workers with {@link
+ *       com.netflix.conductor.sdk.workflow.task.WorkerTask#leaseExtendEnabled()} heartbeat via
+ *       lease extension while the method runs.
+ *   <li>Results are reported through {@link WorkflowExecutor#updateTask}, which drops late updates
+ *       to already-terminal tasks (issue #1322).
+ *   <li>A method returning IN_PROGRESS with {@code callbackAfterSeconds} (the long-running LLM/A2A
+ *       pattern) is re-queued and re-claimed on the next turn — every turn gets the full claim +
+ *       lease protection.
+ * </ul>
+ */
+@Slf4j
+@Component
+public class AnnotatedPollWorkerCoordinator implements SmartLifecycle {
+
+    public static final String MODE_POLL_WORKER = "poll-worker";
+
+    private final WorkerTaskAnnotationScanner scanner;
+    private final ExecutionService executionService;
+    private final WorkflowExecutor workflowExecutor;
+    private final ExecutionDAOFacade executionDAOFacade;
+    private final MetadataDAO metadataDAO;
+    private final boolean enabled;
+    private final long defaultResponseTimeoutSeconds;
+    private final String workerId;
+
+    private final AnnotatedMethodParameterMapper parameterMapper =
+            new AnnotatedMethodParameterMapper();
+    private final AnnotatedMethodResultMapper resultMapper = new AnnotatedMethodResultMapper();
+
+    private volatile boolean running = false;
+    private ExecutorService pollerPool;
+    private ScheduledExecutorService leaseExtender;
+
+    public AnnotatedPollWorkerCoordinator(
+            WorkerTaskAnnotationScanner scanner,
+            ExecutionService executionService,
+            WorkflowExecutor workflowExecutor,
+            ExecutionDAOFacade executionDAOFacade,
+            MetadataDAO metadataDAO,
+            @Value("${conductor.annotated-workers.mode:system-task}") String mode,
+            @Value("${conductor.annotated-workers.response-timeout-seconds:600}")
+                    long defaultResponseTimeoutSeconds) {
+        this.scanner = scanner;
+        this.executionService = executionService;
+        this.workflowExecutor = workflowExecutor;
+        this.executionDAOFacade = executionDAOFacade;
+        this.metadataDAO = metadataDAO;
+        this.enabled = MODE_POLL_WORKER.equals(mode);
+        this.defaultResponseTimeoutSeconds = defaultResponseTimeoutSeconds;
+        this.workerId = resolveWorkerId();
+    }
+
+    @Override
+    public void start() {
+        running = true;
+        if (!enabled) {
+            return;
+        }
+        List<WorkerTaskAnnotationScanner.AnnotatedWorker> workers = scanner.getPollWorkers();
+        if (workers.isEmpty()) {
+            log.info("Annotated poll-worker mode enabled but no @WorkerTask methods discovered");
+            return;
+        }
+        AtomicInteger threadCounter = new AtomicInteger();
+        pollerPool =
+                Executors.newCachedThreadPool(
+                        runnable -> {
+                            Thread thread = new Thread(runnable);
+                            thread.setName(
+                                    "annotated-poll-worker-" + threadCounter.incrementAndGet());
+                            thread.setDaemon(true);
+                            return thread;
+                        });
+        if (workers.stream().anyMatch(worker -> worker.annotation().leaseExtendEnabled())) {
+            leaseExtender =
+                    Executors.newSingleThreadScheduledExecutor(
+                            runnable -> {
+                                Thread thread = new Thread(runnable);
+                                thread.setName("annotated-poll-worker-lease-extender");
+                                thread.setDaemon(true);
+                                return thread;
+                            });
+        }
+        for (WorkerTaskAnnotationScanner.AnnotatedWorker worker : workers) {
+            registerTaskDefIfAbsent(worker.taskType());
+            int pollerCount = Math.max(1, worker.annotation().pollerCount());
+            for (int i = 0; i < pollerCount; i++) {
+                pollerPool.submit(() -> pollLoop(worker));
+            }
+            log.info(
+                    "Started {} poller(s) for annotated worker task {} (worker contract mode)",
+                    pollerCount,
+                    worker.taskType());
+        }
+    }
+
+    @Override
+    public void stop() {
+        running = false;
+        if (pollerPool != null) {
+            pollerPool.shutdownNow();
+        }
+        if (leaseExtender != null) {
+            leaseExtender.shutdownNow();
+        }
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
+
+    /**
+     * Registers a task def so the USER_DEFINED task mapper can schedule the type and so the
+     * response-timeout lease is explicit. No-op when a def already exists (deployments can tune it
+     * like any worker task def).
+     */
+    private void registerTaskDefIfAbsent(String taskType) {
+        try {
+            if (metadataDAO.getTaskDef(taskType) != null) {
+                return;
+            }
+            TaskDef taskDef = new TaskDef(taskType);
+            taskDef.setDescription("Auto-registered for @WorkerTask " + taskType);
+            taskDef.setRetryCount(0);
+            taskDef.setTimeoutSeconds(0);
+            taskDef.setResponseTimeoutSeconds(defaultResponseTimeoutSeconds);
+            taskDef.setOwnerEmail("annotated-workers@conductoross.org");
+            metadataDAO.createTaskDef(taskDef);
+            log.info(
+                    "Auto-registered task def for annotated worker task {} (responseTimeout={}s)",
+                    taskType,
+                    defaultResponseTimeoutSeconds);
+        } catch (Exception e) {
+            // Another node may have won the registration race; the def existing is all we need.
+            log.warn("Could not auto-register task def for {}: {}", taskType, e.getMessage());
+        }
+    }
+
+    private void pollLoop(WorkerTaskAnnotationScanner.AnnotatedWorker worker) {
+        String domain =
+                worker.annotation().domain().isBlank() ? null : worker.annotation().domain();
+        int pollTimeout = Math.max(100, worker.annotation().pollTimeout());
+        int pollingInterval = Math.max(10, worker.annotation().pollingInterval());
+        while (running) {
+            try {
+                List<Task> tasks =
+                        executionService.poll(worker.taskType(), workerId, domain, 1, pollTimeout);
+                if (tasks == null || tasks.isEmpty()) {
+                    TimeUnit.MILLISECONDS.sleep(pollingInterval);
+                    continue;
+                }
+                for (Task task : tasks) {
+                    executeClaimedTask(worker, task);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            } catch (Exception e) {
+                log.error("Error in annotated poll-worker loop for {}", worker.taskType(), e);
+                try {
+                    TimeUnit.MILLISECONDS.sleep(pollingInterval);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+    }
+
+    /**
+     * Executes a task that {@link ExecutionService#poll} has already claimed (IN_PROGRESS
+     * persisted, queue message ACKed) and reports the result through the worker update contract.
+     */
+    private void executeClaimedTask(WorkerTaskAnnotationScanner.AnnotatedWorker worker, Task task) {
+        TaskModel taskModel = executionDAOFacade.getTaskModel(task.getTaskId());
+        if (taskModel == null || taskModel.getStatus().isTerminal()) {
+            return;
+        }
+        TaskContext taskContext = TaskContext.set(taskModel.toTask());
+        taskContext.getTaskResult().setStatus(TaskResult.Status.COMPLETED);
+        taskContext.getTaskResult().setCallbackAfterSeconds(0);
+        ScheduledFuture<?> leaseExtension = maybeScheduleLeaseExtension(worker, taskModel);
+        try {
+            Object[] parameters = parameterMapper.mapParameters(taskModel, worker.method());
+            Object result = worker.method().invoke(worker.bean(), parameters);
+            resultMapper.applyResult(
+                    result, taskModel, worker.method(), taskContext.getTaskResult());
+        } catch (InvocationTargetException e) {
+            applyInvocationFailure(taskModel, e.getCause());
+        } catch (Exception e) {
+            log.error("Error executing annotated worker task {}", worker.taskType(), e);
+            taskModel.setStatus(TaskModel.Status.FAILED);
+            taskModel.setReasonForIncompletion(rootCauseMessage(e));
+        } finally {
+            if (leaseExtension != null) {
+                leaseExtension.cancel(false);
+            }
+            TaskContext.clear();
+        }
+        reportResult(taskModel);
+    }
+
+    private ScheduledFuture<?> maybeScheduleLeaseExtension(
+            WorkerTaskAnnotationScanner.AnnotatedWorker worker, TaskModel taskModel) {
+        if (!worker.annotation().leaseExtendEnabled()) {
+            return null;
+        }
+        // A third of the lease keeps the task alive with margin for two missed heartbeats.
+        long interval = Math.max(1, defaultResponseTimeoutSeconds / 3);
+        String taskId = taskModel.getTaskId();
+        String workflowInstanceId = taskModel.getWorkflowInstanceId();
+        return leaseExtender.scheduleAtFixedRate(
+                () -> {
+                    try {
+                        TaskResult lease = new TaskResult();
+                        lease.setTaskId(taskId);
+                        lease.setWorkflowInstanceId(workflowInstanceId);
+                        lease.setWorkerId(workerId);
+                        lease.setExtendLease(true);
+                        workflowExecutor.updateTask(lease);
+                        log.debug("Extended lease for in-flight annotated task {}", taskId);
+                    } catch (Exception e) {
+                        log.warn("Lease extension failed for task {}: {}", taskId, e.getMessage());
+                    }
+                },
+                interval,
+                interval,
+                TimeUnit.SECONDS);
+    }
+
+    private void applyInvocationFailure(TaskModel taskModel, Throwable cause) {
+        log.error("Annotated worker task {} failed", taskModel.getTaskType(), cause);
+        if (cause instanceof NonRetryableException) {
+            taskModel.setStatus(TaskModel.Status.FAILED_WITH_TERMINAL_ERROR);
+            taskModel.setReasonForIncompletion("Non-retryable error: " + rootCauseMessage(cause));
+        } else {
+            taskModel.setStatus(TaskModel.Status.FAILED);
+            taskModel.setReasonForIncompletion("Task execution failed: " + rootCauseMessage(cause));
+        }
+    }
+
+    /**
+     * Reports the outcome through the same update contract a remote worker uses. Retried a few
+     * times: dropping the result of an already-paid provider call over a transient store/queue
+     * error would force a full re-execution after the response timeout.
+     */
+    private void reportResult(TaskModel taskModel) {
+        TaskResult taskResult = new TaskResult(taskModel.toTask());
+        taskResult.setWorkerId(workerId);
+        taskResult.setStatus(toResultStatus(taskModel.getStatus()));
+        for (int attempt = 1; ; attempt++) {
+            try {
+                workflowExecutor.updateTask(taskResult);
+                return;
+            } catch (Exception e) {
+                if (attempt >= 3) {
+                    // The claim stands (task is IN_PROGRESS); the response-timeout lease governs
+                    // recovery, exactly as it would for a remote worker whose update failed.
+                    log.error(
+                            "Failed to report result for annotated worker task {}/{}",
+                            taskModel.getTaskType(),
+                            taskModel.getTaskId(),
+                            e);
+                    return;
+                }
+                log.warn(
+                        "Retrying result update for task {} (attempt {}): {}",
+                        taskModel.getTaskId(),
+                        attempt,
+                        e.getMessage());
+                try {
+                    TimeUnit.MILLISECONDS.sleep(500L * attempt);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+    }
+
+    private TaskResult.Status toResultStatus(TaskModel.Status status) {
+        return switch (status) {
+            case COMPLETED -> TaskResult.Status.COMPLETED;
+            case FAILED_WITH_TERMINAL_ERROR -> TaskResult.Status.FAILED_WITH_TERMINAL_ERROR;
+            case IN_PROGRESS, SCHEDULED -> TaskResult.Status.IN_PROGRESS;
+            case CANCELED -> TaskResult.Status.CANCELED;
+            default -> TaskResult.Status.FAILED;
+        };
+    }
+
+    private static String rootCauseMessage(Throwable throwable) {
+        Throwable root = throwable;
+        while (root.getCause() != null && root.getCause() != root) {
+            root = root.getCause();
+        }
+        String rootMessage = root.getMessage() != null ? root.getMessage() : root.toString();
+        if (root != throwable && throwable.getMessage() != null) {
+            return throwable.getMessage() + " (root cause: " + rootMessage + ")";
+        }
+        return rootMessage;
+    }
+
+    private static String resolveWorkerId() {
+        try {
+            return "annotated-poll-worker@" + InetAddress.getLocalHost().getHostName();
+        } catch (Exception e) {
+            return "annotated-poll-worker";
+        }
+    }
+}

--- a/core/src/main/java/org/conductoross/conductor/core/execution/tasks/annotated/WorkerTaskAnnotationScanner.java
+++ b/core/src/main/java/org/conductoross/conductor/core/execution/tasks/annotated/WorkerTaskAnnotationScanner.java
@@ -13,6 +13,7 @@
 package org.conductoross.conductor.core.execution.tasks.annotated;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -44,22 +46,35 @@ public class WorkerTaskAnnotationScanner implements InitializingBean {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WorkerTaskAnnotationScanner.class);
 
+    /** One discovered {@code @WorkerTask} method, when running in poll-worker mode. */
+    public record AnnotatedWorker(
+            String taskType, Method method, Object bean, WorkerTask annotation) {}
+
     private final List<AnnotatedSystemTaskWorker> annotatedSystemTaskWorkers;
     private final Set<WorkflowSystemTask> asyncSystemTasks;
     private final Map<String, TaskMapper> taskMappers = new HashMap<>();
     private final ParametersUtils parametersUtils;
     private final MetadataDAO metadataDAO;
+    private final List<AnnotatedWorker> pollWorkers = new ArrayList<>();
+    private final boolean pollWorkerMode;
 
     public WorkerTaskAnnotationScanner(
             List<AnnotatedSystemTaskWorker> annotatedSystemTaskWorkers,
             @Qualifier(SystemTaskRegistry.ASYNC_SYSTEM_TASKS_QUALIFIER)
                     Set<WorkflowSystemTask> asyncSystemTasks,
             @Lazy ParametersUtils parametersUtils,
-            @Lazy MetadataDAO metadataDAO) {
+            @Lazy MetadataDAO metadataDAO,
+            @Value("${conductor.annotated-workers.mode:system-task}") String mode) {
         this.annotatedSystemTaskWorkers = annotatedSystemTaskWorkers;
         this.asyncSystemTasks = asyncSystemTasks;
         this.parametersUtils = parametersUtils;
         this.metadataDAO = metadataDAO;
+        this.pollWorkerMode = AnnotatedPollWorkerCoordinator.MODE_POLL_WORKER.equals(mode);
+    }
+
+    /** The methods to execute through the worker contract; empty unless in poll-worker mode. */
+    public List<AnnotatedWorker> getPollWorkers() {
+        return List.copyOf(pollWorkers);
     }
 
     /**
@@ -93,20 +108,34 @@ public class WorkerTaskAnnotationScanner implements InitializingBean {
                                 beanName,
                                 taskType);
 
-                        AnnotatedWorkflowSystemTask task =
-                                new AnnotatedWorkflowSystemTask(taskType, method, bean, annotation);
+                        if (pollWorkerMode) {
+                            // poll-worker mode: do NOT register as a system task. The type is
+                            // scheduled through the USER_DEFINED task mapper fallback and
+                            // executed by AnnotatedPollWorkerCoordinator through the standard
+                            // worker contract (poll claims + ACKs before the method runs).
+                            pollWorkers.add(
+                                    new AnnotatedWorker(taskType, method, bean, annotation));
+                            LOGGER.info(
+                                    "Registered annotated task type {} as poll-worker", taskType);
+                        } else {
+                            AnnotatedWorkflowSystemTask task =
+                                    new AnnotatedWorkflowSystemTask(
+                                            taskType, method, bean, annotation);
 
-                        // Add to existing asyncSystemTasks collection
-                        asyncSystemTasks.add(task);
+                            // Add to existing asyncSystemTasks collection
+                            asyncSystemTasks.add(task);
 
-                        // Register a TaskMapper for this task type so DeciderService can find it
-                        AnnotatedSystemTaskMapper mapper =
-                                new AnnotatedSystemTaskMapper(
-                                        taskType, parametersUtils, metadataDAO);
-                        LOGGER.info("Adding task mapper {} for task {}", mapper, taskType);
-                        taskMappers.put(taskType, mapper);
+                            // Register a TaskMapper for this task type so DeciderService can
+                            // find it
+                            AnnotatedSystemTaskMapper mapper =
+                                    new AnnotatedSystemTaskMapper(
+                                            taskType, parametersUtils, metadataDAO);
+                            LOGGER.info("Adding task mapper {} for task {}", mapper, taskType);
+                            taskMappers.put(taskType, mapper);
 
-                        LOGGER.debug("Registered TaskMapper for annotated task type: {}", taskType);
+                            LOGGER.debug(
+                                    "Registered TaskMapper for annotated task type: {}", taskType);
+                        }
                         foundMethods++;
                     }
                 }

--- a/core/src/test/java/org/conductoross/conductor/core/execution/tasks/annotated/TestAnnotatedSystemTaskIntegration.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/tasks/annotated/TestAnnotatedSystemTaskIntegration.java
@@ -91,7 +91,7 @@ public class TestAnnotatedSystemTaskIntegration {
                 ParametersUtils parametersUtils,
                 MetadataDAO metadataDAO) {
             return new WorkerTaskAnnotationScanner(
-                    workers, asyncSystemTasks, parametersUtils, metadataDAO);
+                    workers, asyncSystemTasks, parametersUtils, metadataDAO, "system-task");
         }
     }
 

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/AnnotatedPollWorkerModeSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/AnnotatedPollWorkerModeSpec.groovy
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.test.integration
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.TestPropertySource
+
+import com.netflix.conductor.common.metadata.tasks.Task
+import com.netflix.conductor.common.run.Workflow
+import com.netflix.conductor.dao.QueueDAO
+import com.netflix.conductor.test.base.AbstractSpecification
+import com.netflix.conductor.test.utils.ControllablePollWorker
+
+/**
+ * Acceptance tests for {@code conductor.annotated-workers.mode=poll-worker}: annotated
+ * {@code @WorkerTask} methods executed through the standard worker-task contract instead of the
+ * async system-task path.
+ *
+ * <p>Covers the two scenarios behind issues #1321/#1322:
+ *
+ * <ul>
+ *   <li>A single blocking invocation that outlasts any queue redelivery window must execute
+ *       exactly once. In poll-worker mode this holds structurally: the poll claims the task
+ *       (IN_PROGRESS + workerId persisted) and ACKs the queue message BEFORE the method runs, so
+ *       there is nothing left in the queue to redeliver.
+ *   <li>A multi-turn worker (IN_PROGRESS + callbackAfterSeconds, the long-running LLM/A2A
+ *       pattern) must execute each turn exactly once — the scenario the system-task path leaves
+ *       unprotected for turns 2+.
+ * </ul>
+ */
+@TestPropertySource(properties = [
+        "conductor.annotated-workers.mode=poll-worker",
+        "conductor.annotated-workers.response-timeout-seconds=45"
+])
+class AnnotatedPollWorkerModeSpec extends AbstractSpecification {
+
+    @Autowired
+    QueueDAO queueDAO
+
+    @Autowired
+    ControllablePollWorker worker
+
+    static final String WF = 'controllable_poll_worker_wf'
+    static final String QUEUE = ControllablePollWorker.TASK_TYPE
+
+    def setup() {
+        worker.reset()
+        workflowTestUtil.registerWorkflows('controllable_poll_worker_workflow.json')
+    }
+
+    def "blocking annotated task in poll-worker mode executes exactly once"() {
+        when: "the workflow is started"
+        def workflowId = startWorkflow(WF, 1, 'pollworker_' + UUID.randomUUID(), [:], null)
+
+        then: "a poll-worker claims and invokes the method"
+        worker.enteredRun.await(10, TimeUnit.SECONDS)
+
+        when: "the invocation blocks well past any queue redelivery window"
+        Thread.sleep(3000)
+        def runningWf = workflowExecutionService.getExecutionStatus(workflowId, true)
+
+        then: "the task was claimed through the worker contract before the method ran"
+        runningWf.status == Workflow.WorkflowStatus.RUNNING
+        runningWf.tasks.size() == 1
+        runningWf.tasks[0].status == Task.Status.IN_PROGRESS
+        runningWf.tasks[0].workerId?.startsWith('annotated-poll-worker')
+
+        and: "the queue holds nothing to redeliver - the message was ACKed at claim time"
+        queueDAO.getSize(QUEUE) == 0
+
+        and: "the method ran exactly once"
+        assert worker.invocations.get() == 1:
+                "duplicate invocation detected:\n${worker.invocationLog.join('\n')}"
+
+        when: "the simulated provider call finishes"
+        worker.release.countDown()
+
+        then: "the workflow completes with the single attempt's output"
+        conditions.eventually {
+            def completedWf = workflowExecutionService.getExecutionStatus(workflowId, true)
+            assert completedWf.status == Workflow.WorkflowStatus.COMPLETED
+            assert completedWf.tasks[0].outputData['attempt'] == 1
+        }
+        worker.invocations.get() == 1
+
+        cleanup:
+        worker.release?.countDown()
+    }
+
+    def "multi-turn annotated task executes each turn exactly once"() {
+        given: "turn 1 returns IN_PROGRESS with a 1s callback; turn 2 blocks mid-call"
+        worker.inProgressTurns = 1
+        worker.callbackAfterSeconds = 1
+        worker.blockFromAttempt = 2
+        worker.enteredRun = new CountDownLatch(2)
+
+        when: "the workflow is started"
+        def workflowId = startWorkflow(WF, 1, 'pollworker_turn2_' + UUID.randomUUID(), [:], null)
+
+        then: "turn 1 completes and turn 2 is re-claimed after the callback fires"
+        worker.enteredRun.await(15, TimeUnit.SECONDS)
+
+        when: "turn 2 blocks well past any queue redelivery window"
+        Thread.sleep(3000)
+
+        then: "each turn ran exactly once - no duplicate of the in-flight turn"
+        assert worker.invocations.get() == 2:
+                "duplicate invocation detected:\n${worker.invocationLog.join('\n')}"
+
+        and: "the queue holds nothing to redeliver for the in-flight turn"
+        queueDAO.getSize(QUEUE) == 0
+
+        when: "the simulated provider call finishes"
+        worker.release.countDown()
+
+        then: "the workflow completes with turn 2's output"
+        conditions.eventually {
+            def completedWf = workflowExecutionService.getExecutionStatus(workflowId, true)
+            assert completedWf.status == Workflow.WorkflowStatus.COMPLETED
+            assert completedWf.tasks[0].outputData['attempt'] == 2
+        }
+        worker.invocations.get() == 2
+
+        cleanup:
+        worker.release?.countDown()
+    }
+}

--- a/test-harness/src/test/java/com/netflix/conductor/test/utils/ControllablePollWorker.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/utils/ControllablePollWorker.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.test.utils;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.conductoross.conductor.core.execution.tasks.AnnotatedSystemTaskWorker;
+import org.springframework.stereotype.Component;
+
+import com.netflix.conductor.common.metadata.tasks.TaskResult;
+import com.netflix.conductor.sdk.workflow.executor.task.TaskContext;
+import com.netflix.conductor.sdk.workflow.task.WorkerTask;
+
+/**
+ * A controllable blocking annotated worker for redelivery/duplicate-execution specs. It stands in
+ * for a long-running provider call (e.g. an LLM chat completion) and supports the multi-turn
+ * pattern (IN_PROGRESS + callbackAfterSeconds) used by long-running LLM/A2A workers.
+ *
+ * <p>Registered in the shared test context; inert unless a spec arms it via {@link #reset()}.
+ */
+@Component
+public class ControllablePollWorker implements AnnotatedSystemTaskWorker {
+
+    public static final String TASK_TYPE = "CONTROLLABLE_POLL_TASK";
+
+    /** Total number of times {@link #run} has been entered since the last {@link #reset}. */
+    public final AtomicInteger invocations = new AtomicInteger(0);
+
+    /** Thread name per invocation, for failure diagnostics. */
+    public final List<String> invocationLog = new CopyOnWriteArrayList<>();
+
+    /**
+     * Attempts less than or equal to this return IN_PROGRESS + callbackAfterSeconds instead of
+     * completing, simulating a multi-turn worker (same pattern as LLMWorkers.generateVideo).
+     */
+    public volatile int inProgressTurns = 0;
+
+    /** Callback the in-progress turns request before re-invocation. */
+    public volatile long callbackAfterSeconds = 1;
+
+    /** Attempts greater than or equal to this block on the release latch. */
+    public volatile int blockFromAttempt = 1;
+
+    /** Counted down each time {@link #run} is entered (before it blocks). */
+    public volatile CountDownLatch enteredRun = new CountDownLatch(1);
+
+    /** Blocking attempts wait on this latch, simulating the provider call. */
+    public volatile CountDownLatch release = new CountDownLatch(1);
+
+    /** Resets all control state; call from a spec's setup() before driving a scenario. */
+    public void reset() {
+        invocations.set(0);
+        invocationLog.clear();
+        inProgressTurns = 0;
+        callbackAfterSeconds = 1;
+        blockFromAttempt = 1;
+        enteredRun = new CountDownLatch(1);
+        release = new CountDownLatch(1);
+    }
+
+    @WorkerTask(value = TASK_TYPE, pollerCount = 2, leaseExtendEnabled = true)
+    public TaskResult run() throws InterruptedException {
+        int attempt = invocations.incrementAndGet();
+        invocationLog.add(
+                "attempt "
+                        + attempt
+                        + " on "
+                        + Thread.currentThread().getName()
+                        + " at "
+                        + System.currentTimeMillis());
+        enteredRun.countDown();
+
+        if (attempt >= blockFromAttempt) {
+            if (!release.await(30, TimeUnit.SECONDS)) {
+                // Fail the task loudly rather than completing and masking a hung spec.
+                throw new IllegalStateException(
+                        "ControllablePollWorker was never released (attempt " + attempt + ")");
+            }
+        }
+
+        TaskResult result = new TaskResult(TaskContext.get().getTask());
+        result.getOutputData().put("attempt", attempt);
+        if (attempt <= inProgressTurns) {
+            result.setStatus(TaskResult.Status.IN_PROGRESS);
+            result.setCallbackAfterSeconds(callbackAfterSeconds);
+        } else {
+            result.setStatus(TaskResult.Status.COMPLETED);
+        }
+        return result;
+    }
+}

--- a/test-harness/src/test/resources/controllable_poll_worker_workflow.json
+++ b/test-harness/src/test/resources/controllable_poll_worker_workflow.json
@@ -1,0 +1,26 @@
+{
+  "name": "controllable_poll_worker_wf",
+  "description": "workflow with a single controllable annotated task executed in poll-worker mode",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "CONTROLLABLE_POLL_TASK",
+      "taskReferenceName": "controllable_poll_ref",
+      "inputParameters": {},
+      "type": "CONTROLLABLE_POLL_TASK",
+      "startDelay": 0,
+      "optional": false,
+      "asyncComplete": false
+    }
+  ],
+  "inputParameters": [],
+  "outputParameters": {
+    "taskOutput": "${controllable_poll_ref.output.attempt}"
+  },
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false,
+  "timeoutPolicy": "ALERT_ONLY",
+  "timeoutSeconds": 0,
+  "ownerEmail": "test@harness.com"
+}


### PR DESCRIPTION
Relates to #1321, #1322, #1347. Alternative direction to #1349 / #1335.

## Problem

Annotated system tasks (`LLM_CHAT_COMPLETE` etc.) execute blocking provider calls in-process via `AsyncSystemTaskExecutor`: nothing is persisted until `start()` returns and the queue message stays unacked for the whole call, so any call outlasting the unack window is redelivered and executed twice (#1321), and the losing attempt's late write corrupts the execution record (#1322).

Remote worker tasks never had this bug because the poll path claims the task (IN_PROGRESS + workerId persisted) and ACKs the queue message **before** the work starts, with liveness governed by the `responseTimeoutSeconds` lease.

## Change

New opt-in mode `conductor.annotated-workers.mode=poll-worker` that runs annotated methods through that same worker contract, in-process:

- `WorkerTaskAnnotationScanner` skips the system-task registration; the type schedules through the existing `USER_DEFINED` mapper fallback (workflow definitions unchanged), with task defs auto-registered.
- New `AnnotatedPollWorkerCoordinator` polls via `ExecutionService.poll` (claim + ACK before the method runs), executes the method reusing the existing parameter/result mappers and `TaskContext`, heartbeats via lease extension for `leaseExtendEnabled` workers, and reports through `WorkflowExecutor.updateTask` — whose terminal-status guard also prevents the #1322 overwrite.
- Multi-turn workers (IN_PROGRESS + `callbackAfterSeconds`, the long-running LLM/A2A pattern) are re-queued and re-claimed each turn, so **every** turn gets the claim + lease protection — the scenario the system-task path cannot protect for turns 2+.

**Default mode (`system-task`) is byte-identical to today** — the scanner change is the old registration wrapped in an `else`. Nothing changes for any deployment until the flag is flipped.

## Verification

- `AnnotatedPollWorkerModeSpec` (real scanner, real redis queue): a blocking task outlasting any redelivery window executes exactly once — asserted structurally (task IN_PROGRESS with the poller's workerId and queue size 0 while the call blocks, i.e. nothing left to redeliver); a multi-turn worker executes each turn exactly once. 2/2 green.
- Annotated-package unit tests 36/36; default-mode context boot verified via existing spec.
- Full `:conductor-test-harness:test` run in progress; results will be posted here. LLM/A2A workers have not yet been exercised in poll-worker mode against a provider — that's the gate before this leaves draft.

## Open questions for review

- Auto-registered task def defaults (`retryCount=0`, `responseTimeoutSeconds=600`) — retries on paid provider calls are a policy decision.
- Thread model: `pollerCount` pollers execute inline; a real version may want the SDK runtime's poll/execute separation (or literally embed the java-sdk `AnnotatedWorkerExecutor` against localhost).
- Migration story for the ai/agentspan/a2a modules and whether the default should ever flip.