### PR TITLE
Validate SWITCH javascript expressions by syntax only at registration

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/events/ScriptEvaluator.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/ScriptEvaluator.java
@@ -238,6 +238,28 @@ public class ScriptEvaluator {
     }
 
     /**
+     * Validates that the script is syntactically well formed WITHOUT executing it. Registration
+     * time validation must not evaluate expressions: the input bindings still hold unresolved
+     * {@code ${...}} placeholders, so any expression referencing a runtime-bound value would throw
+     * a ReferenceError and wrongly reject a valid definition (issue #1311).
+     *
+     * @param script Script whose syntax should be checked.
+     * @throws IllegalArgumentException if the script has a syntax error.
+     */
+    public static void validateScriptSyntax(String script) {
+        ensureInitialized();
+        try (Context context = createNewContext()) {
+            context.parse(getSource(script));
+        } catch (PolyglotException e) {
+            if (e.isSyntaxError()) {
+                throw new IllegalArgumentException(e.getMessage());
+            }
+            // Anything non-syntactic (e.g. resource limits) is not a validation failure
+            LOGGER.debug("Ignoring non-syntax error while validating script: {}", e.getMessage());
+        }
+    }
+
+    /**
      * Returns a cached compiled {@link Source} for the given script, creating it on first use.
      * Bounded by {@link #sourceCacheMaxSize}; on overflow the cache is cleared (workflow scripts
      * are typically a small, stable set, so the simplest strategy suffices).

--- a/core/src/main/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraint.java
+++ b/core/src/main/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraint.java
@@ -189,7 +189,10 @@ public @interface WorkflowTaskTypeConstraint {
         private void validateScriptExpression(
                 String expression, Map<String, Object> inputParameters) {
             try {
-                Object returnValue = ScriptEvaluator.eval(expression, inputParameters);
+                // Syntax check only: at registration time inputParameters still holds unresolved
+                // ${...} placeholders, so evaluating the expression would throw ReferenceError
+                // for any runtime-bound variable and reject valid definitions (issue #1311).
+                ScriptEvaluator.validateScriptSyntax(expression);
             } catch (Exception e) {
                 throw new IllegalArgumentException(
                         String.format("Expression is not well formatted: %s", e.getMessage()));

--- a/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
@@ -373,7 +373,9 @@ public class MetadataServiceTest {
         workflowTask.setName("hello");
         workflowTask.setType("SWITCH");
         workflowTask.setEvaluatorType("javascript");
-        workflowTask.setExpression("1>abcd");
+        // A genuine syntax error: registration validates syntax only, since expressions
+        // referencing runtime bound values cannot be evaluated at registration time
+        workflowTask.setExpression("1 >");
         WorkflowTask caseTask = new WorkflowTask();
         caseTask.setTaskReferenceName("casetrue");
         caseTask.setName("casetrue");

--- a/core/src/test/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraintTest.java
+++ b/core/src/test/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraintTest.java
@@ -613,6 +613,47 @@ public class WorkflowTaskTypeConstraintTest {
         assertEquals(0, result.size());
     }
 
+    @Test
+    public void testSwitchJavascriptExpressionWithRuntimeBoundVariableIsAccepted() {
+        // Registration must only syntax-check the expression: inputParameters still holds
+        // unresolved ${...} placeholders at this point, so evaluating would throw a
+        // ReferenceError for runtime-bound values and reject a valid definition (issue #1311)
+        WorkflowTask workflowTask = createSampleWorkflowTask();
+        workflowTask.setType("SWITCH");
+        workflowTask.setEvaluatorType("javascript");
+        // At registration $.items is the unresolved placeholder STRING, so evaluating this
+        // expression throws (filter is not a function on a string) even though it is valid at
+        // runtime when the placeholder resolves to an array
+        workflowTask.setExpression("$.items.filter(i => i > 10).length > 0 ? 'big' : 'small'");
+        workflowTask.getInputParameters().put("items", "${workflow.input.items}");
+        workflowTask.setDecisionCases(Map.of("big", List.of(createSampleWorkflowTask())));
+
+        when(mockMetadataDao.getTaskDef(anyString())).thenReturn(new TaskDef());
+
+        List<String> validationErrors = getErrorMessages(workflowTask);
+        assertTrue(
+                "expression must not be rejected: " + validationErrors,
+                validationErrors.stream()
+                        .noneMatch(e -> e.contains("Expression is not well formatted")));
+    }
+
+    @Test
+    public void testSwitchJavascriptExpressionWithSyntaxErrorIsRejected() {
+        WorkflowTask workflowTask = createSampleWorkflowTask();
+        workflowTask.setType("SWITCH");
+        workflowTask.setEvaluatorType("javascript");
+        workflowTask.setExpression("$.inputValue > 10 ? 'big' :");
+        workflowTask.setDecisionCases(Map.of("big", List.of(createSampleWorkflowTask())));
+
+        when(mockMetadataDao.getTaskDef(anyString())).thenReturn(new TaskDef());
+
+        List<String> validationErrors = getErrorMessages(workflowTask);
+        assertTrue(
+                "expected a syntax rejection, got: " + validationErrors,
+                validationErrors.stream()
+                        .anyMatch(e -> e.contains("Expression is not well formatted")));
+    }
+
     private List<String> getErrorMessages(WorkflowTask workflowTask) {
         Set<ConstraintViolation<WorkflowTask>> result = validator.validate(workflowTask);
         List<String> validationErrors = new ArrayList<>();


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

`validateScriptExpression` executed the SWITCH expression via `ScriptEvaluator.eval(expression, inputParameters)` at registration time - but the bindings map still holds unresolved `${...}` placeholders at that point, so any expression operating on runtime-bound values throws and registration wrongly rejects a valid definition. Example that fails today but is perfectly valid at runtime: `$.items.filter(i => i > 10).length > 0 ? 'big' : 'small'` with `items: "${workflow.input.items}"` - at registration `$.items` is a placeholder *string*, so `.filter` throws.

The fix adds `ScriptEvaluator.validateScriptSyntax(String)`: parses the source via GraalJS `Context.parse` **without executing**, throwing only on genuine syntax errors (`PolyglotException.isSyntaxError()`). Registration becomes a syntax check, which is all it can correctly be before placeholder resolution. Bonus: the parse warms the same `Source` cache the runtime eval uses.

Two tests added to `WorkflowTaskTypeConstraintTest`: the runtime-bound expression above must produce no "Expression is not well formatted" violation (verified this test FAILS against the previous implementation - it rejects the expression), and a genuinely malformed expression (`$.inputValue > 10 ? 'big' :`) must still be rejected. 35/35 green; `spotlessApply` run.

Issue #1311

Alternatives considered
----

Treating `ReferenceError` as a pass while still evaluating was considered and rejected: evaluation with placeholder bindings can fail in many shapes (TypeError on string methods, NPE-ish member access), and whitelisting error types is a losing game. Parse-only is the correct semantic for registration.

Developed with AI assistance (Claude Code), reviewed and driven by a human.
