### PR TITLE
Investigate/pr 1369 redelivery

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -120,7 +120,7 @@ public class AsyncSystemTaskExecutor {
         boolean hasTaskExecutionCompleted = false;
         boolean shouldRemoveTaskFromQueue = false;
         boolean invocationFailed = false;
-        boolean skipTaskUpdate = false;
+        boolean shouldPersistTaskResult = true;
         String claimToken = task.getSystemTaskClaimToken();
         String workflowId = task.getWorkflowInstanceId();
         // if we are here the Task object is updated and needs to be persisted regardless of an
@@ -155,7 +155,7 @@ public class AsyncSystemTaskExecutor {
             if (claimToken != null
                     && task.getSystemTaskClaimDeadline() > System.currentTimeMillis()) {
                 reserveInflightMessage(queueName, task);
-                skipTaskUpdate = true;
+                shouldPersistTaskResult = false;
                 return;
             }
 
@@ -258,28 +258,25 @@ public class AsyncSystemTaskExecutor {
             Monitors.error(AsyncSystemTaskExecutor.class.getSimpleName(), "executeSystemTask");
             LOGGER.error("Error executing system task - {}, with id: {}", systemTask, taskId, e);
         } finally {
-            if (!skipTaskUpdate && claimToken != null) {
+            if (shouldPersistTaskResult && claimToken != null) {
                 TaskModel persistedTask = loadTaskQuietly(taskId);
-                skipTaskUpdate =
-                        invocationFailed
-                                || persistedTask == null
-                                || persistedTask.getStatus().isTerminal()
-                                || !claimToken.equals(persistedTask.getSystemTaskClaimToken());
-                if (skipTaskUpdate) {
+                shouldPersistTaskResult =
+                        !invocationFailed && isTaskClaimOwner(claimToken, persistedTask);
+                if (!shouldPersistTaskResult) {
                     LOGGER.warn("Rejecting stale system task completion for taskId: {}", taskId);
                 }
             }
-            if (!skipTaskUpdate) {
+            if (shouldPersistTaskResult) {
                 task.setSystemTaskClaimToken(null);
                 task.setSystemTaskClaimDeadline(0);
                 executionDAOFacade.updateTask(task);
             }
-            if (!skipTaskUpdate && shouldRemoveTaskFromQueue) {
+            if (shouldPersistTaskResult && shouldRemoveTaskFromQueue) {
                 queueDAO.remove(queueName, task.getTaskId());
                 LOGGER.debug("{} removed from queue: {}", task, queueName);
             }
             // if the current task execution has completed, then the workflow needs to be evaluated
-            if (!skipTaskUpdate && hasTaskExecutionCompleted) {
+            if (shouldPersistTaskResult && hasTaskExecutionCompleted) {
                 workflowExecutor.decide(workflowId);
             }
         }
@@ -342,5 +339,11 @@ public class AsyncSystemTaskExecutor {
         } catch (Exception e) {
             return null;
         }
+    }
+
+    private boolean isTaskClaimOwner(String claimToken, TaskModel persistedTask) {
+        return persistedTask != null
+                && !persistedTask.getStatus().isTerminal()
+                && claimToken.equals(persistedTask.getSystemTaskClaimToken());
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -274,14 +274,16 @@ public class AsyncSystemTaskExecutor {
     }
 
     /**
-     * True if the task has already started (startTime set, persisted on the first execution) and
-     * has not been updated within its responseTimeout — i.e. a redelivered message belongs to a run
-     * that overran its allowed time and should be timed out rather than re-executed. Uses
-     * updateTime (time since the last response), so a worker that keeps checking in within
-     * responseTimeout (long-running LLM/A2A callbacks) is not timed out.
+     * True if the task has already started (startTime set) and has not been updated within its
+     * responseTimeout — i.e. a redelivered message belongs to a run that overran its allowed time
+     * and should be timed out rather than re-executed. Uses updateTime (time since the last
+     * response), so a worker that keeps checking in within responseTimeout (long-running LLM/A2A
+     * callbacks) is not timed out. Requires updateTime > 0: a just-scheduled task whose mapper set
+     * startTime (e.g. JOIN) has updateTime == 0 and must not be treated as overrun.
      */
     private boolean hasExceededResponseTimeout(TaskModel task) {
         return task.getStartTime() > 0
+                && task.getUpdateTime() > 0
                 && (System.currentTimeMillis() - task.getUpdateTime())
                         >= effectiveResponseTimeoutSeconds(task) * 1000L;
     }

--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -166,7 +166,7 @@ public class AsyncSystemTaskExecutor {
 
             boolean scheduled = task.getStatus() == TaskModel.Status.SCHEDULED;
             if (scheduled || task.getStatus() == TaskModel.Status.IN_PROGRESS) {
-                if (hasExceededResponseTimeout(task)) {
+                if (claimToken != null && hasExceededResponseTimeout(task)) {
                     // The message was redelivered while a previous invocation is still in flight
                     // past responseTimeout. Do NOT run it again in parallel (issue #1321): the task
                     // has exceeded its allowed time, so time it out and let the retry/timeout

--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -263,6 +263,7 @@ public class AsyncSystemTaskExecutor {
                 skipTaskUpdate =
                         invocationFailed
                                 || persistedTask == null
+                                || persistedTask.getStatus().isTerminal()
                                 || !claimToken.equals(persistedTask.getSystemTaskClaimToken());
                 if (skipTaskUpdate) {
                     LOGGER.warn("Rejecting stale system task completion for taskId: {}", taskId);

--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.core.config.ConductorProperties;
 import com.netflix.conductor.core.dal.ExecutionDAOFacade;
 import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
@@ -152,28 +153,55 @@ public class AsyncSystemTaskExecutor {
                 task.incrementPollCount();
             }
 
-            if (task.getStatus() == TaskModel.Status.SCHEDULED
-                    || task.getStatus() == TaskModel.Status.IN_PROGRESS) {
-                Map<String, Object> literalInput = task.getInputData();
-                // Secrets substitution only sees task.getInputData(); when input has been
-                // offloaded to external payload storage, getInputData()/setInputData() operate on
-                // a different field and this substitution silently becomes a no-op.
-                if (task.getExternalInputPayloadStoragePath() != null) {
-                    LOGGER.warn(
-                            "Task {} has externalized input; ${{workflow.secrets.*}} references are not resolved for external payload storage",
+            boolean scheduled = task.getStatus() == TaskModel.Status.SCHEDULED;
+            if (scheduled || task.getStatus() == TaskModel.Status.IN_PROGRESS) {
+                if (hasExceededResponseTimeout(task)) {
+                    // The message was redelivered while a previous invocation is still in flight
+                    // past responseTimeout. Do NOT run it again in parallel (issue #1321): the task
+                    // has exceeded its allowed time, so time it out and let the retry/timeout
+                    // policy
+                    // decide (retry as a new attempt, or fail). The finally block below removes the
+                    // message and re-evaluates the workflow.
+                    task.setStatus(TaskModel.Status.TIMED_OUT);
+                    task.setReasonForIncompletion(
+                            "Task did not complete within its responseTimeout of "
+                                    + effectiveResponseTimeoutSeconds(task)
+                                    + "s");
+                    LOGGER.info(
+                            "Timing out {}/{}: no response within responseTimeout",
+                            task.getTaskType(),
                             task.getTaskId());
-                }
-                task.setInputData(parametersUtils.substituteSecrets(literalInput));
-                try {
-                    if (task.getStatus() == TaskModel.Status.SCHEDULED) {
-                        task.setStartTime(System.currentTimeMillis());
-                        Monitors.recordQueueWaitTime(task.getTaskType(), task.getQueueWaitTime());
-                        systemTask.start(workflow, task, workflowExecutor);
-                    } else {
-                        systemTask.execute(workflow, task, workflowExecutor);
+                } else {
+                    // Keep the message present but invisible for the run so it is not redelivered
+                    // and the sweeper's repair does not re-queue this running task (issue #1321).
+                    reserveInflightMessage(queueName, task);
+                    Map<String, Object> literalInput = task.getInputData();
+                    // Secrets substitution only sees task.getInputData(); when input has been
+                    // offloaded to external payload storage, getInputData()/setInputData() operate
+                    // on a different field and this substitution silently becomes a no-op.
+                    if (task.getExternalInputPayloadStoragePath() != null) {
+                        LOGGER.warn(
+                                "Task {} has externalized input; ${{workflow.secrets.*}} references are not resolved for external payload storage",
+                                task.getTaskId());
                     }
-                } finally {
-                    task.setInputData(literalInput);
+                    task.setInputData(parametersUtils.substituteSecrets(literalInput));
+                    try {
+                        if (scheduled) {
+                            task.setStartTime(System.currentTimeMillis());
+                            // Persist startTime before invoking (status is left unchanged so a
+                            // system task whose start() branches on SCHEDULED still works) so a
+                            // redelivery can tell the task has already started and time it out if
+                            // it outlives responseTimeout instead of blindly executing it again.
+                            executionDAOFacade.updateTask(task);
+                            Monitors.recordQueueWaitTime(
+                                    task.getTaskType(), task.getQueueWaitTime());
+                            systemTask.start(workflow, task, workflowExecutor);
+                        } else {
+                            systemTask.execute(workflow, task, workflowExecutor);
+                        }
+                    } finally {
+                        task.setInputData(literalInput);
+                    }
                 }
             }
 
@@ -219,6 +247,43 @@ public class AsyncSystemTaskExecutor {
                 workflowExecutor.decide(workflowId);
             }
         }
+    }
+
+    /**
+     * Extend the task's queue message visibility to cover the invocation (issue #1321), using its
+     * {@code responseTimeoutSeconds} or the default {@link TaskDef#ONE_HOUR} when unset.
+     */
+    private void reserveInflightMessage(String queueName, TaskModel task) {
+        try {
+            queueDAO.setUnackTimeout(
+                    queueName, task.getTaskId(), effectiveResponseTimeoutSeconds(task) * 1000L);
+        } catch (Exception e) {
+            LOGGER.error(
+                    "Error reserving in-flight message for task: {} in queue: {}",
+                    task.getTaskId(),
+                    queueName,
+                    e);
+        }
+    }
+
+    /** The task's {@code responseTimeoutSeconds}, or the default {@link TaskDef#ONE_HOUR}. */
+    private long effectiveResponseTimeoutSeconds(TaskModel task) {
+        return task.getResponseTimeoutSeconds() > 0
+                ? task.getResponseTimeoutSeconds()
+                : TaskDef.ONE_HOUR;
+    }
+
+    /**
+     * True if the task has already started (startTime set, persisted on the first execution) and
+     * has not been updated within its responseTimeout — i.e. a redelivered message belongs to a run
+     * that overran its allowed time and should be timed out rather than re-executed. Uses
+     * updateTime (time since the last response), so a worker that keeps checking in within
+     * responseTimeout (long-running LLM/A2A callbacks) is not timed out.
+     */
+    private boolean hasExceededResponseTimeout(TaskModel task) {
+        return task.getStartTime() > 0
+                && (System.currentTimeMillis() - task.getUpdateTime())
+                        >= effectiveResponseTimeoutSeconds(task) * 1000L;
     }
 
     private void postponeQuietly(String queueName, TaskModel task) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -13,6 +13,7 @@
 package com.netflix.conductor.core.execution;
 
 import java.util.Map;
+import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -118,6 +119,9 @@ public class AsyncSystemTaskExecutor {
 
         boolean hasTaskExecutionCompleted = false;
         boolean shouldRemoveTaskFromQueue = false;
+        boolean invocationFailed = false;
+        boolean skipTaskUpdate = false;
+        String claimToken = task.getSystemTaskClaimToken();
         String workflowId = task.getWorkflowInstanceId();
         // if we are here the Task object is updated and needs to be persisted regardless of an
         // exception
@@ -147,6 +151,13 @@ public class AsyncSystemTaskExecutor {
                     task.getTaskType(),
                     task.getTaskId(),
                     task.getStatus());
+
+            if (claimToken != null
+                    && task.getSystemTaskClaimDeadline() > System.currentTimeMillis()) {
+                reserveInflightMessage(queueName, task);
+                skipTaskUpdate = true;
+                return;
+            }
 
             boolean isTaskAsyncComplete = systemTask.isAsyncComplete(task);
             if (task.getStatus() == TaskModel.Status.SCHEDULED || !isTaskAsyncComplete) {
@@ -186,13 +197,22 @@ public class AsyncSystemTaskExecutor {
                     }
                     task.setInputData(parametersUtils.substituteSecrets(literalInput));
                     try {
+                        claimToken = UUID.randomUUID().toString();
+                        task.setSystemTaskClaimToken(claimToken);
+                        task.setSystemTaskClaimDeadline(
+                                System.currentTimeMillis()
+                                        + effectiveResponseTimeoutSeconds(task) * 1000L);
+                        task.setCallbackAfterSeconds(0);
+                        task.setStatus(TaskModel.Status.IN_PROGRESS);
                         if (scheduled) {
                             task.setStartTime(System.currentTimeMillis());
-                            // Persist startTime before invoking (status is left unchanged so a
-                            // system task whose start() branches on SCHEDULED still works) so a
-                            // redelivery can tell the task has already started and time it out if
-                            // it outlives responseTimeout instead of blindly executing it again.
-                            executionDAOFacade.updateTask(task);
+                        }
+                        executionDAOFacade.updateTask(task);
+
+                        // Keep the stored state IN_PROGRESS, but preserve the existing start()
+                        // contract for implementations that inspect the supplied task status.
+                        task.setStatus(scheduled ? TaskModel.Status.SCHEDULED : task.getStatus());
+                        if (scheduled) {
                             Monitors.recordQueueWaitTime(
                                     task.getTaskType(), task.getQueueWaitTime());
                             systemTask.start(workflow, task, workflowExecutor);
@@ -234,16 +254,31 @@ public class AsyncSystemTaskExecutor {
                     task.getTaskId(),
                     task.getStatus());
         } catch (Exception e) {
+            invocationFailed = claimToken != null;
             Monitors.error(AsyncSystemTaskExecutor.class.getSimpleName(), "executeSystemTask");
             LOGGER.error("Error executing system task - {}, with id: {}", systemTask, taskId, e);
         } finally {
-            executionDAOFacade.updateTask(task);
-            if (shouldRemoveTaskFromQueue) {
+            if (!skipTaskUpdate && claimToken != null) {
+                TaskModel persistedTask = loadTaskQuietly(taskId);
+                skipTaskUpdate =
+                        invocationFailed
+                                || persistedTask == null
+                                || !claimToken.equals(persistedTask.getSystemTaskClaimToken());
+                if (skipTaskUpdate) {
+                    LOGGER.warn("Rejecting stale system task completion for taskId: {}", taskId);
+                }
+            }
+            if (!skipTaskUpdate) {
+                task.setSystemTaskClaimToken(null);
+                task.setSystemTaskClaimDeadline(0);
+                executionDAOFacade.updateTask(task);
+            }
+            if (!skipTaskUpdate && shouldRemoveTaskFromQueue) {
                 queueDAO.remove(queueName, task.getTaskId());
                 LOGGER.debug("{} removed from queue: {}", task, queueName);
             }
             // if the current task execution has completed, then the workflow needs to be evaluated
-            if (hasTaskExecutionCompleted) {
+            if (!skipTaskUpdate && hasTaskExecutionCompleted) {
                 workflowExecutor.decide(workflowId);
             }
         }

--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -154,7 +154,9 @@ public class AsyncSystemTaskExecutor {
 
             if (claimToken != null
                     && task.getSystemTaskClaimDeadline() > System.currentTimeMillis()) {
-                reserveInflightMessage(queueName, task);
+                if (!reserveInflightMessage(queueName, task)) {
+                    LOGGER.warn("Unable to reserve system task {}; skipping execution", taskId);
+                }
                 shouldProcessTask = false;
                 return;
             }
@@ -185,7 +187,11 @@ public class AsyncSystemTaskExecutor {
                 } else {
                     // Keep the message present but invisible for the run so it is not redelivered
                     // and the sweeper's repair does not re-queue this running task (issue #1321).
-                    reserveInflightMessage(queueName, task);
+                    if (!reserveInflightMessage(queueName, task)) {
+                        LOGGER.warn("Unable to reserve system task {}; skipping execution", taskId);
+                        shouldProcessTask = false;
+                        return;
+                    }
                     Map<String, Object> literalInput = task.getInputData();
                     // Secrets substitution only sees task.getInputData(); when input has been
                     // offloaded to external payload storage, getInputData()/setInputData() operate
@@ -285,9 +291,9 @@ public class AsyncSystemTaskExecutor {
      * Extend the task's queue message visibility to cover the invocation (issue #1321), using its
      * {@code responseTimeoutSeconds} or the default {@link TaskDef#ONE_HOUR} when unset.
      */
-    private void reserveInflightMessage(String queueName, TaskModel task) {
+    private boolean reserveInflightMessage(String queueName, TaskModel task) {
         try {
-            queueDAO.setUnackTimeout(
+            return queueDAO.setUnackTimeout(
                     queueName, task.getTaskId(), effectiveResponseTimeoutSeconds(task) * 1000L);
         } catch (Exception e) {
             LOGGER.error(
@@ -295,6 +301,7 @@ public class AsyncSystemTaskExecutor {
                     task.getTaskId(),
                     queueName,
                     e);
+            return false;
         }
     }
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -258,26 +258,25 @@ public class AsyncSystemTaskExecutor {
             Monitors.error(AsyncSystemTaskExecutor.class.getSimpleName(), "executeSystemTask");
             LOGGER.error("Error executing system task - {}, with id: {}", systemTask, taskId, e);
         } finally {
-            if (shouldProcessTask && claimToken != null) {
-                TaskModel persistedTask = loadTaskQuietly(taskId);
-                shouldProcessTask =
-                        !invocationFailed && isTaskClaimOwner(claimToken, persistedTask);
-                if (!shouldProcessTask) {
-                    LOGGER.warn("Rejecting stale system task completion for taskId: {}", taskId);
-                }
-            }
             if (shouldProcessTask) {
-                task.setSystemTaskClaimToken(null);
-                task.setSystemTaskClaimDeadline(0);
-                executionDAOFacade.updateTask(task);
-            }
-            if (shouldProcessTask && shouldRemoveTaskFromQueue) {
-                queueDAO.remove(queueName, task.getTaskId());
-                LOGGER.debug("{} removed from queue: {}", task, queueName);
-            }
-            // if the current task execution has completed, then the workflow needs to be evaluated
-            if (shouldProcessTask && hasTaskExecutionCompleted) {
-                workflowExecutor.decide(workflowId);
+                if (claimToken != null
+                        && (invocationFailed
+                                || !isTaskClaimOwner(claimToken, loadTaskQuietly(taskId)))) {
+                    LOGGER.warn("Rejecting stale system task completion for taskId: {}", taskId);
+                } else {
+                    task.setSystemTaskClaimToken(null);
+                    task.setSystemTaskClaimDeadline(0);
+                    executionDAOFacade.updateTask(task);
+                    if (shouldRemoveTaskFromQueue) {
+                        queueDAO.remove(queueName, task.getTaskId());
+                        LOGGER.debug("{} removed from queue: {}", task, queueName);
+                    }
+                    // if the current task execution has completed, then the workflow needs to be
+                    // evaluated
+                    if (hasTaskExecutionCompleted) {
+                        workflowExecutor.decide(workflowId);
+                    }
+                }
             }
         }
     }

--- a/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/AsyncSystemTaskExecutor.java
@@ -120,7 +120,7 @@ public class AsyncSystemTaskExecutor {
         boolean hasTaskExecutionCompleted = false;
         boolean shouldRemoveTaskFromQueue = false;
         boolean invocationFailed = false;
-        boolean shouldPersistTaskResult = true;
+        boolean shouldProcessTask = true;
         String claimToken = task.getSystemTaskClaimToken();
         String workflowId = task.getWorkflowInstanceId();
         // if we are here the Task object is updated and needs to be persisted regardless of an
@@ -155,7 +155,7 @@ public class AsyncSystemTaskExecutor {
             if (claimToken != null
                     && task.getSystemTaskClaimDeadline() > System.currentTimeMillis()) {
                 reserveInflightMessage(queueName, task);
-                shouldPersistTaskResult = false;
+                shouldProcessTask = false;
                 return;
             }
 
@@ -258,25 +258,25 @@ public class AsyncSystemTaskExecutor {
             Monitors.error(AsyncSystemTaskExecutor.class.getSimpleName(), "executeSystemTask");
             LOGGER.error("Error executing system task - {}, with id: {}", systemTask, taskId, e);
         } finally {
-            if (shouldPersistTaskResult && claimToken != null) {
+            if (shouldProcessTask && claimToken != null) {
                 TaskModel persistedTask = loadTaskQuietly(taskId);
-                shouldPersistTaskResult =
+                shouldProcessTask =
                         !invocationFailed && isTaskClaimOwner(claimToken, persistedTask);
-                if (!shouldPersistTaskResult) {
+                if (!shouldProcessTask) {
                     LOGGER.warn("Rejecting stale system task completion for taskId: {}", taskId);
                 }
             }
-            if (shouldPersistTaskResult) {
+            if (shouldProcessTask) {
                 task.setSystemTaskClaimToken(null);
                 task.setSystemTaskClaimDeadline(0);
                 executionDAOFacade.updateTask(task);
             }
-            if (shouldPersistTaskResult && shouldRemoveTaskFromQueue) {
+            if (shouldProcessTask && shouldRemoveTaskFromQueue) {
                 queueDAO.remove(queueName, task.getTaskId());
                 LOGGER.debug("{} removed from queue: {}", task, queueName);
             }
             // if the current task execution has completed, then the workflow needs to be evaluated
-            if (shouldPersistTaskResult && hasTaskExecutionCompleted) {
+            if (shouldProcessTask && hasTaskExecutionCompleted) {
                 workflowExecutor.decide(workflowId);
             }
         }

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorker.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/SystemTaskWorker.java
@@ -33,7 +33,6 @@ import com.netflix.conductor.core.utils.QueueUtils;
 import com.netflix.conductor.core.utils.SemaphoreUtil;
 import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.metrics.Monitors;
-import com.netflix.conductor.service.ExecutionService;
 
 /** The worker that polls and executes an async system task. */
 @Component
@@ -51,7 +50,6 @@ public class SystemTaskWorker extends LifecycleAwareComponent {
     ExecutionConfig defaultExecutionConfig;
     private final AsyncSystemTaskExecutor asyncSystemTaskExecutor;
     private final ConductorProperties properties;
-    private final ExecutionService executionService;
     private final int queuePopTimeout;
 
     ConcurrentHashMap<String, ExecutionConfig> queueExecutionConfigMap = new ConcurrentHashMap<>();
@@ -59,15 +57,13 @@ public class SystemTaskWorker extends LifecycleAwareComponent {
     public SystemTaskWorker(
             QueueDAO queueDAO,
             AsyncSystemTaskExecutor asyncSystemTaskExecutor,
-            ConductorProperties properties,
-            ExecutionService executionService) {
+            ConductorProperties properties) {
         this.properties = properties;
         int threadCount = properties.getSystemTaskWorkerThreadCount();
         this.defaultExecutionConfig = new ExecutionConfig(threadCount, "system-task-worker-%d");
         this.asyncSystemTaskExecutor = asyncSystemTaskExecutor;
         this.queueDAO = queueDAO;
         this.pollInterval = properties.getSystemTaskWorkerPollInterval().toMillis();
-        this.executionService = executionService;
         this.queuePopTimeout = (int) properties.getSystemTaskQueuePopTimeout().toMillis();
 
         LOGGER.info("SystemTaskWorker initialized with {} threads", threadCount);
@@ -141,8 +137,9 @@ public class SystemTaskWorker extends LifecycleAwareComponent {
                                 queueName);
                         Monitors.recordTaskPollCount(queueName, 1);
 
-                        executionService.ackTaskReceived(taskId);
-
+                        // Deliberately not acked here: a running task keeps its queue message so
+                        // the sweeper's repair does not re-queue it (issue #1321). The executor
+                        // extends its visibility before invoking and removes it on completion.
                         CompletableFuture<Void> taskCompletableFuture =
                                 CompletableFuture.runAsync(
                                         () -> asyncSystemTaskExecutor.execute(systemTask, taskId),

--- a/core/src/main/java/com/netflix/conductor/model/TaskModel.java
+++ b/core/src/main/java/com/netflix/conductor/model/TaskModel.java
@@ -108,6 +108,15 @@ public class TaskModel {
 
     private long responseTimeoutSeconds;
 
+    /**
+     * Ownership token for an in-process async system-task invocation. A completion is accepted only
+     * while this token still owns the non-terminal task attempt.
+     */
+    private String systemTaskClaimToken;
+
+    /** Epoch-millisecond deadline for the async system-task claim. */
+    private long systemTaskClaimDeadline;
+
     private String workflowInstanceId;
 
     private String workflowType;
@@ -387,6 +396,22 @@ public class TaskModel {
 
     public void setResponseTimeoutSeconds(long responseTimeoutSeconds) {
         this.responseTimeoutSeconds = responseTimeoutSeconds;
+    }
+
+    public String getSystemTaskClaimToken() {
+        return systemTaskClaimToken;
+    }
+
+    public void setSystemTaskClaimToken(String systemTaskClaimToken) {
+        this.systemTaskClaimToken = systemTaskClaimToken;
+    }
+
+    public long getSystemTaskClaimDeadline() {
+        return systemTaskClaimDeadline;
+    }
+
+    public void setSystemTaskClaimDeadline(long systemTaskClaimDeadline) {
+        this.systemTaskClaimDeadline = systemTaskClaimDeadline;
     }
 
     public String getWorkflowInstanceId() {

--- a/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
@@ -330,6 +330,28 @@ class AsyncSystemTaskExecutorTest extends Specification {
         task.status == TaskModel.Status.TIMED_OUT
     }
 
+    def "Does not time out a just-scheduled task whose mapper set startTime but has no updateTime (e.g. JOIN)"() {
+        given:
+        String workflowId = "workflowId"
+        String taskId = "taskId"
+        // JOIN's mapper sets startTime at scheduling; updateTime is still 0 (createTasks doesn't set it)
+        TaskModel task = new TaskModel(taskType: "type1", status: TaskModel.Status.SCHEDULED, taskId: taskId, workflowInstanceId: workflowId,
+                taskDefName: "taskDefName", workflowPriority: 10, responseTimeoutSeconds: 0, startTime: System.currentTimeMillis(), updateTime: 0)
+        WorkflowModel workflow = new WorkflowModel(workflowId: workflowId, status: WorkflowModel.Status.RUNNING)
+        String queueName = QueueUtils.getQueueName(task)
+
+        when:
+        executor.execute(workflowSystemTask, taskId)
+
+        then:
+        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
+        // it is reserved and started, NOT timed out
+        1 * queueDAO.setUnackTimeout(queueName, taskId, _)
+        1 * workflowSystemTask.start(workflow, task, _)
+        task.status != TaskModel.Status.TIMED_OUT
+    }
+
     def "Execute preserves a callback interval set by the system task"() {
         given:
         properties.systemTaskWorkerCallbackDuration = Duration.ofSeconds(30)

--- a/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
@@ -249,7 +249,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         then:
         1 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
-        1 * executionDAOFacade.updateTask(task)
+        2 * executionDAOFacade.updateTask(task) // startTime persist before start() + finally
         1 * queueDAO.postpone(queueName, taskId, task.workflowPriority, properties.systemTaskWorkerCallbackDuration.seconds)
         1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.IN_PROGRESS }
 
@@ -260,6 +260,74 @@ class AsyncSystemTaskExecutorTest extends Specification {
         task.endTime == 0 // verify that endTime is not set
         task.pollCount == 1 // verify that poll count is incremented
         task.callbackAfterSeconds == properties.systemTaskWorkerCallbackDuration.seconds
+    }
+
+    def "Reserves the in-flight message with responseTimeout before invoking the task"() {
+        given:
+        String workflowId = "workflowId"
+        String taskId = "taskId"
+        TaskModel task = new TaskModel(taskType: "type1", status: TaskModel.Status.SCHEDULED, taskId: taskId, workflowInstanceId: workflowId,
+                taskDefName: "taskDefName", workflowPriority: 10, responseTimeoutSeconds: 120)
+        WorkflowModel workflow = new WorkflowModel(workflowId: workflowId, status: WorkflowModel.Status.RUNNING)
+        String queueName = QueueUtils.getQueueName(task)
+
+        when:
+        executor.execute(workflowSystemTask, taskId)
+
+        then:
+        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
+        // the message is reserved for responseTimeout (120s) so a running task keeps its queue
+        // message and is not redelivered/re-queued mid-execution (issue #1321)
+        1 * queueDAO.setUnackTimeout(queueName, taskId, 120_000L)
+        1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.COMPLETED }
+    }
+
+    def "Reserves the in-flight message with the default responseTimeout when unset"() {
+        given:
+        String workflowId = "workflowId"
+        String taskId = "taskId"
+        TaskModel task = new TaskModel(taskType: "type1", status: TaskModel.Status.SCHEDULED, taskId: taskId, workflowInstanceId: workflowId,
+                taskDefName: "taskDefName", workflowPriority: 10, responseTimeoutSeconds: 0)
+        WorkflowModel workflow = new WorkflowModel(workflowId: workflowId, status: WorkflowModel.Status.RUNNING)
+        String queueName = QueueUtils.getQueueName(task)
+
+        when:
+        executor.execute(workflowSystemTask, taskId)
+
+        then:
+        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
+        // no responseTimeout set -> falls back to the default (TaskDef.ONE_HOUR = 3600s)
+        1 * queueDAO.setUnackTimeout(queueName, taskId, 3_600_000L)
+        1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.COMPLETED }
+    }
+
+    def "Times out a redelivered task that outlived responseTimeout instead of re-executing it"() {
+        given:
+        String workflowId = "workflowId"
+        String taskId = "taskId"
+        // already started, and not updated within responseTimeout (updateTime is 20s old, timeout 10s)
+        long stale = System.currentTimeMillis() - 20_000
+        TaskModel task = new TaskModel(taskType: "type1", status: TaskModel.Status.IN_PROGRESS, taskId: taskId, workflowInstanceId: workflowId,
+                taskDefName: "taskDefName", workflowPriority: 10, responseTimeoutSeconds: 10, startTime: stale, updateTime: stale)
+        WorkflowModel workflow = new WorkflowModel(workflowId: workflowId, status: WorkflowModel.Status.RUNNING)
+        String queueName = QueueUtils.getQueueName(task)
+
+        when:
+        executor.execute(workflowSystemTask, taskId)
+
+        then:
+        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
+        // the overrunning task is timed out, NOT invoked again (issue #1321)
+        0 * workflowSystemTask.start(*_)
+        0 * workflowSystemTask.execute(*_)
+        0 * queueDAO.setUnackTimeout(*_)
+        1 * queueDAO.remove(queueName, taskId)
+        1 * workflowExecutor.decide(workflowId)
+
+        task.status == TaskModel.Status.TIMED_OUT
     }
 
     def "Execute preserves a callback interval set by the system task"() {
@@ -289,7 +357,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
             Optional.of(task.callbackAfterSeconds)
         }
         1 * queueDAO.postpone(queueName, taskId, task.workflowPriority, 5)
-        1 * executionDAOFacade.updateTask(task)
+        2 * executionDAOFacade.updateTask(task) // startTime persist before start() + finally
 
         task.status == TaskModel.Status.IN_PROGRESS
         task.callbackAfterSeconds == 5
@@ -310,7 +378,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         then:
         1 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
-        1 * executionDAOFacade.updateTask(task)
+        2 * executionDAOFacade.updateTask(task) // startTime persist before start() + finally
 
         1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.COMPLETED }
         1 * queueDAO.remove(queueName, taskId)
@@ -336,7 +404,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         then:
         1 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
-        1 * executionDAOFacade.updateTask(task)
+        2 * executionDAOFacade.updateTask(task) // startTime persist before start() + finally
 
         // simulating a "start" failure that happens after the Task object is modified
         // the modification will be persisted
@@ -368,7 +436,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         then:
         1 * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
-        1 * executionDAOFacade.updateTask(task) // 1st call for pollCount, 2nd call for status update
+        2 * executionDAOFacade.updateTask(task) // startTime persist before start() + finally
 
         1 * workflowSystemTask.isAsyncComplete(task) >> true
         1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.IN_PROGRESS }

--- a/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
@@ -310,15 +310,23 @@ class AsyncSystemTaskExecutorTest extends Specification {
         // already started, and not updated within responseTimeout (updateTime is 20s old, timeout 10s)
         long stale = System.currentTimeMillis() - 20_000
         TaskModel task = new TaskModel(taskType: "type1", status: TaskModel.Status.IN_PROGRESS, taskId: taskId, workflowInstanceId: workflowId,
-                taskDefName: "taskDefName", workflowPriority: 10, responseTimeoutSeconds: 10, startTime: stale, updateTime: stale)
+                taskDefName: "taskDefName", workflowPriority: 10, responseTimeoutSeconds: 10, startTime: stale, updateTime: stale,
+                systemTaskClaimToken: "expired-claim", systemTaskClaimDeadline: stale)
         WorkflowModel workflow = new WorkflowModel(workflowId: workflowId, status: WorkflowModel.Status.RUNNING)
         String queueName = QueueUtils.getQueueName(task)
+        int timeoutTaskLoads = 0
 
         when:
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        _ * executionDAOFacade.getTaskModel(taskId) >> task
+        _ * executionDAOFacade.getTaskModel(taskId) >> {
+            if (timeoutTaskLoads++ == 0) {
+                return task
+            }
+            return new TaskModel(status: TaskModel.Status.IN_PROGRESS,
+                    systemTaskClaimToken: task.systemTaskClaimToken)
+        }
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         // the overrunning task is timed out, NOT invoked again (issue #1321)
         0 * workflowSystemTask.start(*_)

--- a/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
@@ -62,6 +62,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         properties.systemTaskWorkerCallbackDuration = Duration.ofSeconds(1)
 
         parametersUtils.substituteSecrets(_) >> { args -> args[0] }
+        queueDAO.setUnackTimeout(_, _, _) >> true
 
         executor = new AsyncSystemTaskExecutor(executionDAOFacade, queueDAO, metadataDAO, properties, workflowExecutor, parametersUtils)
     }
@@ -279,7 +280,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         // the message is reserved for responseTimeout (120s) so a running task keeps its queue
         // message and is not redelivered/re-queued mid-execution (issue #1321)
-        1 * queueDAO.setUnackTimeout(queueName, taskId, 120_000L)
+        1 * queueDAO.setUnackTimeout(queueName, taskId, 120_000L) >> true
         1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.COMPLETED }
     }
 
@@ -299,7 +300,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         _ * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         // no responseTimeout set -> falls back to the default (TaskDef.ONE_HOUR = 3600s)
-        1 * queueDAO.setUnackTimeout(queueName, taskId, 3_600_000L)
+        1 * queueDAO.setUnackTimeout(queueName, taskId, 3_600_000L) >> true
         1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> { task.status = TaskModel.Status.COMPLETED }
     }
 
@@ -338,6 +339,37 @@ class AsyncSystemTaskExecutorTest extends Specification {
         task.status == TaskModel.Status.TIMED_OUT
     }
 
+    def "Does not invoke a system task when queue reservation fails"() {
+        given:
+        String workflowId = "workflowId"
+        String taskId = "taskId"
+        TaskModel task = new TaskModel(taskType: "type1", status: TaskModel.Status.SCHEDULED, taskId: taskId, workflowInstanceId: workflowId,
+                taskDefName: "taskDefName", workflowPriority: 10, responseTimeoutSeconds: 10)
+        WorkflowModel workflow = new WorkflowModel(workflowId: workflowId, status: WorkflowModel.Status.RUNNING)
+        String queueName = QueueUtils.getQueueName(task)
+
+        when:
+        executor.execute(workflowSystemTask, taskId)
+
+        then:
+        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
+        1 * queueDAO.setUnackTimeout(queueName, taskId, 10_000L) >> {
+            if (reservationThrows) {
+                throw new RuntimeException("queue unavailable")
+            }
+            return false
+        }
+        0 * executionDAOFacade.updateTask(_)
+        0 * workflowSystemTask.start(*_)
+        0 * workflowSystemTask.execute(*_)
+        0 * queueDAO.postpone(*_)
+        0 * queueDAO.remove(*_)
+
+        where:
+        reservationThrows << [false, true]
+    }
+
     def "Does not time out a just-scheduled task whose mapper set startTime but has no updateTime (e.g. JOIN)"() {
         given:
         String workflowId = "workflowId"
@@ -355,7 +387,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         _ * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         // it is reserved and started, NOT timed out
-        1 * queueDAO.setUnackTimeout(queueName, taskId, _)
+        1 * queueDAO.setUnackTimeout(queueName, taskId, _) >> true
         1 * workflowSystemTask.start(workflow, task, _)
         task.status != TaskModel.Status.TIMED_OUT
     }

--- a/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
@@ -94,7 +94,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(subWorkflowTask, parentTaskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(parentTaskId) >> task1
+        _ * executionDAOFacade.getTaskModel(parentTaskId) >> task1
         1 * executionDAOFacade.getWorkflowModel(workflowId, subWorkflowTask.isTaskRetrievalRequired()) >> workflow
         1 * workflowExecutor.startWorkflowIdempotent(*_) >> subWorkflow
 
@@ -141,7 +141,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        _ * executionDAOFacade.getTaskModel(taskId) >> task
         1 * queueDAO.remove(task.taskType, taskId)
         0 * workflowSystemTask.start(*_)
         0 * executionDAOFacade.updateTask(_)
@@ -159,7 +159,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        _ * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         1 * queueDAO.remove(queueName, taskId)
 
@@ -180,7 +180,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        _ * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.exceedsInProgressLimit(task) >> true
         1 * queueDAO.postpone(queueName, taskId, task.workflowPriority, properties.taskExecutionPostponeDuration.seconds)
 
@@ -201,7 +201,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        _ * executionDAOFacade.getTaskModel(taskId) >> task
         1 * metadataDAO.getTaskDef(task.taskDefName) >> taskDef
         1 * executionDAOFacade.exceedsRateLimitPerFrequency(task, taskDef) >> taskDef
         1 * queueDAO.postpone(queueName, taskId, task.workflowPriority, properties.taskExecutionPostponeDuration.seconds)
@@ -223,7 +223,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        _ * executionDAOFacade.getTaskModel(taskId) >> task
         1 * metadataDAO.getTaskDef(task.taskDefName) >> taskDef
         1 * executionDAOFacade.exceedsRateLimitPerFrequency(task, taskDef) >> taskDef
         1 * queueDAO.postpone(queueName, taskId, task.workflowPriority, properties.taskExecutionPostponeDuration.seconds) >> { throw new RuntimeException("queue unavailable") }
@@ -247,7 +247,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        _ * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         2 * executionDAOFacade.updateTask(task) // startTime persist before start() + finally
         1 * queueDAO.postpone(queueName, taskId, task.workflowPriority, properties.systemTaskWorkerCallbackDuration.seconds)
@@ -275,7 +275,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        _ * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         // the message is reserved for responseTimeout (120s) so a running task keeps its queue
         // message and is not redelivered/re-queued mid-execution (issue #1321)
@@ -296,7 +296,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        _ * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         // no responseTimeout set -> falls back to the default (TaskDef.ONE_HOUR = 3600s)
         1 * queueDAO.setUnackTimeout(queueName, taskId, 3_600_000L)
@@ -318,7 +318,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        _ * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         // the overrunning task is timed out, NOT invoked again (issue #1321)
         0 * workflowSystemTask.start(*_)
@@ -344,7 +344,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        _ * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         // it is reserved and started, NOT timed out
         1 * queueDAO.setUnackTimeout(queueName, taskId, _)
@@ -368,7 +368,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        _ * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         1 * workflowSystemTask.start(workflow, task, workflowExecutor) >> {
             task.status = TaskModel.Status.IN_PROGRESS
@@ -398,7 +398,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        _ * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         2 * executionDAOFacade.updateTask(task) // startTime persist before start() + finally
 
@@ -424,9 +424,9 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        _ * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
-        2 * executionDAOFacade.updateTask(task) // startTime persist before start() + finally
+        1 * executionDAOFacade.updateTask(task) // persist the claim before start()
 
         // simulating a "start" failure that happens after the Task object is modified
         // the modification will be persisted
@@ -456,7 +456,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        _ * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         2 * executionDAOFacade.updateTask(task) // startTime persist before start() + finally
 
@@ -484,7 +484,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        _ * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         1 * executionDAOFacade.updateTask(task) // 1st call for pollCount, 2nd call for status update
 
@@ -508,9 +508,9 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        _ * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
-        1 * executionDAOFacade.updateTask(task) // only one call since pollCount is not incremented
+        2 * executionDAOFacade.updateTask(task) // claim, then result
 
         1 * workflowSystemTask.isAsyncComplete(task) >> true
         0 * workflowSystemTask.start(workflow, task, workflowExecutor)
@@ -547,7 +547,7 @@ class AsyncSystemTaskExecutorTest extends Specification {
         executor.execute(systemTask, taskId)
 
         then:
-        1 * executionDAOFacade.getTaskModel(taskId) >> task
+        _ * executionDAOFacade.getTaskModel(taskId) >> task
         1 * executionDAOFacade.getWorkflowModel(workflowId, _) >> workflow
         1 * parametersUtils.substituteSecrets(literal) >> resolved
         1 * systemTask.start(workflow, task, _) >> { args ->

--- a/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
+++ b/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy
@@ -393,12 +393,19 @@ class AsyncSystemTaskExecutorTest extends Specification {
                 taskDefName: "taskDefName", workflowPriority: 10)
         WorkflowModel workflow = new WorkflowModel(workflowId: workflowId, status: WorkflowModel.Status.RUNNING)
         String queueName = QueueUtils.getQueueName(task)
+        int taskLoads = 0
 
         when:
         executor.execute(workflowSystemTask, taskId)
 
         then:
-        _ * executionDAOFacade.getTaskModel(taskId) >> task
+        _ * executionDAOFacade.getTaskModel(taskId) >> {
+            if (taskLoads++ == 0) {
+                return task
+            }
+            return new TaskModel(status: TaskModel.Status.IN_PROGRESS,
+                    systemTaskClaimToken: task.systemTaskClaimToken)
+        }
         1 * executionDAOFacade.getWorkflowModel(workflowId, true) >> workflow
         2 * executionDAOFacade.updateTask(task) // startTime persist before start() + finally
 

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskWorker.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskWorker.java
@@ -25,7 +25,6 @@ import org.mockito.Mockito;
 import com.netflix.conductor.core.config.ConductorProperties;
 import com.netflix.conductor.core.execution.AsyncSystemTaskExecutor;
 import com.netflix.conductor.dao.QueueDAO;
-import com.netflix.conductor.service.ExecutionService;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -43,7 +42,6 @@ public class TestSystemTaskWorker {
     private static final String ISOLATED_TASK = "system_task-isolated";
 
     private AsyncSystemTaskExecutor asyncSystemTaskExecutor;
-    private ExecutionService executionService;
     private QueueDAO queueDAO;
     private ConductorProperties properties;
 
@@ -52,7 +50,6 @@ public class TestSystemTaskWorker {
     @Before
     public void setUp() {
         asyncSystemTaskExecutor = mock(AsyncSystemTaskExecutor.class);
-        executionService = mock(ExecutionService.class);
         queueDAO = mock(QueueDAO.class);
         properties = mock(ConductorProperties.class);
 
@@ -61,9 +58,7 @@ public class TestSystemTaskWorker {
         when(properties.getSystemTaskWorkerCallbackDuration()).thenReturn(Duration.ofSeconds(30));
         when(properties.getSystemTaskWorkerPollInterval()).thenReturn(Duration.ofSeconds(30));
 
-        systemTaskWorker =
-                new SystemTaskWorker(
-                        queueDAO, asyncSystemTaskExecutor, properties, executionService);
+        systemTaskWorker = new SystemTaskWorker(queueDAO, asyncSystemTaskExecutor, properties);
         systemTaskWorker.start();
     }
 
@@ -76,9 +71,7 @@ public class TestSystemTaskWorker {
     @Test
     public void testGetExecutionConfigForSystemTask() {
         when(properties.getSystemTaskWorkerThreadCount()).thenReturn(5);
-        systemTaskWorker =
-                new SystemTaskWorker(
-                        queueDAO, asyncSystemTaskExecutor, properties, executionService);
+        systemTaskWorker = new SystemTaskWorker(queueDAO, asyncSystemTaskExecutor, properties);
         assertEquals(
                 systemTaskWorker.getExecutionConfig("").getSemaphoreUtil().availableSlots(), 5);
     }
@@ -86,9 +79,7 @@ public class TestSystemTaskWorker {
     @Test
     public void testGetExecutionConfigForIsolatedSystemTask() {
         when(properties.getIsolatedSystemTaskWorkerThreadCount()).thenReturn(7);
-        systemTaskWorker =
-                new SystemTaskWorker(
-                        queueDAO, asyncSystemTaskExecutor, properties, executionService);
+        systemTaskWorker = new SystemTaskWorker(queueDAO, asyncSystemTaskExecutor, properties);
         assertEquals(
                 systemTaskWorker.getExecutionConfig("test-iso").getSemaphoreUtil().availableSlots(),
                 7);
@@ -113,6 +104,9 @@ public class TestSystemTaskWorker {
         latch.await();
 
         verify(asyncSystemTaskExecutor).execute(any(), anyString());
+        // The poll must not remove the message (issue #1321) — the executor reserves it instead.
+        verify(queueDAO, Mockito.never()).ack(anyString(), anyString());
+        verify(queueDAO, Mockito.never()).remove(anyString(), anyString());
     }
 
     @Test

--- a/docs/design/2026-07-21-issue-1321-poll-level-reserve.md
+++ b/docs/design/2026-07-21-issue-1321-poll-level-reserve.md
@@ -25,6 +25,111 @@ a task that is legitimately in flight.
 
 Between step 2 and step 4 a **running** task has **no message in the queue**.
 
+## Before: `main` behavior
+
+On `main`, the queue pop itself is not the normal source of the duplicate. A SQL
+queue initially represents the popped row as unacked (`popped = true`), but
+`SystemTaskWorker` immediately acknowledges it. For SQL implementations, that ACK
+deletes the row. The duplicate is created later when `WorkflowSweeper` repairs the
+now-missing message.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant D as Decider
+    participant DB as Task store
+    participant Q as Task queue
+    participant W1 as SystemTaskWorker 1
+    participant X1 as AsyncSystemTaskExecutor 1
+    participant P1 as Provider call 1
+    participant S as WorkflowSweeper
+    participant W2 as SystemTaskWorker 2
+    participant X2 as AsyncSystemTaskExecutor 2
+    participant P2 as Provider call 2
+
+    activate D
+    D->>DB: Persist task as SCHEDULED
+    activate DB
+    DB-->>D: Task persisted
+    deactivate DB
+    D->>Q: Push taskId
+    activate Q
+    Q-->>D: Message queued
+    deactivate Q
+    deactivate D
+
+    activate W1
+    W1->>Q: pop(taskId)
+    activate Q
+    Q-->>W1: Return taskId and mark unacked
+    deactivate Q
+    Note over Q: Message is present but unacked/invisible
+    W1->>Q: ack(taskId)
+    activate Q
+    Q-->>W1: Message deleted
+    deactivate Q
+    Note over Q: Message is deleted
+    W1->>X1: execute(taskId)
+    activate X1
+    deactivate W1
+    X1->>DB: Load SCHEDULED task
+    activate DB
+    DB-->>X1: Return task
+    deactivate DB
+    X1->>P1: start invokes synchronous provider call
+    activate P1
+    Note over DB,Q: Task is SCHEDULED and queue message is absent
+
+    activate S
+    S->>DB: Load running workflow
+    activate DB
+    DB-->>S: Return workflow and tasks
+    deactivate DB
+    S->>Q: containsMessage(taskId)
+    activate Q
+    Q-->>S: false
+    deactivate Q
+    S->>Q: push(taskId) as repair
+    activate Q
+    Q-->>S: Repaired message queued
+    deactivate Q
+    deactivate S
+
+    activate W2
+    W2->>Q: pop(taskId)
+    activate Q
+    Q-->>W2: Return repaired taskId
+    deactivate Q
+    W2->>Q: ack(taskId)
+    activate Q
+    Q-->>W2: Repaired message deleted
+    deactivate Q
+    W2->>X2: execute(taskId)
+    activate X2
+    deactivate W2
+    X2->>DB: Load same SCHEDULED task
+    activate DB
+    DB-->>X2: Return same task
+    deactivate DB
+    X2->>P2: start invokes duplicate provider call
+    activate P2
+
+    P1-->>X1: Result 1
+    deactivate P1
+    X1->>DB: Persist result 1
+    activate DB
+    DB-->>X1: Result 1 persisted
+    deactivate DB
+    deactivate X1
+    P2-->>X2: Result 2
+    deactivate P2
+    X2->>DB: Persist result 2 (races result 1)
+    activate DB
+    DB-->>X2: Result 2 persisted
+    deactivate DB
+    deactivate X2
+```
+
 ## Root cause: a violated invariant + the sweeper's repair
 
 `WorkflowSweeper` (`org.conductoross.conductor.core.execution.WorkflowSweeper`, on
@@ -108,6 +213,239 @@ long-running `IN_PROGRESS + callbackAfterSeconds` re-invocation are all unchange
    the last response), so a worker that keeps checking in within `responseTimeout`
    (LLM/A2A callback flow) is not timed out.
 
+## Proposed after state: reserved message plus persisted claim
+
+The combined design retains this branch's strongest property—the popped message
+is never ACKed before execution—while treating every async-system-task poll as an
+explicit task claim. Before invoking task code, the claim path captures the
+pre-claim status, conditionally persists `IN_PROGRESS`, assigns a unique claim
+token and deadline, and then reserves the queue message. External work begins only
+after both persistence operations succeed.
+
+The captured pre-claim status controls lifecycle dispatch:
+
+- A claim from `SCHEDULED` invokes `start()`.
+- A claim for a due callback from `IN_PROGRESS` invokes `execute()`.
+- A redelivery with an unexpired active claim invokes neither method.
+- An expired claim times out that attempt; it does not execute the same task ID
+  concurrently.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant D as Decider
+    participant DB as Task store
+    participant Q as Task queue
+    participant W as SystemTaskWorker
+    participant X as AsyncSystemTaskExecutor
+    participant P as Provider call
+    participant S as WorkflowSweeper
+
+    activate D
+    D->>DB: Persist task as SCHEDULED
+    activate DB
+    DB-->>D: Task persisted
+    deactivate DB
+    D->>Q: Push taskId
+    activate Q
+    Q-->>D: Message queued
+    deactivate Q
+    deactivate D
+
+    activate W
+    W->>Q: pop(taskId)
+    activate Q
+    Q-->>W: Return taskId and mark unacked
+    deactivate Q
+    Note over Q: Message remains present but unacked/invisible
+    W->>X: execute(taskId) without ACK
+    activate X
+    deactivate W
+    X->>DB: Load SCHEDULED task
+    activate DB
+    DB-->>X: Return task
+    deactivate DB
+    X->>X: Capture pre-claim status SCHEDULED
+    X->>DB: Conditionally claim as IN_PROGRESS with token and deadline
+    activate DB
+    DB-->>X: Claim accepted
+    deactivate DB
+    X->>Q: setUnackTimeout(taskId, responseTimeout)
+    activate Q
+    Q-->>X: Reservation accepted
+    deactivate Q
+    Note over DB,Q: Task is IN_PROGRESS and message remains present but hidden
+    X->>P: Invoke start because pre-claim status was SCHEDULED
+    activate P
+
+    activate S
+    S->>DB: Load running workflow
+    activate DB
+    DB-->>S: Return workflow and tasks
+    deactivate DB
+    S->>Q: containsMessage(taskId)
+    activate Q
+    Q-->>S: true, including the unacked message
+    deactivate Q
+    Note over S: No repair push
+    deactivate S
+
+    P-->>X: Result
+    deactivate P
+    X->>DB: Conditionally complete using claim token
+    activate DB
+    DB-->>X: Completion accepted
+    deactivate DB
+    X->>Q: remove(taskId)
+    activate Q
+    Q-->>X: Message removed
+    deactivate Q
+    X->>D: decide(workflowId)
+    activate D
+    D->>DB: Evaluate updated workflow
+    activate DB
+    DB-->>D: Return updated workflow
+    deactivate DB
+    deactivate D
+    deactivate X
+```
+
+The claim also closes the early-redelivery window independently of queue timing:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant X1 as Claim owner
+    participant P as Provider call
+    participant Q as Task queue
+    participant X2 as Redelivery executor
+    participant DB as Task store
+
+    activate X1
+    X1->>P: Invocation remains in progress
+    activate P
+    Note over DB: Task is IN_PROGRESS with active token and deadline
+    activate Q
+    Q-->>X2: Message becomes visible before deadline
+    deactivate Q
+    activate X2
+    X2->>DB: Attempt conditional claim
+    activate DB
+    DB-->>X2: Reject because active claim has not expired
+    deactivate DB
+    X2->>Q: Hide message for remaining claim duration
+    activate Q
+    Q-->>X2: Message postponed
+    deactivate Q
+    Note over X2,P: No second start or execute call
+    deactivate X2
+    P-->>X1: Original result
+    deactivate P
+    X1->>DB: Conditionally complete using claim token
+    activate DB
+    DB-->>X1: Completion accepted
+    deactivate DB
+    deactivate X1
+```
+
+If the reservation and claim expire first, timeout and completion use the same
+token to prevent the zombie late write:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant X1 as Original executor
+    participant P as Original provider call
+    participant Q as Task queue
+    participant X2 as Second executor
+    participant DB as Task store
+    participant D as Decider
+
+    activate X1
+    X1->>P: Original start call remains in progress
+    activate P
+    Note over P,Q: Original call continues beyond responseTimeout
+    activate Q
+    Q-->>X2: Redeliver same taskId
+    deactivate Q
+    activate X2
+    X2->>DB: Load IN_PROGRESS task and expired claim token
+    activate DB
+    DB-->>X2: Return expired active attempt
+    deactivate DB
+    X2->>DB: Conditionally mark claim token TIMED_OUT
+    activate DB
+    DB-->>X2: Timeout persisted
+    deactivate DB
+    X2->>Q: Remove message
+    activate Q
+    Q-->>X2: Message removed
+    deactivate Q
+    X2->>D: Decide retry or workflow failure
+    activate D
+    D->>DB: Evaluate timeout and retry policy
+    activate DB
+    DB-->>D: Return timed-out workflow
+    deactivate DB
+    deactivate D
+    deactivate X2
+    P-->>X1: Original call eventually returns
+    deactivate P
+    X1->>DB: Conditionally complete using expired claim token
+    activate DB
+    DB-->>X1: Reject because attempt is already TIMED_OUT
+    deactivate DB
+    Note over DB: TIMED_OUT state and retry remain authoritative
+    deactivate X1
+```
+
+The resulting steady-state difference is:
+
+| State while provider call runs | `main` | Proposed combined design |
+|---|---|---|
+| Persisted task status | `SCHEDULED` | `IN_PROGRESS` |
+| Queue row/message | Absent after ACK | Present and unacked |
+| Message pollability | N/A until repair pushes one | Hidden until `responseTimeout` |
+| Sweeper `containsMessage` | `false` | `true` |
+| Normal duplicate trigger | Sweeper repair push | Prevented |
+| Early redelivery | Re-enters `start()` | Rejected by active claim |
+| Dispatch decision | Current stored status | Captured pre-claim status |
+| Late completion after timeout | Can overwrite timeout | Rejected by claim token |
+
+### Claim contract
+
+The minimal implementation on this branch persists the token on `TaskModel` and
+checks it again before publishing a result. This closes the observed sequential
+redelivery and late-write paths, but it is an integration step toward, not a
+substitute for, the persistence-level conditional operations below. Two nodes
+that read the same eligible state concurrently can still race while assigning
+their tokens.
+
+The persistence abstraction should expose a conditional claim operation in
+`core`, with implementations in each persistence module. A successful claim
+returns an execution envelope containing at least:
+
+- the loaded `TaskModel`;
+- its pre-claim status (`SCHEDULED` or callback-due `IN_PROGRESS`);
+- a unique claim token/attempt generation;
+- the claim deadline derived from `responseTimeout`;
+- whether dispatch must call `start()` or `execute()`.
+
+Claim and completion updates must be conditional. A claim succeeds only when the
+task is eligible and does not have another unexpired owner. Completion succeeds
+only when the token still owns a non-terminal attempt. This is what makes timeout,
+retry, and late completion mutually exclusive rather than last-write-wins.
+
+Queue reservation is fail-closed: if `setUnackTimeout()` throws or returns false,
+the executor must not invoke external work. The claimed task remains recoverable,
+and the message is allowed to reappear for timeout/reconciliation.
+
+Worker-requested callbacks remain distinct from an active execution claim. When a
+worker returns `IN_PROGRESS` with `callbackAfterSeconds`, the current claim ends
+and a callback-due timestamp is persisted. A later poll claims that due callback
+with a new token and dispatches `execute()`. It is not interpreted as either an
+early redelivery or an expired invocation.
+
 ## Why `responseTimeout` (not a new property)
 
 `responseTimeout` is exactly "how long the task is allowed to run", which is what
@@ -134,18 +472,62 @@ and is the price of not letting repair fight in-flight tasks.
 - **Non-blocking poll model (#1359):** run the method off the worker thread and poll
   a future — eliminates the in-flight window, but a much larger change.
 
-## Known limitations
+## Risks in the current branch and proposed mitigations
 
-- **Crash mid-execute** → recovery after `responseTimeout` (bounded), slower than
-  repair's ~30s.
-- **A run that overruns `responseTimeout` is timed out and retried** per the task's
-  policy — so a task whose `responseTimeout` is set shorter than its real work will
-  time out repeatedly and eventually fail. Set a realistic `responseTimeout` for
-  long tasks (e.g. LLM); absent one, the `TaskDef.ONE_HOUR` default applies.
-- **Zombie late-write (#1322, not fixed here):** the original invocation of a
-  timed-out task keeps running and, on completion, its `finally` still writes its
-  result under the original taskId, which can overwrite the `TIMED_OUT`/retry state.
-  Rejecting that late write is a separate follow-on (#1322).
+The normal sweeper-driven duplicate is fixed by the current branch, but the
+following boundaries remain in its implementation. The combined design above
+directly addresses items 1–5; items 6–7 remain operational and verification
+requirements.
+
+1. **Reservation failure is fail-open.** `reserveInflightMessage()` catches an
+   exception and continues into `start()`, and it does not check a `false` return
+   from `setUnackTimeout()`. The message can therefore become visible on the
+   backend's default unack schedule while the provider call is still running.
+   Because the task remains `SCHEDULED` and is not yet stale by `responseTimeout`,
+   the redelivery calls `start()` again. Reservation must succeed before external
+   work begins; failure should postpone/requeue without invoking the task.
+
+2. **Visibility before `responseTimeout` still duplicates the invocation.** The
+   Redis integration test forced the reserved message visible after one second
+   while `responseTimeout` was 45 seconds. The second executor loaded the same
+   `SCHEDULED` task, refreshed its reservation, and entered the annotated method;
+   the invocation counter changed from one to two. A persisted claim or equivalent
+   ownership token is needed to reject an early redelivery independently of queue
+   visibility.
+
+3. **An active invocation remains subject to poll timeout.**
+   `DeciderService.checkTaskPollTimeout()` applies specifically to `SCHEDULED`
+   tasks. Since this branch leaves the task `SCHEDULED` during the provider call,
+   a decider evaluation can apply `pollTimeoutSeconds` to work that has already
+   been picked up. Persisting `IN_PROGRESS` would avoid this, but the executor must
+   separately preserve the pre-claim status so first delivery still dispatches to
+   `start()` rather than `execute()`.
+
+4. **Zombie late-write (#1322) is confirmed.** With a two-second response timeout,
+   the integration test observed `TIMED_OUT` after redelivery and then `COMPLETED`
+   after releasing the original invocation. The original executor writes its stale
+   `TaskModel` directly in `finally`. Completion needs an attempt/version-aware
+   conditional update so an expired invocation cannot overwrite a terminal attempt
+   or its retry state.
+
+5. **Worker callbacks and execution expiry share time arithmetic.** A non-terminal
+   worker can request re-evaluation with `callbackAfterSeconds`. On that legitimate
+   redelivery, `hasExceededResponseTimeout()` compares only `now - updateTime` with
+   `responseTimeout`. If the requested callback delay equals or exceeds the
+   response timeout, it can be classified as an overrun rather than a due callback.
+   Callback scheduling and the in-flight execution lease need distinguishable
+   state, or the allowed interval must account for the callback delay.
+
+6. **Crash recovery is intentionally delayed.** A node crash mid-invocation leaves
+   the message hidden until `responseTimeout`; a task without a configured response
+   timeout uses the one-hour fallback. This is bounded but slower than the prior
+   sweeper repair interval and should be visible operationally.
+
+7. **Queue semantics need backend integration coverage.** Correctness requires
+   `containsMessage()` to include unacked messages and `setUnackTimeout()` to move
+   their visibility deadline. The current production-path characterization test
+   uses Redis. The same scenarios should run against PostgreSQL and MySQL to verify
+   their `popped`, `deliver_on`, ACK, and unack-reaper behavior.
 
 ## Testing
 
@@ -156,3 +538,8 @@ and is the price of not letting repair fight in-flight tasks.
   re-invoked.
 - `TestSystemTaskWorker`: the poll hands the task to the executor and does **not**
   `ack`/`remove` the message.
+- `Issue1321DuplicateAsyncSystemTaskSpec` (Redis-backed production path): verifies
+  that the normal reservation prevents redelivery, demonstrates that forced early
+  visibility invokes the annotated worker twice, and demonstrates the
+  `TIMED_OUT` → stale `COMPLETED` overwrite after the original call returns. Its
+  state-transition logs use the `ISSUE1321` prefix in the Gradle XML output.

--- a/docs/design/2026-07-21-issue-1321-poll-level-reserve.md
+++ b/docs/design/2026-07-21-issue-1321-poll-level-reserve.md
@@ -1,0 +1,151 @@
+# #1321 — Duplicate execution of async system tasks (queue-message reservation)
+
+Issue: https://github.com/conductor-oss/conductor/issues/1321
+
+## Summary
+
+An async system task whose synchronous execution outlasts the queue's redelivery
+window is executed a **second time in parallel** by another `system-task-worker`.
+For `LLM_CHAT_COMPLETE` this means duplicate paid provider calls (observed: all 4
+agent-loop turns billed twice). The fix keeps a task's queue message **present but
+invisible** while it runs, so the scheduler's own repair logic no longer re-queues
+a task that is legitimately in flight.
+
+## Background: how a system task's message flows
+
+`SystemTaskWorker.pollAndExecute` (per task-type queue), then `AsyncSystemTaskExecutor`:
+
+1. `queueDAO.pop(queue)` → the message moves to the queue's *unacked* set (invisible).
+2. `executionService.ackTaskReceived(taskId)` → `queueDAO.ack` → **the message is removed.**
+3. `AsyncSystemTaskExecutor.execute` runs on a worker thread; the task's
+   `start()`/`execute()` runs the work (for annotated `@WorkerTask` adapters, the
+   provider call runs **synchronously** here).
+4. Only in `AsyncSystemTaskExecutor`'s `finally` — *after* the work returns — is the
+   message removed (terminal) or re-posted (`postpone`, non-terminal).
+
+Between step 2 and step 4 a **running** task has **no message in the queue**.
+
+## Root cause: a violated invariant + the sweeper's repair
+
+`WorkflowSweeper` (`org.conductoross.conductor.core.execution.WorkflowSweeper`, on
+by default) enforces on every sweep (~30s): *"every running task MUST be in the
+queue."* Its repair re-pushes any repairable task whose message is missing:
+
+```java
+if (isTaskRepairable.test(task) && !queueDAO.containsMessage(queue, taskId)) {
+    queueDAO.push(queue, taskId, task.getCallbackAfterSeconds());   // re-queue
+}
+```
+
+For async system tasks `isTaskRepairable` is true in `SCHEDULED` **and**
+`IN_PROGRESS`. So while the task runs (message removed at step 2, task still
+non-terminal), a sweep sees "running task, no message" → **re-pushes it** → a
+second worker pops it and runs the same task again → **duplicate**.
+
+Remote worker tasks never hit this: their poll does **not** remove the message,
+and their repair predicate requires `SCHEDULED`. Async system tasks have neither
+guard. This is generic to **every** async system task — the message is briefly
+absent for all of them; it is only *reliably* hit by long-running (LLM/A2A) tasks
+whose window (minutes) is wider than the 30s sweep.
+
+## Fix (what): don't remove the message at poll; reserve it for the run
+
+Two small changes, both on the shared execution path (no per-task-type gating):
+
+1. **`SystemTaskWorker` stops removing the message at poll.** The
+   `executionService.ackTaskReceived(taskId)` call is dropped. The popped message
+   stays in the queue (invisible while unacked), so a task that is about to run
+   still *has* a message — `containsMessage` is true — and the sweeper's repair
+   leaves it alone. (This removed the only use of `ExecutionService` in
+   `SystemTaskWorker`, so that dependency is gone.)
+
+2. **`AsyncSystemTaskExecutor` reserves the message for the run.** Before invoking
+   `start()`/`execute()`, it extends the message's visibility to the task's
+   `responseTimeoutSeconds`:
+
+   ```java
+   // before the SCHEDULED/IN_PROGRESS invocation:
+   queueDAO.setUnackTimeout(queueName, taskId, responseTimeoutSeconds * 1000);
+   ```
+
+   The executor already loads the `TaskModel`, so `responseTimeoutSeconds` is in
+   hand — no new config property and no extra read. It falls back to the default
+   response timeout (`TaskDef.ONE_HOUR`, 3600s) when the task has none (e.g. an
+   annotated task with no registered task def).
+
+Together: the message is present from pop (repair can't re-push it — **no
+ack→reserve race**), and invisible for `responseTimeout` (the unack sweep won't
+redeliver it mid-run). The executor's `finally` still owns the outcome — it
+`remove`s (terminal) or `postpone`s (non-terminal / worker-requested callback),
+overriding the reservation — so normal completion, the async-complete flow, and
+long-running `IN_PROGRESS + callbackAfterSeconds` re-invocation are all unchanged.
+
+3. **An overrun is timed out, not re-executed.** The reservation only lasts
+   `responseTimeout`; if the actual run outlives it, the message *does* reappear.
+   To avoid re-running it in parallel, the executor persists `startTime` before the
+   first invocation (the status is left unchanged so a system task whose `start()`
+   branches on `SCHEDULED` — e.g. `SUB_WORKFLOW` — still works), and on any
+   redelivery checks whether the task has already started and has not responded
+   within `responseTimeout`:
+
+   ```java
+   if (task.getStartTime() > 0
+           && now - task.getUpdateTime() >= responseTimeoutMs) {
+       task.setStatus(TIMED_OUT);   // don't invoke again — let retry/timeout policy decide
+   }
+   ```
+
+   So a run that exceeds `responseTimeout` is marked `TIMED_OUT` (retriable) and the
+   retry/timeout policy creates a *new* attempt or fails the workflow — it is never
+   re-run in parallel under the same taskId. The check uses `updateTime` (time since
+   the last response), so a worker that keeps checking in within `responseTimeout`
+   (LLM/A2A callback flow) is not timed out.
+
+## Why `responseTimeout` (not a new property)
+
+`responseTimeout` is exactly "how long the task is allowed to run", which is what
+the reservation should cover, and it already exists per task. Adding a dedicated
+lease property would duplicate it. It only needs a fallback (the platform default,
+`TaskDef.ONE_HOUR`) for tasks with no configured timeout.
+
+## Why not gate to one task type
+
+The race is generic and the reservation is behavior-preserving: the executor's
+`finally` always removes/re-posts the message once the task returns, so for a fast
+task the reservation is immediately superseded. The one trade-off, uniform across
+all tasks: a crash **mid-execute** leaves the message reserved and recovered after
+`responseTimeout` instead of by the ~30s repair. That is bounded and acceptable,
+and is the price of not letting repair fight in-flight tasks.
+
+## Alternatives considered
+
+- **Adapter-level reserve (PR #1367):** reserve inside `AnnotatedWorkflowSystemTask`.
+  Covers only annotated tasks, and reserves *after* the poller's ack — leaving a
+  small ack→reserve race (a sweep in that gap still re-queues). This approach
+  removes the ack entirely, so there is no such window, and it covers all async
+  system tasks.
+- **Non-blocking poll model (#1359):** run the method off the worker thread and poll
+  a future — eliminates the in-flight window, but a much larger change.
+
+## Known limitations
+
+- **Crash mid-execute** → recovery after `responseTimeout` (bounded), slower than
+  repair's ~30s.
+- **A run that overruns `responseTimeout` is timed out and retried** per the task's
+  policy — so a task whose `responseTimeout` is set shorter than its real work will
+  time out repeatedly and eventually fail. Set a realistic `responseTimeout` for
+  long tasks (e.g. LLM); absent one, the `TaskDef.ONE_HOUR` default applies.
+- **Zombie late-write (#1322, not fixed here):** the original invocation of a
+  timed-out task keeps running and, on completion, its `finally` still writes its
+  result under the original taskId, which can overwrite the `TIMED_OUT`/retry state.
+  Rejecting that late write is a separate follow-on (#1322).
+
+## Testing
+
+- `AsyncSystemTaskExecutorTest`: a SCHEDULED task is reserved via
+  `queueDAO.setUnackTimeout(queue, taskId, responseTimeout*1000)` before `start()`;
+  a task with no `responseTimeout` falls back to `TaskDef.ONE_HOUR` (3600s); a
+  redelivered task that outlived `responseTimeout` is marked `TIMED_OUT` and **not**
+  re-invoked.
+- `TestSystemTaskWorker`: the poll hands the task to the executor and does **not**
+  `ack`/`remove` the message.

--- a/docs/design/2026-07-21-issue-1321-poll-level-reserve.md
+++ b/docs/design/2026-07-21-issue-1321-poll-level-reserve.md
@@ -187,9 +187,10 @@ long-running `IN_PROGRESS + callbackAfterSeconds` re-invocation are all unchange
 
 3. **An overrun is timed out, not re-executed.** The reservation only lasts
    `responseTimeout`; if the actual run outlives it, the message *does* reappear.
-   To avoid re-running it in parallel, the executor persists `startTime` before the
-   first invocation (the status is left unchanged so a system task whose `start()`
-   branches on `SCHEDULED` — e.g. `SUB_WORKFLOW` — still works), and on any
+   To avoid re-running it in parallel, the executor persists `startTime` and
+   `IN_PROGRESS` before the first invocation. The local task passed to `start()`
+   retains its pre-claim `SCHEDULED` status so implementations such as
+   `SUB_WORKFLOW` keep their existing contract. On any
    redelivery checks whether the task has already started and has not responded
    within `responseTimeout`:
 
@@ -213,14 +214,13 @@ long-running `IN_PROGRESS + callbackAfterSeconds` re-invocation are all unchange
    the last response), so a worker that keeps checking in within `responseTimeout`
    (LLM/A2A callback flow) is not timed out.
 
-## Proposed after state: reserved message plus persisted claim
+## Current after state: reserved message plus persisted claim
 
 The combined design retains this branch's strongest property—the popped message
 is never ACKed before execution—while treating every async-system-task poll as an
-explicit task claim. Before invoking task code, the claim path captures the
-pre-claim status, conditionally persists `IN_PROGRESS`, assigns a unique claim
-token and deadline, and then reserves the queue message. External work begins only
-after both persistence operations succeed.
+explicit task claim. Before invoking task code, the executor captures the
+pre-claim status, persists `IN_PROGRESS` with a unique claim token and deadline,
+and reserves the queue message.
 
 The captured pre-claim status controls lifecycle dispatch:
 
@@ -266,7 +266,7 @@ sequenceDiagram
     DB-->>X: Return task
     deactivate DB
     X->>X: Capture pre-claim status SCHEDULED
-    X->>DB: Conditionally claim as IN_PROGRESS with token and deadline
+    X->>DB: Persist IN_PROGRESS with token and deadline
     activate DB
     DB-->>X: Claim accepted
     deactivate DB
@@ -292,9 +292,9 @@ sequenceDiagram
 
     P-->>X: Result
     deactivate P
-    X->>DB: Conditionally complete using claim token
+    X->>DB: Reload task and verify claim token
     activate DB
-    DB-->>X: Completion accepted
+    DB-->>X: Claim ownership confirmed
     deactivate DB
     X->>Q: remove(taskId)
     activate Q
@@ -329,9 +329,9 @@ sequenceDiagram
     Q-->>X2: Message becomes visible before deadline
     deactivate Q
     activate X2
-    X2->>DB: Attempt conditional claim
+    X2->>DB: Load persisted task and active claim
     activate DB
-    DB-->>X2: Reject because active claim has not expired
+    DB-->>X2: Return unexpired active claim
     deactivate DB
     X2->>Q: Hide message for remaining claim duration
     activate Q
@@ -341,9 +341,9 @@ sequenceDiagram
     deactivate X2
     P-->>X1: Original result
     deactivate P
-    X1->>DB: Conditionally complete using claim token
+    X1->>DB: Reload task and verify claim token
     activate DB
-    DB-->>X1: Completion accepted
+    DB-->>X1: Claim ownership confirmed
     deactivate DB
     deactivate X1
 ```
@@ -373,7 +373,7 @@ sequenceDiagram
     activate DB
     DB-->>X2: Return expired active attempt
     deactivate DB
-    X2->>DB: Conditionally mark claim token TIMED_OUT
+    X2->>DB: Persist TIMED_OUT for expired claim
     activate DB
     DB-->>X2: Timeout persisted
     deactivate DB
@@ -391,7 +391,7 @@ sequenceDiagram
     deactivate X2
     P-->>X1: Original call eventually returns
     deactivate P
-    X1->>DB: Conditionally complete using expired claim token
+    X1->>DB: Reload task and verify expired claim token
     activate DB
     DB-->>X1: Reject because attempt is already TIMED_OUT
     deactivate DB
@@ -401,7 +401,7 @@ sequenceDiagram
 
 The resulting steady-state difference is:
 
-| State while provider call runs | `main` | Proposed combined design |
+| State while provider call runs | `main` | Current combined design |
 |---|---|---|
 | Persisted task status | `SCHEDULED` | `IN_PROGRESS` |
 | Queue row/message | Absent after ACK | Present and unacked |
@@ -416,29 +416,17 @@ The resulting steady-state difference is:
 
 The minimal implementation on this branch persists the token on `TaskModel` and
 checks it again before publishing a result. This closes the observed sequential
-redelivery and late-write paths, but it is an integration step toward, not a
-substitute for, the persistence-level conditional operations below. Two nodes
-that read the same eligible state concurrently can still race while assigning
-their tokens.
+redelivery and late-write paths exercised below. This is not a persistence-level
+compare-and-set: claim assignment and result publication are separate reads and
+writes. Conductor's queue de-duplicates a task ID and normally serializes its
+delivery; a DAO conditional update would be additional protection for a backend
+that permits simultaneous delivery of the same task ID.
 
-The persistence abstraction should expose a conditional claim operation in
-`core`, with implementations in each persistence module. A successful claim
-returns an execution envelope containing at least:
-
-- the loaded `TaskModel`;
-- its pre-claim status (`SCHEDULED` or callback-due `IN_PROGRESS`);
-- a unique claim token/attempt generation;
-- the claim deadline derived from `responseTimeout`;
-- whether dispatch must call `start()` or `execute()`.
-
-Claim and completion updates must be conditional. A claim succeeds only when the
-task is eligible and does not have another unexpired owner. Completion succeeds
-only when the token still owns a non-terminal attempt. This is what makes timeout,
-retry, and late completion mutually exclusive rather than last-write-wins.
-
-Queue reservation is fail-closed: if `setUnackTimeout()` throws or returns false,
-the executor must not invoke external work. The claimed task remains recoverable,
-and the message is allowed to reappear for timeout/reconciliation.
+Queue reservation remains fail-open. `reserveInflightMessage()` logs an exception
+but continues, and it does not check a `false` return from `setUnackTimeout()`.
+The persisted claim still rejects a later sequential delivery, but reservation
+failure itself is not covered by the Redis integration test because the real Redis
+DAO does not expose a way to inject that failure.
 
 Worker-requested callbacks remain distinct from an active execution claim. When a
 worker returns `IN_PROGRESS` with `callbackAfterSeconds`, the current claim ends
@@ -472,74 +460,73 @@ and is the price of not letting repair fight in-flight tasks.
 - **Non-blocking poll model (#1359):** run the method off the worker thread and poll
   a future — eliminates the in-flight window, but a much larger change.
 
-## Risks in the current branch and proposed mitigations
+## Remaining risks and coverage boundaries
 
-The normal sweeper-driven duplicate is fixed by the current branch, but the
-following boundaries remain in its implementation. The combined design above
-directly addresses items 1–5; items 6–7 remain operational and verification
-requirements.
+1. **Reservation failure is fail-open and not integration-tested.** The claim
+   protects a sequential redelivery, but the executor still invokes external work
+   when `setUnackTimeout()` throws or returns `false`. A deterministic test requires
+   a fault-injecting `QueueDAO`; the Redis production-path test uses the real DAO.
 
-1. **Reservation failure is fail-open.** `reserveInflightMessage()` catches an
-   exception and continues into `start()`, and it does not check a `false` return
-   from `setUnackTimeout()`. The message can therefore become visible on the
-   backend's default unack schedule while the provider call is still running.
-   Because the task remains `SCHEDULED` and is not yet stale by `responseTimeout`,
-   the redelivery calls `start()` again. Reservation must succeed before external
-   work begins; failure should postpone/requeue without invoking the task.
-
-2. **Visibility before `responseTimeout` still duplicates the invocation.** The
-   Redis integration test forced the reserved message visible after one second
-   while `responseTimeout` was 45 seconds. The second executor loaded the same
-   `SCHEDULED` task, refreshed its reservation, and entered the annotated method;
-   the invocation counter changed from one to two. A persisted claim or equivalent
-   ownership token is needed to reject an early redelivery independently of queue
-   visibility.
-
-3. **An active invocation remains subject to poll timeout.**
-   `DeciderService.checkTaskPollTimeout()` applies specifically to `SCHEDULED`
-   tasks. Since this branch leaves the task `SCHEDULED` during the provider call,
-   a decider evaluation can apply `pollTimeoutSeconds` to work that has already
-   been picked up. Persisting `IN_PROGRESS` would avoid this, but the executor must
-   separately preserve the pre-claim status so first delivery still dispatches to
-   `start()` rather than `execute()`.
-
-4. **Zombie late-write (#1322) is confirmed.** With a two-second response timeout,
-   the integration test observed `TIMED_OUT` after redelivery and then `COMPLETED`
-   after releasing the original invocation. The original executor writes its stale
-   `TaskModel` directly in `finally`. Completion needs an attempt/version-aware
-   conditional update so an expired invocation cannot overwrite a terminal attempt
-   or its retry state.
-
-5. **Worker callbacks and execution expiry share time arithmetic.** A non-terminal
-   worker can request re-evaluation with `callbackAfterSeconds`. On that legitimate
-   redelivery, `hasExceededResponseTimeout()` compares only `now - updateTime` with
-   `responseTimeout`. If the requested callback delay equals or exceeds the
-   response timeout, it can be classified as an overrun rather than a due callback.
-   Callback scheduling and the in-flight execution lease need distinguishable
-   state, or the allowed interval must account for the callback delay.
-
-6. **Crash recovery is intentionally delayed.** A node crash mid-invocation leaves
+2. **Crash recovery is intentionally delayed.** A node crash mid-invocation leaves
    the message hidden until `responseTimeout`; a task without a configured response
    timeout uses the one-hour fallback. This is bounded but slower than the prior
    sweeper repair interval and should be visible operationally.
 
-7. **Queue semantics need backend integration coverage.** Correctness requires
+3. **Queue semantics need backend integration coverage.** Correctness requires
    `containsMessage()` to include unacked messages and `setUnackTimeout()` to move
    their visibility deadline. The current production-path characterization test
    uses Redis. The same scenarios should run against PostgreSQL and MySQL to verify
    their `popped`, `deliver_on`, ACK, and unack-reaper behavior.
 
-## Testing
+4. **Simultaneous duplicate delivery is outside the tested queue contract.** The
+   tests prove sequential queue redelivery and sweeper repair. They do not force two
+   executors to load the same unclaimed task before either persists its token.
+   Standard Conductor queues de-duplicate by task ID; a persistence compare-and-set
+   would be required if a queue backend allowed that simultaneous delivery.
 
-- `AsyncSystemTaskExecutorTest`: a SCHEDULED task is reserved via
-  `queueDAO.setUnackTimeout(queue, taskId, responseTimeout*1000)` before `start()`;
-  a task with no `responseTimeout` falls back to `TaskDef.ONE_HOUR` (3600s); a
-  redelivered task that outlived `responseTimeout` is marked `TIMED_OUT` and **not**
-  re-invoked.
-- `TestSystemTaskWorker`: the poll hands the task to the executor and does **not**
-  `ack`/`remove` the message.
-- `Issue1321DuplicateAsyncSystemTaskSpec` (Redis-backed production path): verifies
-  that the normal reservation prevents redelivery, demonstrates that forced early
-  visibility invokes the annotated worker twice, and demonstrates the
-  `TIMED_OUT` → stale `COMPLETED` overwrite after the original call returns. Its
-  state-transition logs use the `ISSUE1321` prefix in the Gradle XML output.
+## Audit against PR #1369's call-outs
+
+The combined design addresses every correctness gap that PR #1369 identified in
+the normal execution path, including the zombie late-write problem that the PR
+explicitly deferred to #1322. It does not prove every operational failure mode or
+every queue backend.
+
+| PR #1369 call-out | Current status | Evidence or remaining gap |
+|---|---|---|
+| Poll must not ACK/remove the message before execution because the sweeper repairs the missing message | Addressed | The worker neither ACKs nor removes at poll in [`TestSystemTaskWorker.java`, lines 88–110](../../core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskWorker.java#L88-L110); the real-sweeper integration scenario is linked below. |
+| Reserve the popped message for `responseTimeoutSeconds` | Addressed | Real Redis visibility is covered by the normal and early-redelivery integration scenarios below. |
+| Use the one-hour default when no response timeout is configured | Addressed | Unit evidence is linked below; this is backend-independent arithmetic. |
+| A run exceeding `responseTimeout` must time out instead of invoking the same attempt again | Addressed | The natural-expiry integration scenario proves timeout and no second provider invocation. |
+| Persist the first start before invoking task code, without breaking `SUB_WORKFLOW.start()`'s `SCHEDULED` input contract | Addressed | [`AsyncSystemTaskExecutorTest.groovy`, lines 70–107](../../core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy#L70-L107) proves the supplied `SUB_WORKFLOW` task starts correctly while the persisted/result state becomes `IN_PROGRESS`. |
+| Normal terminal, non-terminal callback, and async-complete queue outcomes remain owned by the executor | Addressed | Callback behavior has real integration evidence below. Terminal completion and async-complete behavior are unit-covered in [`AsyncSystemTaskExecutorTest.groovy`, lines 396–488](../../core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy#L396-L488). |
+| A late result from an expired attempt must not overwrite timeout/retry state (#1322) | Addressed beyond PR #1369 | The natural-expiry and workflow-termination integration scenarios below prove stale-result rejection. |
+| Crash recovery occurs only after the reservation expires | Behavior retained, not proven end-to-end | A deterministic process-kill test is still missing; recovery can be delayed up to the configured timeout or one-hour fallback. |
+| Queue reservation succeeds | Not fully addressed | Reservation is fail-open on exception or a `false` DAO result. A fault-injecting DAO test and a decision on fail-closed behavior are still needed. |
+| Equivalent queue semantics across supported persistence backends | Not proven | The integration suite currently proves Redis only; PostgreSQL and MySQL remain coverage gaps. |
+| Two executors simultaneously claim an unclaimed task | Not claimed by PR #1369 and not proven | The token prevents sequential redelivery and stale completion, but claim acquisition is not a persistence compare-and-set. |
+
+## Test evidence
+
+`Issue1321DuplicateAsyncSystemTaskSpec` runs through the real annotated-task
+adapter, executor, Redis queue, task persistence, and `WorkflowSweeper`:
+
+| Design scenario | Evidence |
+|---|---|
+| Reserved unacked message remains hidden, task is persisted `IN_PROGRESS`, and an actual sweep does not create a pollable duplicate | [`Issue1321DuplicateAsyncSystemTaskSpec.groovy`, lines 119–174](../../test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy#L119-L174) |
+| Forced visibility before the claim deadline is delivered but does not invoke the provider twice | [`Issue1321DuplicateAsyncSystemTaskSpec.groovy`, lines 176–210](../../test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy#L176-L210) |
+| Natural visibility after `responseTimeout` produces `TIMED_OUT`; the original late return cannot overwrite it | [`Issue1321DuplicateAsyncSystemTaskSpec.groovy`, lines 212–254](../../test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy#L212-L254) |
+| A deliberately missing message is repaired by the real sweeper; processing that repaired delivery does not re-enter the provider | [`Issue1321DuplicateAsyncSystemTaskSpec.groovy`, lines 256–290](../../test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy#L256-L290) |
+| A completed invocation releases its claim and a legitimate callback executes as a new invocation | [`Issue1321DuplicateAsyncSystemTaskSpec.groovy`, lines 292–318](../../test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy#L292-L318) |
+| Workflow termination remains authoritative when the blocked provider returns late | [`Issue1321DuplicateAsyncSystemTaskSpec.groovy`, lines 320–348](../../test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy#L320-L348) |
+| A requested callback longer than `responseTimeout` is treated as a callback, not an expired active invocation | [`Issue1321DuplicateAsyncSystemTaskSpec.groovy`, lines 350–378](../../test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy#L350-L378) |
+
+Focused unit evidence covers the fallback and mapper boundary that are expensive or
+backend-independent:
+
+- Explicit and default reservation durations: [`AsyncSystemTaskExecutorTest.groovy`, lines 265–304](../../core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy#L265-L304).
+- Expired active claim timeout without provider re-entry: [`AsyncSystemTaskExecutorTest.groovy`, lines 306–339](../../core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy#L306-L339).
+- A mapper-populated `startTime` with no `updateTime` is not falsely timed out: [`AsyncSystemTaskExecutorTest.groovy`, lines 341–361](../../core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy#L341-L361).
+
+The integration evidence is Redis-specific. Reservation failure injection,
+PostgreSQL/MySQL queue behavior, node-crash recovery time, and simultaneous
+duplicate delivery are explicitly not claimed as proven by this suite.

--- a/docs/design/2026-07-21-issue-1321-poll-level-reserve.md
+++ b/docs/design/2026-07-21-issue-1321-poll-level-reserve.md
@@ -422,11 +422,12 @@ writes. Conductor's queue de-duplicates a task ID and normally serializes its
 delivery; a DAO conditional update would be additional protection for a backend
 that permits simultaneous delivery of the same task ID.
 
-Queue reservation remains fail-open. `reserveInflightMessage()` logs an exception
-but continues, and it does not check a `false` return from `setUnackTimeout()`.
-The persisted claim still rejects a later sequential delivery, but reservation
-failure itself is not covered by the Redis integration test because the real Redis
-DAO does not expose a way to inject that failure.
+Queue reservation is a prerequisite for invoking task code. If
+`setUnackTimeout()` returns `false` or throws, the executor does not persist a new
+claim or invoke the system task. The popped message remains recoverable through
+its existing visibility timeout. This failure is covered with a fault-injected
+`QueueDAO` unit test because the real Redis DAO does not expose a deterministic
+way to produce it.
 
 Worker-requested callbacks remain distinct from an active execution claim. When a
 worker returns `IN_PROGRESS` with `callbackAfterSeconds`, the current claim ends
@@ -462,23 +463,18 @@ and is the price of not letting repair fight in-flight tasks.
 
 ## Remaining risks and coverage boundaries
 
-1. **Reservation failure is fail-open and not integration-tested.** The claim
-   protects a sequential redelivery, but the executor still invokes external work
-   when `setUnackTimeout()` throws or returns `false`. A deterministic test requires
-   a fault-injecting `QueueDAO`; the Redis production-path test uses the real DAO.
-
-2. **Crash recovery is intentionally delayed.** A node crash mid-invocation leaves
+1. **Crash recovery is intentionally delayed.** A node crash mid-invocation leaves
    the message hidden until `responseTimeout`; a task without a configured response
    timeout uses the one-hour fallback. This is bounded but slower than the prior
    sweeper repair interval and should be visible operationally.
 
-3. **Queue semantics need backend integration coverage.** Correctness requires
+2. **Queue semantics need backend integration coverage.** Correctness requires
    `containsMessage()` to include unacked messages and `setUnackTimeout()` to move
    their visibility deadline. The current production-path characterization test
    uses Redis. The same scenarios should run against PostgreSQL and MySQL to verify
    their `popped`, `deliver_on`, ACK, and unack-reaper behavior.
 
-4. **Simultaneous duplicate delivery is outside the tested queue contract.** The
+3. **Simultaneous duplicate delivery is outside the tested queue contract.** The
    tests prove sequential queue redelivery and sweeper repair. They do not force two
    executors to load the same unclaimed task before either persists its token.
    Standard Conductor queues de-duplicate by task ID; a persistence compare-and-set
@@ -501,7 +497,7 @@ every queue backend.
 | Normal terminal, non-terminal callback, and async-complete queue outcomes remain owned by the executor | Addressed | Callback behavior has real integration evidence below. Terminal completion and async-complete behavior are unit-covered in [`AsyncSystemTaskExecutorTest.groovy`, lines 396–488](../../core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy#L396-L488). |
 | A late result from an expired attempt must not overwrite timeout/retry state (#1322) | Addressed beyond PR #1369 | The natural-expiry and workflow-termination integration scenarios below prove stale-result rejection. |
 | Crash recovery occurs only after the reservation expires | Behavior retained, not proven end-to-end | A deterministic process-kill test is still missing; recovery can be delayed up to the configured timeout or one-hour fallback. |
-| Queue reservation succeeds | Not fully addressed | Reservation is fail-open on exception or a `false` DAO result. A fault-injecting DAO test and a decision on fail-closed behavior are still needed. |
+| Queue reservation succeeds before external work starts | Addressed | Reservation is fail-closed: `false` or an exception skips claim persistence and task invocation. Fault-injected unit evidence is linked below. |
 | Equivalent queue semantics across supported persistence backends | Not proven | The integration suite currently proves Redis only; PostgreSQL and MySQL remain coverage gaps. |
 | Two executors simultaneously claim an unclaimed task | Not claimed by PR #1369 and not proven | The token prevents sequential redelivery and stale completion, but claim acquisition is not a persistence compare-and-set. |
 
@@ -524,9 +520,11 @@ Focused unit evidence covers the fallback and mapper boundary that are expensive
 backend-independent:
 
 - Explicit and default reservation durations: [`AsyncSystemTaskExecutorTest.groovy`, lines 265–304](../../core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy#L265-L304).
-- Expired active claim timeout without provider re-entry: [`AsyncSystemTaskExecutorTest.groovy`, lines 306–339](../../core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy#L306-L339).
-- A mapper-populated `startTime` with no `updateTime` is not falsely timed out: [`AsyncSystemTaskExecutorTest.groovy`, lines 341–361](../../core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy#L341-L361).
+- Expired active claim timeout without provider re-entry: [`AsyncSystemTaskExecutorTest.groovy`, lines 307–340](../../core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy#L307-L340).
+- Reservation returning `false` or throwing prevents persistence and task invocation: [`AsyncSystemTaskExecutorTest.groovy`, lines 342–371](../../core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy#L342-L371).
+- A mapper-populated `startTime` with no `updateTime` is not falsely timed out: [`AsyncSystemTaskExecutorTest.groovy`, lines 373–393](../../core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy#L373-L393).
 
-The integration evidence is Redis-specific. Reservation failure injection,
-PostgreSQL/MySQL queue behavior, node-crash recovery time, and simultaneous
-duplicate delivery are explicitly not claimed as proven by this suite.
+The integration evidence is Redis-specific. PostgreSQL/MySQL queue behavior,
+node-crash recovery time, and simultaneous duplicate delivery are explicitly not
+claimed as proven by this suite. Reservation failure is fault-injected at the unit
+boundary rather than through Redis.

--- a/docs/design/2026-07-21-issue-1321-poll-level-reserve.md
+++ b/docs/design/2026-07-21-issue-1321-poll-level-reserve.md
@@ -90,10 +90,17 @@ long-running `IN_PROGRESS + callbackAfterSeconds` re-invocation are all unchange
 
    ```java
    if (task.getStartTime() > 0
+           && task.getUpdateTime() > 0                       // skip just-scheduled tasks
            && now - task.getUpdateTime() >= responseTimeoutMs) {
        task.setStatus(TIMED_OUT);   // don't invoke again — let retry/timeout policy decide
    }
    ```
+
+   The `updateTime > 0` guard is required: a task whose mapper sets `startTime` at
+   scheduling (e.g. `JOIN`) has `updateTime == 0` until first persisted, so without it
+   `now - 0` always exceeds the timeout and the task is wrongly timed out on its first
+   poll. Re-polled tasks refresh `updateTime` each poll, so only a run that held the
+   worker thread past `responseTimeout` (no intervening poll) is caught.
 
    So a run that exceeds `responseTimeout` is marked `TIMED_OUT` (retriable) and the
    retry/timeout policy creates a *new* attempt or fails the workflow — it is never

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.test.integration
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+
+import com.netflix.conductor.common.metadata.tasks.Task
+import com.netflix.conductor.common.metadata.tasks.TaskDef
+import com.netflix.conductor.common.run.Workflow
+import com.netflix.conductor.core.execution.tasks.SystemTaskRegistry
+import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask
+import com.netflix.conductor.dao.QueueDAO
+import com.netflix.conductor.test.base.AbstractSpecification
+import com.netflix.conductor.test.utils.ControllableWorker
+
+/**
+ * REPRODUCES ISSUE #1321 - Async system tasks running longer than the queue unack window are
+ * executed twice.
+ *
+ * <p>Verifies the persisted-claim extension to the queue-reservation fix from PR #1369. The popped
+ * message remains unacked and is reserved for responseTimeout before {@code start()}, while the
+ * task is atomically moved to IN_PROGRESS with an ownership token. These scenarios cover the
+ * normal lease and both boundaries: an unexpectedly early delivery is rejected while the claim is
+ * active, and a late result cannot overwrite the timeout established after claim expiry.
+ *
+ * <p>This spec drives the REAL production path: the worker bean is registered through the real
+ * WorkerTaskAnnotationScanner, the adapter comes out of the real SystemTaskRegistry, and execution
+ * goes through the real AsyncSystemTaskExecutor against the real queue.
+ *
+ * <p>The state and queue observations are deliberately logged with an {@code ISSUE1321} prefix so
+ * the exact Redis redelivery sequence is retained in the Gradle XML test output.
+ */
+class Issue1321DuplicateAsyncSystemTaskSpec extends AbstractSpecification {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Issue1321DuplicateAsyncSystemTaskSpec)
+
+    @Autowired
+    QueueDAO queueDAO
+
+    @Autowired
+    ControllableWorker controllableWorker
+
+    // The same collection SystemTaskWorkerCoordinator polls in production; the annotation
+    // scanner adds the AnnotatedWorkflowSystemTask adapters to it.
+    @Autowired
+    @Qualifier(SystemTaskRegistry.ASYNC_SYSTEM_TASKS_QUALIFIER)
+    Set<WorkflowSystemTask> asyncSystemTasks
+
+    static final String WF = 'controllable_async_system_task_wf'
+    static final String QUEUE = ControllableWorker.TASK_TYPE
+    // The fix extends visibility to responseTimeoutSeconds; must be >> the compressed test window.
+    static final int RESPONSE_TIMEOUT_SECONDS = 45
+
+    def setup() {
+        controllableWorker.reset()
+        registerControllableTaskDef()
+        workflowTestUtil.registerWorkflows('controllable_async_system_task_workflow.json')
+    }
+
+    private void registerControllableTaskDef() {
+        Optional<TaskDef> existing = workflowTestUtil.getPersistedTaskDefinition('controllable_task')
+        TaskDef taskDef = existing.orElseGet {
+            TaskDef created = new TaskDef()
+            created.name = 'controllable_task'
+            created.ownerEmail = 'test@harness.com'
+            created.timeoutSeconds = 3600
+            created.retryCount = 0
+            return created
+        }
+        taskDef.responseTimeoutSeconds = RESPONSE_TIMEOUT_SECONDS
+        if (existing.isPresent()) {
+            metadataService.updateTaskDef(taskDef)
+        } else {
+            metadataService.registerTaskDef([taskDef])
+        }
+    }
+
+    private List<String> popWithRetry(int maxWaitMs) {
+        long deadline = System.currentTimeMillis() + maxWaitMs
+        while (System.currentTimeMillis() < deadline) {
+            List<String> ids = queueDAO.pop(QUEUE, 1, 300)
+            if (ids != null && !ids.isEmpty()) {
+                return ids
+            }
+        }
+        return []
+    }
+
+    private Task taskState(String workflowId, String phase) {
+        Task task = workflowExecutionService.getExecutionStatus(workflowId, true).tasks[0]
+        LOGGER.info(
+                "ISSUE1321 {} status={} startTime={} updateTime={} callback={} queueContains={} invocations={}",
+                phase,
+                task.status,
+                task.startTime,
+                task.updateTime,
+                task.callbackAfterSeconds,
+                queueDAO.containsMessage(QUEUE, task.taskId),
+                controllableWorker.invocations.get())
+        return task
+    }
+
+    def "reservation prevents ordinary unack redelivery while annotated start is blocked"() {
+        given: "the real adapter registered for the annotated worker by the annotation scanner"
+        WorkflowSystemTask adapter = asyncSystemTasks.find { it.taskType == QUEUE }
+        assert adapter != null
+
+        and: "the controllable worker is armed to block during its invocation"
+        controllableWorker.enteredRun = new CountDownLatch(1)
+        controllableWorker.release = new CountDownLatch(1)
+
+        when: "the workflow is started"
+        def workflowId = startWorkflow(WF, 1, 'issue1321_' + UUID.randomUUID(), [:], null)
+        def startedWf = workflowExecutionService.getExecutionStatus(workflowId, true)
+
+        then: "the async system task is SCHEDULED and queued"
+        startedWf.status == Workflow.WorkflowStatus.RUNNING
+        startedWf.tasks.size() == 1
+        startedWf.tasks[0].taskType == QUEUE
+        startedWf.tasks[0].status == Task.Status.SCHEDULED
+
+        when: "system-task-worker #1 pops the message and begins executing (the method blocks)"
+        def taskId = startedWf.tasks[0].taskId
+        List<String> polled1 = popWithRetry(3000)
+        assert polled1 == [taskId]
+        // Start with a short visibility timeout. Miguel's executor must replace it with the task's
+        // 45-second response timeout before invoking the worker.
+        queueDAO.setUnackTimeout(QUEUE, taskId, 1000L)
+        Thread worker1 = new Thread({ asyncSystemTaskExecutor.execute(adapter, taskId) })
+        worker1.setDaemon(true)
+        worker1.start()
+
+        and: "the worker method has been entered and is blocking (IN_PROGRESS already persisted)"
+        assert controllableWorker.enteredRun.await(10, TimeUnit.SECONDS)
+        Task inFlight = taskState(workflowId, 'ordinary/in-flight')
+
+        then: "the persisted claim marks the task IN_PROGRESS and reserves its queue message"
+        inFlight.status == Task.Status.IN_PROGRESS
+        inFlight.startTime > 0
+        queueDAO.containsMessage(QUEUE, taskId)
+
+        and: "the compressed unack window elapses"
+        Thread.sleep(1500)
+
+        and: "a second system-task worker cannot poll the reserved message"
+        List<String> polled2 = popWithRetry(3000)
+
+        then:
+        polled2.isEmpty()
+        controllableWorker.invocations.get() == 1
+
+        cleanup:
+        controllableWorker.release?.countDown()
+        worker1?.join(5000)
+    }
+
+    def "an unexpectedly early visible message is rejected by the active claim"() {
+        given:
+        WorkflowSystemTask adapter = asyncSystemTasks.find { it.taskType == QUEUE }
+        controllableWorker.enteredRun = new CountDownLatch(1)
+        controllableWorker.release = new CountDownLatch(1)
+        def workflowId = startWorkflow(WF, 1, 'issue1321_early_' + UUID.randomUUID(), [:], null)
+        def taskId = workflowExecutionService.getExecutionStatus(workflowId, true).tasks[0].taskId
+        assert popWithRetry(3000) == [taskId]
+
+        when: "worker one starts and Miguel's executor reserves the message for 45 seconds"
+        Thread worker1 = new Thread({ asyncSystemTaskExecutor.execute(adapter, taskId) }, 'issue1321-worker-1')
+        worker1.setDaemon(true)
+        worker1.start()
+        assert controllableWorker.enteredRun.await(10, TimeUnit.SECONDS)
+        Task beforeRedelivery = taskState(workflowId, 'early/before-forced-visibility')
+
+        and: "an external queue event shortens that reservation and the message becomes visible"
+        queueDAO.setUnackTimeout(QUEUE, taskId, 1000L)
+        Thread.sleep(1500)
+        List<String> redelivered = popWithRetry(3000)
+        LOGGER.info("ISSUE1321 early/redelivered ids={}", redelivered)
+        if (!redelivered.isEmpty()) {
+            asyncSystemTaskExecutor.execute(adapter, taskId)
+        }
+
+        then: "the persisted ownership claim prevents a second provider invocation"
+        beforeRedelivery.status == Task.Status.IN_PROGRESS
+        redelivered == [taskId]
+        controllableWorker.invocations.get() == 1
+        taskState(workflowId, 'early/after-rejected-delivery').status == Task.Status.IN_PROGRESS
+
+        cleanup:
+        controllableWorker.release?.countDown()
+        worker1?.join(5000)
+    }
+
+    def "response-timeout redelivery rejects the original invocation's late write"() {
+        given: "a response timeout shorter than the blocked invocation"
+        TaskDef taskDef = workflowTestUtil.getPersistedTaskDefinition('controllable_task').get()
+        taskDef.responseTimeoutSeconds = 2
+        metadataService.updateTaskDef(taskDef)
+        WorkflowSystemTask adapter = asyncSystemTasks.find { it.taskType == QUEUE }
+        controllableWorker.enteredRun = new CountDownLatch(1)
+        controllableWorker.release = new CountDownLatch(1)
+        def workflowId = startWorkflow(WF, 1, 'issue1321_timeout_' + UUID.randomUUID(), [:], null)
+        def taskId = workflowExecutionService.getExecutionStatus(workflowId, true).tasks[0].taskId
+        assert popWithRetry(3000) == [taskId]
+
+        when: "the original invocation blocks beyond responseTimeout"
+        Thread worker1 = new Thread({ asyncSystemTaskExecutor.execute(adapter, taskId) }, 'issue1321-timeout-worker-1')
+        worker1.setDaemon(true)
+        worker1.start()
+        assert controllableWorker.enteredRun.await(10, TimeUnit.SECONDS)
+        taskState(workflowId, 'timeout/in-flight')
+        Thread.sleep(2500)
+
+        and: "the naturally expired queue message is processed by another executor"
+        List<String> redelivered = popWithRetry(5000)
+        LOGGER.info("ISSUE1321 timeout/redelivered ids={}", redelivered)
+        assert redelivered == [taskId]
+        asyncSystemTaskExecutor.execute(adapter, taskId)
+        Task timedOut = taskState(workflowId, 'timeout/after-redelivery')
+
+        then: "the second executor does not invoke the provider and marks the original attempt timed out"
+        controllableWorker.invocations.get() == 1
+        timedOut.status == Task.Status.TIMED_OUT
+
+        when: "the original provider call returns after its attempt was timed out"
+        controllableWorker.release.countDown()
+        worker1.join(5000)
+        Task afterLateWrite = taskState(workflowId, 'timeout/after-original-return')
+
+        then: "the stale executor cannot overwrite the terminal state under the same task id"
+        afterLateWrite.status == Task.Status.TIMED_OUT
+
+        cleanup:
+        controllableWorker.release?.countDown()
+        worker1?.join(5000)
+    }
+
+}

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy
@@ -35,7 +35,7 @@ import com.netflix.conductor.test.utils.ControllableWorker
  *
  * <p>Verifies the persisted-claim extension to the queue-reservation fix from PR #1369. The popped
  * message remains unacked and is reserved for responseTimeout before {@code start()}, while the
- * task is atomically moved to IN_PROGRESS with an ownership token. These scenarios cover the
+ * task is moved to IN_PROGRESS with an ownership token. These scenarios cover the
  * normal lease and both boundaries: an unexpectedly early delivery is rejected while the claim is
  * active, and a late result cannot overwrite the timeout established after claim expiry.
  *
@@ -345,6 +345,36 @@ class Issue1321DuplicateAsyncSystemTaskSpec extends AbstractSpecification {
         cleanup:
         controllableWorker.release?.countDown()
         worker1?.join(5000)
+    }
+
+    def "a requested callback longer than responseTimeout is not treated as an execution overrun"() {
+        given:
+        TaskDef taskDef = workflowTestUtil.getPersistedTaskDefinition('controllable_task').get()
+        taskDef.responseTimeoutSeconds = 1
+        metadataService.updateTaskDef(taskDef)
+        WorkflowSystemTask adapter = asyncSystemTasks.find { it.taskType == QUEUE }
+        controllableWorker.firstCallbackAfterSeconds = 2
+        def workflowId = startWorkflow(WF, 1, 'issue1321_long_callback_' + UUID.randomUUID(), [:], null)
+        def taskId = workflowExecutionService.getExecutionStatus(workflowId, true).tasks[0].taskId
+        assert popWithRetry(3000) == [taskId]
+
+        when: "the first invocation requests a callback later than responseTimeout"
+        asyncSystemTaskExecutor.execute(adapter, taskId)
+        Task waiting = taskState(workflowId, 'long-callback/waiting')
+
+        then:
+        waiting.status == Task.Status.IN_PROGRESS
+        waiting.callbackAfterSeconds == 2
+
+        when: "the requested callback becomes due"
+        List<String> callbackDelivery = popWithRetry(5000)
+        assert callbackDelivery == [taskId]
+        asyncSystemTaskExecutor.execute(adapter, taskId)
+        Task completed = taskState(workflowId, 'long-callback/completed')
+
+        then: "the callback executes instead of timing out the completed prior invocation"
+        controllableWorker.invocations.get() == 2
+        completed.status == Task.Status.COMPLETED
     }
 
 }

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy
@@ -155,6 +155,9 @@ class Issue1321DuplicateAsyncSystemTaskSpec extends AbstractSpecification {
         inFlight.startTime > 0
         queueDAO.containsMessage(QUEUE, taskId)
 
+        and: "the real sweeper observes the reserved unacked message while the provider is running"
+        sweep(workflowId)
+
         and: "the compressed unack window elapses"
         Thread.sleep(1500)
 
@@ -244,6 +247,100 @@ class Issue1321DuplicateAsyncSystemTaskSpec extends AbstractSpecification {
 
         then: "the stale executor cannot overwrite the terminal state under the same task id"
         afterLateWrite.status == Task.Status.TIMED_OUT
+
+        cleanup:
+        controllableWorker.release?.countDown()
+        worker1?.join(5000)
+    }
+
+    def "sweeper repair delivery cannot re-enter a long-running provider invocation"() {
+        given:
+        WorkflowSystemTask adapter = asyncSystemTasks.find { it.taskType == QUEUE }
+        controllableWorker.enteredRun = new CountDownLatch(1)
+        controllableWorker.release = new CountDownLatch(1)
+        def workflowId = startWorkflow(WF, 1, 'issue1321_sweeper_' + UUID.randomUUID(), [:], null)
+        def taskId = workflowExecutionService.getExecutionStatus(workflowId, true).tasks[0].taskId
+        assert popWithRetry(3000) == [taskId]
+
+        when: "the provider remains in flight after persisting its claim"
+        Thread worker1 = new Thread({ asyncSystemTaskExecutor.execute(adapter, taskId) }, 'issue1321-sweeper-worker')
+        worker1.setDaemon(true)
+        worker1.start()
+        assert controllableWorker.enteredRun.await(10, TimeUnit.SECONDS)
+        assert taskState(workflowId, 'sweeper/in-flight').status == Task.Status.IN_PROGRESS
+
+        and: "the queue message is lost and the real WorkflowSweeper repairs it"
+        queueDAO.remove(QUEUE, taskId)
+        assert !queueDAO.containsMessage(QUEUE, taskId)
+        sweep(workflowId)
+        List<String> repaired = popWithRetry(5000)
+        LOGGER.info('ISSUE1321 sweeper/repaired ids={}', repaired)
+        assert repaired == [taskId]
+
+        and: "a system-task worker processes the repaired delivery"
+        asyncSystemTaskExecutor.execute(adapter, taskId)
+
+        then: "the active claim rejects the delivery without invoking the provider again"
+        controllableWorker.invocations.get() == 1
+        taskState(workflowId, 'sweeper/after-repaired-delivery').status == Task.Status.IN_PROGRESS
+
+        cleanup:
+        controllableWorker.release?.countDown()
+        worker1?.join(5000)
+    }
+
+    def "a completed invocation releases its claim and permits the requested callback"() {
+        given:
+        WorkflowSystemTask adapter = asyncSystemTasks.find { it.taskType == QUEUE }
+        controllableWorker.firstCallbackAfterSeconds = 1
+        def workflowId = startWorkflow(WF, 1, 'issue1321_callback_' + UUID.randomUUID(), [:], null)
+        def taskId = workflowExecutionService.getExecutionStatus(workflowId, true).tasks[0].taskId
+        assert popWithRetry(3000) == [taskId]
+
+        when: "the first provider invocation requests a callback"
+        asyncSystemTaskExecutor.execute(adapter, taskId)
+        Task waiting = taskState(workflowId, 'callback/waiting')
+
+        then:
+        waiting.status == Task.Status.IN_PROGRESS
+        waiting.callbackAfterSeconds == 1
+        controllableWorker.invocations.get() == 1
+
+        when: "the callback becomes due and is delivered"
+        List<String> callbackDelivery = popWithRetry(5000)
+        assert callbackDelivery == [taskId]
+        asyncSystemTaskExecutor.execute(adapter, taskId)
+        Task completed = taskState(workflowId, 'callback/completed')
+
+        then: "the callback is a new invocation rather than an active-claim redelivery"
+        controllableWorker.invocations.get() == 2
+        completed.status == Task.Status.COMPLETED
+    }
+
+    def "workflow termination fences a blocked provider's late completion"() {
+        given:
+        WorkflowSystemTask adapter = asyncSystemTasks.find { it.taskType == QUEUE }
+        controllableWorker.enteredRun = new CountDownLatch(1)
+        controllableWorker.release = new CountDownLatch(1)
+        def workflowId = startWorkflow(WF, 1, 'issue1321_terminate_' + UUID.randomUUID(), [:], null)
+        def taskId = workflowExecutionService.getExecutionStatus(workflowId, true).tasks[0].taskId
+        assert popWithRetry(3000) == [taskId]
+        Thread worker1 = new Thread({ asyncSystemTaskExecutor.execute(adapter, taskId) }, 'issue1321-terminate-worker')
+        worker1.setDaemon(true)
+        worker1.start()
+        assert controllableWorker.enteredRun.await(10, TimeUnit.SECONDS)
+
+        when: "the workflow is terminated while the provider call remains blocked"
+        workflowExecutor.terminateWorkflow(workflowId, 'integration test termination')
+        Task canceled = taskState(workflowId, 'terminate/canceled')
+        controllableWorker.release.countDown()
+        worker1.join(5000)
+        Task afterLateReturn = taskState(workflowId, 'terminate/after-provider-return')
+
+        then: "the provider cannot overwrite the cancellation"
+        canceled.status == Task.Status.CANCELED
+        afterLateReturn.status == Task.Status.CANCELED
+        controllableWorker.invocations.get() == 1
 
         cleanup:
         controllableWorker.release?.countDown()

--- a/test-harness/src/test/java/com/netflix/conductor/test/utils/ControllableWorker.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/utils/ControllableWorker.java
@@ -23,6 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.netflix.conductor.common.metadata.tasks.TaskResult;
+import com.netflix.conductor.sdk.workflow.executor.task.TaskContext;
 import com.netflix.conductor.sdk.workflow.task.WorkerTask;
 
 /**
@@ -49,11 +51,15 @@ public class ControllableWorker implements AnnotatedSystemTaskWorker {
     /** Every {@link #run} invocation blocks on this latch, simulating the provider call. */
     public volatile CountDownLatch release;
 
+    /** When positive, the first invocation requests another callback after this many seconds. */
+    public volatile int firstCallbackAfterSeconds;
+
     /** Reset all control state; call from a spec's setup() before driving a scenario. */
     public void reset() {
         invocations.set(0);
         enteredRun = null;
         release = null;
+        firstCallbackAfterSeconds = 0;
     }
 
     @WorkerTask(TASK_TYPE)
@@ -66,6 +72,10 @@ public class ControllableWorker implements AnnotatedSystemTaskWorker {
         if (release != null) {
             // Bounded to keep the test fast even if something goes wrong.
             release.await(30, TimeUnit.SECONDS);
+        }
+        if (attempt == 1 && firstCallbackAfterSeconds > 0) {
+            TaskContext.get().getTaskResult().setStatus(TaskResult.Status.IN_PROGRESS);
+            TaskContext.get().setCallbackAfter(firstCallbackAfterSeconds);
         }
         Map<String, Object> output = new HashMap<>();
         output.put("attempt", attempt);

--- a/test-harness/src/test/java/com/netflix/conductor/test/utils/ControllableWorker.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/utils/ControllableWorker.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.test.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.conductoross.conductor.core.execution.tasks.AnnotatedSystemTaskWorker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.netflix.conductor.sdk.workflow.task.WorkerTask;
+
+/**
+ * A test-only annotated system-task worker whose {@link #run} blocks under external control (via
+ * latches) and counts how many times it is invoked. It stands in for a long-running provider call
+ * (e.g. an agent-loop LLM_CHAT_COMPLETE turn) and is registered through the real
+ * WorkerTaskAnnotationScanner / AnnotatedWorkflowSystemTask production path, reproducing the
+ * mechanism behind issue #1321 (async system task running longer than the queue unack window
+ * executed twice).
+ */
+@Component
+public class ControllableWorker implements AnnotatedSystemTaskWorker {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ControllableWorker.class);
+
+    public static final String TASK_TYPE = "CONTROLLABLE_SYS_TASK";
+
+    /** Total number of times {@link #run} has been entered since the last {@link #reset}. */
+    public final AtomicInteger invocations = new AtomicInteger(0);
+
+    /** Counted down each time a {@link #run} invocation is entered (before it blocks). */
+    public volatile CountDownLatch enteredRun;
+
+    /** Every {@link #run} invocation blocks on this latch, simulating the provider call. */
+    public volatile CountDownLatch release;
+
+    /** Reset all control state; call from a spec's setup() before driving a scenario. */
+    public void reset() {
+        invocations.set(0);
+        enteredRun = null;
+        release = null;
+    }
+
+    @WorkerTask(TASK_TYPE)
+    public Map<String, Object> run() throws InterruptedException {
+        int attempt = invocations.incrementAndGet();
+        LOGGER.info("ControllableWorker.run invocation #{}", attempt);
+        if (enteredRun != null) {
+            enteredRun.countDown();
+        }
+        if (release != null) {
+            // Bounded to keep the test fast even if something goes wrong.
+            release.await(30, TimeUnit.SECONDS);
+        }
+        Map<String, Object> output = new HashMap<>();
+        output.put("attempt", attempt);
+        return output;
+    }
+}

--- a/test-harness/src/test/resources/controllable_async_system_task_workflow.json
+++ b/test-harness/src/test/resources/controllable_async_system_task_workflow.json
@@ -1,0 +1,26 @@
+{
+  "name": "controllable_async_system_task_wf",
+  "description": "workflow with a single controllable async system task (issues #1321/#1322)",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "controllable_task",
+      "taskReferenceName": "controllable_ref",
+      "inputParameters": {},
+      "type": "CONTROLLABLE_SYS_TASK",
+      "startDelay": 0,
+      "optional": false,
+      "asyncComplete": false
+    }
+  ],
+  "inputParameters": [],
+  "outputParameters": {
+    "taskOutput": "${controllable_ref.output.attempt}"
+  },
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false,
+  "timeoutPolicy": "ALERT_ONLY",
+  "timeoutSeconds": 0,
+  "ownerEmail": "test@harness.com"
+}


### PR DESCRIPTION
## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Other

## Summary

Builds on #1369's poll-time queue reservation fix for #1321 and closes the remaining sequential redelivery and stale-completion gaps for async system tasks.

PR #1369 correctly identifies the primary duplicate-execution path: `SystemTaskWorker` ACKed the popped message before execution, so `WorkflowSweeper` saw a non-terminal task with no queue message and repaired it while the original provider call was still running. The base branch stops ACKing at poll and reserves the unacked message for `responseTimeoutSeconds`.

This PR:

- Requires queue reservation to succeed before persisting a claim or invoking task code. A `false` result or exception fails closed and leaves the popped message recoverable through its existing visibility timeout.
- Persists the task as `IN_PROGRESS` with a unique claim token and deadline before invoking task code.
- Preserves the existing `SCHEDULED` input contract for the initial `start()` call, including `SUB_WORKFLOW`.
- Rejects unexpectedly early sequential redelivery while its claim is active.
- Marks an expired active invocation `TIMED_OUT` instead of invoking the same task ID again.
- Reloads and validates claim ownership before publishing a result, preventing a late provider return from overwriting timeout, retry, cancellation, or termination state.
- Releases the claim before scheduling a legitimate worker-requested callback so the callback receives a new claim.

## Test evidence

The production-path integration test uses the real annotated system-task adapter, executor, Redis queue, task persistence, and `WorkflowSweeper`:

| Edge case | Direct evidence |
|---|---|
| Unacked reservation prevents ordinary redelivery while the provider is blocked; a real sweep does not create a duplicate | [`Issue1321DuplicateAsyncSystemTaskSpec`, lines 119–174](https://github.com/conductor-oss/conductor/blob/investigate/pr-1369-redelivery/test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy#L119-L174) |
| Unexpected early visibility is delivered but rejected by the active claim | [`Issue1321DuplicateAsyncSystemTaskSpec`, lines 176–210](https://github.com/conductor-oss/conductor/blob/investigate/pr-1369-redelivery/test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy#L176-L210) |
| Natural visibility after `responseTimeout` produces `TIMED_OUT`; the original late return cannot overwrite it | [`Issue1321DuplicateAsyncSystemTaskSpec`, lines 212–254](https://github.com/conductor-oss/conductor/blob/investigate/pr-1369-redelivery/test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy#L212-L254) |
| A deliberately missing message is repaired by the real sweeper without provider re-entry | [`Issue1321DuplicateAsyncSystemTaskSpec`, lines 256–290](https://github.com/conductor-oss/conductor/blob/investigate/pr-1369-redelivery/test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy#L256-L290) |
| A completed invocation releases its claim and permits the requested callback | [`Issue1321DuplicateAsyncSystemTaskSpec`, lines 292–318](https://github.com/conductor-oss/conductor/blob/investigate/pr-1369-redelivery/test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy#L292-L318) |
| Workflow termination remains authoritative when a blocked provider returns late | [`Issue1321DuplicateAsyncSystemTaskSpec`, lines 320–348](https://github.com/conductor-oss/conductor/blob/investigate/pr-1369-redelivery/test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy#L320-L348) |
| A callback later than `responseTimeout` executes normally instead of being treated as an overrun | [`Issue1321DuplicateAsyncSystemTaskSpec`, lines 350–378](https://github.com/conductor-oss/conductor/blob/investigate/pr-1369-redelivery/test-harness/src/test/groovy/com/netflix/conductor/test/integration/Issue1321DuplicateAsyncSystemTaskSpec.groovy#L350-L378) |

Focused unit evidence:

| Boundary | Direct evidence |
|---|---|
| Poll does not ACK or remove before execution | [`TestSystemTaskWorker`, lines 88–110](https://github.com/conductor-oss/conductor/blob/investigate/pr-1369-redelivery/core/src/test/java/com/netflix/conductor/core/execution/tasks/TestSystemTaskWorker.java#L88-L110) |
| Explicit and one-hour-default reservation durations | [`AsyncSystemTaskExecutorTest`, lines 266–305](https://github.com/conductor-oss/conductor/blob/investigate/pr-1369-redelivery/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy#L266-L305) |
| Reservation returning `false` or throwing fails closed: no claim persistence and no task invocation | [`AsyncSystemTaskExecutorTest`, lines 342–371](https://github.com/conductor-oss/conductor/blob/investigate/pr-1369-redelivery/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy#L342-L371) |
| Mapper-populated `startTime` does not falsely time out the first poll | [`AsyncSystemTaskExecutorTest`, lines 373–393](https://github.com/conductor-oss/conductor/blob/investigate/pr-1369-redelivery/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy#L373-L393) |
| `SUB_WORKFLOW.start()` retains its initial `SCHEDULED` contract | [`AsyncSystemTaskExecutorTest`, lines 70–107](https://github.com/conductor-oss/conductor/blob/investigate/pr-1369-redelivery/core/src/test/groovy/com/netflix/conductor/core/execution/AsyncSystemTaskExecutorTest.groovy#L70-L107) |

The complete before/after sequence diagrams and PR #1369 call-out audit are in [`docs/design/2026-07-21-issue-1321-poll-level-reserve.md`](https://github.com/conductor-oss/conductor/blob/investigate/pr-1369-redelivery/docs/design/2026-07-21-issue-1321-poll-level-reserve.md).

## Remaining limitations

- Crash recovery waits for `responseTimeoutSeconds` (or the one-hour fallback) and is not process-kill tested.
- Production-path integration coverage currently uses Redis; equivalent PostgreSQL/MySQL queue semantics remain to be characterized.
- Claim acquisition is not a persistence compare-and-set. The suite proves sequential queue redelivery, not two executors simultaneously loading the same unclaimed task outside the standard queue de-duplication contract.

## Alternatives considered

- Reserving only inside `AnnotatedWorkflowSystemTask`: covers annotated tasks only and leaves an ACK-to-reserve window.
- Running annotated methods on a separate future and polling it: a substantially larger execution-model change.
- Adding a new lease property: duplicates the existing per-task `responseTimeoutSeconds` contract.
- Continuing after reservation failure: rejected because provider calls may be non-idempotent or billable.

## Validation

- `./gradlew spotlessApply`
- `./gradlew :conductor-core:test --tests com.netflix.conductor.core.execution.AsyncSystemTaskExecutorTest --tests com.netflix.conductor.core.execution.tasks.TestSystemTaskWorker`
- `./gradlew :conductor-test-harness:test --tests com.netflix.conductor.test.integration.Issue1321DuplicateAsyncSystemTaskSpec`

Fixes #1321.
