### PR TITLE
Fix #1321: reserve an async system task's queue message while it runs

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -155,12 +155,15 @@ public class AsyncSystemTaskExecutor {
 
             boolean scheduled = task.getStatus() == TaskModel.Status.SCHEDULED;
             if (scheduled || task.getStatus() == TaskModel.Status.IN_PROGRESS) {
-                if (hasExceededResponseTimeout(task)) {
-                    // The message was redelivered while a previous invocation is still in flight
-                    // past responseTimeout. Do NOT run it again in parallel (issue #1321): the task
-                    // has exceeded its allowed time, so time it out and let the retry/timeout
-                    // policy
-                    // decide (retry as a new attempt, or fail). The finally block below removes the
+                if (scheduled && hasExceededResponseTimeout(task)) {
+                    // A blocking task's start() runs synchronously and never moves the task to
+                    // IN_PROGRESS, so it stays SCHEDULED for its whole run. If the message is
+                    // redelivered (reservation lapsed) while that run is still in flight past
+                    // responseTimeout, do NOT run it again in parallel (issue #1321): time it out
+                    // and let the retry/timeout policy decide. Only SCHEDULED is handled here;
+                    // IN_PROGRESS response-timeouts are owned by DeciderService.isResponseTimedOut
+                    // (invoked from decide()), which uses responseTimeout + callbackAfterSeconds and
+                    // so must not be duplicated/pre-empted here. The finally block removes the
                     // message and re-evaluates the workflow.
                     task.setStatus(TaskModel.Status.TIMED_OUT);
                     task.setReasonForIncompletion(
@@ -276,10 +279,10 @@ public class AsyncSystemTaskExecutor {
     /**
      * True if the task has already started (startTime set) and has not been updated within its
      * responseTimeout — i.e. a redelivered message belongs to a run that overran its allowed time
-     * and should be timed out rather than re-executed. Uses updateTime (time since the last
-     * response), so a worker that keeps checking in within responseTimeout (long-running LLM/A2A
-     * callbacks) is not timed out. Requires updateTime > 0: a just-scheduled task whose mapper set
-     * startTime (e.g. JOIN) has updateTime == 0 and must not be treated as overrun.
+     * and should be timed out rather than re-executed. Only meaningful for a SCHEDULED task (a
+     * blocking start() that never returned); the caller gates on that. Requires updateTime > 0: a
+     * just-scheduled task whose mapper set startTime (e.g. JOIN) has updateTime == 0 and must not be
+     * treated as overrun.
      */
     private boolean hasExceededResponseTimeout(TaskModel task) {
         return task.getStartTime() > 0

--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -274,14 +274,16 @@ public class AsyncSystemTaskExecutor {
     }
 
     /**
-     * True if the task has already started (startTime set, persisted on the first execution) and
-     * has not been updated within its responseTimeout — i.e. a redelivered message belongs to a run
-     * that overran its allowed time and should be timed out rather than re-executed. Uses
-     * updateTime (time since the last response), so a worker that keeps checking in within
-     * responseTimeout (long-running LLM/A2A callbacks) is not timed out.
+     * True if the task has already started (startTime set) and has not been updated within its
+     * responseTimeout — i.e. a redelivered message belongs to a run that overran its allowed time
+     * and should be timed out rather than re-executed. Uses updateTime (time since the last
+     * response), so a worker that keeps checking in within responseTimeout (long-running LLM/A2A
+     * callbacks) is not timed out. Requires updateTime > 0: a just-scheduled task whose mapper set
+     * startTime (e.g. JOIN) has updateTime == 0 and must not be treated as overrun.
      */
     private boolean hasExceededResponseTimeout(TaskModel task) {
         return task.getStartTime() > 0
+                && task.getUpdateTime() > 0
                 && (System.currentTimeMillis() - task.getUpdateTime())
                         >= effectiveResponseTimeoutSeconds(task) * 1000L;
     }

--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.core.config.ConductorProperties;
 import com.netflix.conductor.core.dal.ExecutionDAOFacade;
 import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
@@ -152,28 +153,55 @@ public class AsyncSystemTaskExecutor {
                 task.incrementPollCount();
             }
 
-            if (task.getStatus() == TaskModel.Status.SCHEDULED
-                    || task.getStatus() == TaskModel.Status.IN_PROGRESS) {
-                Map<String, Object> literalInput = task.getInputData();
-                // Secrets substitution only sees task.getInputData(); when input has been
-                // offloaded to external payload storage, getInputData()/setInputData() operate on
-                // a different field and this substitution silently becomes a no-op.
-                if (task.getExternalInputPayloadStoragePath() != null) {
-                    LOGGER.warn(
-                            "Task {} has externalized input; ${{workflow.secrets.*}} references are not resolved for external payload storage",
+            boolean scheduled = task.getStatus() == TaskModel.Status.SCHEDULED;
+            if (scheduled || task.getStatus() == TaskModel.Status.IN_PROGRESS) {
+                if (hasExceededResponseTimeout(task)) {
+                    // The message was redelivered while a previous invocation is still in flight
+                    // past responseTimeout. Do NOT run it again in parallel (issue #1321): the task
+                    // has exceeded its allowed time, so time it out and let the retry/timeout
+                    // policy
+                    // decide (retry as a new attempt, or fail). The finally block below removes the
+                    // message and re-evaluates the workflow.
+                    task.setStatus(TaskModel.Status.TIMED_OUT);
+                    task.setReasonForIncompletion(
+                            "Task did not complete within its responseTimeout of "
+                                    + effectiveResponseTimeoutSeconds(task)
+                                    + "s");
+                    LOGGER.info(
+                            "Timing out {}/{}: no response within responseTimeout",
+                            task.getTaskType(),
                             task.getTaskId());
-                }
-                task.setInputData(parametersUtils.substituteSecrets(literalInput));
-                try {
-                    if (task.getStatus() == TaskModel.Status.SCHEDULED) {
-                        task.setStartTime(System.currentTimeMillis());
-                        Monitors.recordQueueWaitTime(task.getTaskType(), task.getQueueWaitTime());
-                        systemTask.start(workflow, task, workflowExecutor);
-                    } else {
-                        systemTask.execute(workflow, task, workflowExecutor);
+                } else {
+                    // Keep the message present but invisible for the run so it is not redelivered
+                    // and the sweeper's repair does not re-queue this running task (issue #1321).
+                    reserveInflightMessage(queueName, task);
+                    Map<String, Object> literalInput = task.getInputData();
+                    // Secrets substitution only sees task.getInputData(); when input has been
+                    // offloaded to external payload storage, getInputData()/setInputData() operate
+                    // on a different field and this substitution silently becomes a no-op.
+                    if (task.getExternalInputPayloadStoragePath() != null) {
+                        LOGGER.warn(
+                                "Task {} has externalized input; ${{workflow.secrets.*}} references are not resolved for external payload storage",
+                                task.getTaskId());
                     }
-                } finally {
-                    task.setInputData(literalInput);
+                    task.setInputData(parametersUtils.substituteSecrets(literalInput));
+                    try {
+                        if (scheduled) {
+                            task.setStartTime(System.currentTimeMillis());
+                            // Persist startTime before invoking (status is left unchanged so a
+                            // system task whose start() branches on SCHEDULED still works) so a
+                            // redelivery can tell the task has already started and time it out if
+                            // it outlives responseTimeout instead of blindly executing it again.
+                            executionDAOFacade.updateTask(task);
+                            Monitors.recordQueueWaitTime(
+                                    task.getTaskType(), task.getQueueWaitTime());
+                            systemTask.start(workflow, task, workflowExecutor);
+                        } else {
+                            systemTask.execute(workflow, task, workflowExecutor);
+                        }
+                    } finally {
+                        task.setInputData(literalInput);
+                    }
                 }
             }
 
@@ -219,6 +247,43 @@ public class AsyncSystemTaskExecutor {
                 workflowExecutor.decide(workflowId);
             }
         }
+    }
+
+    /**
+     * Extend the task's queue message visibility to cover the invocation (issue #1321), using its
+     * {@code responseTimeoutSeconds} or the default {@link TaskDef#ONE_HOUR} when unset.
+     */
+    private void reserveInflightMessage(String queueName, TaskModel task) {
+        try {
+            queueDAO.setUnackTimeout(
+                    queueName, task.getTaskId(), effectiveResponseTimeoutSeconds(task) * 1000L);
+        } catch (Exception e) {
+            LOGGER.error(
+                    "Error reserving in-flight message for task: {} in queue: {}",
+                    task.getTaskId(),
+                    queueName,
+                    e);
+        }
+    }
+
+    /** The task's {@code responseTimeoutSeconds}, or the default {@link TaskDef#ONE_HOUR}. */
+    private long effectiveResponseTimeoutSeconds(TaskModel task) {
+        return task.getResponseTimeoutSeconds() > 0
+                ? task.getResponseTimeoutSeconds()
+                : TaskDef.ONE_HOUR;
+    }
+
+    /**
+     * True if the task has already started (startTime set, persisted on the first execution) and
+     * has not been updated within its responseTimeout — i.e. a redelivered message belongs to a run
+     * that overran its allowed time and should be timed out rather than re-executed. Uses
+     * updateTime (time since the last response), so a worker that keeps checking in within
+     * responseTimeout (long-running LLM/A2A callbacks) is not timed out.
+     */
+    private boolean hasExceededResponseTimeout(TaskModel task) {
+        return task.getStartTime() > 0
+                && (System.currentTimeMillis() - task.getUpdateTime())
+                        >= effectiveResponseTimeoutSeconds(task) * 1000L;
     }
 
     private void postponeQuietly(String queueName, TaskModel task) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -172,8 +172,16 @@ public class AsyncSystemTaskExecutor {
                             task.getTaskId());
                 } else {
                     // Keep the message present but invisible for the run so repair can't re-queue
-                    // this running task (#1321).
-                    reserveInflightMessage(queueName, task);
+                    // this running task (#1321). If the reserve fails, the message stays leased at
+                    // the queue's default unack timeout and would redeliver and run in parallel, so
+                    // don't start it: leave the still-SCHEDULED message to redeliver and retry.
+                    if (!reserveInflightMessage(queueName, task)) {
+                        LOGGER.warn(
+                                "Could not reserve in-flight message for {}/{}; skipping execution, will retry on redelivery",
+                                task.getTaskType(),
+                                task.getTaskId());
+                        return;
+                    }
                     Map<String, Object> literalInput = task.getInputData();
                     // Secrets substitution only sees task.getInputData(); when input has been
                     // offloaded to external payload storage, getInputData()/setInputData() operate
@@ -247,19 +255,25 @@ public class AsyncSystemTaskExecutor {
     }
 
     /**
-     * Extend the task's queue message visibility to cover the invocation (issue #1321), using its
-     * {@code responseTimeoutSeconds} or the default {@link TaskDef#ONE_HOUR} when unset.
+     * Extend the popped message's unack lease so it stays reserved (unacked, not redelivered) for
+     * the duration of the invocation (issue #1321), using the task's {@code responseTimeoutSeconds}
+     * or the default {@link TaskDef#ONE_HOUR} when unset. Returns {@code false} if the reserve
+     * failed, in which case the caller must not start the task: the message is still leased at only
+     * the queue's default unack timeout and would otherwise redeliver and run a second time in
+     * parallel.
      */
-    private void reserveInflightMessage(String queueName, TaskModel task) {
+    private boolean reserveInflightMessage(String queueName, TaskModel task) {
         try {
             queueDAO.setUnackTimeout(
                     queueName, task.getTaskId(), effectiveResponseTimeoutSeconds(task) * 1000L);
+            return true;
         } catch (Exception e) {
             LOGGER.error(
                     "Error reserving in-flight message for task: {} in queue: {}",
                     task.getTaskId(),
                     queueName,
                     e);
+            return false;
         }
     }
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -156,15 +156,11 @@ public class AsyncSystemTaskExecutor {
             boolean scheduled = task.getStatus() == TaskModel.Status.SCHEDULED;
             if (scheduled || task.getStatus() == TaskModel.Status.IN_PROGRESS) {
                 if (scheduled && hasExceededResponseTimeout(task)) {
-                    // A blocking task's start() runs synchronously and never moves the task to
-                    // IN_PROGRESS, so it stays SCHEDULED for its whole run. If the message is
-                    // redelivered (reservation lapsed) while that run is still in flight past
-                    // responseTimeout, do NOT run it again in parallel (issue #1321): time it out
-                    // and let the retry/timeout policy decide. Only SCHEDULED is handled here;
-                    // IN_PROGRESS response-timeouts are owned by DeciderService.isResponseTimedOut
-                    // (invoked from decide()), which uses responseTimeout + callbackAfterSeconds and
-                    // so must not be duplicated/pre-empted here. The finally block removes the
-                    // message and re-evaluates the workflow.
+                    // A blocking start() never leaves SCHEDULED, so a redelivered SCHEDULED task
+                    // past responseTimeout means its run overran: time it out, don't re-run it
+                    // (#1321). IN_PROGRESS response-timeouts are
+                    // DeciderService.isResponseTimedOut's
+                    // job (it budgets responseTimeout + callbackAfterSeconds).
                     task.setStatus(TaskModel.Status.TIMED_OUT);
                     task.setReasonForIncompletion(
                             "Task did not complete within its responseTimeout of "
@@ -175,13 +171,12 @@ public class AsyncSystemTaskExecutor {
                             task.getTaskType(),
                             task.getTaskId());
                 } else {
-                    // Keep the message present but invisible for the run so it is not redelivered
-                    // and the sweeper's repair does not re-queue this running task (issue #1321).
+                    // Keep the message present but invisible for the run so repair can't re-queue
+                    // this running task (#1321).
                     reserveInflightMessage(queueName, task);
                     Map<String, Object> literalInput = task.getInputData();
-                    // Secrets substitution only sees task.getInputData(); when input has been
-                    // offloaded to external payload storage, getInputData()/setInputData() operate
-                    // on a different field and this substitution silently becomes a no-op.
+                    // Secrets substitution only sees getInputData(); with external payload storage
+                    // it operates on a different field and silently becomes a no-op.
                     if (task.getExternalInputPayloadStoragePath() != null) {
                         LOGGER.warn(
                                 "Task {} has externalized input; ${{workflow.secrets.*}} references are not resolved for external payload storage",
@@ -191,10 +186,8 @@ public class AsyncSystemTaskExecutor {
                     try {
                         if (scheduled) {
                             task.setStartTime(System.currentTimeMillis());
-                            // Persist startTime before invoking (status is left unchanged so a
-                            // system task whose start() branches on SCHEDULED still works) so a
-                            // redelivery can tell the task has already started and time it out if
-                            // it outlives responseTimeout instead of blindly executing it again.
+                            // Persist startTime before invoking so a redelivery can detect an
+                            // overrun (status left unchanged for start()'s SCHEDULED branch).
                             executionDAOFacade.updateTask(task);
                             Monitors.recordQueueWaitTime(
                                     task.getTaskType(), task.getQueueWaitTime());
@@ -281,8 +274,8 @@ public class AsyncSystemTaskExecutor {
      * responseTimeout — i.e. a redelivered message belongs to a run that overran its allowed time
      * and should be timed out rather than re-executed. Only meaningful for a SCHEDULED task (a
      * blocking start() that never returned); the caller gates on that. Requires updateTime > 0: a
-     * just-scheduled task whose mapper set startTime (e.g. JOIN) has updateTime == 0 and must not be
-     * treated as overrun.
+     * just-scheduled task whose mapper set startTime (e.g. JOIN) has updateTime == 0 and must not
+     * be treated as overrun.
      */
     private boolean hasExceededResponseTimeout(TaskModel task) {
         return task.getStartTime() > 0

--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -175,8 +175,9 @@ public class AsyncSystemTaskExecutor {
                     // this running task (#1321).
                     reserveInflightMessage(queueName, task);
                     Map<String, Object> literalInput = task.getInputData();
-                    // Secrets substitution only sees getInputData(); with external payload storage
-                    // it operates on a different field and silently becomes a no-op.
+                    // Secrets substitution only sees task.getInputData(); when input has been
+                    // offloaded to external payload storage, getInputData()/setInputData() operate
+                    // on a different field and this substitution silently becomes a no-op.
                     if (task.getExternalInputPayloadStoragePath() != null) {
                         LOGGER.warn(
                                 "Task {} has externalized input; ${{workflow.secrets.*}} references are not resolved for external payload storage",

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorker.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorker.java
@@ -33,7 +33,6 @@ import com.netflix.conductor.core.utils.QueueUtils;
 import com.netflix.conductor.core.utils.SemaphoreUtil;
 import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.metrics.Monitors;
-import com.netflix.conductor.service.ExecutionService;
 
 /** The worker that polls and executes an async system task. */
 @Component
@@ -51,7 +50,6 @@ public class SystemTaskWorker extends LifecycleAwareComponent {
     ExecutionConfig defaultExecutionConfig;
     private final AsyncSystemTaskExecutor asyncSystemTaskExecutor;
     private final ConductorProperties properties;
-    private final ExecutionService executionService;
     private final int queuePopTimeout;
 
     ConcurrentHashMap<String, ExecutionConfig> queueExecutionConfigMap = new ConcurrentHashMap<>();
@@ -59,15 +57,13 @@ public class SystemTaskWorker extends LifecycleAwareComponent {
     public SystemTaskWorker(
             QueueDAO queueDAO,
             AsyncSystemTaskExecutor asyncSystemTaskExecutor,
-            ConductorProperties properties,
-            ExecutionService executionService) {
+            ConductorProperties properties) {
         this.properties = properties;
         int threadCount = properties.getSystemTaskWorkerThreadCount();
         this.defaultExecutionConfig = new ExecutionConfig(threadCount, "system-task-worker-%d");
         this.asyncSystemTaskExecutor = asyncSystemTaskExecutor;
         this.queueDAO = queueDAO;
         this.pollInterval = properties.getSystemTaskWorkerPollInterval().toMillis();
-        this.executionService = executionService;
         this.queuePopTimeout = (int) properties.getSystemTaskQueuePopTimeout().toMillis();
 
         LOGGER.info("SystemTaskWorker initialized with {} threads", threadCount);
@@ -141,8 +137,9 @@ public class SystemTaskWorker extends LifecycleAwareComponent {
                                 queueName);
                         Monitors.recordTaskPollCount(queueName, 1);
 
-                        executionService.ackTaskReceived(taskId);
-
+                        // Deliberately not acked here: a running task keeps its queue message so
+                        // the sweeper's repair does not re-queue it (issue #1321). The executor
+                        // extends its visibility before invoking and removes it on completion.
                         CompletableFuture<Void> taskCompletableFuture =
                                 CompletableFuture.runAsync(
                                         () -> asyncSystemTaskExecutor.execute(systemTask, taskId),

--- a/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
@@ -303,6 +303,34 @@ class AsyncSystemTaskExecutorTest extends Specification {
         1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.COMPLETED }
     }
 
+    def "Does not start the task when reserving the in-flight message fails"() {
+        given:
+        String workflowId = "workflowId"
+        String taskId = "taskId"
+        TaskModel task = new TaskModel(taskType: "type1", status: TaskModel.Status.SCHEDULED, taskId: taskId, workflowInstanceId: workflowId,
+                taskDefName: "taskDefName", workflowPriority: 10, responseTimeoutSeconds: 120)
+        WorkflowModel workflow = new WorkflowModel(workflowId: workflowId, status: WorkflowModel.Status.RUNNING)
+        String queueName = QueueUtils.getQueueName(task)
+
+        when:
+        executor.execute(workflowSystemTask, taskId)
+
+        then:
+        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
+        // the reserve fails (e.g. transient queue error); the message is still leased at the queue's
+        // default unack timeout, so starting the task would risk a parallel re-run on redelivery (#1321)
+        1 * queueDAO.setUnackTimeout(queueName, taskId, 120_000L) >> { throw new RuntimeException("queue unavailable") }
+        // so the task is NOT started and the message is left to redeliver and retry cleanly
+        0 * workflowSystemTask.start(*_)
+        0 * workflowSystemTask.execute(*_)
+        0 * queueDAO.postpone(*_)
+        0 * queueDAO.remove(*_)
+
+        task.status == TaskModel.Status.SCHEDULED
+        task.startTime == 0
+    }
+
     def "Times out a redelivered SCHEDULED task whose blocking start() outlived responseTimeout instead of re-executing it"() {
         given:
         String workflowId = "workflowId"

--- a/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
@@ -330,6 +330,28 @@ class AsyncSystemTaskExecutorTest extends Specification {
         task.status == TaskModel.Status.TIMED_OUT
     }
 
+    def "Does not time out a just-scheduled task whose mapper set startTime but has no updateTime (e.g. JOIN)"() {
+        given:
+        String workflowId = "workflowId"
+        String taskId = "taskId"
+        // JOIN's mapper sets startTime at scheduling; updateTime is still 0 (createTasks doesn't set it)
+        TaskModel task = new TaskModel(taskType: "type1", status: TaskModel.Status.SCHEDULED, taskId: taskId, workflowInstanceId: workflowId,
+                taskDefName: "taskDefName", workflowPriority: 10, responseTimeoutSeconds: 0, startTime: System.currentTimeMillis(), updateTime: 0)
+        WorkflowModel workflow = new WorkflowModel(workflowId: workflowId, status: WorkflowModel.Status.RUNNING)
+        String queueName = QueueUtils.getQueueName(task)
+
+        when:
+        executor.execute(workflowSystemTask, taskId)
+
+        then:
+        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
+        // it is reserved and started, NOT timed out
+        1 * queueDAO.setUnackTimeout(queueName, taskId, _)
+        1 * workflowSystemTask.start(workflow, task, _)
+        task.status != TaskModel.Status.TIMED_OUT
+    }
+
     def "Execute preserves a callback interval set by the system task"() {
         given:
         properties.systemTaskWorkerCallbackDuration = Duration.ofSeconds(30)

--- a/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
@@ -249,7 +249,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         then:
         1 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
-        1 * executionDAOFacade.updateTask(task)
+        2 * executionDAOFacade.updateTask(task) // startTime persist before start() + finally
         1 * queueDAO.postpone(queueName, taskId, task.workflowPriority, properties.systemTaskWorkerCallbackDuration.seconds)
         1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.IN_PROGRESS }
 
@@ -260,6 +260,74 @@ class AsyncSystemTaskExecutorTest extends Specification {
         task.endTime == 0 // verify that endTime is not set
         task.pollCount == 1 // verify that poll count is incremented
         task.callbackAfterSeconds == properties.systemTaskWorkerCallbackDuration.seconds
+    }
+
+    def "Reserves the in-flight message with responseTimeout before invoking the task"() {
+        given:
+        String workflowId = "workflowId"
+        String taskId = "taskId"
+        TaskModel task = new TaskModel(taskType: "type1", status: TaskModel.Status.SCHEDULED, taskId: taskId, workflowInstanceId: workflowId,
+                taskDefName: "taskDefName", workflowPriority: 10, responseTimeoutSeconds: 120)
+        WorkflowModel workflow = new WorkflowModel(workflowId: workflowId, status: WorkflowModel.Status.RUNNING)
+        String queueName = QueueUtils.getQueueName(task)
+
+        when:
+        executor.execute(workflowSystemTask, taskId)
+
+        then:
+        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
+        // the message is reserved for responseTimeout (120s) so a running task keeps its queue
+        // message and is not redelivered/re-queued mid-execution (issue #1321)
+        1 * queueDAO.setUnackTimeout(queueName, taskId, 120_000L)
+        1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.COMPLETED }
+    }
+
+    def "Reserves the in-flight message with the default responseTimeout when unset"() {
+        given:
+        String workflowId = "workflowId"
+        String taskId = "taskId"
+        TaskModel task = new TaskModel(taskType: "type1", status: TaskModel.Status.SCHEDULED, taskId: taskId, workflowInstanceId: workflowId,
+                taskDefName: "taskDefName", workflowPriority: 10, responseTimeoutSeconds: 0)
+        WorkflowModel workflow = new WorkflowModel(workflowId: workflowId, status: WorkflowModel.Status.RUNNING)
+        String queueName = QueueUtils.getQueueName(task)
+
+        when:
+        executor.execute(workflowSystemTask, taskId)
+
+        then:
+        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
+        // no responseTimeout set -> falls back to the default (TaskDef.ONE_HOUR = 3600s)
+        1 * queueDAO.setUnackTimeout(queueName, taskId, 3_600_000L)
+        1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.COMPLETED }
+    }
+
+    def "Times out a redelivered task that outlived responseTimeout instead of re-executing it"() {
+        given:
+        String workflowId = "workflowId"
+        String taskId = "taskId"
+        // already started, and not updated within responseTimeout (updateTime is 20s old, timeout 10s)
+        long stale = System.currentTimeMillis() - 20_000
+        TaskModel task = new TaskModel(taskType: "type1", status: TaskModel.Status.IN_PROGRESS, taskId: taskId, workflowInstanceId: workflowId,
+                taskDefName: "taskDefName", workflowPriority: 10, responseTimeoutSeconds: 10, startTime: stale, updateTime: stale)
+        WorkflowModel workflow = new WorkflowModel(workflowId: workflowId, status: WorkflowModel.Status.RUNNING)
+        String queueName = QueueUtils.getQueueName(task)
+
+        when:
+        executor.execute(workflowSystemTask, taskId)
+
+        then:
+        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
+        // the overrunning task is timed out, NOT invoked again (issue #1321)
+        0 * workflowSystemTask.start(*_)
+        0 * workflowSystemTask.execute(*_)
+        0 * queueDAO.setUnackTimeout(*_)
+        1 * queueDAO.remove(queueName, taskId)
+        1 * workflowExecutor.decide(workflowId)
+
+        task.status == TaskModel.Status.TIMED_OUT
     }
 
     def "Execute preserves a callback interval set by the system task"() {
@@ -289,7 +357,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
             Optional.of(task.callbackAfterSeconds)
         }
         1 * queueDAO.postpone(queueName, taskId, task.workflowPriority, 5)
-        1 * executionDAOFacade.updateTask(task)
+        2 * executionDAOFacade.updateTask(task) // startTime persist before start() + finally
 
         task.status == TaskModel.Status.IN_PROGRESS
         task.callbackAfterSeconds == 5
@@ -310,7 +378,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         then:
         1 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
-        1 * executionDAOFacade.updateTask(task)
+        2 * executionDAOFacade.updateTask(task) // startTime persist before start() + finally
 
         1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.COMPLETED }
         1 * queueDAO.remove(queueName, taskId)
@@ -336,7 +404,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         then:
         1 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
-        1 * executionDAOFacade.updateTask(task)
+        2 * executionDAOFacade.updateTask(task) // startTime persist before start() + finally
 
         // simulating a "start" failure that happens after the Task object is modified
         // the modification will be persisted
@@ -368,7 +436,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         then:
         1 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
-        1 * executionDAOFacade.updateTask(task) // 1st call for pollCount, 2nd call for status update
+        2 * executionDAOFacade.updateTask(task) // startTime persist before start() + finally
 
         1 * workflowSystemTask.isAsyncComplete(task) >> true
         1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.IN_PROGRESS }

--- a/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
@@ -303,13 +303,14 @@ class AsyncSystemTaskExecutorTest extends Specification {
         1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.COMPLETED }
     }
 
-    def "Times out a redelivered task that outlived responseTimeout instead of re-executing it"() {
+    def "Times out a redelivered SCHEDULED task whose blocking start() outlived responseTimeout instead of re-executing it"() {
         given:
         String workflowId = "workflowId"
         String taskId = "taskId"
-        // already started, and not updated within responseTimeout (updateTime is 20s old, timeout 10s)
+        // A blocking start() never moves the task off SCHEDULED; here it started but has not been
+        // updated within responseTimeout (updateTime is 20s old, timeout 10s) — the run overran.
         long stale = System.currentTimeMillis() - 20_000
-        TaskModel task = new TaskModel(taskType: "type1", status: TaskModel.Status.IN_PROGRESS, taskId: taskId, workflowInstanceId: workflowId,
+        TaskModel task = new TaskModel(taskType: "type1", status: TaskModel.Status.SCHEDULED, taskId: taskId, workflowInstanceId: workflowId,
                 taskDefName: "taskDefName", workflowPriority: 10, responseTimeoutSeconds: 10, startTime: stale, updateTime: stale)
         WorkflowModel workflow = new WorkflowModel(workflowId: workflowId, status: WorkflowModel.Status.RUNNING)
         String queueName = QueueUtils.getQueueName(task)
@@ -328,6 +329,34 @@ class AsyncSystemTaskExecutorTest extends Specification {
         1 * workflowExecutor.decide(workflowId)
 
         task.status == TaskModel.Status.TIMED_OUT
+    }
+
+    def "Does not time out an IN_PROGRESS task waiting for its callback even when the callback interval exceeds responseTimeout"() {
+        given:
+        String workflowId = "workflowId"
+        String taskId = "taskId"
+        // IN_PROGRESS task re-polled after its callback; the updateTime gap (40s) exceeds
+        // responseTimeout (10s). The executor must NOT time it out — IN_PROGRESS response-timeouts
+        // are owned by DeciderService.isResponseTimedOut, which budgets responseTimeout +
+        // callbackAfterSeconds. Timing out here would fire earlier than DeciderService whenever
+        // callbackAfterSeconds >= responseTimeout.
+        long stale = System.currentTimeMillis() - 40_000
+        TaskModel task = new TaskModel(taskType: "type1", status: TaskModel.Status.IN_PROGRESS, taskId: taskId, workflowInstanceId: workflowId,
+                taskDefName: "taskDefName", workflowPriority: 10, responseTimeoutSeconds: 10, startTime: stale, updateTime: stale)
+        WorkflowModel workflow = new WorkflowModel(workflowId: workflowId, status: WorkflowModel.Status.RUNNING)
+        String queueName = QueueUtils.getQueueName(task)
+
+        when:
+        executor.execute(workflowSystemTask, taskId)
+
+        then:
+        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
+        // reserved and executed (normal callback loop), NOT timed out
+        1 * queueDAO.setUnackTimeout(queueName, taskId, _)
+        1 * workflowSystemTask.execute(workflow, task, _)
+        0 * workflowSystemTask.start(*_)
+        task.status != TaskModel.Status.TIMED_OUT
     }
 
     def "Does not time out a just-scheduled task whose mapper set startTime but has no updateTime (e.g. JOIN)"() {

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskWorker.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskWorker.java
@@ -25,7 +25,6 @@ import org.mockito.Mockito;
 import com.netflix.conductor.core.config.ConductorProperties;
 import com.netflix.conductor.core.execution.AsyncSystemTaskExecutor;
 import com.netflix.conductor.dao.QueueDAO;
-import com.netflix.conductor.service.ExecutionService;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -43,7 +42,6 @@ public class TestSystemTaskWorker {
     private static final String ISOLATED_TASK = "system_task-isolated";
 
     private AsyncSystemTaskExecutor asyncSystemTaskExecutor;
-    private ExecutionService executionService;
     private QueueDAO queueDAO;
     private ConductorProperties properties;
 
@@ -52,7 +50,6 @@ public class TestSystemTaskWorker {
     @Before
     public void setUp() {
         asyncSystemTaskExecutor = mock(AsyncSystemTaskExecutor.class);
-        executionService = mock(ExecutionService.class);
         queueDAO = mock(QueueDAO.class);
         properties = mock(ConductorProperties.class);
 
@@ -61,9 +58,7 @@ public class TestSystemTaskWorker {
         when(properties.getSystemTaskWorkerCallbackDuration()).thenReturn(Duration.ofSeconds(30));
         when(properties.getSystemTaskWorkerPollInterval()).thenReturn(Duration.ofSeconds(30));
 
-        systemTaskWorker =
-                new SystemTaskWorker(
-                        queueDAO, asyncSystemTaskExecutor, properties, executionService);
+        systemTaskWorker = new SystemTaskWorker(queueDAO, asyncSystemTaskExecutor, properties);
         systemTaskWorker.start();
     }
 
@@ -76,9 +71,7 @@ public class TestSystemTaskWorker {
     @Test
     public void testGetExecutionConfigForSystemTask() {
         when(properties.getSystemTaskWorkerThreadCount()).thenReturn(5);
-        systemTaskWorker =
-                new SystemTaskWorker(
-                        queueDAO, asyncSystemTaskExecutor, properties, executionService);
+        systemTaskWorker = new SystemTaskWorker(queueDAO, asyncSystemTaskExecutor, properties);
         assertEquals(
                 systemTaskWorker.getExecutionConfig("").getSemaphoreUtil().availableSlots(), 5);
     }
@@ -86,9 +79,7 @@ public class TestSystemTaskWorker {
     @Test
     public void testGetExecutionConfigForIsolatedSystemTask() {
         when(properties.getIsolatedSystemTaskWorkerThreadCount()).thenReturn(7);
-        systemTaskWorker =
-                new SystemTaskWorker(
-                        queueDAO, asyncSystemTaskExecutor, properties, executionService);
+        systemTaskWorker = new SystemTaskWorker(queueDAO, asyncSystemTaskExecutor, properties);
         assertEquals(
                 systemTaskWorker.getExecutionConfig("test-iso").getSemaphoreUtil().availableSlots(),
                 7);
@@ -113,6 +104,9 @@ public class TestSystemTaskWorker {
         latch.await();
 
         verify(asyncSystemTaskExecutor).execute(any(), anyString());
+        // The poll must not remove the message (issue #1321) — the executor reserves it instead.
+        verify(queueDAO, Mockito.never()).ack(anyString(), anyString());
+        verify(queueDAO, Mockito.never()).remove(anyString(), anyString());
     }
 
     @Test

--- a/core/src/test/java/org/conductoross/conductor/core/execution/WorkflowSweeperTest.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/WorkflowSweeperTest.java
@@ -186,6 +186,37 @@ public class WorkflowSweeperTest {
         verify(executionLockService).releaseLock(WORKFLOW_ID);
     }
 
+    @Test
+    public void sweepDoesNotRepushInFlightAsyncSystemTaskWhenMessagePresent() {
+        // Core #1321 invariant: a running async system task keeps its queue message, so repair must
+        // leave it alone. Regression guard for the duplicate execution reported in #202 / #630 —
+        // before the poll-level-reserve fix the message was removed at poll and repair re-queued the
+        // in-flight task, running it a second time.
+        TaskModel httpTask =
+                newTask("http-task", TaskType.TASK_TYPE_HTTP, TaskModel.Status.IN_PROGRESS);
+        WorkflowModel workflow = newWorkflow(List.of(httpTask));
+
+        WorkflowSystemTask httpSystemTask = mock(WorkflowSystemTask.class);
+        when(executionLockService.acquireLock(WORKFLOW_ID)).thenReturn(true);
+        when(workflowExecutor.getWorkflow(WORKFLOW_ID, true)).thenReturn(workflow);
+        when(workflowExecutor.decide(WORKFLOW_ID)).thenReturn(workflow);
+        when(systemTaskRegistry.isSystemTask(TaskType.TASK_TYPE_HTTP)).thenReturn(true);
+        when(systemTaskRegistry.get(TaskType.TASK_TYPE_HTTP)).thenReturn(httpSystemTask);
+        when(httpSystemTask.isAsync()).thenReturn(true);
+        when(httpSystemTask.isAsyncComplete(httpTask)).thenReturn(false);
+        // the task is in flight and its message is still present (reserved by the executor)
+        when(queueDAO.containsMessage(TaskType.TASK_TYPE_HTTP, httpTask.getTaskId()))
+                .thenReturn(true);
+
+        workflowSweeper.sweep(WORKFLOW_ID);
+
+        // it was treated as repairable (containsMessage was queried) but, because the message is
+        // present, it was NOT re-queued — no second execution.
+        verify(queueDAO).containsMessage(TaskType.TASK_TYPE_HTTP, httpTask.getTaskId());
+        verify(queueDAO, never()).push(anyString(), anyString(), anyLong());
+        verify(executionLockService).releaseLock(WORKFLOW_ID);
+    }
+
     private WorkflowModel newWorkflow(List<TaskModel> tasks) {
         WorkflowModel workflowModel = new WorkflowModel();
         workflowModel.setWorkflowId(WORKFLOW_ID);

--- a/core/src/test/java/org/conductoross/conductor/core/execution/WorkflowSweeperTest.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/WorkflowSweeperTest.java
@@ -190,7 +190,8 @@ public class WorkflowSweeperTest {
     public void sweepDoesNotRepushInFlightAsyncSystemTaskWhenMessagePresent() {
         // Core #1321 invariant: a running async system task keeps its queue message, so repair must
         // leave it alone. Regression guard for the duplicate execution reported in #202 / #630 —
-        // before the poll-level-reserve fix the message was removed at poll and repair re-queued the
+        // before the poll-level-reserve fix the message was removed at poll and repair re-queued
+        // the
         // in-flight task, running it a second time.
         TaskModel httpTask =
                 newTask("http-task", TaskType.TASK_TYPE_HTTP, TaskModel.Status.IN_PROGRESS);

--- a/docs/design/2026-07-21-issue-1321-poll-level-reserve.md
+++ b/docs/design/2026-07-21-issue-1321-poll-level-reserve.md
@@ -1,0 +1,151 @@
+# #1321 — Duplicate execution of async system tasks (queue-message reservation)
+
+Issue: https://github.com/conductor-oss/conductor/issues/1321
+
+## Summary
+
+An async system task whose synchronous execution outlasts the queue's redelivery
+window is executed a **second time in parallel** by another `system-task-worker`.
+For `LLM_CHAT_COMPLETE` this means duplicate paid provider calls (observed: all 4
+agent-loop turns billed twice). The fix keeps a task's queue message **present but
+invisible** while it runs, so the scheduler's own repair logic no longer re-queues
+a task that is legitimately in flight.
+
+## Background: how a system task's message flows
+
+`SystemTaskWorker.pollAndExecute` (per task-type queue), then `AsyncSystemTaskExecutor`:
+
+1. `queueDAO.pop(queue)` → the message moves to the queue's *unacked* set (invisible).
+2. `executionService.ackTaskReceived(taskId)` → `queueDAO.ack` → **the message is removed.**
+3. `AsyncSystemTaskExecutor.execute` runs on a worker thread; the task's
+   `start()`/`execute()` runs the work (for annotated `@WorkerTask` adapters, the
+   provider call runs **synchronously** here).
+4. Only in `AsyncSystemTaskExecutor`'s `finally` — *after* the work returns — is the
+   message removed (terminal) or re-posted (`postpone`, non-terminal).
+
+Between step 2 and step 4 a **running** task has **no message in the queue**.
+
+## Root cause: a violated invariant + the sweeper's repair
+
+`WorkflowSweeper` (`org.conductoross.conductor.core.execution.WorkflowSweeper`, on
+by default) enforces on every sweep (~30s): *"every running task MUST be in the
+queue."* Its repair re-pushes any repairable task whose message is missing:
+
+```java
+if (isTaskRepairable.test(task) && !queueDAO.containsMessage(queue, taskId)) {
+    queueDAO.push(queue, taskId, task.getCallbackAfterSeconds());   // re-queue
+}
+```
+
+For async system tasks `isTaskRepairable` is true in `SCHEDULED` **and**
+`IN_PROGRESS`. So while the task runs (message removed at step 2, task still
+non-terminal), a sweep sees "running task, no message" → **re-pushes it** → a
+second worker pops it and runs the same task again → **duplicate**.
+
+Remote worker tasks never hit this: their poll does **not** remove the message,
+and their repair predicate requires `SCHEDULED`. Async system tasks have neither
+guard. This is generic to **every** async system task — the message is briefly
+absent for all of them; it is only *reliably* hit by long-running (LLM/A2A) tasks
+whose window (minutes) is wider than the 30s sweep.
+
+## Fix (what): don't remove the message at poll; reserve it for the run
+
+Two small changes, both on the shared execution path (no per-task-type gating):
+
+1. **`SystemTaskWorker` stops removing the message at poll.** The
+   `executionService.ackTaskReceived(taskId)` call is dropped. The popped message
+   stays in the queue (invisible while unacked), so a task that is about to run
+   still *has* a message — `containsMessage` is true — and the sweeper's repair
+   leaves it alone. (This removed the only use of `ExecutionService` in
+   `SystemTaskWorker`, so that dependency is gone.)
+
+2. **`AsyncSystemTaskExecutor` reserves the message for the run.** Before invoking
+   `start()`/`execute()`, it extends the message's visibility to the task's
+   `responseTimeoutSeconds`:
+
+   ```java
+   // before the SCHEDULED/IN_PROGRESS invocation:
+   queueDAO.setUnackTimeout(queueName, taskId, responseTimeoutSeconds * 1000);
+   ```
+
+   The executor already loads the `TaskModel`, so `responseTimeoutSeconds` is in
+   hand — no new config property and no extra read. It falls back to the default
+   response timeout (`TaskDef.ONE_HOUR`, 3600s) when the task has none (e.g. an
+   annotated task with no registered task def).
+
+Together: the message is present from pop (repair can't re-push it — **no
+ack→reserve race**), and invisible for `responseTimeout` (the unack sweep won't
+redeliver it mid-run). The executor's `finally` still owns the outcome — it
+`remove`s (terminal) or `postpone`s (non-terminal / worker-requested callback),
+overriding the reservation — so normal completion, the async-complete flow, and
+long-running `IN_PROGRESS + callbackAfterSeconds` re-invocation are all unchanged.
+
+3. **An overrun is timed out, not re-executed.** The reservation only lasts
+   `responseTimeout`; if the actual run outlives it, the message *does* reappear.
+   To avoid re-running it in parallel, the executor persists `startTime` before the
+   first invocation (the status is left unchanged so a system task whose `start()`
+   branches on `SCHEDULED` — e.g. `SUB_WORKFLOW` — still works), and on any
+   redelivery checks whether the task has already started and has not responded
+   within `responseTimeout`:
+
+   ```java
+   if (task.getStartTime() > 0
+           && now - task.getUpdateTime() >= responseTimeoutMs) {
+       task.setStatus(TIMED_OUT);   // don't invoke again — let retry/timeout policy decide
+   }
+   ```
+
+   So a run that exceeds `responseTimeout` is marked `TIMED_OUT` (retriable) and the
+   retry/timeout policy creates a *new* attempt or fails the workflow — it is never
+   re-run in parallel under the same taskId. The check uses `updateTime` (time since
+   the last response), so a worker that keeps checking in within `responseTimeout`
+   (LLM/A2A callback flow) is not timed out.
+
+## Why `responseTimeout` (not a new property)
+
+`responseTimeout` is exactly "how long the task is allowed to run", which is what
+the reservation should cover, and it already exists per task. Adding a dedicated
+lease property would duplicate it. It only needs a fallback (the platform default,
+`TaskDef.ONE_HOUR`) for tasks with no configured timeout.
+
+## Why not gate to one task type
+
+The race is generic and the reservation is behavior-preserving: the executor's
+`finally` always removes/re-posts the message once the task returns, so for a fast
+task the reservation is immediately superseded. The one trade-off, uniform across
+all tasks: a crash **mid-execute** leaves the message reserved and recovered after
+`responseTimeout` instead of by the ~30s repair. That is bounded and acceptable,
+and is the price of not letting repair fight in-flight tasks.
+
+## Alternatives considered
+
+- **Adapter-level reserve (PR #1367):** reserve inside `AnnotatedWorkflowSystemTask`.
+  Covers only annotated tasks, and reserves *after* the poller's ack — leaving a
+  small ack→reserve race (a sweep in that gap still re-queues). This approach
+  removes the ack entirely, so there is no such window, and it covers all async
+  system tasks.
+- **Non-blocking poll model (#1359):** run the method off the worker thread and poll
+  a future — eliminates the in-flight window, but a much larger change.
+
+## Known limitations
+
+- **Crash mid-execute** → recovery after `responseTimeout` (bounded), slower than
+  repair's ~30s.
+- **A run that overruns `responseTimeout` is timed out and retried** per the task's
+  policy — so a task whose `responseTimeout` is set shorter than its real work will
+  time out repeatedly and eventually fail. Set a realistic `responseTimeout` for
+  long tasks (e.g. LLM); absent one, the `TaskDef.ONE_HOUR` default applies.
+- **Zombie late-write (#1322, not fixed here):** the original invocation of a
+  timed-out task keeps running and, on completion, its `finally` still writes its
+  result under the original taskId, which can overwrite the `TIMED_OUT`/retry state.
+  Rejecting that late write is a separate follow-on (#1322).
+
+## Testing
+
+- `AsyncSystemTaskExecutorTest`: a SCHEDULED task is reserved via
+  `queueDAO.setUnackTimeout(queue, taskId, responseTimeout*1000)` before `start()`;
+  a task with no `responseTimeout` falls back to `TaskDef.ONE_HOUR` (3600s); a
+  redelivered task that outlived `responseTimeout` is marked `TIMED_OUT` and **not**
+  re-invoked.
+- `TestSystemTaskWorker`: the poll hands the task to the executor and does **not**
+  `ack`/`remove` the message.

--- a/docs/design/2026-07-21-issue-1321-poll-level-reserve.md
+++ b/docs/design/2026-07-21-issue-1321-poll-level-reserve.md
@@ -90,10 +90,17 @@ long-running `IN_PROGRESS + callbackAfterSeconds` re-invocation are all unchange
 
    ```java
    if (task.getStartTime() > 0
+           && task.getUpdateTime() > 0                       // skip just-scheduled tasks
            && now - task.getUpdateTime() >= responseTimeoutMs) {
        task.setStatus(TIMED_OUT);   // don't invoke again — let retry/timeout policy decide
    }
    ```
+
+   The `updateTime > 0` guard is required: a task whose mapper sets `startTime` at
+   scheduling (e.g. `JOIN`) has `updateTime == 0` until first persisted, so without it
+   `now - 0` always exceeds the timeout and the task is wrongly timed out on its first
+   poll. Re-polled tasks refresh `updateTime` each poll, so only a run that held the
+   worker thread past `responseTimeout` (no intervening poll) is caught.
 
    So a run that exceeds `responseTimeout` is marked `TIMED_OUT` (retriable) and the
    retry/timeout policy creates a *new* attempt or fails the workflow — it is never

--- a/docs/design/2026-07-21-issue-1321-poll-level-reserve.md
+++ b/docs/design/2026-07-21-issue-1321-poll-level-reserve.md
@@ -80,33 +80,41 @@ redeliver it mid-run). The executor's `finally` still owns the outcome — it
 overriding the reservation — so normal completion, the async-complete flow, and
 long-running `IN_PROGRESS + callbackAfterSeconds` re-invocation are all unchanged.
 
-3. **An overrun is timed out, not re-executed.** The reservation only lasts
+3. **A blocking overrun is timed out, not re-executed.** The reservation only lasts
    `responseTimeout`; if the actual run outlives it, the message *does* reappear.
    To avoid re-running it in parallel, the executor persists `startTime` before the
    first invocation (the status is left unchanged so a system task whose `start()`
-   branches on `SCHEDULED` — e.g. `SUB_WORKFLOW` — still works), and on any
-   redelivery checks whether the task has already started and has not responded
-   within `responseTimeout`:
+   branches on `SCHEDULED` — e.g. `SUB_WORKFLOW` — still works), and on redelivery of a
+   still-`SCHEDULED` task checks whether it started and has not responded within
+   `responseTimeout`:
 
    ```java
-   if (task.getStartTime() > 0
+   if (scheduled                                             // SCHEDULED only — see below
+           && task.getStartTime() > 0
            && task.getUpdateTime() > 0                       // skip just-scheduled tasks
            && now - task.getUpdateTime() >= responseTimeoutMs) {
        task.setStatus(TIMED_OUT);   // don't invoke again — let retry/timeout policy decide
    }
    ```
 
-   The `updateTime > 0` guard is required: a task whose mapper sets `startTime` at
+   **Only `SCHEDULED` is handled here.** A blocking `start()` runs synchronously and
+   never moves the task to `IN_PROGRESS`, so it stays `SCHEDULED` for its whole run —
+   that is the only overrun the normal response-timeout path can't already see.
+   `IN_PROGRESS` response-timeouts are owned by `DeciderService.isResponseTimedOut`
+   (invoked from `decide()`), which budgets `responseTimeout + callbackAfterSeconds`.
+   Applying this executor check to `IN_PROGRESS` tasks would fire *earlier* than
+   `DeciderService` (it omits `callbackAfterSeconds`) and wrongly time out a task that
+   is merely waiting for its next scheduled callback whenever
+   `callbackAfterSeconds >= responseTimeout`.
+
+   The `updateTime > 0` guard is also required: a task whose mapper sets `startTime` at
    scheduling (e.g. `JOIN`) has `updateTime == 0` until first persisted, so without it
    `now - 0` always exceeds the timeout and the task is wrongly timed out on its first
-   poll. Re-polled tasks refresh `updateTime` each poll, so only a run that held the
-   worker thread past `responseTimeout` (no intervening poll) is caught.
+   poll.
 
-   So a run that exceeds `responseTimeout` is marked `TIMED_OUT` (retriable) and the
-   retry/timeout policy creates a *new* attempt or fails the workflow — it is never
-   re-run in parallel under the same taskId. The check uses `updateTime` (time since
-   the last response), so a worker that keeps checking in within `responseTimeout`
-   (LLM/A2A callback flow) is not timed out.
+   So a blocking run that exceeds `responseTimeout` is marked `TIMED_OUT` (retriable)
+   and the retry/timeout policy creates a *new* attempt or fails the workflow — it is
+   never re-run in parallel under the same taskId.
 
 ## Why `responseTimeout` (not a new property)
 
@@ -138,10 +146,26 @@ and is the price of not letting repair fight in-flight tasks.
 
 - **Crash mid-execute** → recovery after `responseTimeout` (bounded), slower than
   repair's ~30s.
-- **A run that overruns `responseTimeout` is timed out and retried** per the task's
-  policy — so a task whose `responseTimeout` is set shorter than its real work will
-  time out repeatedly and eventually fail. Set a realistic `responseTimeout` for
-  long tasks (e.g. LLM); absent one, the `TaskDef.ONE_HOUR` default applies.
+- **A blocking run that overruns `responseTimeout` is timed out and retried** per the
+  task's policy — so a task whose `responseTimeout` is set shorter than its real work
+  will time out repeatedly and eventually fail. Set a realistic `responseTimeout` for
+  long tasks (e.g. LLM); absent one, the `TaskDef.ONE_HOUR` default applies. This is a
+  de-facto 1-hour execution cap **only for blocking (`SCHEDULED`-throughout) tasks**;
+  `IN_PROGRESS` waiters (HUMAN, WAIT) are unaffected — their timeout stays governed by
+  `DeciderService.isResponseTimedOut`.
+- **`pop` → reserve window.** The message is left unacked at the queue's default unack
+  timeout between `pop` (poller thread) and `reserveInflightMessage` (executor thread).
+  This is safe while a queue's semaphore permits equal its pool threads
+  (`ExecutionConfig`): a popped id always has a free thread, so it reserves within
+  milliseconds — far inside the default unack timeout. If a future change decouples
+  in-flight permits from thread count (e.g. a per-type `permitCount`, PR #1204), a
+  popped id could queue behind busy threads and the pre-reserve gap could exceed the
+  unack timeout → redelivery → the very duplicate this fixes. In that case, reserve on
+  the poller thread immediately after `pop` instead of in the executor.
+- **Extra persistence on the schedule path.** Persisting `startTime` before `start()`
+  adds one `executionDAOFacade.updateTask` (and its index write) per async system task,
+  **once per task** (only on the first, `SCHEDULED` invocation — not per callback).
+  Required so `startTime` is durable before a blocking `start()`.
 - **Zombie late-write (#1322, not fixed here):** the original invocation of a
   timed-out task keeps running and, on completion, its `finally` still writes its
   result under the original taskId, which can overwrite the `TIMED_OUT`/retry state.
@@ -149,10 +173,23 @@ and is the price of not letting repair fight in-flight tasks.
 
 ## Testing
 
-- `AsyncSystemTaskExecutorTest`: a SCHEDULED task is reserved via
-  `queueDAO.setUnackTimeout(queue, taskId, responseTimeout*1000)` before `start()`;
-  a task with no `responseTimeout` falls back to `TaskDef.ONE_HOUR` (3600s); a
-  redelivered task that outlived `responseTimeout` is marked `TIMED_OUT` and **not**
-  re-invoked.
+- `AsyncSystemTaskExecutorTest`:
+  - a SCHEDULED task is reserved via
+    `queueDAO.setUnackTimeout(queue, taskId, responseTimeout*1000)` before `start()`;
+    a task with no `responseTimeout` falls back to `TaskDef.ONE_HOUR` (3600s).
+  - a redelivered **SCHEDULED** task whose blocking `start()` outlived `responseTimeout`
+    is marked `TIMED_OUT` and **not** re-invoked.
+  - a **just-scheduled** task with `startTime` set but `updateTime == 0` (e.g. `JOIN`)
+    is reserved and started, **not** timed out (the `updateTime > 0` guard).
+  - an **`IN_PROGRESS`** task whose callback interval exceeds `responseTimeout` is
+    reserved and `execute()`d, **not** timed out (the `SCHEDULED`-only gate — the
+    response-timeout is left to `DeciderService.isResponseTimedOut`).
+- `WorkflowSweeperTest`: an in-flight async system task (`isAsync`, not
+  `asyncComplete`) whose queue message is **present** (`containsMessage == true`) is
+  **not** re-pushed by repair — the regression guard for #202 / #630.
 - `TestSystemTaskWorker`: the poll hands the task to the executor and does **not**
   `ack`/`remove` the message.
+- End-to-end: the full `conductor-test-harness` suite passes, including the fork/join
+  integration tests (`ForkJoinSyncModeIntegrationTest` et al.) that exercise `JOIN`
+  through the async executor and would fail if a freshly-scheduled `JOIN` were timed
+  out.


### PR DESCRIPTION
Fixes #1321. Alternative to #1367 — fixes the duplicate at the queue/scheduler layer instead of in the annotated adapter.

## Problem

The `system-task-worker` **removes** a message at poll (`ackTaskReceived`) so while a task runs it has **no** queue message — and the `WorkflowSweeper` repair or `WorkflowRepairService` re-queue any running task whose message is "missing". This is causing duplicates.

Affects every async system task; long-running LLM/A2A tasks hit it reliably (their run outlasts the ~30s sweep).

We didn't find a new bug, we found an old one that keeps coming back:
- https://github.com/Netflix/conductor-community/issues/70
- https://github.com/conductor-oss/conductor/issues/202
- https://github.com/conductor-oss/conductor/issues/630

## Fix
1. Keep a running task's message present so repair leaves it alone. 
2. Time out a run that overruns instead of re-executing it — on the shared path, no per-task gating:

- **`SystemTaskWorker`** no longer removes the message at poll. The popped message stays in the queue (invisible while unacked), so a running task still *has* a message.
- **`AsyncSystemTaskExecutor`** reserves the message before invoking: `setUnackTimeout(queue, taskId, responseTimeoutSeconds)` Uses the existing per-task `responseTimeout` (no new property), falling back to `TaskDef.ONE_HOUR` when unset.
- **Overruns time out, not duplicate.** The executor persists `startTime` before the first invocation (status left unchanged so `SUB_WORKFLOW` etc. whose `start()` branches on `SCHEDULED` still work). On any redelivery, if the task has started and hasn't responded within `responseTimeout` (`now - updateTime ≥ responseTimeout`), it's marked `TIMED_OUT` (retriable) — the retry/timeout policy makes a new attempt or fails; it is never re-run in parallel under the same taskId. Using `updateTime` keeps the long-running `IN_PROGRESS + callbackAfterSeconds` (LLM/A2A) flow from timing out while it checks in.

`AsyncSystemTaskExecutor`'s `finally` still owns the normal outcome (remove on terminal, postpone on non-terminal).

## How to test
`./gradlew :conductor-core:test --tests "*AsyncSystemTaskExecutorTest*" --tests "*TestSystemTaskWorker*"` — reserve with `responseTimeout` (and `ONE_HOUR` fallback) before `start()`; a redelivered overrun is `TIMED_OUT`, not re-invoked; the poll no longer acks/removes the message.

## Notes
- A crash *mid-execute* leaves the message reserved and recovered after `responseTimeout` (bounded), slower than repair's ~30s.
- Set a realistic `responseTimeout` for long tasks; a task whose `responseTimeout` is shorter than its work will time out and (per policy) retry/fail rather than run twice.
- **Zombie late-write (#1322, not fixed here):** a timed-out task's original invocation keeps running and, on completion, can overwrite the `TIMED_OUT`/retry state under the original taskId — rejecting that late write is a separate follow-on.
- Design write-up: `docs/design/2026-07-21-issue-1321-poll-level-reserve.md`.

## Update (review follow-up)

The overrun timeout is now scoped to **`SCHEDULED`** tasks only. A blocking `start()` never leaves `SCHEDULED`, so that's the only overrun `DeciderService.isResponseTimedOut` (which budgets `responseTimeout + callbackAfterSeconds`) can't already see. The earlier unscoped check fired sooner than the decider and could wrongly time out an `IN_PROGRESS` task waiting for its next callback when `callbackAfterSeconds ≥ responseTimeout`; `IN_PROGRESS` response-timeouts stay with the decider. Added tests: an `IN_PROGRESS` callback-loop task is not timed out, and `WorkflowSweeperTest` proves repair does not re-queue an in-flight async system task whose message is present (#202/#630 guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
