### PR TITLE
fix(e2e): scope FileStorageE2ETest to postgres + redis-es8

### DIFF
--- a/docker/docker-compose-postgres.yaml
+++ b/docker/docker-compose-postgres.yaml
@@ -21,6 +21,9 @@ services:
     ports:
       - 8000:8080
       - 8127:5000
+    volumes:
+      # Shared with host so file:// URIs from the server resolve on the e2e runner.
+      - /tmp/conductor-file-storage-e2e:/tmp/conductor-file-storage-e2e
     healthcheck:
       test: [ "CMD", "curl","-I" ,"-XGET", "http://localhost:8080/health" ]
       interval: 60s

--- a/docker/server/config/config-postgres.properties
+++ b/docker/server/config/config-postgres.properties
@@ -24,3 +24,9 @@ loadSample=true
 
 # Shorten postpone duration to speed up concurrent execution limit tests (default is 60s)
 conductor.app.taskExecutionPostponeDuration=10s
+
+# File-storage: local backend shared with the host via bind mount so file:// URIs resolve
+# identically on both sides. Required by FileStorageE2ETest.
+conductor.file-storage.enabled=true
+conductor.file-storage.type=local
+conductor.file-storage.local.directory=/tmp/conductor-file-storage-e2e

--- a/e2e/build.gradle
+++ b/e2e/build.gradle
@@ -17,7 +17,14 @@ dependencies {
 }
 
 test {
-    useJUnitPlatform()
+    useJUnitPlatform {
+        // FileStorageE2ETest needs conductor.file-storage.enabled=true server-side (only
+        // postgres and redis-es8 configs set it). Skipped by default everywhere else;
+        // opt in with -PrunFileStorageTests.
+        if (!project.hasProperty('runFileStorageTests')) {
+            excludeTags 'file-storage'
+        }
+    }
     maxParallelForks = 4
     minHeapSize = '512m'
     maxHeapSize = '2g'

--- a/e2e/run_tests-es8.sh
+++ b/e2e/run_tests-es8.sh
@@ -39,6 +39,6 @@ done
 
 cd "$SCRIPT_DIR/.."
 set +e
-./gradlew :conductor-e2e:test -PrunE2E -DSERVER_ROOT_URI="$SERVER_ROOT_URI" "$@"
+./gradlew :conductor-e2e:test -PrunE2E -PrunFileStorageTests -DSERVER_ROOT_URI="$SERVER_ROOT_URI" "$@"
 EXIT_CODE=$?
 exit $EXIT_CODE

--- a/e2e/run_tests-postgres.sh
+++ b/e2e/run_tests-postgres.sh
@@ -3,7 +3,12 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPOSE_FILE="$SCRIPT_DIR/../docker/docker-compose-postgres.yaml"
+STORAGE_DIR="/tmp/conductor-file-storage-e2e"
 export SERVER_ROOT_URI="${SERVER_ROOT_URI:-http://localhost:8000}"
+
+echo "Preparing shared storage dir at $STORAGE_DIR ..."
+rm -rf "$STORAGE_DIR"
+mkdir -p "$STORAGE_DIR"
 
 echo "Starting Conductor (Postgres + Elasticsearch 7)..."
 docker compose -f "$COMPOSE_FILE" build conductor-server
@@ -26,7 +31,7 @@ for i in $(seq 1 60); do
 done
 
 cd "$SCRIPT_DIR/.."
-./gradlew :conductor-e2e:test -PrunE2E -DSERVER_ROOT_URI="$SERVER_ROOT_URI" "$@"
+./gradlew :conductor-e2e:test -PrunE2E -PrunFileStorageTests -DSERVER_ROOT_URI="$SERVER_ROOT_URI" "$@"
 EXIT_CODE=$?
 
 docker compose -f "$COMPOSE_FILE" down -v

--- a/e2e/src/test/java/io/conductor/e2e/filestorage/FileStorageE2ETest.java
+++ b/e2e/src/test/java/io/conductor/e2e/filestorage/FileStorageE2ETest.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.UUID;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import com.netflix.conductor.client.exception.ConductorClientException;
@@ -39,8 +40,11 @@ import static org.junit.jupiter.api.Assertions.fail;
  * {@code type=local}). A bind mount shares the server's storage directory with the host so the
  * {@code file:///...} URIs returned by the API resolve on both sides.
  *
- * <p>Run via: {@code e2e/run_tests-es8.sh}.
+ * <p>Tagged {@code file-storage}; excluded by default (see {@code e2e/build.gradle}). Only {@code
+ * e2e/run_tests-postgres.sh} and {@code e2e/run_tests-es8.sh} opt back in with {@code
+ * -PrunFileStorageTests}, since those are the only lanes whose server config enables file-storage.
  */
+@Tag("file-storage")
 class FileStorageE2ETest {
 
     private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

- `FileStorageE2ETest` ran on every e2e lane, but only redis-es8's config enables
  `conductor.file-storage.enabled` → 9 test failures (generic 404) on every other lane.
- Tagged the class `@Tag("file-storage")`; `e2e/build.gradle` excludes that tag by default.
- `run_tests-postgres.sh` and `run_tests-es8.sh` opt back in via `-PrunFileStorageTests`; postgres
  also gets file-storage enabled server-side (config properties + compose bind mount), mirroring
  es8. No other lane's script changes — new default is "excluded."

Issue #

Alternatives considered
----

- `@EnabledIfSystemProperty` gated by a flag derived from each lane's own config file — smaller
  diff, no drift risk. Not used here per reviewer preference for tag+`excludeTags`.
