### PR TITLE
test(ai): live media-input integration tests per provider, runnable from GitHub Actions

### DIFF
--- a/.github/workflows/llm-media-integration.yml
+++ b/.github/workflows/llm-media-integration.yml
@@ -17,6 +17,14 @@ on:
   pull_request:
     paths:
       - ".github/workflows/llm-media-integration.yml"
+      # Provider adapter changes are exactly what these tests exist to catch;
+      # everything else in the repo never triggers a paid run.
+      - "ai/src/main/java/org/conductoross/conductor/ai/providers/**"
+
+# A rapid series of pushes should not stack paid runs — keep only the latest.
+concurrency:
+  group: llm-media-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/llm-media-integration.yml
+++ b/.github/workflows/llm-media-integration.yml
@@ -46,9 +46,14 @@ jobs:
       - name: Run provider media integration tests
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GROK_API_KEY: ${{ secrets.GROK_API_KEY }}
           PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
           # Not configured at org level today; the Cohere test self-skips until it is.
           COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
         run: >

--- a/.github/workflows/llm-media-integration.yml
+++ b/.github/workflows/llm-media-integration.yml
@@ -1,0 +1,65 @@
+name: LLM Provider Media Integration
+
+# Live-API regression coverage for the provider media fixes (#1238 Anthropic,
+# #1241 Gemini, #1243 Grok/Perplexity, #1246 Cohere): each test sends an image
+# embedding a machine-unguessable token to a vision model and asserts the model
+# transcribes it — proving the adapter actually attached the media.
+#
+# Provider keys are org-level secrets. Tests self-skip for any key that is
+# absent (COHERE_API_KEY is not configured today), so this workflow stays green
+# while showing per-provider SKIPPED/PASSED status in the report.
+
+on:
+  workflow_dispatch:
+  # GitHub Actions cron expressions are UTC. Weekly — these burn paid provider calls.
+  schedule:
+    - cron: "30 5 * * 1"
+  pull_request:
+    paths:
+      - ".github/workflows/llm-media-integration.yml"
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  media-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Set up Zulu JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: "zulu"
+          java-version: "21"
+      - name: Cache Gradle packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+      - name: Run provider media integration tests
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GROK_API_KEY: ${{ secrets.GROK_API_KEY }}
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+          # Not configured at org level today; the Cohere test self-skips until it is.
+          COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
+        run: >
+          ./gradlew :conductor-ai:test
+          --tests "*testChatCompletionWithImageMedia*"
+          --rerun
+      - name: Publish media integration test report
+        uses: mikepenz/action-junit-report@v6
+        if: always()
+        with:
+          report_paths: "ai/build/test-results/test/TEST-*.xml"
+          check_name: LLM Media Integration Report
+          include_passed: true
+          detailed_summary: true

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicTest.java
@@ -13,7 +13,9 @@
 package org.conductoross.conductor.ai.providers.anthropic;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import org.conductoross.conductor.ai.model.ChatCompletion;
 import org.conductoross.conductor.ai.model.ToolSpec;
@@ -23,6 +25,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.content.Media;
+import org.springframework.util.MimeTypeUtils;
 
 import okhttp3.OkHttpClient;
 
@@ -226,6 +230,47 @@ class AnthropicTest {
             assertNotNull(response.getResult());
             assertNotNull(response.getResult().getOutput());
             assertFalse(response.getResult().getOutput().getText().isEmpty());
+        }
+
+        @Test
+        void testChatCompletionWithImageMedia() throws Exception {
+            // Live regression for the media fix (PR #1238): the vision model must actually
+            // see the image bytes forwarded by the adapter. The image embeds a
+            // machine-unguessable token, so a correct transcription can only come from
+            // the image — pre-fix the media was silently dropped.
+            byte[] png =
+                    Objects.requireNonNull(
+                                    getClass().getResourceAsStream("/media/melon7391.png"),
+                                    "test asset /media/melon7391.png missing")
+                            .readAllBytes();
+
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("claude-haiku-4-5");
+            input.setMaxTokens(100);
+
+            UserMessage userMsg =
+                    UserMessage.builder()
+                            .text(
+                                    "Transcribe the exact text shown in the image. Reply with"
+                                            + " only that text and nothing else.")
+                            .media(
+                                    List.of(
+                                            Media.builder()
+                                                    .data(png)
+                                                    .mimeType(MimeTypeUtils.IMAGE_PNG)
+                                                    .build()))
+                            .build();
+
+            var response =
+                    anthropic
+                            .getChatModel()
+                            .call(new Prompt(List.of(userMsg), anthropic.getChatOptions(input)));
+
+            String text = response.getResult().getOutput().getText();
+            assertNotNull(text);
+            assertTrue(
+                    text.toUpperCase(Locale.ROOT).replaceAll("[^A-Z0-9]", "").contains("MELON7391"),
+                    "vision model must transcribe the embedded token MELON7391; got: " + text);
         }
 
         @Test

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicTest.java
@@ -19,7 +19,6 @@ import java.util.Objects;
 
 import org.conductoross.conductor.ai.model.ChatCompletion;
 import org.conductoross.conductor.ai.model.ToolSpec;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -37,12 +36,6 @@ import static org.junit.jupiter.api.Assertions.*;
 class AnthropicTest {
 
     private static final String ENV_API_KEY = "ANTHROPIC_API_KEY";
-    private static final String API_USAGE_LIMIT_MESSAGE =
-            "You have reached your specified API usage limits.";
-
-    private static boolean isApiUsageLimit(RuntimeException exception) {
-        return String.valueOf(exception.getMessage()).contains(API_USAGE_LIMIT_MESSAGE);
-    }
 
     @Nested
     class UnitTests {
@@ -136,15 +129,6 @@ class AnthropicTest {
             var chatModel = anthropic.getChatModel();
             assertNotNull(chatModel);
             assertInstanceOf(AnthropicChatModel.class, chatModel);
-        }
-
-        @Test
-        void testIsApiUsageLimit() {
-            assertTrue(
-                    isApiUsageLimit(
-                            new RuntimeException(
-                                    "Anthropic API failed: " + API_USAGE_LIMIT_MESSAGE)));
-            assertFalse(isApiUsageLimit(new RuntimeException("Anthropic API failed: invalid key")));
         }
 
         @Test
@@ -278,23 +262,10 @@ class AnthropicTest {
                                                     .build()))
                             .build();
 
-            ChatResponse response;
-            try {
-                response =
-                        anthropic
-                                .getChatModel()
-                                .call(
-                                        new Prompt(
-                                                List.of(userMsg), anthropic.getChatOptions(input)));
-            } catch (RuntimeException exception) {
-                // This is an external account-budget condition, not a media-adapter regression.
-                // Abort so JUnit records the live test as skipped while preserving all other
-                // provider failures as release-blocking failures.
-                Assumptions.assumeFalse(
-                        isApiUsageLimit(exception),
-                        "Anthropic API usage limit reached; skipping live media integration test");
-                throw exception;
-            }
+            ChatResponse response =
+                    anthropic
+                            .getChatModel()
+                            .call(new Prompt(List.of(userMsg), anthropic.getChatOptions(input)));
 
             String text = response.getResult().getOutput().getText();
             assertNotNull(text);

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/anthropic/AnthropicTest.java
@@ -19,11 +19,13 @@ import java.util.Objects;
 
 import org.conductoross.conductor.ai.model.ChatCompletion;
 import org.conductoross.conductor.ai.model.ToolSpec;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 import org.springframework.util.MimeTypeUtils;
@@ -35,6 +37,12 @@ import static org.junit.jupiter.api.Assertions.*;
 class AnthropicTest {
 
     private static final String ENV_API_KEY = "ANTHROPIC_API_KEY";
+    private static final String API_USAGE_LIMIT_MESSAGE =
+            "You have reached your specified API usage limits.";
+
+    private static boolean isApiUsageLimit(RuntimeException exception) {
+        return String.valueOf(exception.getMessage()).contains(API_USAGE_LIMIT_MESSAGE);
+    }
 
     @Nested
     class UnitTests {
@@ -128,6 +136,15 @@ class AnthropicTest {
             var chatModel = anthropic.getChatModel();
             assertNotNull(chatModel);
             assertInstanceOf(AnthropicChatModel.class, chatModel);
+        }
+
+        @Test
+        void testIsApiUsageLimit() {
+            assertTrue(
+                    isApiUsageLimit(
+                            new RuntimeException(
+                                    "Anthropic API failed: " + API_USAGE_LIMIT_MESSAGE)));
+            assertFalse(isApiUsageLimit(new RuntimeException("Anthropic API failed: invalid key")));
         }
 
         @Test
@@ -261,10 +278,23 @@ class AnthropicTest {
                                                     .build()))
                             .build();
 
-            var response =
-                    anthropic
-                            .getChatModel()
-                            .call(new Prompt(List.of(userMsg), anthropic.getChatOptions(input)));
+            ChatResponse response;
+            try {
+                response =
+                        anthropic
+                                .getChatModel()
+                                .call(
+                                        new Prompt(
+                                                List.of(userMsg), anthropic.getChatOptions(input)));
+            } catch (RuntimeException exception) {
+                // This is an external account-budget condition, not a media-adapter regression.
+                // Abort so JUnit records the live test as skipped while preserving all other
+                // provider failures as release-blocking failures.
+                Assumptions.assumeFalse(
+                        isApiUsageLimit(exception),
+                        "Anthropic API usage limit reached; skipping live media integration test");
+                throw exception;
+            }
 
             String text = response.getResult().getOutput().getText();
             assertNotNull(text);

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAITest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/azureopenai/AzureOpenAITest.java
@@ -13,6 +13,8 @@
 package org.conductoross.conductor.ai.providers.azureopenai;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 
 import org.conductoross.conductor.ai.model.ChatCompletion;
 import org.conductoross.conductor.ai.model.EmbeddingGenRequest;
@@ -26,6 +28,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.content.Media;
+import org.springframework.util.MimeTypeUtils;
 
 import okhttp3.OkHttpClient;
 
@@ -133,6 +137,47 @@ class AzureOpenAITest {
             assertNotNull(response.getResult());
             assertNotNull(response.getResult().getOutput());
             assertFalse(response.getResult().getOutput().getText().isEmpty());
+        }
+
+        @Test
+        void testChatCompletionWithImageMedia() throws Exception {
+            // Live lock for Azure OpenAI media input (same OpenAIResponsesChatModel input_image
+            // path).
+            // The image embeds a machine-unguessable token, so a correct transcription
+            // can only come from the image actually reaching the model.
+            byte[] png =
+                    Objects.requireNonNull(
+                                    getClass().getResourceAsStream("/media/melon7391.png"),
+                                    "test asset /media/melon7391.png missing")
+                            .readAllBytes();
+
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("gpt-4o-mini");
+            input.setMaxTokens(100);
+
+            UserMessage userMsg =
+                    UserMessage.builder()
+                            .text(
+                                    "Transcribe the exact text shown in the image. Reply with"
+                                            + " only that text and nothing else.")
+                            .media(
+                                    List.of(
+                                            Media.builder()
+                                                    .data(png)
+                                                    .mimeType(MimeTypeUtils.IMAGE_PNG)
+                                                    .build()))
+                            .build();
+
+            var response =
+                    azureOpenAI
+                            .getChatModel()
+                            .call(new Prompt(List.of(userMsg), azureOpenAI.getChatOptions(input)));
+
+            String text = response.getResult().getOutput().getText();
+            assertNotNull(text);
+            assertTrue(
+                    text.toUpperCase(Locale.ROOT).replaceAll("[^A-Z0-9]", "").contains("MELON7391"),
+                    "vision model must transcribe the embedded token MELON7391; got: " + text);
         }
 
         @Test

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/bedrock/BedrockTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/bedrock/BedrockTest.java
@@ -165,7 +165,10 @@ class BedrockTest {
                             .readAllBytes();
 
             ChatCompletion input = new ChatCompletion();
-            input.setModel("anthropic.claude-3-haiku-20240307-v1:0");
+            // Inference-profile id: bare model ids are rejected for on-demand throughput
+            // ("Invocation of model ID ... isn't supported. Retry your request with the
+            // ID or ARN of an inference profile").
+            input.setModel("us.anthropic.claude-3-haiku-20240307-v1:0");
             input.setMaxTokens(100);
 
             UserMessage userMsg =

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/bedrock/BedrockTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/bedrock/BedrockTest.java
@@ -13,6 +13,8 @@
 package org.conductoross.conductor.ai.providers.bedrock;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 
 import org.conductoross.conductor.ai.model.ChatCompletion;
 import org.conductoross.conductor.ai.model.EmbeddingGenRequest;
@@ -22,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.content.Media;
+import org.springframework.util.MimeTypeUtils;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -29,6 +33,7 @@ class BedrockTest {
 
     private static final String ENV_ACCESS_KEY = "AWS_ACCESS_KEY_ID";
     private static final String ENV_SECRET_KEY = "AWS_SECRET_ACCESS_KEY";
+    private static final String ENV_BEARER_TOKEN = "AWS_BEARER_TOKEN_BEDROCK";
 
     @Nested
     class UnitTests {
@@ -121,6 +126,70 @@ class BedrockTest {
 
             assertNotNull(embeddings);
             assertFalse(embeddings.isEmpty());
+        }
+    }
+
+    /**
+     * Live tests using Bedrock API-key (bearer token) auth — the dedicated {@code
+     * AWS_BEARER_TOKEN_BEDROCK} credential, matching the server's {@code
+     * conductor.ai.bedrock.bearerToken} binding. Separate from {@link IntegrationTests} because the
+     * generic AWS access keys in CI are provisioned for artifact publishing and may not carry
+     * Bedrock invoke permissions.
+     */
+    @Nested
+    @EnabledIfEnvironmentVariable(named = ENV_BEARER_TOKEN, matches = ".+")
+    class BearerIntegrationTests {
+
+        private Bedrock bedrock;
+
+        @BeforeEach
+        void setUp() {
+            BedrockConfiguration config = new BedrockConfiguration();
+            config.setBearerToken(System.getenv(ENV_BEARER_TOKEN));
+            config.setRegion(
+                    System.getenv("AWS_REGION") != null
+                            ? System.getenv("AWS_REGION")
+                            : "us-east-1");
+            bedrock = new Bedrock(config);
+        }
+
+        @Test
+        void testChatCompletionWithImageMedia() throws Exception {
+            // Live lock for Bedrock media input (Spring AI Converse maps Media to image
+            // blocks). The image embeds a machine-unguessable token, so a correct
+            // transcription can only come from the image actually reaching the model.
+            byte[] png =
+                    Objects.requireNonNull(
+                                    getClass().getResourceAsStream("/media/melon7391.png"),
+                                    "test asset /media/melon7391.png missing")
+                            .readAllBytes();
+
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("anthropic.claude-3-haiku-20240307-v1:0");
+            input.setMaxTokens(100);
+
+            UserMessage userMsg =
+                    UserMessage.builder()
+                            .text(
+                                    "Transcribe the exact text shown in the image. Reply with"
+                                            + " only that text and nothing else.")
+                            .media(
+                                    List.of(
+                                            Media.builder()
+                                                    .data(png)
+                                                    .mimeType(MimeTypeUtils.IMAGE_PNG)
+                                                    .build()))
+                            .build();
+
+            var response =
+                    bedrock.getChatModel()
+                            .call(new Prompt(List.of(userMsg), bedrock.getChatOptions(input)));
+
+            String text = response.getResult().getOutput().getText();
+            assertNotNull(text);
+            assertTrue(
+                    text.toUpperCase(Locale.ROOT).replaceAll("[^A-Z0-9]", "").contains("MELON7391"),
+                    "vision model must transcribe the embedded token MELON7391; got: " + text);
         }
     }
 }

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/bedrock/BedrockTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/bedrock/BedrockTest.java
@@ -165,10 +165,10 @@ class BedrockTest {
                             .readAllBytes();
 
             ChatCompletion input = new ChatCompletion();
-            // Inference-profile id: bare model ids are rejected for on-demand throughput
-            // ("Invocation of model ID ... isn't supported. Retry your request with the
-            // ID or ARN of an inference profile").
-            input.setModel("us.anthropic.claude-3-haiku-20240307-v1:0");
+            // Inference-profile id (bare model ids are rejected for on-demand
+            // throughput), on a current model: claude-3-haiku is marked Legacy by the
+            // provider and Bedrock blocks it after 30 days of inactivity.
+            input.setModel("us.anthropic.claude-haiku-4-5-20251001-v1:0");
             input.setMaxTokens(100);
 
             UserMessage userMsg =

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/bedrock/BedrockTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/bedrock/BedrockTest.java
@@ -100,7 +100,7 @@ class BedrockTest {
         @Test
         void testChatCompletion() {
             ChatCompletion input = new ChatCompletion();
-            input.setModel("anthropic.claude-3-haiku-20240307-v1:0");
+            input.setModel("us.anthropic.claude-haiku-4-5-20251001-v1:0");
             input.setMaxTokens(100);
             input.setTemperature(0.7);
 

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexTest.java
@@ -13,6 +13,8 @@
 package org.conductoross.conductor.ai.providers.gemini;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 
 import org.conductoross.conductor.ai.model.ChatCompletion;
 import org.conductoross.conductor.ai.model.EmbeddingGenRequest;
@@ -22,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.content.Media;
+import org.springframework.util.MimeTypeUtils;
 
 import okhttp3.OkHttpClient;
 
@@ -31,6 +35,7 @@ class GeminiVertexTest {
 
     private static final String ENV_PROJECT_ID = "GOOGLE_CLOUD_PROJECT";
     private static final String ENV_LOCATION = "GOOGLE_CLOUD_LOCATION";
+    private static final String ENV_API_KEY = "GEMINI_API_KEY";
 
     @Nested
     class UnitTests {
@@ -198,6 +203,83 @@ class GeminiVertexTest {
 
             assertNotNull(embeddings);
             assertFalse(embeddings.isEmpty());
+        }
+    }
+
+    /**
+     * Live tests in API-key (AI Studio / generativelanguage.googleapis.com) mode — the mode the
+     * server uses when only {@code conductor.ai.gemini.api-key} (GEMINI_API_KEY) is configured, as
+     * opposed to the Vertex mode covered by {@link IntegrationTests}.
+     */
+    @Nested
+    @EnabledIfEnvironmentVariable(named = ENV_API_KEY, matches = ".+")
+    class ApiKeyIntegrationTests {
+
+        private GeminiVertex gemini;
+
+        @BeforeEach
+        void setUp() {
+            GeminiVertexConfiguration config = new GeminiVertexConfiguration();
+            config.setApiKey(System.getenv(ENV_API_KEY));
+            gemini = new GeminiVertex(config, new OkHttpClient());
+        }
+
+        @Test
+        void testChatCompletion() {
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("gemini-2.5-flash");
+            input.setMaxTokens(100);
+            input.setTemperature(0.7);
+
+            Prompt prompt =
+                    new Prompt(
+                            List.of(new UserMessage("Say hello in one word")),
+                            gemini.getChatOptions(input));
+            var response = gemini.getChatModel().call(prompt);
+
+            assertNotNull(response);
+            assertNotNull(response.getResult());
+            assertFalse(response.getResult().getOutput().getText().isEmpty());
+        }
+
+        @Test
+        void testChatCompletionWithImageMedia() throws Exception {
+            // Live regression for the media fix (PR #1241): the vision model must actually
+            // see the image bytes forwarded by the adapter. The image embeds a
+            // machine-unguessable token, so a correct transcription can only come from
+            // the image — pre-fix the media was silently dropped.
+            byte[] png =
+                    Objects.requireNonNull(
+                                    getClass().getResourceAsStream("/media/melon7391.png"),
+                                    "test asset /media/melon7391.png missing")
+                            .readAllBytes();
+
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("gemini-2.5-flash");
+            input.setMaxTokens(100);
+
+            UserMessage userMsg =
+                    UserMessage.builder()
+                            .text(
+                                    "Transcribe the exact text shown in the image. Reply with"
+                                            + " only that text and nothing else.")
+                            .media(
+                                    List.of(
+                                            Media.builder()
+                                                    .data(png)
+                                                    .mimeType(MimeTypeUtils.IMAGE_PNG)
+                                                    .build()))
+                            .build();
+
+            var response =
+                    gemini.getChatModel()
+                            .call(new Prompt(List.of(userMsg), gemini.getChatOptions(input)));
+
+            String text = response.getResult().getOutput().getText();
+            assertNotNull(text);
+            assertTrue(
+                    text.toUpperCase(Locale.ROOT).replaceAll("[^A-Z0-9]", "").contains("MELON7391"),
+                    "vision model must transcribe the embedded token MELON7391; got: " + text);
         }
     }
 }

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/gemini/GeminiVertexTest.java
@@ -177,7 +177,7 @@ class GeminiVertexTest {
         @Test
         void testChatCompletion() {
             ChatCompletion input = new ChatCompletion();
-            input.setModel("gemini-1.5-flash");
+            input.setModel("gemini-2.5-flash");
             input.setMaxTokens(100);
             input.setTemperature(0.7);
 

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/grok/GrokTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/grok/GrokTest.java
@@ -13,6 +13,8 @@
 package org.conductoross.conductor.ai.providers.grok;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 
 import org.conductoross.conductor.ai.model.ChatCompletion;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +23,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.content.Media;
+import org.springframework.util.MimeTypeUtils;
 
 import okhttp3.OkHttpClient;
 
@@ -106,6 +110,46 @@ class GrokTest {
             assertNotNull(response.getResult());
             assertNotNull(response.getResult().getOutput());
             assertFalse(response.getResult().getOutput().getText().isEmpty());
+        }
+
+        @Test
+        void testChatCompletionWithImageMedia() throws Exception {
+            // Live regression for the media fix (PR #1243): the vision model must actually
+            // see the image bytes forwarded by the adapter. The image embeds a
+            // machine-unguessable token, so a correct transcription can only come from
+            // the image — pre-fix the media was silently dropped.
+            byte[] png =
+                    Objects.requireNonNull(
+                                    getClass().getResourceAsStream("/media/melon7391.png"),
+                                    "test asset /media/melon7391.png missing")
+                            .readAllBytes();
+
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("grok-4.5");
+            input.setMaxTokens(100);
+
+            UserMessage userMsg =
+                    UserMessage.builder()
+                            .text(
+                                    "Transcribe the exact text shown in the image. Reply with"
+                                            + " only that text and nothing else.")
+                            .media(
+                                    List.of(
+                                            Media.builder()
+                                                    .data(png)
+                                                    .mimeType(MimeTypeUtils.IMAGE_PNG)
+                                                    .build()))
+                            .build();
+
+            var response =
+                    grok.getChatModel()
+                            .call(new Prompt(List.of(userMsg), grok.getChatOptions(input)));
+
+            String text = response.getResult().getOutput().getText();
+            assertNotNull(text);
+            assertTrue(
+                    text.toUpperCase(Locale.ROOT).replaceAll("[^A-Z0-9]", "").contains("MELON7391"),
+                    "vision model must transcribe the embedded token MELON7391; got: " + text);
         }
     }
 }

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/openai/OpenAITest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/openai/OpenAITest.java
@@ -13,6 +13,8 @@
 package org.conductoross.conductor.ai.providers.openai;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 
 import org.conductoross.conductor.ai.model.ChatCompletion;
 import org.conductoross.conductor.ai.model.EmbeddingGenRequest;
@@ -23,6 +25,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.content.Media;
+import org.springframework.util.MimeTypeUtils;
 
 import okhttp3.OkHttpClient;
 
@@ -212,6 +216,45 @@ class OpenAITest {
             assertNotNull(response.getResult());
             assertNotNull(response.getResult().getOutput());
             assertFalse(response.getResult().getOutput().getText().isEmpty());
+        }
+
+        @Test
+        void testChatCompletionWithImageMedia() throws Exception {
+            // Live lock for OpenAI media input (Responses API input_image parts).
+            // The image embeds a machine-unguessable token, so a correct transcription
+            // can only come from the image actually reaching the model.
+            byte[] png =
+                    Objects.requireNonNull(
+                                    getClass().getResourceAsStream("/media/melon7391.png"),
+                                    "test asset /media/melon7391.png missing")
+                            .readAllBytes();
+
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("gpt-4o-mini");
+            input.setMaxTokens(100);
+
+            UserMessage userMsg =
+                    UserMessage.builder()
+                            .text(
+                                    "Transcribe the exact text shown in the image. Reply with"
+                                            + " only that text and nothing else.")
+                            .media(
+                                    List.of(
+                                            Media.builder()
+                                                    .data(png)
+                                                    .mimeType(MimeTypeUtils.IMAGE_PNG)
+                                                    .build()))
+                            .build();
+
+            var response =
+                    openAI.getChatModel()
+                            .call(new Prompt(List.of(userMsg), openAI.getChatOptions(input)));
+
+            String text = response.getResult().getOutput().getText();
+            assertNotNull(text);
+            assertTrue(
+                    text.toUpperCase(Locale.ROOT).replaceAll("[^A-Z0-9]", "").contains("MELON7391"),
+                    "vision model must transcribe the embedded token MELON7391; got: " + text);
         }
 
         @Test

--- a/ai/src/test/java/org/conductoross/conductor/ai/providers/perplexity/PerplexityAITest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/providers/perplexity/PerplexityAITest.java
@@ -13,6 +13,8 @@
 package org.conductoross.conductor.ai.providers.perplexity;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 
 import org.conductoross.conductor.ai.model.ChatCompletion;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +23,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.content.Media;
+import org.springframework.util.MimeTypeUtils;
 
 import okhttp3.OkHttpClient;
 
@@ -108,6 +112,47 @@ class PerplexityAITest {
             assertNotNull(response.getResult());
             assertNotNull(response.getResult().getOutput());
             assertFalse(response.getResult().getOutput().getText().isEmpty());
+        }
+
+        @Test
+        void testChatCompletionWithImageMedia() throws Exception {
+            // Live regression for the media fix (PR #1243): the vision model must actually
+            // see the image bytes forwarded by the adapter. The image embeds a
+            // machine-unguessable token, so a correct transcription can only come from
+            // the image — pre-fix the media was silently dropped.
+            byte[] png =
+                    Objects.requireNonNull(
+                                    getClass().getResourceAsStream("/media/melon7391.png"),
+                                    "test asset /media/melon7391.png missing")
+                            .readAllBytes();
+
+            ChatCompletion input = new ChatCompletion();
+            input.setModel("sonar");
+            input.setMaxTokens(100);
+
+            UserMessage userMsg =
+                    UserMessage.builder()
+                            .text(
+                                    "Transcribe the exact text shown in the image. Reply with"
+                                            + " only that text and nothing else.")
+                            .media(
+                                    List.of(
+                                            Media.builder()
+                                                    .data(png)
+                                                    .mimeType(MimeTypeUtils.IMAGE_PNG)
+                                                    .build()))
+                            .build();
+
+            var response =
+                    perplexityAI
+                            .getChatModel()
+                            .call(new Prompt(List.of(userMsg), perplexityAI.getChatOptions(input)));
+
+            String text = response.getResult().getOutput().getText();
+            assertNotNull(text);
+            assertTrue(
+                    text.toUpperCase(Locale.ROOT).replaceAll("[^A-Z0-9]", "").contains("MELON7391"),
+                    "vision model must transcribe the embedded token MELON7391; got: " + text);
         }
     }
 }

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -261,7 +261,7 @@ conductor.ai.mistral.api-key=${MISTRAL_API_KEY:}
 conductor.ai.cohere.api-key=${COHERE_API_KEY:}
 
 # Grok / xAI (Grok-3, Grok-3-mini)
-conductor.ai.grok.api-key=${XAI_API_KEY:}
+conductor.ai.grok.api-key=${XAI_API_KEY:${GROK_API_KEY:}}
 
 # Perplexity AI (Sonar, Sonar Pro)
 conductor.ai.perplexity.api-key=${PERPLEXITY_API_KEY:}


### PR DESCRIPTION
## What

Live-API regression coverage for the provider media-input fixes (#1238 Anthropic, #1241 Gemini, #1243 Grok/Perplexity, #1246 Cohere) plus live locks for the pre-existing OpenAI-family media path — runnable from GitHub using the org-level provider secrets.

- `testChatCompletionWithImageMedia` added to the key-gated live nests of `AnthropicTest`, `GrokTest`, `PerplexityAITest`, `OpenAITest`, `AzureOpenAITest`; new `ApiKeyIntegrationTests` nest in `GeminiVertexTest` (AI-Studio mode, `GEMINI_API_KEY` — the mode the server uses via `conductor.ai.gemini.api-key`); new `BearerIntegrationTests` nest in `BedrockTest` (`AWS_BEARER_TOKEN_BEDROCK`, matching the server's `conductor.ai.bedrock.bearerToken` — separate from the access-key nest because the CI AWS keys are provisioned for artifact publishing). `CohereAITest` already had the equivalent test from #1246.
- Each test sends the repo's deterministic token image (`MELON7391`, `ai/src/test/resources/media/melon7391.png`) to a vision-capable model and asserts the token is transcribed — a pass proves the adapter actually attached the media; the token cannot be answered by luck (pattern from agentspan-ai/agentspan#301).
- New workflow **`llm-media-integration.yml`**: weekly cron + `workflow_dispatch` + PR runs when the workflow file changes. Publishes a per-provider JUnit report ("LLM Media Integration Report").

## Results (this PR's workflow run — live APIs, org secrets)

| Provider | Model | Result |
|---|---|---|
| Anthropic | `claude-haiku-4-5` | ✅ pass |
| OpenAI | `gpt-4o-mini` | ✅ pass |
| Azure OpenAI | `gpt-4o-mini` deployment | ✅ pass |
| Gemini | `gemini-2.5-flash` (AI Studio) | ✅ pass |
| Grok | `grok-4.5` | ✅ pass |
| Perplexity | `sonar` | ✅ pass |
| Bedrock | `us.anthropic.claude-haiku-4-5-20251001-v1:0` (bearer auth) | ✅ pass |
| Cohere | `command-a-vision-07-2025` | ⏭ skipped — no `COHERE_API_KEY` org secret; activates automatically once added |

**8 tests run, 7 passed, 1 skipped, 0 failed.**

## Fixes folded in along the way

- **Grok env-var mismatch**: the org secret and tests use `GROK_API_KEY`, but the server bound only `XAI_API_KEY`. `application.properties` now falls back `${XAI_API_KEY:${GROK_API_KEY:}}`, so either name configures the provider (XAI wins when both are set).
- **Bedrock model-id lessons** (discovered by the live runs, encoded as comments): bare model ids are rejected for on-demand throughput — inference-profile ids (`us.` prefix) are required; and `claude-3-haiku` is provider-Legacy and blocked after 30 days of inactivity. The pre-existing access-key-gated Bedrock chat test was updated to the current Haiku 4.5 profile id accordingly.
- **Stale Gemini model** in the Vertex live test: `gemini-1.5-flash` → `gemini-2.5-flash`.

## Budget control — when the paid tests run (and don't)

Live provider calls cost real money, so the triggers are deliberately narrow:

- **Unrelated changes never trigger a run.** The `pull_request` trigger is path-filtered to the workflow file itself and `ai/src/main/java/org/conductoross/conductor/ai/providers/**` — the exact code these tests exist to guard. A PR touching anything else in the repo spends nothing.
- **Fork PRs structurally cannot spend**: GitHub withholds org/repo secrets from fork-originated runs, so every key-gated test reports SKIPPED.
- **Rapid pushes don't stack runs**: a `concurrency` group (`llm-media-${{ github.ref }}`, `cancel-in-progress: true`) cancels superseded runs.
- **Per-run cost is bounded**: fixed 8 tests, `maxTokens(100)`, one ~3.5 KB image — roughly 8 calls × ~300 tokens, i.e. a fraction of a cent per run.
- **Scheduled spend**: weekly cron (`30 5 * * 1` UTC) — pennies per year; plus on-demand `workflow_dispatch`.

If stricter control is ever wanted, the next steps are a PR label gate (run only with a `run-llm-tests` label) or moving the secrets behind a protected GitHub *environment* with required reviewers, which also gates cron and manual dispatches behind human approval.

## Not covered — no org-level key configured ✘

These providers have **no** secret at the org level, so their live coverage cannot run in CI at all:

- **`MISTRAL_API_KEY`** — `MistralAITest.IntegrationTests` exists but can never run in CI until a key is added.
- **`COHERE_API_KEY`** — the Cohere live tests (adapter integration test from #1246 + the row in this suite) stay dormant; they activate automatically, zero code changes, the moment the secret is added.
- **`HUGGINGFACE_API_KEY`** — `HuggingFaceTest`'s key-gated live nest likewise can never run in CI.
- **`STABILITY_API_KEY`** — no key, so no live Stability coverage is possible in CI (image-generation provider; not part of the media-input fix series).

## Follow-ups (not in this PR)

- Add `COHERE_API_KEY` as an org secret (org admin) to activate the Cohere row — no code change needed.
- Optionally provision `MISTRAL_API_KEY` / `HUGGINGFACE_API_KEY` / `STABILITY_API_KEY` the same way; the existing key-gated nests pick them up automatically.

