### PR TITLE
Fix mysql boot crashes

### DIFF
--- a/mysql-persistence/src/main/java/com/netflix/conductor/mysql/config/MySQLConfiguration.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/mysql/config/MySQLConfiguration.java
@@ -22,6 +22,7 @@ import org.conductoross.conductor.mysql.dao.MySQLSkillPackageDAO;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -49,6 +50,13 @@ import static com.mysql.cj.exceptions.MysqlErrorNumbers.ER_LOCK_DEADLOCK;
 // the 'flyway' and 'flywayInitializer' beans exist before the MySQL DAOs are initialized.
 @Import({DataSourceAutoConfiguration.class, FlywayAutoConfiguration.class})
 public class MySQLConfiguration {
+
+    // scheduler flyway shares this schema (own history table, baseline 0) — baseline-0 here too
+    // so the non-empty-schema check can't fail when the scheduler migrates first
+    @Bean
+    public FlywayConfigurationCustomizer mysqlFlywayCustomizer() {
+        return configuration -> configuration.baselineOnMigrate(true).baselineVersion("0");
+    }
 
     @Bean
     @DependsOn({"flyway", "flywayInitializer"})

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
@@ -79,6 +79,9 @@ public class PostgresConfiguration {
                 .dataSource(dataSource)
                 .outOfOrder(true)
                 .baselineOnMigrate(true)
+                // default baseline version 1 would skip V1 when the scheduler flyway
+                // (same schema, own history table) migrates first
+                .baselineVersion("0")
                 .load();
     }
 

--- a/scheduler/core/src/testFixtures/java/io/orkes/conductor/scheduler/config/AbstractSchedulerAutoConfigurationSmokeTest.java
+++ b/scheduler/core/src/testFixtures/java/io/orkes/conductor/scheduler/config/AbstractSchedulerAutoConfigurationSmokeTest.java
@@ -56,6 +56,12 @@ public abstract class AbstractSchedulerAutoConfigurationSmokeTest {
         public RetryTemplate postgresRetryTemplate() {
             return new RetryTemplate();
         }
+
+        // mysql scheduler config injects by this name (server context has 3 RetryTemplates)
+        @Bean
+        public RetryTemplate mysqlRetryTemplate() {
+            return new RetryTemplate();
+        }
     }
 
     private ApplicationContextRunner baseRunner() {

--- a/scheduler/mysql-persistence/src/main/java/org/conductoross/conductor/scheduler/mysql/config/MySQLSchedulerConfiguration.java
+++ b/scheduler/mysql-persistence/src/main/java/org/conductoross/conductor/scheduler/mysql/config/MySQLSchedulerConfiguration.java
@@ -17,6 +17,7 @@ import javax.sql.DataSource;
 import org.conductoross.conductor.scheduler.mysql.dao.MySQLSchedulerArchivalDAO;
 import org.conductoross.conductor.scheduler.mysql.dao.MySQLSchedulerDAO;
 import org.flywaydb.core.Flyway;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
@@ -55,14 +56,18 @@ public class MySQLSchedulerConfiguration {
     @Bean
     @DependsOn("flywayForScheduler")
     public SchedulerDAO schedulerDAO(
-            RetryTemplate retryTemplate, DataSource dataSource, ObjectMapper objectMapper) {
+            @Qualifier("mysqlRetryTemplate") RetryTemplate retryTemplate,
+            DataSource dataSource,
+            ObjectMapper objectMapper) {
         return new MySQLSchedulerDAO(retryTemplate, objectMapper, dataSource);
     }
 
     @Bean
     @DependsOn("flywayForScheduler")
     public SchedulerArchivalDAO schedulerArchivalDAO(
-            RetryTemplate retryTemplate, DataSource dataSource, ObjectMapper objectMapper) {
+            @Qualifier("mysqlRetryTemplate") RetryTemplate retryTemplate,
+            DataSource dataSource,
+            ObjectMapper objectMapper) {
         return new MySQLSchedulerArchivalDAO(retryTemplate, objectMapper, dataSource);
     }
 }

--- a/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/config/SqliteConfiguration.java
+++ b/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/config/SqliteConfiguration.java
@@ -101,6 +101,10 @@ public class SqliteConfiguration {
                         .sqlMigrationSeparator("__") // V1__description
                         .mixed(true) // Allow mixed migrations (both versioned and repeatable)
                         .validateOnMigrate(true)
+                        // scheduler flyway shares this db (own history table, baseline 0) —
+                        // baseline-0 keeps boot independent of migration order
+                        .baselineOnMigrate(true)
+                        .baselineVersion("0")
                         .cleanDisabled(false);
 
         return new Flyway(config);


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

- Core Flyway and the scheduler's Flyway share the `conductor` schema (separate history tables).
  Whichever migrates second sees a non-empty schema, no history table → mysql throws
  `FlywayException` on boot.
- Fix: `baselineOnMigrate(true)` + `baselineVersion("0")` on core Flyway for mysql (new
  `FlywayConfigurationCustomizer`), postgres (had `baselineOnMigrate` only), sqlite (had neither).
- Also fixes `MySQLSchedulerConfiguration`'s unqualified `RetryTemplate` injection
  (`NoUniqueBeanDefinitionException` with 3 candidate beans) via `@Qualifier("mysqlRetryTemplate")`,
  same pattern postgres already used.

Issue #

Limitations
----

The dual-Flyway-chain design (core migrations + scheduler migrations, same schema, two independent
`FlywayConfigurationCustomizer`/bean setups) is not removed by this PR — `baselineVersion("0")` just
makes the existing race harmless regardless of which chain runs first. The two chains still exist,
still migrate independently, and still depend on their migration numbering never overlapping.

Alternatives considered
----

- `@DependsOn` to force scheduler-Flyway after core-Flyway instead of baseline-0 — fixes ordering
  but leaves an implicit ordering contract instead of an order-independent fix.
