### PR TITLE
Rework agent executions Basic/Advanced search

### DIFF
--- a/ui-next/src/pages/agent/executions/AgentSearch.tsx
+++ b/ui-next/src/pages/agent/executions/AgentSearch.tsx
@@ -2,7 +2,6 @@ import { Box, FormControlLabel, Switch } from "@mui/material";
 import MuiTypography from "components/ui/MuiTypography";
 import PlayIcon from "components/icons/PlayIcon";
 import _isEqual from "lodash/isEqual";
-import { useEffect, useState } from "react";
 import { Helmet } from "react-helmet";
 import { useQueryState } from "react-router-use-location-state";
 import SectionContainer from "components/ui/layout/SectionContainer";
@@ -13,10 +12,7 @@ import { TaskExecutionResult } from "types/TaskExecution";
 import { DoSearchProps } from "types/WorkflowExecution";
 import { RUN_AGENT_URL } from "utils/constants/route";
 import { pluralizeResults } from "utils/helpers";
-import { dateToEpoch } from "utils/date";
-import { commonlyUsedDateTime, getSearchDateTime } from "utils/date";
 import { usePushHistory } from "utils/hooks/usePushHistory";
-import { tryToJson } from "utils/utils";
 import AdvancedSearch from "./workflowSearchComponents/AdvancedSearch";
 import BasicSearch from "./workflowSearchComponents/BasicSearch";
 
@@ -51,55 +47,6 @@ const SwitchComponent = ({
 
 export default function AgentPanel() {
   const [asQuery, setAsQuery] = useQueryState("asQuery", false);
-  const [freeText, setFreeText] = useQueryState("freeText", "");
-  const [status, setStatus] = useQueryState<string[]>("status", []);
-  const [openDateSelect, setOpenDateSelect] = useState(false);
-  const [openStartDatePicker, setStartOpenDatePicker] = useState(false);
-  const [openEndDatePicker, setEndOpenDatePicker] = useState(false);
-  const [startTimeFrom, setStartTimeFrom] = useQueryState(
-    "startFrom",
-    commonlyUsedDateTime("last72Hours").rangeStart,
-  );
-  const [startTimeTo, setStartTimeTo] = useQueryState("startTo", "");
-  const [endTimeFrom, setEndTimeFrom] = useQueryState("endTimeFrom", "");
-  const [endTimeTo, setEndTimeTo] = useQueryState("endTimeTo", "");
-  const [fromDisplayTime, setFromDisplayTime] = useState(
-    startTimeFrom
-      ? getSearchDateTime(startTimeFrom, startTimeTo)
-      : "Last 72 Hours",
-  );
-  const [toDisplayTime, setToDisplayTime] = useState(
-    endTimeTo ? getSearchDateTime(endTimeFrom, endTimeTo) : "Select time range",
-  );
-
-  const last72HoursTimestamp = Date.now() - 72 * 60 * 60 * 1000;
-
-  const recentSearches =
-    (tryToJson(localStorage.getItem("recentTaskSearch")) as {
-      start: string;
-      end: string;
-    }) || {};
-
-  useEffect(() => {
-    if (!startTimeFrom) {
-      setStartTimeFrom(last72HoursTimestamp.toString());
-      setStartTimeTo("");
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const onStartFromChange = (val: string) => {
-    setStartTimeFrom(val ? String(dateToEpoch(val)) : "");
-  };
-  const onStartToChange = (val: string) => {
-    setStartTimeTo(val ? String(dateToEpoch(val)) : "");
-  };
-  const onEndFromChange = (val: string) => {
-    setEndTimeFrom(val ? String(dateToEpoch(val)) : "");
-  };
-  const onEndToChange = (val: string) => {
-    setEndTimeTo(val ? String(dateToEpoch(val)) : "");
-  };
 
   const doSearch = ({
     queryFT,
@@ -136,6 +83,14 @@ export default function AgentPanel() {
     );
   };
 
+  const sharedSearchProps = {
+    doSearch,
+    SwitchComponent: (
+      <SwitchComponent asQuery={asQuery} setAsQuery={setAsQuery} />
+    ),
+    getTableTitle,
+  };
+
   return (
     <>
       <Helmet>
@@ -159,75 +114,9 @@ export default function AgentPanel() {
       />
       <SectionContainer>
         {asQuery ? (
-          <AdvancedSearch
-            doSearch={doSearch}
-            SwitchComponent={
-              <SwitchComponent asQuery={asQuery} setAsQuery={setAsQuery} />
-            }
-            getTableTitle={getTableTitle}
-            freeText={freeText}
-            setFreeText={setFreeText}
-            status={status}
-            setStatus={setStatus}
-            startTimeFrom={startTimeFrom}
-            setStartTimeFrom={setStartTimeFrom}
-            onStartFromChange={onStartFromChange}
-            startTimeTo={startTimeTo}
-            setStartTimeTo={setStartTimeTo}
-            onStartToChange={onStartToChange}
-            endTimeFrom={endTimeFrom}
-            setEndTimeFrom={setEndTimeFrom}
-            onEndFromChange={onEndFromChange}
-            endTimeTo={endTimeTo}
-            setEndTimeTo={setEndTimeTo}
-            onEndToChange={onEndToChange}
-            fromDisplayTime={fromDisplayTime}
-            setFromDisplayTime={setFromDisplayTime}
-            toDisplayTime={toDisplayTime}
-            setToDisplayTime={setToDisplayTime}
-            openDateSelect={openDateSelect}
-            setOpenDateSelect={setOpenDateSelect}
-            openStartDatePicker={openStartDatePicker}
-            setStartOpenDatePicker={setStartOpenDatePicker}
-            openEndDatePicker={openEndDatePicker}
-            setEndOpenDatePicker={setEndOpenDatePicker}
-            recentSearches={recentSearches}
-          />
+          <AdvancedSearch {...sharedSearchProps} />
         ) : (
-          <BasicSearch
-            doSearch={doSearch}
-            SwitchComponent={
-              <SwitchComponent asQuery={asQuery} setAsQuery={setAsQuery} />
-            }
-            getTableTitle={getTableTitle}
-            freeText={freeText}
-            setFreeText={setFreeText}
-            status={status}
-            setStatus={setStatus}
-            startTimeFrom={startTimeFrom}
-            setStartTimeFrom={setStartTimeFrom}
-            onStartFromChange={onStartFromChange}
-            startTimeTo={startTimeTo}
-            setStartTimeTo={setStartTimeTo}
-            onStartToChange={onStartToChange}
-            endTimeFrom={endTimeFrom}
-            setEndTimeFrom={setEndTimeFrom}
-            onEndFromChange={onEndFromChange}
-            endTimeTo={endTimeTo}
-            setEndTimeTo={setEndTimeTo}
-            onEndToChange={onEndToChange}
-            fromDisplayTime={fromDisplayTime}
-            setFromDisplayTime={setFromDisplayTime}
-            toDisplayTime={toDisplayTime}
-            setToDisplayTime={setToDisplayTime}
-            openDateSelect={openDateSelect}
-            setOpenDateSelect={setOpenDateSelect}
-            openStartDatePicker={openStartDatePicker}
-            setStartOpenDatePicker={setStartOpenDatePicker}
-            openEndDatePicker={openEndDatePicker}
-            setEndOpenDatePicker={setEndOpenDatePicker}
-            recentSearches={recentSearches}
-          />
+          <BasicSearch {...sharedSearchProps} />
         )}
       </SectionContainer>
     </>

--- a/ui-next/src/pages/agent/executions/DateControlComponent.tsx
+++ b/ui-next/src/pages/agent/executions/DateControlComponent.tsx
@@ -135,16 +135,11 @@ export const DateControlComponent = ({
       sx={{
         display: "flex",
         height: "100%",
-        alignItems: "start",
+        alignItems: "center",
         justifyContent: "start",
       }}
     >
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-        }}
-      >
+      <Box sx={{ display: "flex", alignItems: "center", height: 42 }}>
         <Box>
           <CustomisedTooltip
             open={openStartDatePicker}

--- a/ui-next/src/pages/agent/executions/ResultsTable.tsx
+++ b/ui-next/src/pages/agent/executions/ResultsTable.tsx
@@ -334,7 +334,7 @@ export default function ResultsTable({
             />
           }
           label="Hide sub-agent executions"
-          sx={{ ml: 1, mb: 1 }}
+          sx={{ ml: 1, mb: 1, mt: 3 }}
         />
       )}
       <DataTable

--- a/ui-next/src/pages/agent/executions/useAgentSearchFilters.ts
+++ b/ui-next/src/pages/agent/executions/useAgentSearchFilters.ts
@@ -1,0 +1,162 @@
+import { useState } from "react";
+import { useQueryState } from "react-router-use-location-state";
+import {
+  commonlyUsedDateTime,
+  dateToEpoch,
+  getSearchDateTime,
+} from "utils/date";
+import { tryToJson } from "utils/utils";
+import type { DateControlComponentProps } from "./DateControlComponent";
+
+/** Shared Basic/Advanced search filter state owned by AgentSearch. */
+export type AgentSearchFilters = {
+  freeText: string;
+  setFreeText: (val: string) => void;
+  status: string[];
+  setStatus: (val: string[]) => void;
+  startTimeFrom: string;
+  setStartTimeFrom: (val: string) => void;
+  startTimeTo: string;
+  setStartTimeTo: (val: string) => void;
+  endTimeFrom: string;
+  setEndTimeFrom: (val: string) => void;
+  endTimeTo: string;
+  setEndTimeTo: (val: string) => void;
+  fromDisplayTime: string;
+  setFromDisplayTime: (val: string) => void;
+  toDisplayTime: string;
+  setToDisplayTime: (val: string) => void;
+  openDateSelect: boolean;
+  setOpenDateSelect: (val: boolean) => void;
+  openStartDatePicker: boolean;
+  setStartOpenDatePicker: (val: boolean) => void;
+  openEndDatePicker: boolean;
+  setEndOpenDatePicker: (val: boolean) => void;
+  onStartFromChange: (val: string) => void;
+  onStartToChange: (val: string) => void;
+  onEndFromChange: (val: string) => void;
+  onEndToChange: (val: string) => void;
+  recentSearches: { start: string; end: string };
+};
+
+/** Map shared filters onto DateControlComponent's prop names. */
+export function toDateControlProps(
+  filters: AgentSearchFilters,
+): Pick<
+  DateControlComponentProps,
+  | "startTime"
+  | "onStartFromChange"
+  | "startTimeEnd"
+  | "onStartToChange"
+  | "endTimeStart"
+  | "onEndFromChange"
+  | "endTime"
+  | "onEndToChange"
+  | "fromDisplayTime"
+  | "setFromDisplayTime"
+  | "toDisplayTime"
+  | "setToDisplayTime"
+  | "openDateSelect"
+  | "setOpenDateSelect"
+  | "openStartDatePicker"
+  | "setStartOpenDatePicker"
+  | "openEndDatePicker"
+  | "setEndOpenDatePicker"
+  | "recentSearches"
+> {
+  return {
+    startTime: filters.startTimeFrom,
+    onStartFromChange: filters.onStartFromChange,
+    startTimeEnd: filters.startTimeTo,
+    onStartToChange: filters.onStartToChange,
+    endTimeStart: filters.endTimeFrom,
+    onEndFromChange: filters.onEndFromChange,
+    endTime: filters.endTimeTo,
+    onEndToChange: filters.onEndToChange,
+    fromDisplayTime: filters.fromDisplayTime,
+    setFromDisplayTime: filters.setFromDisplayTime,
+    toDisplayTime: filters.toDisplayTime,
+    setToDisplayTime: filters.setToDisplayTime,
+    openDateSelect: filters.openDateSelect,
+    setOpenDateSelect: filters.setOpenDateSelect,
+    openStartDatePicker: filters.openStartDatePicker,
+    setStartOpenDatePicker: filters.setStartOpenDatePicker,
+    openEndDatePicker: filters.openEndDatePicker,
+    setEndOpenDatePicker: filters.setEndOpenDatePicker,
+    recentSearches: filters.recentSearches,
+  };
+}
+
+/** URL + local state shared by Basic and Advanced agent execution search. */
+export function useAgentSearchFilters(): AgentSearchFilters {
+  const [freeText, setFreeText] = useQueryState("freeText", "");
+  const [status, setStatus] = useQueryState<string[]>("status", []);
+  const [openDateSelect, setOpenDateSelect] = useState(false);
+  const [openStartDatePicker, setStartOpenDatePicker] = useState(false);
+  const [openEndDatePicker, setEndOpenDatePicker] = useState(false);
+  const [startTimeFrom, setStartTimeFrom] = useQueryState(
+    "startFrom",
+    // Default lives here — no mount effect needed to backfill last-72h.
+    commonlyUsedDateTime("last72Hours").rangeStart,
+  );
+  const [startTimeTo, setStartTimeTo] = useQueryState("startTo", "");
+  const [endTimeFrom, setEndTimeFrom] = useQueryState("endTimeFrom", "");
+  const [endTimeTo, setEndTimeTo] = useQueryState("endTimeTo", "");
+  const [fromDisplayTime, setFromDisplayTime] = useState(
+    startTimeFrom
+      ? getSearchDateTime(startTimeFrom, startTimeTo)
+      : "Last 72 Hours",
+  );
+  const [toDisplayTime, setToDisplayTime] = useState(
+    endTimeTo ? getSearchDateTime(endTimeFrom, endTimeTo) : "Select time range",
+  );
+
+  const recentSearches =
+    (tryToJson(localStorage.getItem("recentTaskSearch")) as {
+      start: string;
+      end: string;
+    }) || {};
+
+  const onStartFromChange = (val: string) => {
+    setStartTimeFrom(val ? String(dateToEpoch(val)) : "");
+  };
+  const onStartToChange = (val: string) => {
+    setStartTimeTo(val ? String(dateToEpoch(val)) : "");
+  };
+  const onEndFromChange = (val: string) => {
+    setEndTimeFrom(val ? String(dateToEpoch(val)) : "");
+  };
+  const onEndToChange = (val: string) => {
+    setEndTimeTo(val ? String(dateToEpoch(val)) : "");
+  };
+
+  return {
+    freeText,
+    setFreeText,
+    status,
+    setStatus,
+    startTimeFrom,
+    setStartTimeFrom,
+    startTimeTo,
+    setStartTimeTo,
+    endTimeFrom,
+    setEndTimeFrom,
+    endTimeTo,
+    setEndTimeTo,
+    fromDisplayTime,
+    setFromDisplayTime,
+    toDisplayTime,
+    setToDisplayTime,
+    openDateSelect,
+    setOpenDateSelect,
+    openStartDatePicker,
+    setStartOpenDatePicker,
+    openEndDatePicker,
+    setEndOpenDatePicker,
+    onStartFromChange,
+    onStartToChange,
+    onEndFromChange,
+    onEndToChange,
+    recentSearches,
+  };
+}

--- a/ui-next/src/pages/agent/executions/workflowSearchComponents/AdvancedSearch.tsx
+++ b/ui-next/src/pages/agent/executions/workflowSearchComponents/AdvancedSearch.tsx
@@ -1,5 +1,12 @@
 import { Monaco } from "@monaco-editor/react";
-import { Box, Grid } from "@mui/material";
+import {
+  Box,
+  FormControl,
+  Grid,
+  InputLabel,
+  useMediaQuery,
+} from "@mui/material";
+import { Theme } from "@mui/material/styles";
 import { Button, Paper } from "components";
 import { DEFAULT_ROWS_PER_PAGE } from "components/ui/DataTable/DataTable";
 import MuiTypography from "components/ui/MuiTypography";
@@ -7,7 +14,6 @@ import StatusBadge from "components/StatusBadge";
 import { renderStatusTagChip } from "components/StatusTagChip";
 import { ConductorAutoComplete } from "components/ui/inputs";
 import { ConductorCodeBlockInput } from "components/ui/inputs/ConductorCodeBlockInput";
-import ConductorInput from "components/ui/inputs/ConductorInput";
 import SplitButton from "components/ui/buttons/ConductorSplitButton";
 import ResetIcon from "components/icons/ResetIcon";
 import SearchIcon from "components/icons/SearchIcon";
@@ -25,7 +31,6 @@ import { Navigate } from "react-router";
 import { useQueryState } from "react-router-use-location-state";
 import { colors } from "theme/tokens/variables";
 import { Key } from "ts-key-enum";
-import { IObject } from "types/common";
 import { WorkflowExecutionStatus } from "types/Execution";
 import { TaskExecutionResult } from "types/TaskExecution";
 import { DoSearchProps } from "types/WorkflowExecution";
@@ -38,9 +43,19 @@ import { ApiSearchModalIntegration } from "../ApiSearchModalIntegration";
 import { DateControlComponent } from "../DateControlComponent";
 import ResultsTable from "../ResultsTable";
 import { ExampleSearchQuery } from "../SearchExampleQuery";
+import {
+  toDateControlProps,
+  useAgentSearchFilters,
+} from "../useAgentSearchFilters";
 
 const DEFAULT_SORT = "startTime:DESC";
 const workflowStatuses = Object.values(WorkflowExecutionStatus);
+
+/** Shape shown in the results snackbar (from getErrors or fetch Response). */
+type ExecutionSearchError = {
+  message?: string;
+  statusText?: string;
+} & Record<string, unknown>;
 
 export interface AdvancedSearchProps {
   doSearch: ({
@@ -54,69 +69,40 @@ export interface AdvancedSearchProps {
   }: DoSearchProps) => void;
   SwitchComponent: ReactNode;
   getTableTitle: (resultObj: TaskExecutionResult) => ReactNode;
-  freeText: string;
-  setFreeText: (val: string) => void;
-  status: string[];
-  setStatus: (val: string[]) => void;
-  startTimeFrom: string;
-  setStartTimeFrom: (val: string) => void;
-  onStartFromChange: (val: string) => void;
-  startTimeTo: string;
-  setStartTimeTo: (val: string) => void;
-  onStartToChange: (val: string) => void;
-  endTimeFrom: string;
-  setEndTimeFrom: (val: string) => void;
-  onEndFromChange: (val: string) => void;
-  endTimeTo: string;
-  setEndTimeTo: (val: string) => void;
-  onEndToChange: (val: string) => void;
-  fromDisplayTime: string;
-  setFromDisplayTime: (val: string) => void;
-  toDisplayTime: string;
-  setToDisplayTime: (val: string) => void;
-  openDateSelect: boolean;
-  setOpenDateSelect: (val: boolean) => void;
-  openStartDatePicker: boolean;
-  setStartOpenDatePicker: (val: boolean) => void;
-  openEndDatePicker: boolean;
-  setEndOpenDatePicker: (val: boolean) => void;
-  recentSearches: { start: string; end: string };
 }
 
 export default function AdvancedSearch({
   doSearch,
   SwitchComponent,
   getTableTitle,
-  freeText,
-  setFreeText,
-  status,
-  setStatus,
-  startTimeFrom,
-  setStartTimeFrom,
-  onStartFromChange,
-  startTimeTo,
-  setStartTimeTo,
-  onStartToChange,
-  endTimeFrom,
-  setEndTimeFrom,
-  onEndFromChange,
-  endTimeTo,
-  setEndTimeTo,
-  onEndToChange,
-  fromDisplayTime,
-  setFromDisplayTime,
-  toDisplayTime,
-  setToDisplayTime,
-  openDateSelect,
-  setOpenDateSelect,
-  openStartDatePicker,
-  setStartOpenDatePicker,
-  openEndDatePicker,
-  setEndOpenDatePicker,
-  recentSearches,
 }: AdvancedSearchProps) {
+  const filters = useAgentSearchFilters();
+  const {
+    status,
+    setStatus,
+    startTimeFrom,
+    setStartTimeFrom,
+    startTimeTo,
+    setStartTimeTo,
+    endTimeFrom,
+    setEndTimeFrom,
+    endTimeTo,
+    setEndTimeTo,
+    setFromDisplayTime,
+    setToDisplayTime,
+  } = filters;
+
   const disposeRef = useRef<null | (() => void)>(null);
   const [queryText, setQueryText] = useQueryState("query", "");
+  // Local draft so SQL keystrokes do not rewrite the URL on every change.
+  // Sync when committed queryText changes (reset, back/forward).
+  const [queryInput, setQueryInput] = useState(queryText);
+  const [prevQueryText, setPrevQueryText] = useState(queryText);
+  if (queryText !== prevQueryText) {
+    setPrevQueryText(queryText);
+    setQueryInput(queryText);
+  }
+
   const [page, setPage] = useQueryState("page", 1);
   const [rowsPerPage, setRowsPerPage] = useQueryState(
     "rowsPerPage",
@@ -125,12 +111,18 @@ export default function AdvancedSearch({
   const [sort, setSort] = useQueryState("sort", DEFAULT_SORT);
   const [showCodeDialog, setShowCodeDialog] = useQueryState("displayCode", "");
 
-  const [errorMessage, setErrorMessage] = useState<IObject | null>(null);
+  const [errorMessage, setErrorMessage] = useState<ExecutionSearchError | null>(
+    null,
+  );
 
   const [unauthorized, setUnauthorized] = useState<{
     message?: string;
     error?: string;
   } | null>(null);
+
+  const isMobile = useMediaQuery((theme: Theme) =>
+    theme.breakpoints.down("sm"),
+  );
 
   // For dropdown
   const agentNames = useAgentNames();
@@ -157,11 +149,11 @@ export default function AdvancedSearch({
   const buildQuery = useCallback(() => {
     const clauses = [];
 
-    if (!_isEmpty(status) && !queryText.includes("status")) {
+    if (!_isEmpty(status) && !queryInput.includes("status")) {
       clauses.push(`status IN (${status.join(",")})`);
     }
 
-    if (!queryText.includes("startTime")) {
+    if (!queryInput.includes("startTime")) {
       if (!_isEmpty(startTimeFrom)) {
         clauses.push(`startTime>${dateToEpoch(startTimeFrom)}`);
       }
@@ -177,23 +169,15 @@ export default function AdvancedSearch({
       clauses.push(`endTime<${dateToEpoch(endTimeTo)}`);
     }
 
-    if (!_isEmpty(queryText)) {
-      clauses.push(queryText);
+    if (!_isEmpty(queryInput)) {
+      clauses.push(queryInput);
     }
 
     return {
       query: clauses.join(" AND "),
-      freeText: _isEmpty(freeText) ? "*" : freeText,
+      freeText: "*",
     };
-  }, [
-    freeText,
-    startTimeFrom,
-    startTimeTo,
-    endTimeFrom,
-    endTimeTo,
-    status,
-    queryText,
-  ]);
+  }, [startTimeFrom, startTimeTo, endTimeFrom, endTimeTo, status, queryInput]);
 
   const [queryFT, setQueryFT] = useState(buildQuery);
   const [hideSubWorkflows, setHideSubWorkflows] = useState(true);
@@ -216,13 +200,13 @@ export default function AdvancedSearch({
     },
     {},
     {
-      onError: (error: any) => {
+      onError: (error: unknown) => {
         if (error) {
           getErrors(error as Response).then((result) => {
             if (result?.["workflowName"] === "must not be empty") {
               setErrorMessage({ message: "Agent name should not be empty" });
             } else {
-              setErrorMessage(result);
+              setErrorMessage(result as ExecutionSearchError);
             }
           });
         } else {
@@ -233,32 +217,48 @@ export default function AdvancedSearch({
     },
   );
 
+  const setRecentTaskSearch = useCallback(() => {
+    if (startTimeFrom || startTimeTo || endTimeFrom || endTimeTo) {
+      localStorage.setItem(
+        "recentTaskSearch",
+        JSON.stringify({
+          start: startTimeFrom || startTimeTo,
+          end: endTimeTo || endTimeFrom,
+        }),
+      );
+    }
+  }, [startTimeFrom, startTimeTo, endTimeFrom, endTimeTo]);
+
+  const runSearch = useCallback(() => {
+    setQueryText(queryInput);
+    doSearch({
+      resultObj,
+      queryFT,
+      buildQuery,
+      setQueryFT,
+      refetch,
+      setPage,
+      setRecentTaskSearch,
+    });
+  }, [
+    queryInput,
+    setQueryText,
+    doSearch,
+    resultObj,
+    queryFT,
+    buildQuery,
+    refetch,
+    setPage,
+    setRecentTaskSearch,
+  ]);
+
   // hotkeys to search execution
-  useHotkeys(
-    `${Key.Meta}+${Key.Enter}`,
-    () =>
-      doSearch({
-        resultObj,
-        queryFT,
-        buildQuery,
-        setQueryFT,
-        refetch,
-        setPage,
-        setRecentTaskSearch,
-      }),
-    {
-      enableOnFormTags: ["INPUT", "TEXTAREA", "SELECT"],
-    },
-  );
+  useHotkeys(`${Key.Meta}+${Key.Enter}`, () => runSearch(), {
+    enableOnFormTags: ["INPUT", "TEXTAREA", "SELECT"],
+  });
 
   // Must be called before any early returns to follow Rules of Hooks
-  const filterOn = useMemo(() => {
-    if (queryFT.query !== "" || queryFT.freeText !== "*") {
-      return true;
-    } else {
-      return false;
-    }
-  }, [queryFT]);
+  const filterOn = useMemo(() => queryFT.query !== "", [queryFT]);
 
   const handlePage = (page: number) => {
     setPage(page);
@@ -304,7 +304,7 @@ export default function AdvancedSearch({
     return <Navigate to={ERROR_URL} />;
   }
 
-  const handleError = (error: any) => {
+  const handleError = (error: ExecutionSearchError) => {
     setErrorMessage(error);
   };
   const handleClearError = () => {
@@ -319,7 +319,7 @@ export default function AdvancedSearch({
     setEndTimeTo("");
     setToDisplayTime("");
     setFromDisplayTime("Last 72 Hours");
-    setFreeText("");
+    setQueryInput("");
     setQueryText("");
   };
 
@@ -339,23 +339,11 @@ export default function AdvancedSearch({
     setRowsPerPage(rowsPerPage);
   };
 
-  const setRecentTaskSearch = () => {
-    if (startTimeFrom || startTimeTo || endTimeFrom || endTimeTo) {
-      localStorage.setItem(
-        "recentTaskSearch",
-        JSON.stringify({
-          start: startTimeFrom || startTimeTo,
-          end: endTimeTo || endTimeFrom,
-        }),
-      );
-    }
-  };
-
   return (
     <>
       <Paper variant="outlined" sx={{ marginBottom: 6 }}>
         {SwitchComponent}
-        <Box>
+        <Box sx={{ padding: SwitchComponent ? "0 24px 24px 24px" : 6 }}>
           {showCodeDialog && (
             <ApiSearchModalIntegration
               onClose={() => setShowCodeDialog("")}
@@ -363,19 +351,25 @@ export default function AdvancedSearch({
                 start: (page - 1) * rowsPerPage,
                 size: rowsPerPage,
                 sort,
-                freeText,
+                freeText: "*",
                 query: buildQuery().query,
               }}
             />
           )}
-          <Grid container sx={{ width: "100%" }} spacing={3} p={6} pt={2}>
+          <Grid
+            container
+            sx={{ width: "100%" }}
+            spacing={3}
+            pt={2}
+            alignItems="flex-end"
+          >
             <Grid size={12}>
               <ConductorCodeBlockInput
                 label="Search"
                 language="sql"
                 minHeight={30}
-                value={queryText}
-                onChange={setQueryText}
+                value={queryInput}
+                onChange={setQueryInput}
                 autoFocus
                 options={{
                   lineNumbers: "off",
@@ -445,69 +439,15 @@ export default function AdvancedSearch({
             <Grid
               size={{
                 xs: 12,
-                sm: 12,
-                md: 5.5,
-                lg: 5,
-              }}
-            >
-              <DateControlComponent
-                startTime={startTimeFrom}
-                onStartFromChange={onStartFromChange}
-                startTimeEnd={startTimeTo}
-                onStartToChange={onStartToChange}
-                endTimeStart={endTimeFrom}
-                onEndFromChange={onEndFromChange}
-                endTime={endTimeTo}
-                onEndToChange={onEndToChange}
-                fromDisplayTime={fromDisplayTime}
-                setFromDisplayTime={setFromDisplayTime}
-                toDisplayTime={toDisplayTime}
-                setToDisplayTime={setToDisplayTime}
-                openDateSelect={openDateSelect}
-                setOpenDateSelect={setOpenDateSelect}
-                openStartDatePicker={openStartDatePicker}
-                setStartOpenDatePicker={setStartOpenDatePicker}
-                openEndDatePicker={openEndDatePicker}
-                setEndOpenDatePicker={setEndOpenDatePicker}
-                disabled={
-                  queryText.includes("startTime") ||
-                  queryText.includes("endTime")
-                }
-                recentSearches={recentSearches}
-                startTimeLabel="Execution Start Time"
-                endTimeLabel="Execution End Time"
-              />
-            </Grid>
-
-            <Grid
-              size={{
-                xs: 12,
-                sm: 12,
-                md: 2,
-                lg: 2.5,
-              }}
-            >
-              <ConductorInput
-                fullWidth
-                label="Free text search"
-                value={freeText}
-                onTextInputChange={setFreeText}
-                showClearButton
-              />
-            </Grid>
-
-            <Grid
-              size={{
-                xs: 12,
                 sm: 6,
-                md: 2,
+                md: 3,
                 lg: 2,
               }}
             >
               <ConductorAutoComplete
                 id="workflow-search-status"
                 label="Status"
-                disabled={queryText.includes("status")}
+                disabled={queryInput.includes("status")}
                 fullWidth
                 options={workflowStatuses}
                 multiple
@@ -524,26 +464,53 @@ export default function AdvancedSearch({
 
             <Grid
               display="flex"
-              justifyContent="end"
+              alignItems="end"
               size={{
                 xs: 12,
                 sm: 6,
-                md: 2.5,
-                lg: 2.5,
+                md: 5,
+                lg: 6,
               }}
             >
-              <Grid alignSelf="center" size={5}>
+              <DateControlComponent
+                {...toDateControlProps(filters)}
+                disabled={
+                  queryInput.includes("startTime") ||
+                  queryInput.includes("endTime")
+                }
+                startDialogTitle="Execution Start Time"
+                startDialogHelpText="Select a date range within which the Execution has started."
+                endDialogTitle="Execution End Time"
+                endDialogHelpText="Select a date range within which the Execution has ended."
+                startTimeLabel="Execution Start Time"
+                endTimeLabel="Execution End Time"
+              />
+            </Grid>
+
+            <Grid
+              display="flex"
+              justifyContent="end"
+              alignItems="end"
+              gap={1}
+              size={{
+                xs: 12,
+                md: 4,
+                lg: 4,
+              }}
+            >
+              <FormControl>
+                {!isMobile && <InputLabel>&nbsp;</InputLabel>}
                 <Button
                   id="reset-workflow-btn"
                   variant="text"
                   onClick={handleReset}
-                  style={{ width: "100%" }}
                   startIcon={<ResetIcon />}
                 >
                   Reset
                 </Button>
-              </Grid>
-              <Grid alignSelf="center">
+              </FormControl>
+              <FormControl>
+                {!isMobile && <InputLabel>&nbsp;</InputLabel>}
                 <SplitButton
                   id="search-workflow-btn"
                   startIcon={<SearchIcon />}
@@ -553,21 +520,11 @@ export default function AdvancedSearch({
                       onClick: () => setShowCodeDialog("active"),
                     },
                   ]}
-                  primaryOnClick={() =>
-                    doSearch({
-                      resultObj,
-                      queryFT,
-                      buildQuery,
-                      setQueryFT,
-                      refetch,
-                      setPage,
-                      setRecentTaskSearch,
-                    })
-                  }
+                  primaryOnClick={runSearch}
                 >
                   Search
                 </SplitButton>
-              </Grid>
+              </FormControl>
             </Grid>
           </Grid>
         </Box>

--- a/ui-next/src/pages/agent/executions/workflowSearchComponents/BasicSearch.tsx
+++ b/ui-next/src/pages/agent/executions/workflowSearchComponents/BasicSearch.tsx
@@ -15,8 +15,7 @@ import ConductorInput from "components/ui/inputs/ConductorInput";
 import SplitButton from "components/ui/buttons/ConductorSplitButton";
 import ResetIcon from "components/icons/ResetIcon";
 import SearchIcon from "components/icons/SearchIcon";
-import _isEmpty from "lodash/isEmpty";
-import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { ReactNode, useCallback, useMemo, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { Navigate } from "react-router";
 import { useQueryState } from "react-router-use-location-state";
@@ -24,15 +23,28 @@ import { Key } from "ts-key-enum";
 import { WorkflowExecutionStatus } from "types/Execution";
 import { TaskExecutionResult } from "types/TaskExecution";
 import { DoSearchProps } from "types/WorkflowExecution";
-import { IObject } from "types/common";
-import { dateToEpoch, useLocalStorage } from "utils";
+import { useLocalStorage } from "utils";
 import { ERROR_URL } from "utils/constants/route";
-import { useAutoCompleteInputValidation } from "utils/hooks/useAutoCompleteInputValidation";
 import { useAgentNames, useWorkflowSearch } from "utils/query";
 import { getErrors } from "utils/utils";
 import { ApiSearchModalIntegration } from "../ApiSearchModalIntegration";
 import { DateControlComponent } from "../DateControlComponent";
 import ResultsTable from "../ResultsTable";
+import {
+  toDateControlProps,
+  useAgentSearchFilters,
+} from "../useAgentSearchFilters";
+import {
+  buildBasicSearchQuery,
+  isWorkflowIdQuery,
+  mergeUniqueSortedNames,
+} from "./buildBasicSearchQuery";
+
+/** Shape shown in the results snackbar (from getErrors or fetch Response). */
+type ExecutionSearchError = {
+  message?: string;
+  statusText?: string;
+} & Record<string, unknown>;
 
 const DEFAULT_SORT = "startTime:DESC";
 const workflowStatuses = Object.values(WorkflowExecutionStatus);
@@ -49,79 +61,33 @@ export interface BasicSearchProps {
   }: DoSearchProps) => void;
   SwitchComponent: ReactNode;
   getTableTitle: (resultObj: TaskExecutionResult) => ReactNode;
-  freeText: string;
-  setFreeText: (val: string) => void;
-  status: string[];
-  setStatus: (val: string[]) => void;
-  startTimeFrom: string;
-  setStartTimeFrom: (val: string) => void;
-  onStartFromChange: (val: string) => void;
-  startTimeTo: string;
-  setStartTimeTo: (val: string) => void;
-  onStartToChange: (val: string) => void;
-  endTimeFrom: string;
-  setEndTimeFrom: (val: string) => void;
-  onEndFromChange: (val: string) => void;
-  endTimeTo: string;
-  setEndTimeTo: (val: string) => void;
-  onEndToChange: (val: string) => void;
-  fromDisplayTime: string;
-  setFromDisplayTime: (val: string) => void;
-  toDisplayTime: string;
-  setToDisplayTime: (val: string) => void;
-  openDateSelect: boolean;
-  setOpenDateSelect: (val: boolean) => void;
-  openStartDatePicker: boolean;
-  setStartOpenDatePicker: (val: boolean) => void;
-  openEndDatePicker: boolean;
-  setEndOpenDatePicker: (val: boolean) => void;
-  recentSearches: { start: string; end: string };
 }
 
 export default function BasicSearch({
   doSearch,
   SwitchComponent,
   getTableTitle,
-  freeText,
-  setFreeText,
-  status,
-  setStatus,
-  startTimeFrom,
-  setStartTimeFrom,
-  onStartFromChange,
-  startTimeTo,
-  setStartTimeTo,
-  onStartToChange,
-  endTimeFrom,
-  setEndTimeFrom,
-  onEndFromChange,
-  endTimeTo,
-  setEndTimeTo,
-  onEndToChange,
-  fromDisplayTime,
-  setFromDisplayTime,
-  toDisplayTime,
-  setToDisplayTime,
-  openDateSelect,
-  setOpenDateSelect,
-  openStartDatePicker,
-  setStartOpenDatePicker,
-  openEndDatePicker,
-  setEndOpenDatePicker,
-  recentSearches,
 }: BasicSearchProps) {
+  const filters = useAgentSearchFilters();
+  const {
+    freeText,
+    setFreeText,
+    status,
+    setStatus,
+    startTimeFrom,
+    setStartTimeFrom,
+    startTimeTo,
+    setStartTimeTo,
+    endTimeFrom,
+    setEndTimeFrom,
+    endTimeTo,
+    setEndTimeTo,
+    setFromDisplayTime,
+    setToDisplayTime,
+  } = filters;
   const [page, setPage] = useQueryState("page", 1);
   const [workflowType, setWorkflowType] = useQueryState<string[]>(
     "workflowType",
-    [],
-  );
-  const [workflowId, setWorkflowId] = useQueryState("workflowId", "");
-  const [correlationIds, setCorrelationIds] = useQueryState<string[]>(
-    "correlationIds",
-    [],
-  );
-  const [idempotencyKey, setIdempotencyKey] = useQueryState<string[]>(
-    "idempotencyKey",
     [],
   );
 
@@ -135,24 +101,54 @@ export default function BasicSearch({
   const [sort, setSort] = useQueryState("sort", DEFAULT_SORT);
   const [showCodeDialog, setShowCodeDialog] = useQueryState("displayCode", "");
 
-  const {
-    setValue: setCorrelationInputVal,
-    setFocused: setCorrelationFieldFocus,
-    hasError: correlationIdHasError,
-  } = useAutoCompleteInputValidation();
-
-  const {
-    setValue: setIdempotencyKeyInputVal,
-    setFocused: setIdempotencyKeyFieldFocus,
-    hasError: idempotencyKeyHasError,
-  } = useAutoCompleteInputValidation();
+  const [agentNameInput, setAgentNameInput] = useState("");
+  // Local draft so keystrokes do not rewrite the URL on every change.
+  // When committed freeText changes (reset, back/forward, Advanced↔Basic),
+  // sync during render instead of an effect — see React "adjusting state
+  // when a prop changes".
+  const [searchInput, setSearchInput] = useState(freeText);
+  const [prevFreeText, setPrevFreeText] = useState(freeText);
+  if (freeText !== prevFreeText) {
+    setPrevFreeText(freeText);
+    setSearchInput(freeText);
+  }
 
   const isMobile = useMediaQuery((theme: Theme) =>
     theme.breakpoints.down("sm"),
   );
 
-  // For dropdown
-  const agentNames = useAgentNames();
+  // Registered agent definitions (often empty if nothing is deployed via AgentSpan).
+  const registeredAgentNames = useAgentNames();
+
+  // Stable lookback so the hint query key does not change every render.
+  const [nameHintLookbackMs] = useState(
+    () => Date.now() - 30 * 24 * 60 * 60 * 1000,
+  );
+
+  // Supplement the dropdown with names seen on recent agent executions so the
+  // select is useful even when /agent/list returns [].
+  const { data: agentNameHintResult } = useWorkflowSearch<{
+    results?: { workflowType?: string }[];
+  }>(
+    {
+      page: 1,
+      rowsPerPage: 100,
+      sort: DEFAULT_SORT,
+      query: `startTime>${nameHintLookbackMs}`,
+      freeText: "*",
+      classifier: "agent",
+      topLevelOnly: true,
+    },
+    { staleTime: 60_000 },
+  );
+
+  const knownAgentNames = useMemo(() => {
+    const fromExecutions =
+      agentNameHintResult?.results
+        ?.map((row) => row.workflowType)
+        .filter((name): name is string => Boolean(name)) ?? [];
+    return mergeUniqueSortedNames(registeredAgentNames, fromExecutions);
+  }, [registeredAgentNames, agentNameHintResult]);
 
   // for tooltip flag in localstorage
   const [tooltipFlags, setTooltipFlags] = useLocalStorage("tooltipFlags", {});
@@ -169,12 +165,11 @@ export default function BasicSearch({
 
   const clearAllFields = () => {
     setWorkflowType([]);
-    setCorrelationIds([]);
-    setIdempotencyKey([]);
-    setWorkflowId("");
+    setAgentNameInput("");
     setStatus([]);
     setStartTimeFrom("");
     setStartTimeTo("");
+    setSearchInput("");
     setFreeText("");
     setModifiedFrom("");
     setModifiedTo("");
@@ -200,73 +195,68 @@ export default function BasicSearch({
     setQueryFT(newQueryFT);
   };
 
-  const [errorMessage, setErrorMessage] = useState<IObject | null>(null);
+  const [errorMessage, setErrorMessage] = useState<ExecutionSearchError | null>(
+    null,
+  );
 
   const [unauthorized, setUnauthorized] = useState<{
     message?: string;
     error?: string;
   } | null>(null);
 
-  const buildQuery = useCallback(() => {
-    const clauses = [];
-    if (!_isEmpty(workflowType)) {
-      clauses.push(`workflowType IN (${workflowType.join(",")})`);
+  // Include typed-but-not-committed agent name so Search works without Enter
+  const resolvedWorkflowTypes = useCallback(() => {
+    const types = [...workflowType];
+    const pending = agentNameInput.trim();
+    if (pending && !types.includes(pending)) {
+      types.push(pending);
     }
-    if (!_isEmpty(workflowId)) {
-      clauses.push(`workflowId='${workflowId}'`);
-    }
-    if (!_isEmpty(status)) {
-      clauses.push(`status IN (${status.join(",")})`);
-    }
-    if (!_isEmpty(startTimeFrom)) {
-      clauses.push(`startTime>${dateToEpoch(startTimeFrom)}`);
-    }
-    if (!_isEmpty(startTimeTo)) {
-      clauses.push(`startTime<${dateToEpoch(startTimeTo)}`);
-    }
-    if (!_isEmpty(endTimeFrom)) {
-      clauses.push(`endTime>${dateToEpoch(endTimeFrom)}`);
-    }
-    if (!_isEmpty(endTimeTo)) {
-      clauses.push(`endTime<${dateToEpoch(endTimeTo)}`);
-    }
+    return types;
+  }, [workflowType, agentNameInput]);
 
-    if (!_isEmpty(modifiedFrom)) {
-      clauses.push(`modifiedTime>${modifiedFrom}`);
+  const commitPendingAgentName = useCallback(() => {
+    const pending = agentNameInput.trim();
+    if (pending && !workflowType.includes(pending)) {
+      setWorkflowType([...workflowType, pending]);
     }
-    if (!_isEmpty(modifiedTo)) {
-      clauses.push(`modifiedTime<${modifiedTo}`);
-    }
+    setAgentNameInput("");
+  }, [agentNameInput, workflowType, setWorkflowType]);
 
-    if (!_isEmpty(correlationIds)) {
-      clauses.push(`correlationId IN (${correlationIds.join(",")})`);
-    }
-
-    if (!_isEmpty(idempotencyKey)) {
-      clauses.push(`idempotencyKey IN (${idempotencyKey.join(",")})`);
-    }
-
-    return {
-      query: clauses.join(" AND "),
-      freeText: _isEmpty(freeText) ? "*" : freeText,
-    };
-  }, [
-    freeText,
-    startTimeFrom,
-    startTimeTo,
-    status,
-    workflowId,
-    workflowType,
-    modifiedFrom,
-    modifiedTo,
-    correlationIds,
-    idempotencyKey,
-    endTimeFrom,
-    endTimeTo,
-  ]);
+  const buildQuery = useCallback(
+    () =>
+      buildBasicSearchQuery({
+        searchInput,
+        selectedTypes: resolvedWorkflowTypes(),
+        knownAgentNames,
+        status,
+        startTimeFrom,
+        startTimeTo,
+        endTimeFrom,
+        endTimeTo,
+        modifiedFrom,
+        modifiedTo,
+      }),
+    [
+      searchInput,
+      startTimeFrom,
+      startTimeTo,
+      status,
+      resolvedWorkflowTypes,
+      modifiedFrom,
+      modifiedTo,
+      endTimeFrom,
+      endTimeTo,
+      knownAgentNames,
+    ],
+  );
 
   const [queryFT, setQueryFT] = useState(buildQuery);
   const [hideSubWorkflows, setHideSubWorkflows] = useState(true);
+
+  // Direct execution-id lookup should not also require classifier=agent /
+  // topLevelOnly — older or mis-tagged rows would otherwise return 0 hits.
+  const isExecutionIdQuery = isWorkflowIdQuery(queryFT.query);
+
   const {
     data: resultObj,
     error,
@@ -279,20 +269,23 @@ export default function BasicSearch({
       sort,
       query: queryFT.query,
       freeText: queryFT.freeText,
-      // Scope results to a single classifier: "workflow" for plain workflow
-      // executions, "agent" for AgentSpan agent runs on the Agents pages.
-      classifier: "agent",
-      topLevelOnly: hideSubWorkflows,
+      // Scope results to agent executions unless looking up a specific id.
+      ...(isExecutionIdQuery
+        ? {}
+        : {
+            classifier: "agent",
+            topLevelOnly: hideSubWorkflows,
+          }),
     },
     {},
     {
-      onError: (error: any) => {
+      onError: (error: unknown) => {
         if (error) {
           getErrors(error as Response).then((result) => {
             if (result?.["workflowName"] === "must not be empty") {
               setErrorMessage({ message: "Agent name should not be empty" });
             } else {
-              setErrorMessage(result);
+              setErrorMessage(result as ExecutionSearchError);
             }
           });
         } else {
@@ -302,23 +295,46 @@ export default function BasicSearch({
     },
   );
 
+  // Dropdown options: registered defs + recent executions + names from current results
+  const agentNameOptions = useMemo(() => {
+    const fromResults =
+      resultObj?.results
+        ?.map((row: { workflowType?: string }) => row.workflowType)
+        .filter((name: string | undefined): name is string => Boolean(name)) ??
+      [];
+    return mergeUniqueSortedNames(knownAgentNames, fromResults);
+  }, [knownAgentNames, resultObj]);
+
+  const setRecentTaskSearch = () => {
+    if (startTimeFrom || startTimeTo || endTimeFrom || endTimeTo) {
+      localStorage.setItem(
+        "recentTaskSearch",
+        JSON.stringify({
+          start: startTimeFrom || startTimeTo,
+          end: endTimeTo || endTimeFrom,
+        }),
+      );
+    }
+  };
+
+  const runSearch = () => {
+    setFreeText(searchInput);
+    commitPendingAgentName();
+    doSearch({
+      resultObj,
+      queryFT,
+      buildQuery,
+      setQueryFT,
+      refetch,
+      setPage,
+      setRecentTaskSearch,
+    });
+  };
+
   // hotkeys to search execution
-  useHotkeys(
-    `${Key.Meta}+${Key.Enter}`,
-    () =>
-      doSearch({
-        resultObj,
-        queryFT,
-        buildQuery,
-        setQueryFT,
-        refetch,
-        setPage,
-        setRecentTaskSearch,
-      }),
-    {
-      enableOnFormTags: ["INPUT", "TEXTAREA", "SELECT"],
-    },
-  );
+  useHotkeys(`${Key.Meta}+${Key.Enter}`, () => runSearch(), {
+    enableOnFormTags: ["INPUT", "TEXTAREA", "SELECT"],
+  });
 
   const handleSort = (changedColumn: string, direction: string) => {
     const sortColumn =
@@ -344,33 +360,10 @@ export default function BasicSearch({
     }
   }, [queryFT]);
 
-  const setRecentTaskSearch = () => {
-    if (startTimeFrom || startTimeTo || endTimeFrom || endTimeTo) {
-      localStorage.setItem(
-        "recentTaskSearch",
-        JSON.stringify({
-          start: startTimeFrom || startTimeTo,
-          end: endTimeTo || endTimeFrom,
-        }),
-      );
-    }
-  };
-
-  useEffect(() => {
-    if (!startTimeFrom) {
-      const currentTime = Date.now();
-      const timestamp72HoursAgo = currentTime - 72 * 60 * 60 * 1000;
-      setStartTimeFrom(String(timestamp72HoursAgo));
-    }
-    // eslint-disable-next-line
-  }, []);
-
-  // @ts-ignore
   if (error?.status === 401) {
     const errorResult = error;
     const parseErrorResponse = async () => {
       try {
-        // @ts-ignore
         const json = await errorResult.clone().json();
         setUnauthorized(json);
       } catch {
@@ -392,7 +385,7 @@ export default function BasicSearch({
     return <Navigate to={ERROR_URL} />;
   }
 
-  const handleError = (error: any) => {
+  const handleError = (error: ExecutionSearchError) => {
     setErrorMessage(error);
   };
   const handleClearError = () => {
@@ -411,7 +404,7 @@ export default function BasicSearch({
                 start: (page - 1) * rowsPerPage,
                 size: rowsPerPage,
                 sort,
-                freeText,
+                freeText: buildQuery().freeText,
                 query: buildQuery().query,
               }}
             />
@@ -421,12 +414,41 @@ export default function BasicSearch({
             sx={{ width: "100%" }}
             spacing={3}
             pt={2}
-            justifyContent="flex-end"
+            alignItems="flex-end"
           >
             <Grid
               size={{
-                xs: 6,
-                md: 6,
+                xs: 12,
+                md: 7,
+                lg: 8,
+              }}
+            >
+              <ConductorInput
+                id="workflow-search-combined"
+                fullWidth
+                label="Search"
+                placeholder="Full execution ID, correlation ID, idempotency key, or agent name"
+                value={searchInput}
+                onTextInputChange={setSearchInput}
+                showClearButton
+                autoFocus
+                onKeyDown={(event) => {
+                  if (event.key === Key.Enter) {
+                    event.preventDefault();
+                    runSearch();
+                  }
+                }}
+                tooltip={{
+                  title: "General search",
+                  content:
+                    "Matches a full execution ID (UUID), correlation ID, idempotency key, and free text. Partial agent names match known agents (e.g. aa finds aaaa). Use a wildcard (e.g. my-*) when the agent is not in the known list yet.",
+                }}
+              />
+            </Grid>
+            <Grid
+              size={{
+                xs: 12,
+                md: 5,
                 lg: 4,
               }}
             >
@@ -434,125 +456,47 @@ export default function BasicSearch({
                 id="workflow-search-name-dropdown"
                 fullWidth
                 label="Agent name"
-                options={agentNames.sort((a, b) =>
-                  a.toLowerCase().localeCompare(b.toLowerCase()),
-                )}
+                placeholder="Select agents…"
+                options={agentNameOptions}
                 multiple
                 freeSolo
-                onChange={(__, val: string[]) => setWorkflowType(val)}
+                openOnFocus
+                onInputChange={(__, val: string, reason: string) => {
+                  // Track typed text for Search-without-Enter, but do not
+                  // control inputValue — that breaks the options dropdown.
+                  if (reason === "input" || reason === "clear") {
+                    setAgentNameInput(val);
+                  }
+                  if (reason === "reset") {
+                    setAgentNameInput("");
+                  }
+                }}
+                onChange={(__, val: string[]) => {
+                  setAgentNameInput("");
+                  setWorkflowType(val);
+                }}
                 value={workflowType}
                 autoFocus
                 conductorInputProps={{
                   tooltip: {
-                    title: "Partial Name Search",
+                    title: "Filter by agent",
                     content:
-                      "Search agents by partial names with a wildcard * in your keyword. Then hit ENTER, and now you can click SEARCH. i.e. my-agen* or *bot*",
+                      "Select from registered agents and recently run agent names. You can also type a name or wildcard (e.g. my-agen* or *bot*) and press Enter to add it as a filter — this is not a free-text search.",
                     placement: "top",
                     showInitial: !tooltipFlags.executionSearch ? true : false,
                     initialTimeout: 2000,
                     onClose: handleToolTipOnClose,
                   },
                   autoFocus: true,
-                }}
-              />
-            </Grid>
-            <Grid
-              size={{
-                xs: 6,
-                md: 6,
-                lg: 2,
-              }}
-            >
-              <ConductorInput
-                id="workflow-search-id"
-                fullWidth
-                label="Execution id"
-                value={workflowId}
-                onTextInputChange={setWorkflowId}
-                showClearButton
-              />
-            </Grid>
-            <Grid
-              position="relative"
-              size={{
-                xs: 6,
-                md: 6,
-                lg: 2,
-              }}
-            >
-              <ConductorAutoComplete
-                id="workflow-search-correlation-id"
-                fullWidth
-                label="Correlation id"
-                options={[]}
-                multiple
-                freeSolo
-                onTextInputChange={(typingValue: string) => {
-                  setCorrelationInputVal(typingValue);
-                }}
-                onChange={(evt: any, val: string[]) => {
-                  if (evt.key === "Backspace" || evt.key === "Enter") {
-                    setCorrelationInputVal("");
-                  }
-                  setCorrelationIds(val);
-                }}
-                onFocus={() => setCorrelationFieldFocus(true)}
-                onBlur={() => setCorrelationFieldFocus(false)}
-                value={correlationIds}
-                error={correlationIdHasError}
-                conductorInputProps={{
-                  tooltip: {
-                    title: "Get Agents by Correlation ID",
-                    content:
-                      "Search executions by Correlation ID. This field has support for multiple values, so please remember to press 'Enter' for each value to apply the search.",
-                  },
-                  error: correlationIdHasError,
-                }}
-              />
-            </Grid>
-            <Grid
-              position="relative"
-              size={{
-                xs: 6,
-                md: 6,
-                lg: 2,
-              }}
-            >
-              <ConductorAutoComplete
-                id="workflow-search-idempotency-key"
-                fullWidth
-                label="Idempotency key"
-                options={[]}
-                multiple
-                freeSolo
-                onTextInputChange={(typingValue: string) => {
-                  setIdempotencyKeyInputVal(typingValue);
-                }}
-                onChange={(evt: any, val: string[]) => {
-                  if (evt.key === "Backspace" || evt.key === "Enter") {
-                    setIdempotencyKeyInputVal("");
-                  }
-
-                  setIdempotencyKey(val);
-                }}
-                onFocus={() => setIdempotencyKeyFieldFocus(true)}
-                onBlur={() => setIdempotencyKeyFieldFocus(false)}
-                value={idempotencyKey}
-                error={idempotencyKeyHasError}
-                conductorInputProps={{
-                  tooltip: {
-                    title: "Get Executions by Idempotency key",
-                    content:
-                      "Search executions by Idempotency key. This field has support for multiple values, so please remember to press 'Enter' for each value to apply the search.",
-                  },
-                  error: idempotencyKeyHasError,
+                  placeholder: "Select agents…",
                 }}
               />
             </Grid>
             <Grid
               size={{
                 xs: 12,
-                md: 6,
+                sm: 6,
+                md: 3,
                 lg: 2,
               }}
             >
@@ -577,31 +521,13 @@ export default function BasicSearch({
               alignItems="end"
               size={{
                 xs: 12,
-                sm: 12,
-                md: 6,
+                sm: 6,
+                md: 5,
                 lg: 6,
               }}
             >
               <DateControlComponent
-                startTime={startTimeFrom}
-                onStartFromChange={onStartFromChange}
-                startTimeEnd={startTimeTo}
-                onStartToChange={onStartToChange}
-                endTimeStart={endTimeFrom}
-                onEndFromChange={onEndFromChange}
-                endTime={endTimeTo}
-                onEndToChange={onEndToChange}
-                fromDisplayTime={fromDisplayTime}
-                setFromDisplayTime={setFromDisplayTime}
-                toDisplayTime={toDisplayTime}
-                setToDisplayTime={setToDisplayTime}
-                openDateSelect={openDateSelect}
-                setOpenDateSelect={setOpenDateSelect}
-                openStartDatePicker={openStartDatePicker}
-                setStartOpenDatePicker={setStartOpenDatePicker}
-                openEndDatePicker={openEndDatePicker}
-                setEndOpenDatePicker={setEndOpenDatePicker}
-                recentSearches={recentSearches}
+                {...toDateControlProps(filters)}
                 startDialogTitle="Execution Start Time"
                 startDialogHelpText="Select a date range within which the Execution has started."
                 endDialogTitle="Execution End Time"
@@ -611,74 +537,43 @@ export default function BasicSearch({
               />
             </Grid>
             <Grid
-              size={{
-                xs: 12,
-                sm: 6,
-                md: 6,
-                lg: 3,
-              }}
-            >
-              <ConductorInput
-                fullWidth
-                label="Free text search"
-                value={freeText}
-                onTextInputChange={setFreeText}
-                showClearButton
-              />
-            </Grid>
-            <Grid
               display="flex"
               justifyContent="end"
+              alignItems="end"
+              gap={1}
               size={{
                 xs: 12,
-                sm: 6,
-                md: 6,
-                lg: 3,
+                md: 4,
+                lg: 4,
               }}
             >
-              <Grid size={5}>
-                <FormControl>
-                  {!isMobile && <InputLabel>&nbsp;</InputLabel>}
-                  <Button
-                    id="reset-workflow-btn"
-                    variant="text"
-                    onClick={handleReset}
-                    style={{ width: "100%" }}
-                    startIcon={<ResetIcon />}
-                  >
-                    Reset
-                  </Button>
-                </FormControl>
-              </Grid>
-              <Grid>
-                <FormControl>
-                  {!isMobile && <InputLabel>&nbsp;</InputLabel>}
-
-                  <SplitButton
-                    id="search-workflow-btn"
-                    startIcon={<SearchIcon />}
-                    options={[
-                      {
-                        label: "Show as code",
-                        onClick: () => setShowCodeDialog("active"),
-                      },
-                    ]}
-                    primaryOnClick={() =>
-                      doSearch({
-                        resultObj,
-                        queryFT,
-                        buildQuery,
-                        setQueryFT,
-                        refetch,
-                        setPage,
-                        setRecentTaskSearch,
-                      })
-                    }
-                  >
-                    Search
-                  </SplitButton>
-                </FormControl>
-              </Grid>
+              <FormControl>
+                {!isMobile && <InputLabel>&nbsp;</InputLabel>}
+                <Button
+                  id="reset-workflow-btn"
+                  variant="text"
+                  onClick={handleReset}
+                  startIcon={<ResetIcon />}
+                >
+                  Reset
+                </Button>
+              </FormControl>
+              <FormControl>
+                {!isMobile && <InputLabel>&nbsp;</InputLabel>}
+                <SplitButton
+                  id="search-workflow-btn"
+                  startIcon={<SearchIcon />}
+                  options={[
+                    {
+                      label: "Show as code",
+                      onClick: () => setShowCodeDialog("active"),
+                    },
+                  ]}
+                  primaryOnClick={runSearch}
+                >
+                  Search
+                </SplitButton>
+              </FormControl>
             </Grid>
           </Grid>
         </Box>

--- a/ui-next/src/pages/agent/executions/workflowSearchComponents/buildBasicSearchQuery.test.ts
+++ b/ui-next/src/pages/agent/executions/workflowSearchComponents/buildBasicSearchQuery.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { dateToEpoch } from "utils";
+import {
+  buildBasicSearchQuery,
+  isWorkflowIdQuery,
+  mergeUniqueSortedNames,
+} from "./buildBasicSearchQuery";
+
+const emptyFilters = {
+  selectedTypes: [] as string[],
+  knownAgentNames: [] as string[],
+  status: [] as string[],
+  startTimeFrom: "",
+  startTimeTo: "",
+  endTimeFrom: "",
+  endTimeTo: "",
+  modifiedFrom: "",
+  modifiedTo: "",
+};
+
+describe("isWorkflowIdQuery", () => {
+  it("detects a standalone workflowId equality clause", () => {
+    expect(isWorkflowIdQuery("workflowId='abc'")).toBe(true);
+  });
+
+  it("detects workflowId ANDed with other clauses", () => {
+    expect(
+      isWorkflowIdQuery("status IN (COMPLETED) AND workflowId='abc'"),
+    ).toBe(true);
+  });
+
+  it("ignores queries without workflowId=", () => {
+    expect(isWorkflowIdQuery("workflowType IN ('bot')")).toBe(false);
+    expect(isWorkflowIdQuery("")).toBe(false);
+  });
+});
+
+describe("mergeUniqueSortedNames", () => {
+  it("dedupes and sorts case-insensitively", () => {
+    expect(
+      mergeUniqueSortedNames(["zeta", "Alpha"], ["alpha", "beta"]),
+    ).toEqual(["Alpha", "alpha", "beta", "zeta"]);
+  });
+
+  it("drops empty strings", () => {
+    expect(mergeUniqueSortedNames(["a", ""], ["b"])).toEqual(["a", "b"]);
+  });
+});
+
+describe("buildBasicSearchQuery", () => {
+  it("returns empty query and freeText * with no filters", () => {
+    expect(
+      buildBasicSearchQuery({
+        searchInput: "",
+        ...emptyFilters,
+      }),
+    ).toEqual({ query: "", freeText: "*" });
+  });
+
+  it("routes a full UUID to workflowId only and ignores other filters", () => {
+    const id = "baecfd5f-8462-11f1-b677-26be8ee7cf9f";
+    expect(
+      buildBasicSearchQuery({
+        searchInput: id,
+        ...emptyFilters,
+        selectedTypes: ["payment-bot"],
+        status: ["COMPLETED"],
+        startTimeFrom: "1700000000000",
+      }),
+    ).toEqual({
+      query: `workflowId='${id}'`,
+      freeText: "*",
+    });
+  });
+
+  it("ANDs agent, status, and startTime with freeText from combined search", () => {
+    const start = "1700000000000";
+    const result = buildBasicSearchQuery({
+      searchInput: "correlation123",
+      ...emptyFilters,
+      selectedTypes: ["payment-bot"],
+      status: ["RUNNING", "COMPLETED"],
+      startTimeFrom: start,
+    });
+
+    expect(result.freeText).toBe("correlation123");
+    expect(result.query).toBe(
+      [
+        "workflowType IN ('payment-bot')",
+        "status IN (RUNNING,COMPLETED)",
+        `startTime>${dateToEpoch(start)}`,
+      ].join(" AND "),
+    );
+  });
+
+  it("routes known agent substring from search input to workflowType", () => {
+    expect(
+      buildBasicSearchQuery({
+        searchInput: "aa",
+        ...emptyFilters,
+        knownAgentNames: ["aaaa", "payment-bot"],
+      }),
+    ).toEqual({
+      query: "workflowType IN ('aaaa')",
+      freeText: "*",
+    });
+  });
+});

--- a/ui-next/src/pages/agent/executions/workflowSearchComponents/buildBasicSearchQuery.ts
+++ b/ui-next/src/pages/agent/executions/workflowSearchComponents/buildBasicSearchQuery.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure query builder for agent BasicSearch.
+ * Keeps filter AND-ing out of the React component so it can be unit-tested.
+ */
+
+import _isEmpty from "lodash/isEmpty";
+import { dateToEpoch } from "utils";
+import {
+  resolveCombinedSearch,
+  workflowTypeClause,
+} from "./combinedSearchQuery";
+
+export type BasicSearchQueryInput = {
+  searchInput: string;
+  selectedTypes: string[];
+  knownAgentNames: string[];
+  status: string[];
+  startTimeFrom: string;
+  startTimeTo: string;
+  endTimeFrom: string;
+  endTimeTo: string;
+  modifiedFrom: string;
+  modifiedTo: string;
+};
+
+export type SearchQueryFT = { query: string; freeText: string };
+
+/** True when the structured query is a direct workflowId= lookup. */
+export function isWorkflowIdQuery(query: string): boolean {
+  return /(?:^|AND\s)workflowId\s*=/i.test(query);
+}
+
+/** Dedupe and case-insensitive sort for agent-name dropdown options. */
+export function mergeUniqueSortedNames(...lists: string[][]): string[] {
+  return Array.from(new Set(lists.flat().filter(Boolean))).sort((a, b) =>
+    a.toLowerCase().localeCompare(b.toLowerCase()),
+  );
+}
+
+/**
+ * Build the Conductor search `query` + `freeText` for Basic Search.
+ * Full UUID → identity-only workflowId clause (no date/status/agent AND).
+ */
+export function buildBasicSearchQuery(
+  input: BasicSearchQueryInput,
+): SearchQueryFT {
+  const {
+    searchInput,
+    selectedTypes,
+    knownAgentNames,
+    status,
+    startTimeFrom,
+    startTimeTo,
+    endTimeFrom,
+    endTimeTo,
+    modifiedFrom,
+    modifiedTo,
+  } = input;
+
+  const clauses: string[] = [];
+
+  const {
+    searchClauses,
+    freeText: resolvedFreeText,
+    isExecutionIdSearch,
+  } = resolveCombinedSearch(searchInput, {
+    selectedTypes,
+    knownAgentNames,
+  });
+
+  // Full execution-id lookup is identity-only: do not AND other filters
+  // (date window, agent name, status) or a matching id can still return 0.
+  // Partial IDs are not supported — paste the full UUID.
+  if (isExecutionIdSearch) {
+    return {
+      query: searchClauses.join(" AND "),
+      freeText: "*",
+    };
+  }
+
+  if (!_isEmpty(selectedTypes)) {
+    clauses.push(workflowTypeClause(selectedTypes));
+  }
+  if (!_isEmpty(status)) {
+    clauses.push(`status IN (${status.join(",")})`);
+  }
+  if (!_isEmpty(startTimeFrom)) {
+    clauses.push(`startTime>${dateToEpoch(startTimeFrom)}`);
+  }
+  if (!_isEmpty(startTimeTo)) {
+    clauses.push(`startTime<${dateToEpoch(startTimeTo)}`);
+  }
+  if (!_isEmpty(endTimeFrom)) {
+    clauses.push(`endTime>${dateToEpoch(endTimeFrom)}`);
+  }
+  if (!_isEmpty(endTimeTo)) {
+    clauses.push(`endTime<${dateToEpoch(endTimeTo)}`);
+  }
+  if (!_isEmpty(modifiedFrom)) {
+    clauses.push(`modifiedTime>${modifiedFrom}`);
+  }
+  if (!_isEmpty(modifiedTo)) {
+    clauses.push(`modifiedTime<${modifiedTo}`);
+  }
+
+  clauses.push(...searchClauses);
+
+  return {
+    query: clauses.join(" AND "),
+    freeText: resolvedFreeText,
+  };
+}

--- a/ui-next/src/pages/agent/executions/workflowSearchComponents/combinedSearchQuery.test.ts
+++ b/ui-next/src/pages/agent/executions/workflowSearchComponents/combinedSearchQuery.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  identifierMatchClause,
+  isHyphenatedToken,
   isUnsafeForFreeText,
   matchAgentNames,
   quoteQueryValue,
@@ -21,6 +23,32 @@ describe("isUnsafeForFreeText", () => {
     expect(isUnsafeForFreeText("correlation123")).toBe(false);
     expect(isUnsafeForFreeText("hello world")).toBe(false);
     expect(isUnsafeForFreeText("idempotency_key")).toBe(false);
+  });
+});
+
+describe("isHyphenatedToken", () => {
+  it("matches alphanumeric segments joined by hyphens", () => {
+    expect(isHyphenatedToken("corr-test")).toBe(true);
+    expect(isHyphenatedToken("a-b-c")).toBe(true);
+  });
+
+  it("rejects plain tokens and other special characters", () => {
+    expect(isHyphenatedToken("correlationid12345")).toBe(false);
+    expect(isHyphenatedToken("order.123")).toBe(false);
+  });
+});
+
+describe("identifierMatchClause", () => {
+  it("emits Orkes identifier= when useOrkesIdentifierField is true", () => {
+    expect(identifierMatchClause("corr-test", true)).toBe(
+      "identifier='corr-test'",
+    );
+  });
+
+  it("emits OSS correlationId when useOrkesIdentifierField is false", () => {
+    expect(identifierMatchClause("corr-test", false)).toBe(
+      "correlationId='corr-test'",
+    );
   });
 });
 
@@ -121,6 +149,39 @@ describe("resolveCombinedSearch", () => {
     });
   });
 
+  it("routes unknown hyphenated terms to Orkes identifier=, not workflowType", () => {
+    expect(
+      resolveCombinedSearch("corr-test", { useOrkesIdentifierField: true }),
+    ).toEqual({
+      searchClauses: ["identifier='corr-test'"],
+      freeText: "*",
+      isExecutionIdSearch: false,
+    });
+  });
+
+  it("routes unknown hyphenated terms to correlationId when not Orkes", () => {
+    expect(
+      resolveCombinedSearch("corr-test", { useOrkesIdentifierField: false }),
+    ).toEqual({
+      searchClauses: ["correlationId='corr-test'"],
+      freeText: "*",
+      isExecutionIdSearch: false,
+    });
+  });
+
+  it("still prefers known hyphenated agent names over identifier", () => {
+    expect(
+      resolveCombinedSearch("my-agent", {
+        knownAgentNames: KNOWN_AGENTS,
+        useOrkesIdentifierField: true,
+      }),
+    ).toEqual({
+      searchClauses: ["workflowType IN ('my-agent')"],
+      freeText: "*",
+      isExecutionIdSearch: false,
+    });
+  });
+
   it("routes agent wildcards with no list hits to workflowType LIKE", () => {
     expect(resolveCombinedSearch("my-*")).toEqual({
       searchClauses: ["workflowType=my-*"],
@@ -167,6 +228,19 @@ describe("resolveCombinedSearch", () => {
       resolveCombinedSearch("@!@&/2/", { selectedTypes: ["payment-bot"] }),
     ).toEqual({
       searchClauses: [],
+      freeText: "*",
+      isExecutionIdSearch: false,
+    });
+  });
+
+  it("ANDs hyphenated identifier with an existing agent dropdown filter", () => {
+    expect(
+      resolveCombinedSearch("corr-test", {
+        selectedTypes: ["payment-bot"],
+        useOrkesIdentifierField: true,
+      }),
+    ).toEqual({
+      searchClauses: ["identifier='corr-test'"],
       freeText: "*",
       isExecutionIdSearch: false,
     });

--- a/ui-next/src/pages/agent/executions/workflowSearchComponents/combinedSearchQuery.test.ts
+++ b/ui-next/src/pages/agent/executions/workflowSearchComponents/combinedSearchQuery.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import {
+  isUnsafeForFreeText,
+  matchAgentNames,
+  quoteQueryValue,
+  resolveCombinedSearch,
+  workflowIdClause,
+  workflowTypeClause,
+} from "./combinedSearchQuery";
+
+const KNOWN_AGENTS = ["aaaa", "payment-bot", "my-agent", "@!@&/2/"];
+
+describe("isUnsafeForFreeText", () => {
+  it("flags characters that break postgres to_tsquery", () => {
+    expect(isUnsafeForFreeText("@!@&/2/")).toBe(true);
+    expect(isUnsafeForFreeText("my-agent")).toBe(true);
+    expect(isUnsafeForFreeText("order.123")).toBe(true);
+  });
+
+  it("allows plain alphanumeric free text", () => {
+    expect(isUnsafeForFreeText("correlation123")).toBe(false);
+    expect(isUnsafeForFreeText("hello world")).toBe(false);
+    expect(isUnsafeForFreeText("idempotency_key")).toBe(false);
+  });
+});
+
+describe("matchAgentNames", () => {
+  it("matches substring agent names case-insensitively", () => {
+    expect(matchAgentNames("aa", KNOWN_AGENTS)).toEqual(["aaaa"]);
+    expect(matchAgentNames("PAY", KNOWN_AGENTS)).toEqual(["payment-bot"]);
+  });
+
+  it("matches wildcard patterns against known agents", () => {
+    expect(matchAgentNames("my-*", KNOWN_AGENTS)).toEqual(["my-agent"]);
+    expect(matchAgentNames("*bot*", KNOWN_AGENTS)).toEqual(["payment-bot"]);
+  });
+
+  it("returns empty when nothing matches", () => {
+    expect(matchAgentNames("zzz", KNOWN_AGENTS)).toEqual([]);
+  });
+});
+
+describe("workflowTypeClause / workflowIdClause", () => {
+  it("quotes workflowType values for the query DSL", () => {
+    expect(workflowTypeClause(["@!@&/2/"])).toBe("workflowType IN ('@!@&/2/')");
+  });
+
+  it("keeps a single wildcard as equality/LIKE form", () => {
+    expect(workflowTypeClause(["my-*"])).toBe("workflowType=my-*");
+  });
+
+  it("quotes exact workflowId values", () => {
+    expect(workflowIdClause("ABCDEF12-3456-7890-abcd-ef1234567890")).toBe(
+      "workflowId='abcdef12-3456-7890-abcd-ef1234567890'",
+    );
+  });
+
+  it("strips single quotes from quoted values", () => {
+    expect(quoteQueryValue("a'b")).toBe("'ab'");
+  });
+});
+
+describe("resolveCombinedSearch", () => {
+  it("returns freeText * and no clauses for empty input", () => {
+    expect(resolveCombinedSearch("")).toEqual({
+      searchClauses: [],
+      freeText: "*",
+      isExecutionIdSearch: false,
+    });
+    expect(resolveCombinedSearch("   ")).toEqual({
+      searchClauses: [],
+      freeText: "*",
+      isExecutionIdSearch: false,
+    });
+  });
+
+  it("routes a full UUID to an exact workflowId clause", () => {
+    const id = "20c3f74f-71bb-4b59-8a61-f261b94123ef";
+    expect(resolveCombinedSearch(id)).toEqual({
+      searchClauses: [`workflowId='${id}'`],
+      freeText: "*",
+      isExecutionIdSearch: true,
+    });
+  });
+
+  it("does not treat partial UUIDs as execution-id search", () => {
+    // Partial ids are unsupported — fall through to freeText when safe.
+    expect(resolveCombinedSearch("abcdef12")).toEqual({
+      searchClauses: [],
+      freeText: "abcdef12",
+      isExecutionIdSearch: false,
+    });
+  });
+
+  it("routes substring matches to known agents as workflowType", () => {
+    expect(
+      resolveCombinedSearch("aa", { knownAgentNames: KNOWN_AGENTS }),
+    ).toEqual({
+      searchClauses: ["workflowType IN ('aaaa')"],
+      freeText: "*",
+      isExecutionIdSearch: false,
+    });
+  });
+
+  it("routes special-character agent names to workflowType, not freeText", () => {
+    expect(
+      resolveCombinedSearch("@!@&/2/", { knownAgentNames: KNOWN_AGENTS }),
+    ).toEqual({
+      searchClauses: ["workflowType IN ('@!@&/2/')"],
+      freeText: "*",
+      isExecutionIdSearch: false,
+    });
+  });
+
+  it("routes unknown special-character terms to workflowType", () => {
+    // Not in known list — still must not go to freeText/to_tsquery.
+    expect(resolveCombinedSearch("@weird/name")).toEqual({
+      searchClauses: ["workflowType IN ('@weird/name')"],
+      freeText: "*",
+      isExecutionIdSearch: false,
+    });
+  });
+
+  it("routes agent wildcards with no list hits to workflowType LIKE", () => {
+    expect(resolveCombinedSearch("my-*")).toEqual({
+      searchClauses: ["workflowType=my-*"],
+      freeText: "*",
+      isExecutionIdSearch: false,
+    });
+  });
+
+  it("routes plain alphanumeric terms to freeText", () => {
+    expect(resolveCombinedSearch("correlation123")).toEqual({
+      searchClauses: [],
+      freeText: "correlation123",
+      isExecutionIdSearch: false,
+    });
+  });
+
+  it("does not override an existing agent dropdown filter with agent routing", () => {
+    // Dropdown already selected agents — search becomes freeText when safe.
+    expect(
+      resolveCombinedSearch("correlation123", {
+        selectedTypes: ["payment-bot"],
+        knownAgentNames: KNOWN_AGENTS,
+      }),
+    ).toEqual({
+      searchClauses: [],
+      freeText: "correlation123",
+      isExecutionIdSearch: false,
+    });
+  });
+
+  it("still routes full UUID searches when an agent dropdown filter is set", () => {
+    const id = "20c3f74f-71bb-4b59-8a61-f261b94123ef";
+    expect(
+      resolveCombinedSearch(id, { selectedTypes: ["payment-bot"] }),
+    ).toEqual({
+      searchClauses: [`workflowId='${id}'`],
+      freeText: "*",
+      isExecutionIdSearch: true,
+    });
+  });
+
+  it("drops unsafe freeText when an agent dropdown filter is already set", () => {
+    expect(
+      resolveCombinedSearch("@!@&/2/", { selectedTypes: ["payment-bot"] }),
+    ).toEqual({
+      searchClauses: [],
+      freeText: "*",
+      isExecutionIdSearch: false,
+    });
+  });
+
+  it("trims whitespace before routing", () => {
+    expect(resolveCombinedSearch("  correlation123  ")).toEqual({
+      searchClauses: [],
+      freeText: "correlation123",
+      isExecutionIdSearch: false,
+    });
+  });
+});

--- a/ui-next/src/pages/agent/executions/workflowSearchComponents/combinedSearchQuery.ts
+++ b/ui-next/src/pages/agent/executions/workflowSearchComponents/combinedSearchQuery.ts
@@ -1,0 +1,117 @@
+/**
+ * Routing for the agent executions combined search input.
+ * Keeps structured query vs freeText decisions out of the React component so
+ * they can be unit-tested without mounting the full search form.
+ */
+
+/** Conductor execution IDs are typically UUIDs. */
+export const WORKFLOW_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Exact workflowId equality. Only full UUIDs are supported — Orkes/ES does not
+ * treat `*` inside a quoted workflowId value as a wildcard.
+ */
+export function workflowIdClause(value: string): string {
+  return `workflowId=${quoteQueryValue(value.trim().toLowerCase())}`;
+}
+
+/**
+ * Postgres freeText uses to_tsquery(), which treats many characters as
+ * operators (e.g. !, &, |, -, /). Those terms must use structured query
+ * filters instead (workflowType / workflowId).
+ */
+export function isUnsafeForFreeText(value: string): boolean {
+  return /[^a-zA-Z0-9_\s]/.test(value);
+}
+
+/** Quote a value for Conductor's query DSL; the server strips the quotes. */
+export function quoteQueryValue(value: string): string {
+  return `'${value.replace(/'/g, "")}'`;
+}
+
+function wildcardToRegExp(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^${escaped.replace(/\*/g, ".*")}$`, "i");
+}
+
+/** Match a search term against known agent names (substring, or * wildcards). */
+export function matchAgentNames(term: string, agentNames: string[]): string[] {
+  const trimmed = term.trim();
+  if (!trimmed) {
+    return [];
+  }
+  if (trimmed.includes("*")) {
+    const re = wildcardToRegExp(trimmed);
+    return agentNames.filter((name) => re.test(name));
+  }
+  const lower = trimmed.toLowerCase();
+  // Substring so "aa" matches agent "aaaa" (exact match alone is too strict).
+  return agentNames.filter((name) => name.toLowerCase().includes(lower));
+}
+
+/** Build a workflowType clause, quoting values that need it. */
+export function workflowTypeClause(names: string[]): string {
+  if (names.length === 1 && names[0].includes("*")) {
+    return `workflowType=${names[0]}`;
+  }
+  return `workflowType IN (${names.map(quoteQueryValue).join(",")})`;
+}
+
+export type CombinedSearchResolution = {
+  /** Query clauses contributed by the search input alone. */
+  searchClauses: string[];
+  freeText: string;
+  /** True when the input was routed to a workflowId (execution id) filter. */
+  isExecutionIdSearch: boolean;
+};
+
+/**
+ * Resolve the combined search box into structured query clauses and/or freeText.
+ * Does not include status, date, or dropdown agent-name filters — callers AND
+ * those in separately.
+ *
+ * Execution IDs require a full UUID. Partial IDs are not supported.
+ */
+export function resolveCombinedSearch(
+  searchInput: string,
+  {
+    selectedTypes = [],
+    knownAgentNames = [],
+  }: {
+    selectedTypes?: string[];
+    knownAgentNames?: string[];
+  } = {},
+): CombinedSearchResolution {
+  const search = searchInput.trim();
+  const searchClauses: string[] = [];
+  let freeText = "*";
+  let isExecutionIdSearch = false;
+
+  if (!search) {
+    return { searchClauses, freeText, isExecutionIdSearch };
+  }
+
+  if (WORKFLOW_ID_RE.test(search)) {
+    searchClauses.push(workflowIdClause(search));
+    isExecutionIdSearch = true;
+  } else if (selectedTypes.length === 0) {
+    const matchedAgents = matchAgentNames(search, knownAgentNames);
+    // Prefer workflowType when: known agent, wildcard, or freeText-unsafe
+    // (e.g. @!@&/2/). Agent executions often use names that are not in
+    // /agent/list, so unsafe terms still try exact workflowType match.
+    if (matchedAgents.length) {
+      searchClauses.push(workflowTypeClause(matchedAgents));
+    } else if (search.includes("*") || isUnsafeForFreeText(search)) {
+      searchClauses.push(workflowTypeClause([search]));
+    } else {
+      freeText = search;
+    }
+  } else if (!isUnsafeForFreeText(search)) {
+    freeText = search;
+  }
+  // else: agent filter already applied; skip freeText — special characters
+  // would break to_tsquery and are not safe to AND as another field.
+
+  return { searchClauses, freeText, isExecutionIdSearch };
+}

--- a/ui-next/src/pages/agent/executions/workflowSearchComponents/combinedSearchQuery.ts
+++ b/ui-next/src/pages/agent/executions/workflowSearchComponents/combinedSearchQuery.ts
@@ -4,6 +4,8 @@
  * they can be unit-tested without mounting the full search form.
  */
 
+import { FEATURES, featureFlags } from "utils/flags";
+
 /** Conductor execution IDs are typically UUIDs. */
 export const WORKFLOW_ID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -19,15 +21,47 @@ export function workflowIdClause(value: string): string {
 /**
  * Postgres freeText uses to_tsquery(), which treats many characters as
  * operators (e.g. !, &, |, -, /). Those terms must use structured query
- * filters instead (workflowType / workflowId).
+ * filters instead (workflowType / workflowId / identifier).
  */
 export function isUnsafeForFreeText(value: string): boolean {
   return /[^a-zA-Z0-9_\s]/.test(value);
 }
 
+/**
+ * Alphanumeric segments joined by hyphens (e.g. `corr-test`). Common for
+ * correlation IDs / idempotency keys; `-` is unsafe in freeText (to_tsquery
+ * NOT), so these are routed to an identifier match clause.
+ */
+export function isHyphenatedToken(value: string): boolean {
+  return /^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)+$/.test(value);
+}
+
 /** Quote a value for Conductor's query DSL; the server strips the quotes. */
 export function quoteQueryValue(value: string): string {
   return `'${value.replace(/'/g, "")}'`;
+}
+
+/**
+ * Match an identifier-like term (correlation / idempotency key).
+ *
+ * Orkes archive search only supports AND between clauses, so Orkes uses
+ * `identifier=` which the backend expands to a SQL OR across correlationId
+ * and idempotencyKey.
+ *
+ * OSS (SQLite index) only parses `AND`-joined equality clauses — parenthesized
+ * `OR` is treated as a single invalid attribute and returns 0 hits. Agent
+ * starts already stamp idempotencyKey onto correlationId, so matching
+ * correlationId alone covers both on OSS.
+ */
+export function identifierMatchClause(
+  value: string,
+  useOrkesIdentifierField = featureFlags.isEnabled(FEATURES.ACCESS_MANAGEMENT),
+): string {
+  const quoted = quoteQueryValue(value);
+  if (useOrkesIdentifierField) {
+    return `identifier=${quoted}`;
+  }
+  return `correlationId=${quoted}`;
 }
 
 function wildcardToRegExp(pattern: string): RegExp {
@@ -78,9 +112,14 @@ export function resolveCombinedSearch(
   {
     selectedTypes = [],
     knownAgentNames = [],
+    useOrkesIdentifierField = featureFlags.isEnabled(
+      FEATURES.ACCESS_MANAGEMENT,
+    ),
   }: {
     selectedTypes?: string[];
     knownAgentNames?: string[];
+    /** Orkes `identifier=` vs OSS `(correlationId OR idempotencyKey)`. */
+    useOrkesIdentifierField?: boolean;
   } = {},
 ): CombinedSearchResolution {
   const search = searchInput.trim();
@@ -98,15 +137,24 @@ export function resolveCombinedSearch(
   } else if (selectedTypes.length === 0) {
     const matchedAgents = matchAgentNames(search, knownAgentNames);
     // Prefer workflowType when: known agent, wildcard, or freeText-unsafe
-    // (e.g. @!@&/2/). Agent executions often use names that are not in
-    // /agent/list, so unsafe terms still try exact workflowType match.
+    // (e.g. @!@&/2/), except hyphenated tokens → identifier OR.
+    // Agent executions often use names that are not in /agent/list, so other
+    // unsafe terms still try exact workflowType match.
     if (matchedAgents.length) {
       searchClauses.push(workflowTypeClause(matchedAgents));
-    } else if (search.includes("*") || isUnsafeForFreeText(search)) {
+    } else if (search.includes("*")) {
+      searchClauses.push(workflowTypeClause([search]));
+    } else if (isHyphenatedToken(search)) {
+      searchClauses.push(
+        identifierMatchClause(search, useOrkesIdentifierField),
+      );
+    } else if (isUnsafeForFreeText(search)) {
       searchClauses.push(workflowTypeClause([search]));
     } else {
       freeText = search;
     }
+  } else if (isHyphenatedToken(search)) {
+    searchClauses.push(identifierMatchClause(search, useOrkesIdentifierField));
   } else if (!isUnsafeForFreeText(search)) {
     freeText = search;
   }

--- a/ui-next/src/pages/definition/task/state/validator.ts
+++ b/ui-next/src/pages/definition/task/state/validator.ts
@@ -124,16 +124,48 @@ export const validateTask = (
   return null;
 };
 
+const crossFieldErrors = (task: TaskDefinitionDto): ErrorObject[] => {
+  const result: ErrorObject[] = [];
+
+  const { timeoutSeconds, responseTimeoutSeconds } = task;
+
+  if (
+    typeof timeoutSeconds === "number" &&
+    typeof responseTimeoutSeconds === "number" &&
+    timeoutSeconds > 0 &&
+    responseTimeoutSeconds > timeoutSeconds
+  ) {
+    result.push({
+      instancePath: "/responseTimeoutSeconds",
+      schemaPath: "#/properties/responseTimeoutSeconds/maximum",
+      keyword: "maximum",
+      params: { comparison: "<=", limit: timeoutSeconds },
+      message: `Must be ≤ Timeout Seconds (${timeoutSeconds}).`,
+    });
+  }
+
+  return result;
+};
+
 export const validatingService = async (
   modifiedTaskDefinition: TaskDefinitionDto | TaskDefinitionDto[],
   isBulk: boolean,
 ) => {
   try {
-    const errors = validateTask(modifiedTaskDefinition, isBulk);
+    const schemaErrors = validateTask(modifiedTaskDefinition, isBulk);
+
+    const extra: ErrorObject[] = isBulk
+      ? (modifiedTaskDefinition as TaskDefinitionDto[]).flatMap(
+          crossFieldErrors,
+        )
+      : crossFieldErrors(modifiedTaskDefinition as TaskDefinitionDto);
+
+    const errors: ErrorObject[] | null =
+      schemaErrors || extra.length ? [...(schemaErrors ?? []), ...extra] : null;
 
     return {
       error: parseErrors(errors),
-      numberOfError: errors?.length || 0,
+      numberOfError: errors?.length ?? 0,
     };
   } catch (error: any) {
     const errorDetail = await getErrors(error as Response);

--- a/ui-next/src/pages/execution/Execution.tsx
+++ b/ui-next/src/pages/execution/Execution.tsx
@@ -351,6 +351,9 @@ export default function Execution() {
   ] = useExecutionMachine();
   const location = useLocation();
   const navigate = useNavigate();
+  const isAgentExecutionRoute = location.pathname.startsWith(
+    `${AGENT_EXECUTIONS_URL.BASE}/`,
+  );
 
   // Agent executions can be reached via a bookmarked/shared "/execution/:id"
   // link (or any other pre-existing entry point) rather than the Agents
@@ -620,9 +623,6 @@ export default function Execution() {
   };
 
   if (isNotFound) {
-    const isAgentExecutionRoute = location.pathname.startsWith(
-      `${AGENT_EXECUTIONS_URL.BASE}/`,
-    );
     return (
       <Box
         sx={{
@@ -743,7 +743,14 @@ export default function Execution() {
                 </Stack>
               }
               breadcrumbItems={[
-                { label: "Workflow Executions", to: "/executions" },
+                {
+                  label: isAgentExecutionRoute
+                    ? "Agent Executions"
+                    : "Workflow Executions",
+                  to: isAgentExecutionRoute
+                    ? AGENT_EXECUTIONS_URL.BASE
+                    : "/executions",
+                },
                 {
                   label: execution.workflowId || "",
                   to: "",

--- a/ui-next/src/utils/pluralizeResults.test.ts
+++ b/ui-next/src/utils/pluralizeResults.test.ts
@@ -15,17 +15,15 @@ describe("pluralizeResults", () => {
 
 describe("createTableTitle", () => {
   it("singularizes when a single row is shown", () => {
-    expect(createTableTitle({ filteredData: [1], data: [1] })).toBe(
-      "1 result",
-    );
+    expect(createTableTitle({ filteredData: [1], data: [1] })).toBe("1 result");
   });
 
   it("pluralizes and reports hidden rows when filtered", () => {
-    expect(
-      createTableTitle({ filteredData: [1], data: [1, 2, 3] }),
-    ).toBe("1 result (2 not shown)");
-    expect(
-      createTableTitle({ filteredData: [1, 2], data: [1, 2] }),
-    ).toBe("2 results");
+    expect(createTableTitle({ filteredData: [1], data: [1, 2, 3] })).toBe(
+      "1 result (2 not shown)",
+    );
+    expect(createTableTitle({ filteredData: [1, 2], data: [1, 2] })).toBe(
+      "2 results",
+    );
   });
 });

--- a/ui-next/src/utils/query.ts
+++ b/ui-next/src/utils/query.ts
@@ -499,10 +499,12 @@ export function useAgentNames(
     ...optionsOverride,
   });
 
-  return useMemo(
-    () => (data ? data.map((agent) => agent.name).filter(Boolean) : []),
-    [data],
-  );
+  return useMemo(() => {
+    if (!Array.isArray(data)) return [];
+    return Array.from(
+      new Set(data.map((agent) => agent.name).filter(Boolean)),
+    ).sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+  }, [data]);
 }
 
 export const useSharedQueryContext = (): {


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
- Rework agent executions Basic/Advanced search: combined search box, agent-name autocomplete (registered + recent runs), layout cleanup, and SQL Advanced form without a separate free-text field.
- Extract shared filter state (`useAgentSearchFilters`) and pure query builders (`combinedSearchQuery`, `buildBasicSearchQuery`) with unit tests; keep URL updates off the hot path while typing (local drafts for Basic search + Advanced SQL).
- Full execution ID (UUID) search uses exact `workflowId=`; partial IDs are not supported (Orkes/ES quotes wildcards literally). Execution-id lookups skip date/status/agent filters and `classifier` so matches are not AND’d away.
- Also: agent execution breadcrumb points back to Agent Executions; task definition validator enforces `responseTimeoutSeconds ≤ timeoutSeconds`.

Fixes https://github.com/conductor-oss/conductor/issues/1315

Relevant tickets: 
- https://github.com/orkes-io/conductor-ui/issues/4303
- https://github.com/orkes-io/conductor-ui/issues/4256

https://www.loom.com/share/2ae63884e3f1424e8b53d4cc3c7e04f1