### PR TITLE
Guard pruneExecutions against overflow and non-positive age deleting recent executions

### DIFF
--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentService.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentService.java
@@ -30,6 +30,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import com.netflix.conductor.annotations.VisibleForTesting;
 import com.netflix.conductor.common.config.ObjectMapperProvider;
 import com.netflix.conductor.common.metadata.tasks.Task;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
@@ -567,6 +568,27 @@ public class AgentService {
     }
 
     /**
+     * Computes the prune cutoff, guarding the two ways an unchecked {@code olderThanDays} turned
+     * the prune into a data-loss operation (issue #1331): non-positive values put the cutoff in the
+     * future (matching every terminal execution), and very large values push the computed epoch
+     * negative, which the search backend matched against recent executions. A cutoff clamped to
+     * epoch start matches nothing, which is the correct meaning of "older than anything that
+     * exists".
+     *
+     * @param olderThanDays minimum age in days, must be >= 1
+     * @param now the current instant
+     * @return cutoff in epoch milliseconds, never negative
+     */
+    @VisibleForTesting
+    static long computePruneCutoffEpochMs(int olderThanDays, Instant now) {
+        if (olderThanDays < 1) {
+            throw new IllegalArgumentException(
+                    "pruneExecutions: olderThanDays must be >= 1, got " + olderThanDays);
+        }
+        return Math.max(0L, now.minus(olderThanDays, ChronoUnit.DAYS).toEpochMilli());
+    }
+
+    /**
      * Bulk-delete completed execution records older than {@code olderThanDays} days.
      *
      * <p>Searches for COMPLETED, FAILED, TERMINATED, and TIMED_OUT executions whose end time is
@@ -577,7 +599,7 @@ public class AgentService {
      * @return number of executions deleted
      */
     public int pruneExecutions(int olderThanDays, boolean archiveTasks) {
-        long cutoffEpochMs = Instant.now().minus(olderThanDays, ChronoUnit.DAYS).toEpochMilli();
+        long cutoffEpochMs = computePruneCutoffEpochMs(olderThanDays, Instant.now());
         String[] terminalStatuses = {"COMPLETED", "FAILED", "TERMINATED", "TIMED_OUT"};
 
         List<String> workflowNames =

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentServicePruneCutoffTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentServicePruneCutoffTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.agentspan.runtime.service;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link AgentService#computePruneCutoffEpochMs(int, Instant)} — the guard against
+ * the prune endpoint deleting recent executions (issue #1331). Deterministic — pure time arithmetic
+ * against a fixed clock.
+ */
+class AgentServicePruneCutoffTest {
+
+    private static final Instant NOW = Instant.parse("2026-07-20T12:00:00Z");
+
+    @Test
+    void normalAgeYieldsThePlainCutoff() {
+        long cutoff = AgentService.computePruneCutoffEpochMs(30, NOW);
+
+        assertThat(cutoff).isEqualTo(NOW.minus(30, ChronoUnit.DAYS).toEpochMilli());
+        assertThat(cutoff).isPositive();
+    }
+
+    @Test
+    void hugeAgeClampsToEpochStartInsteadOfGoingNegative() {
+        // 99999 days before 2026 is far before the epoch: unclamped this is a negative epoch
+        // value, which the search backend matched against recent executions and deleted them
+        long cutoff = AgentService.computePruneCutoffEpochMs(99_999, NOW);
+
+        assertThat(cutoff).isZero();
+    }
+
+    @Test
+    void largestAgeStillYieldingPositiveCutoffIsNotClamped() {
+        long daysSinceEpoch = ChronoUnit.DAYS.between(Instant.EPOCH, NOW);
+
+        long cutoff = AgentService.computePruneCutoffEpochMs((int) daysSinceEpoch, NOW);
+
+        assertThat(cutoff).isNotNegative();
+        assertThat(cutoff).isEqualTo(NOW.minus(daysSinceEpoch, ChronoUnit.DAYS).toEpochMilli());
+    }
+
+    @Test
+    void zeroAndNegativeAgesAreRejected() {
+        // A cutoff at or after "now" matches every terminal execution: reject instead of delete
+        assertThatThrownBy(() -> AgentService.computePruneCutoffEpochMs(0, NOW))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("olderThanDays");
+        assertThatThrownBy(() -> AgentService.computePruneCutoffEpochMs(-5, NOW))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("olderThanDays");
+    }
+}


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

`pruneExecutions` computed its cutoff as `Instant.now().minus(olderThanDays, DAYS).toEpochMilli()` with no bounds check. Two ways that turned the prune endpoint into a data-loss operation:

- very large values (the issue's `olderThanDays=99999`) push the computed epoch **negative**, and the search backend matched recent executions against the negative bound, which were then hard-deleted in batches
- non-positive values put the cutoff **in the future**, matching every terminal execution

The fix extracts the cutoff computation into `computePruneCutoffEpochMs(int, Instant)`: rejects `olderThanDays < 1` with a clear message, and clamps the cutoff to epoch start, where `endTime < 0` correctly matches nothing ("older than anything that exists").

Extracted as a static method with an injectable clock so the boundary behavior is unit-testable deterministically: `AgentServicePruneCutoffTest` covers the normal case, the 99999-day clamp, the largest non-clamped age, and rejection of zero/negative. 4/4 green; `spotlessApply` run.

Issue #1331

Alternatives considered
----

Also considered chasing why the search backend matches positive `endTime` values against a negative long bound (the second layer of the bug) - worth a follow-up in the search query serialization, but the guard here closes the data-loss hole regardless of backend behavior.

Developed with AI assistance (Claude Code), reviewed and driven by a human.
