### PR TITLE
Fix #1321: reserve the task queue message before a blocking annotated-task invocation

### DIFF
--- a/core/src/main/java/org/conductoross/conductor/core/execution/tasks/annotated/AnnotatedWorkflowSystemTask.java
+++ b/core/src/main/java/org/conductoross/conductor/core/execution/tasks/annotated/AnnotatedWorkflowSystemTask.java
@@ -21,6 +21,8 @@ import org.conductoross.conductor.core.execution.tasks.TaskCancellationHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskResult;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
+import com.netflix.conductor.core.utils.QueueUtils;
+import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
 import com.netflix.conductor.sdk.workflow.executor.task.NonRetryableException;
@@ -49,21 +51,35 @@ public class AnnotatedWorkflowSystemTask extends WorkflowSystemTask {
     private final AnnotatedMethodResultMapper resultMapper;
 
     /**
+     * Queue used to reserve (postpone) the task's own message before a blocking invocation. May be
+     * null in unit tests that exercise the invocation directly; when null the reserve is skipped.
+     */
+    private final QueueDAO queueDAO;
+
+    /**
      * Creates a new AnnotatedWorkflowSystemTask.
      *
      * @param taskType The task type name
      * @param method The annotated method to invoke
      * @param bean The Spring bean instance containing the method
      * @param annotation The @WorkerTask annotation metadata
+     * @param queueDAO Queue used to reserve the task's message before a blocking call
      */
     public AnnotatedWorkflowSystemTask(
-            String taskType, Method method, Object bean, WorkerTask annotation) {
+            String taskType, Method method, Object bean, WorkerTask annotation, QueueDAO queueDAO) {
         super(taskType);
         this.method = method;
         this.bean = bean;
         this.annotation = annotation;
+        this.queueDAO = queueDAO;
         this.parameterMapper = new AnnotatedMethodParameterMapper();
         this.resultMapper = new AnnotatedMethodResultMapper();
+    }
+
+    /** Convenience constructor without a queue (test use); the reserve step is skipped. */
+    public AnnotatedWorkflowSystemTask(
+            String taskType, Method method, Object bean, WorkerTask annotation) {
+        this(taskType, method, bean, annotation, null);
     }
 
     @Override
@@ -72,6 +88,21 @@ public class AnnotatedWorkflowSystemTask extends WorkflowSystemTask {
         return true;
     }
 
+    /**
+     * Postpone applied to the task's queue message while a blocking invocation is in flight, when
+     * the task carries no response timeout. Doubles as the crash-recovery redelivery delay.
+     */
+    static final long DEFAULT_IN_FLIGHT_POSTPONE_SECONDS = 3600;
+
+    /**
+     * start() and execute() do the same thing: reserve the task's queue message, then invoke the
+     * annotated method. The annotated method runs synchronously and can block for minutes (e.g. an
+     * LLM provider call); reserving first keeps the message present and invisible for the duration
+     * of the call, so the sweeper's repair check does not re-push it and a mid-call redelivery
+     * cannot hand the same task to a second worker (issue #1321). Long-running workers (LLM/A2A)
+     * that return IN_PROGRESS + callbackAfterSeconds set their own re-invocation cadence, which the
+     * engine's post-execution postpone then honors.
+     */
     @Override
     public void start(WorkflowModel workflow, TaskModel task, WorkflowExecutor workflowExecutor) {
         execute(workflow, task, workflowExecutor);
@@ -80,6 +111,32 @@ public class AnnotatedWorkflowSystemTask extends WorkflowSystemTask {
     @Override
     public boolean execute(
             WorkflowModel workflow, TaskModel task, WorkflowExecutor workflowExecutor) {
+        reserveQueueMessage(task);
+        return invokeWorker(workflow, task);
+    }
+
+    /**
+     * Postpone the task's own queue message out past the blocking call, directly on the queue.
+     * Postponing the message (not touching callbackAfterSeconds) keeps it present so the sweeper's
+     * repair check leaves it alone, without inflating the response-timeout budget the way routing
+     * through {@code updateTask(callbackAfterSeconds=responseTimeout)} would.
+     */
+    private void reserveQueueMessage(TaskModel task) {
+        if (queueDAO == null) {
+            return;
+        }
+        long postpone =
+                task.getResponseTimeoutSeconds() > 0
+                        ? task.getResponseTimeoutSeconds()
+                        : DEFAULT_IN_FLIGHT_POSTPONE_SECONDS;
+        queueDAO.postpone(
+                QueueUtils.getQueueName(task),
+                task.getTaskId(),
+                task.getWorkflowPriority(),
+                postpone);
+    }
+
+    private boolean invokeWorker(WorkflowModel workflow, TaskModel task) {
         TaskContext taskContext = TaskContext.set(task.toTask());
         // A plain annotated-worker return value is terminal by default. Long-running workers can
         // override this execution state through their TaskContext without leaking TaskResult into

--- a/core/src/main/java/org/conductoross/conductor/core/execution/tasks/annotated/WorkerTaskAnnotationScanner.java
+++ b/core/src/main/java/org/conductoross/conductor/core/execution/tasks/annotated/WorkerTaskAnnotationScanner.java
@@ -33,6 +33,7 @@ import com.netflix.conductor.core.execution.tasks.SystemTaskRegistry;
 import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
 import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.sdk.workflow.task.WorkerTask;
 
 /**
@@ -49,17 +50,20 @@ public class WorkerTaskAnnotationScanner implements InitializingBean {
     private final Map<String, TaskMapper> taskMappers = new HashMap<>();
     private final ParametersUtils parametersUtils;
     private final MetadataDAO metadataDAO;
+    private final QueueDAO queueDAO;
 
     public WorkerTaskAnnotationScanner(
             List<AnnotatedSystemTaskWorker> annotatedSystemTaskWorkers,
             @Qualifier(SystemTaskRegistry.ASYNC_SYSTEM_TASKS_QUALIFIER)
                     Set<WorkflowSystemTask> asyncSystemTasks,
             @Lazy ParametersUtils parametersUtils,
-            @Lazy MetadataDAO metadataDAO) {
+            @Lazy MetadataDAO metadataDAO,
+            @Lazy QueueDAO queueDAO) {
         this.annotatedSystemTaskWorkers = annotatedSystemTaskWorkers;
         this.asyncSystemTasks = asyncSystemTasks;
         this.parametersUtils = parametersUtils;
         this.metadataDAO = metadataDAO;
+        this.queueDAO = queueDAO;
     }
 
     /**
@@ -94,7 +98,8 @@ public class WorkerTaskAnnotationScanner implements InitializingBean {
                                 taskType);
 
                         AnnotatedWorkflowSystemTask task =
-                                new AnnotatedWorkflowSystemTask(taskType, method, bean, annotation);
+                                new AnnotatedWorkflowSystemTask(
+                                        taskType, method, bean, annotation, queueDAO);
 
                         // Add to existing asyncSystemTasks collection
                         asyncSystemTasks.add(task);

--- a/core/src/test/java/org/conductoross/conductor/core/execution/tasks/annotated/TestAnnotatedSystemTaskIntegration.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/tasks/annotated/TestAnnotatedSystemTaskIntegration.java
@@ -91,7 +91,11 @@ public class TestAnnotatedSystemTaskIntegration {
                 ParametersUtils parametersUtils,
                 MetadataDAO metadataDAO) {
             return new WorkerTaskAnnotationScanner(
-                    workers, asyncSystemTasks, parametersUtils, metadataDAO);
+                    workers,
+                    asyncSystemTasks,
+                    parametersUtils,
+                    metadataDAO,
+                    mock(com.netflix.conductor.dao.QueueDAO.class));
         }
     }
 

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.test.integration
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+
+import com.netflix.conductor.common.metadata.tasks.Task
+import com.netflix.conductor.common.metadata.tasks.TaskDef
+import com.netflix.conductor.common.run.Workflow
+import com.netflix.conductor.core.execution.tasks.SystemTaskRegistry
+import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask
+import com.netflix.conductor.dao.QueueDAO
+import com.netflix.conductor.test.base.AbstractSpecification
+import com.netflix.conductor.test.utils.ControllableWorker
+
+/**
+ * REPRODUCES ISSUE #1321 - Async system tasks running longer than the queue unack window are
+ * executed twice.
+ *
+ * <p>The fix: before invoking, the adapter reserves the task's own queue message — postponing it
+ * out to responseTimeout via WorkflowExecutor.updateTask — so it stays present and invisible for
+ * the duration of the call and is not redelivered mid-invocation.
+ *
+ * <p>Drives the real path (WorkerTaskAnnotationScanner, SystemTaskRegistry, AsyncSystemTaskExecutor,
+ * real queue) and asserts the underlying operation is invoked EXACTLY ONCE.
+ */
+class Issue1321DuplicateAsyncSystemTaskSpec extends AbstractSpecification {
+
+    @Autowired
+    QueueDAO queueDAO
+
+    @Autowired
+    ControllableWorker controllableWorker
+
+    // The same collection SystemTaskWorkerCoordinator polls in production; the annotation
+    // scanner adds the AnnotatedWorkflowSystemTask adapters to it.
+    @Autowired
+    @Qualifier(SystemTaskRegistry.ASYNC_SYSTEM_TASKS_QUALIFIER)
+    Set<WorkflowSystemTask> asyncSystemTasks
+
+    static final String WF = 'controllable_async_system_task_wf'
+    static final String QUEUE = ControllableWorker.TASK_TYPE
+    static final int RESPONSE_TIMEOUT_SECONDS = 45
+
+    def setup() {
+        controllableWorker.reset()
+        registerControllableTaskDef()
+        workflowTestUtil.registerWorkflows('controllable_async_system_task_workflow.json')
+    }
+
+    private void registerControllableTaskDef() {
+        if (workflowTestUtil.getPersistedTaskDefinition('controllable_task').isEmpty()) {
+            TaskDef taskDef = new TaskDef()
+            taskDef.name = 'controllable_task'
+            taskDef.ownerEmail = 'test@harness.com'
+            taskDef.responseTimeoutSeconds = RESPONSE_TIMEOUT_SECONDS
+            taskDef.timeoutSeconds = 3600
+            taskDef.retryCount = 0
+            metadataService.registerTaskDef([taskDef])
+        }
+    }
+
+    private List<String> popWithRetry(int maxWaitMs) {
+        long deadline = System.currentTimeMillis() + maxWaitMs
+        while (System.currentTimeMillis() < deadline) {
+            List<String> ids = queueDAO.pop(QUEUE, 1, 300)
+            if (ids != null && !ids.isEmpty()) {
+                return ids
+            }
+        }
+        return []
+    }
+
+    def "annotated async system task that outlasts the unack window must execute exactly once"() {
+        given: "the real adapter registered for the annotated worker by the annotation scanner"
+        WorkflowSystemTask adapter = asyncSystemTasks.find { it.taskType == QUEUE }
+        assert adapter != null
+
+        and: "the controllable worker is armed to block during its invocation"
+        controllableWorker.enteredRun = new CountDownLatch(1)
+        controllableWorker.release = new CountDownLatch(1)
+
+        when: "the workflow is started"
+        def workflowId = startWorkflow(WF, 1, 'issue1321_' + UUID.randomUUID(), [:], null)
+        def startedWf = workflowExecutionService.getExecutionStatus(workflowId, true)
+
+        then: "the async system task is SCHEDULED and queued"
+        startedWf.status == Workflow.WorkflowStatus.RUNNING
+        startedWf.tasks.size() == 1
+        startedWf.tasks[0].taskType == QUEUE
+        startedWf.tasks[0].status == Task.Status.SCHEDULED
+
+        when: "worker #1 pops and executes (reserve + invoke); the method blocks"
+        def taskId = startedWf.tasks[0].taskId
+        List<String> polled1 = popWithRetry(3000)
+        assert polled1 == [taskId]
+        // compress the visibility window; the fix's reserve (postpone to responseTimeout) overrides it
+        queueDAO.setUnackTimeout(QUEUE, taskId, 1000L)
+        Thread worker1 = new Thread({ asyncSystemTaskExecutor.execute(adapter, taskId) })
+        worker1.setDaemon(true)
+        worker1.start()
+        assert controllableWorker.enteredRun.await(10, TimeUnit.SECONDS)
+
+        and: "the compressed window elapses and a second worker polls (redelivery attempt)"
+        Thread.sleep(1500)
+        List<String> polled2 = popWithRetry(3000)
+        if (!polled2.isEmpty()) {
+            asyncSystemTaskExecutor.execute(adapter, polled2[0]) // pre-fix: duplicate invocation
+        }
+
+        then: "the underlying operation was invoked EXACTLY ONCE"
+        controllableWorker.invocations.get() == 1
+
+        cleanup:
+        controllableWorker.release?.countDown()
+        worker1?.join(5000)
+    }
+}

--- a/test-harness/src/test/java/com/netflix/conductor/test/utils/ControllableWorker.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/utils/ControllableWorker.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.test.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.conductoross.conductor.core.execution.tasks.AnnotatedSystemTaskWorker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.netflix.conductor.sdk.workflow.task.WorkerTask;
+
+/**
+ * A test-only annotated system-task worker whose {@link #run} blocks under external control (via
+ * latches) and counts how many times it is invoked. It stands in for a long-running provider call
+ * (e.g. an agent-loop LLM_CHAT_COMPLETE turn) and is registered through the real
+ * WorkerTaskAnnotationScanner / AnnotatedWorkflowSystemTask production path, reproducing the
+ * mechanism behind issue #1321 (async system task running longer than the queue unack window
+ * executed twice).
+ */
+@Component
+public class ControllableWorker implements AnnotatedSystemTaskWorker {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ControllableWorker.class);
+
+    public static final String TASK_TYPE = "CONTROLLABLE_SYS_TASK";
+
+    /** Total number of times {@link #run} has been entered since the last {@link #reset}. */
+    public final AtomicInteger invocations = new AtomicInteger(0);
+
+    /** Counted down each time a {@link #run} invocation is entered (before it blocks). */
+    public volatile CountDownLatch enteredRun;
+
+    /** Every {@link #run} invocation blocks on this latch, simulating the provider call. */
+    public volatile CountDownLatch release;
+
+    /** Reset all control state; call from a spec's setup() before driving a scenario. */
+    public void reset() {
+        invocations.set(0);
+        enteredRun = null;
+        release = null;
+    }
+
+    @WorkerTask(TASK_TYPE)
+    public Map<String, Object> run() throws InterruptedException {
+        int attempt = invocations.incrementAndGet();
+        LOGGER.info("ControllableWorker.run invocation #{}", attempt);
+        if (enteredRun != null) {
+            enteredRun.countDown();
+        }
+        if (release != null) {
+            // Bounded to keep the test fast even if something goes wrong.
+            release.await(30, TimeUnit.SECONDS);
+        }
+        Map<String, Object> output = new HashMap<>();
+        output.put("attempt", attempt);
+        return output;
+    }
+}

--- a/test-harness/src/test/resources/controllable_async_system_task_workflow.json
+++ b/test-harness/src/test/resources/controllable_async_system_task_workflow.json
@@ -1,0 +1,26 @@
+{
+  "name": "controllable_async_system_task_wf",
+  "description": "workflow with a single controllable async system task (issues #1321/#1322)",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "controllable_task",
+      "taskReferenceName": "controllable_ref",
+      "inputParameters": {},
+      "type": "CONTROLLABLE_SYS_TASK",
+      "startDelay": 0,
+      "optional": false,
+      "asyncComplete": false
+    }
+  ],
+  "inputParameters": [],
+  "outputParameters": {
+    "taskOutput": "${controllable_ref.output.attempt}"
+  },
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false,
+  "timeoutPolicy": "ALERT_ONLY",
+  "timeoutSeconds": 0,
+  "ownerEmail": "test@harness.com"
+}


### PR DESCRIPTION
Fixes #1321.

## Problem
An annotated `@WorkerTask` system task (`LLM_CHAT_COMPLETE`, etc.) runs a blocking provider call synchronously. While it blocks, the task's queue message is absent, so the always-on `WorkflowSweeper` repair pass finds the still-running task's message "missing" and re-pushes it — a second `system-task-worker` runs the same task again → a duplicate paid provider call.

## Fix
`AnnotatedWorkflowSystemTask.start()`/`execute()` reserve the task's own queue message before invoking: postpone it out to `responseTimeout` (3600s default) **directly via `queueDAO.postpone`**, then invoke. The message stays present (so the sweeper's repair check leaves it alone) and invisible for the duration of the call, so it isn't redelivered mid-invocation.

Postponing on the queue — rather than routing through `updateTask(callbackAfterSeconds = responseTimeout)` — avoids inflating the response-timeout watchdog budget (`responseTimeout + callbackAfterSeconds`); the redelivery window and the timeout budget stay at `responseTimeout` (1×). Long-running LLM/A2A workers that return `IN_PROGRESS + callbackAfterSeconds` keep their own re-invocation cadence via the engine's post-execution postpone. `QueueDAO` is injected into the adapter via `WorkerTaskAnnotationScanner`; `AsyncSystemTaskExecutor` is untouched.

## Test
`Issue1321DuplicateAsyncSystemTaskSpec` drives the real scanner/executor/queue and asserts the worker runs exactly once when it outlasts a compressed redelivery window. A2A + existing annotated unit tests pass unchanged.

## Known limitation
There is a small race between the poller's `ack` (`SystemTaskWorker` removes the message) and the adapter's reserve (re-adds it): if a sweep lands in that gap, it can repair-repush the still-`SCHEDULED` task and cause a duplicate. The window is the `runAsync` hop between ack and reserve (tiny when idle, larger under worker backlog). Fully closing it means extending the message's visibility at the poll/ack point (e.g. `setUnackTimeout(responseTimeout)` instead of removing) rather than re-adding it after — deliberately kept out of this PR to leave the shared poller untouched. Correctness also relies on `responseTimeout ≥ call duration` (a longer call redelivers and re-runs — bounded), and the call still blocks a worker thread (#1204, separate). Same core mechanism as #1349, confined to the adapter.
