### PR TITLE
fix(cassandra): add CassandraRateLimitingDAO

### DIFF
--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/config/CassandraConfiguration.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/config/CassandraConfiguration.java
@@ -26,11 +26,13 @@ import com.netflix.conductor.cassandra.dao.CassandraEventHandlerDAO;
 import com.netflix.conductor.cassandra.dao.CassandraExecutionDAO;
 import com.netflix.conductor.cassandra.dao.CassandraMetadataDAO;
 import com.netflix.conductor.cassandra.dao.CassandraPollDataDAO;
+import com.netflix.conductor.cassandra.dao.CassandraRateLimitingDAO;
 import com.netflix.conductor.cassandra.util.Statements;
 import com.netflix.conductor.dao.EventHandlerDAO;
 import com.netflix.conductor.dao.ExecutionDAO;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.dao.QueueDAO;
+import com.netflix.conductor.dao.RateLimitingDAO;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Metadata;
@@ -109,6 +111,15 @@ public class CassandraConfiguration {
     @Bean
     public CassandraPollDataDAO cassandraPollDataDAO() {
         return new CassandraPollDataDAO();
+    }
+
+    @Bean
+    public RateLimitingDAO cassandraRateLimitingDAO(
+            Session session,
+            ObjectMapper objectMapper,
+            CassandraProperties properties,
+            Statements statements) {
+        return new CassandraRateLimitingDAO(session, objectMapper, properties, statements);
     }
 
     @Bean

--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraBaseDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraBaseDAO.java
@@ -37,12 +37,14 @@ import static com.netflix.conductor.cassandra.util.Constants.EVENT_HANDLER_NAME_
 import static com.netflix.conductor.cassandra.util.Constants.HANDLERS_KEY;
 import static com.netflix.conductor.cassandra.util.Constants.MESSAGE_ID_KEY;
 import static com.netflix.conductor.cassandra.util.Constants.PAYLOAD_KEY;
+import static com.netflix.conductor.cassandra.util.Constants.RATE_LIMIT_BUCKET_ID_KEY;
 import static com.netflix.conductor.cassandra.util.Constants.SHARD_ID_KEY;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_EVENT_EXECUTIONS;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_EVENT_HANDLERS;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_TASK_DEFS;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_TASK_DEF_LIMIT;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_TASK_LOOKUP;
+import static com.netflix.conductor.cassandra.util.Constants.TABLE_TASK_RATE_LIMIT;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_WORKFLOWS;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_WORKFLOW_DEFS;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_WORKFLOW_DEFS_INDEX;
@@ -75,6 +77,9 @@ import static com.netflix.conductor.cassandra.util.Constants.WORKFLOW_VERSION_KE
  *
  * <p>CREATE TABLE IF NOT EXISTS conductor.task_def_limit( task_def_name text, task_id uuid,
  * workflow_id uuid, PRIMARY KEY ((task_def_name), task_id_key) );
+ *
+ * <p>CREATE TABLE IF NOT EXISTS conductor.task_rate_limit( task_def_name text, rate_limit_bucket_id
+ * timeuuid, PRIMARY KEY ((task_def_name), rate_limit_bucket_id) );
  *
  * <p>CREATE TABLE IF NOT EXISTS conductor.workflow_definitions( workflow_def_name text, version
  * int, workflow_definition text, PRIMARY KEY ((workflow_def_name), version) );
@@ -127,6 +132,7 @@ public abstract class CassandraBaseDAO {
                 session.execute(getCreateWorkflowsTableStatement());
                 session.execute(getCreateTaskLookupTableStatement());
                 session.execute(getCreateTaskDefLimitTableStatement());
+                session.execute(getCreateTaskRateLimitTableStatement());
                 session.execute(getCreateWorkflowDefsTableStatement());
                 session.execute(getCreateWorkflowDefsIndexTableStatement());
                 session.execute(getCreateTaskDefsTableStatement());
@@ -183,6 +189,14 @@ public abstract class CassandraBaseDAO {
                 .addPartitionKey(TASK_DEF_NAME_KEY, DataType.text())
                 .addClusteringColumn(TASK_ID_KEY, DataType.uuid())
                 .addColumn(WORKFLOW_ID_KEY, DataType.uuid())
+                .getQueryString();
+    }
+
+    private String getCreateTaskRateLimitTableStatement() {
+        return SchemaBuilder.createTable(properties.getKeyspace(), TABLE_TASK_RATE_LIMIT)
+                .ifNotExists()
+                .addPartitionKey(TASK_DEF_NAME_KEY, DataType.text())
+                .addClusteringColumn(RATE_LIMIT_BUCKET_ID_KEY, DataType.timeuuid())
                 .getQueryString();
     }
 

--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraRateLimitingDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraRateLimitingDAO.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.cassandra.dao;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.conductor.annotations.Trace;
+import com.netflix.conductor.cassandra.config.CassandraProperties;
+import com.netflix.conductor.cassandra.util.Statements;
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.core.exception.TransientException;
+import com.netflix.conductor.dao.RateLimitingDAO;
+import com.netflix.conductor.metrics.Monitors;
+import com.netflix.conductor.model.TaskModel;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.DriverException;
+import com.datastax.driver.core.utils.UUIDs;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Rate limits tasks using a "task_rate_limit" bucket table: one row per task execution within the
+ * rate limit frequency window, keyed by a timeuuid and expiring via TTL once the window elapses.
+ */
+@Trace
+public class CassandraRateLimitingDAO extends CassandraBaseDAO implements RateLimitingDAO {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CassandraRateLimitingDAO.class);
+    private static final String CLASS_NAME = CassandraRateLimitingDAO.class.getSimpleName();
+
+    private final PreparedStatement selectRateLimitCountStatement;
+    private final PreparedStatement insertRateLimitBucketStatement;
+
+    public CassandraRateLimitingDAO(
+            Session session,
+            ObjectMapper objectMapper,
+            CassandraProperties properties,
+            Statements statements) {
+        super(session, objectMapper, properties);
+        this.selectRateLimitCountStatement =
+                session.prepare(statements.getSelectRateLimitCountStatement());
+        this.insertRateLimitBucketStatement =
+                session.prepare(statements.getInsertRateLimitBucketStatement());
+    }
+
+    @Override
+    public boolean exceedsRateLimitPerFrequency(TaskModel task, TaskDef taskDef) {
+        ImmutablePair<Integer, Integer> rateLimitPair =
+                Optional.ofNullable(taskDef)
+                        .map(
+                                definition ->
+                                        new ImmutablePair<>(
+                                                definition.getRateLimitPerFrequency(),
+                                                definition.getRateLimitFrequencyInSeconds()))
+                        .orElse(
+                                new ImmutablePair<>(
+                                        task.getRateLimitPerFrequency(),
+                                        task.getRateLimitFrequencyInSeconds()));
+
+        int rateLimitPerFrequency = rateLimitPair.getLeft();
+        int rateLimitFrequencyInSeconds = rateLimitPair.getRight();
+        if (rateLimitPerFrequency <= 0 || rateLimitFrequencyInSeconds <= 0) {
+            LOGGER.debug(
+                    "Rate limit not applied to the Task: {} either rateLimitPerFrequency: {} or rateLimitFrequencyInSeconds: {} is 0 or less",
+                    task,
+                    rateLimitPerFrequency,
+                    rateLimitFrequencyInSeconds);
+            return false;
+        }
+
+        try {
+            recordCassandraDaoRequests("exceedsRateLimitPerFrequency");
+            long nowMillis = System.currentTimeMillis();
+            UUID windowStart = UUIDs.startOf(nowMillis - (rateLimitFrequencyInSeconds * 1000L));
+            ResultSet resultSet =
+                    session.execute(
+                            selectRateLimitCountStatement.bind(task.getTaskDefName(), windowStart));
+            long currentBucketCount = resultSet.one().getLong(0);
+
+            if (currentBucketCount < rateLimitPerFrequency) {
+                session.execute(
+                        insertRateLimitBucketStatement.bind(
+                                task.getTaskDefName(),
+                                UUIDs.timeBased(),
+                                rateLimitFrequencyInSeconds));
+                LOGGER.info(
+                        "TaskId: {} with TaskDefinition of: {} has rateLimitPerFrequency: {} and rateLimitFrequencyInSeconds: {} within the rate limit with current count {}",
+                        task.getTaskId(),
+                        task.getTaskDefName(),
+                        rateLimitPerFrequency,
+                        rateLimitFrequencyInSeconds,
+                        currentBucketCount + 1);
+                Monitors.recordTaskRateLimited(task.getTaskDefName(), rateLimitPerFrequency);
+                return false;
+            } else {
+                LOGGER.info(
+                        "TaskId: {} with TaskDefinition of: {} has rateLimitPerFrequency: {} and rateLimitFrequencyInSeconds: {} is out of bounds of rate limit with current count {}",
+                        task.getTaskId(),
+                        task.getTaskDefName(),
+                        rateLimitPerFrequency,
+                        rateLimitFrequencyInSeconds,
+                        currentBucketCount);
+                return true;
+            }
+        } catch (DriverException e) {
+            Monitors.error(CLASS_NAME, "exceedsRateLimitPerFrequency");
+            String errorMsg =
+                    String.format(
+                            "Failed to check rate limit for task: %s in taskDef: %s",
+                            task.getTaskId(), task.getTaskDefName());
+            LOGGER.error(errorMsg, e);
+            throw new TransientException(errorMsg, e);
+        }
+    }
+}

--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/util/Constants.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/util/Constants.java
@@ -19,6 +19,7 @@ public interface Constants {
     String TABLE_WORKFLOWS = "workflows";
     String TABLE_TASK_LOOKUP = "task_lookup";
     String TABLE_TASK_DEF_LIMIT = "task_def_limit";
+    String TABLE_TASK_RATE_LIMIT = "task_rate_limit";
     String TABLE_WORKFLOW_DEFS = "workflow_definitions";
     String TABLE_WORKFLOW_DEFS_INDEX = "workflow_defs_index";
     String TABLE_TASK_DEFS = "task_definitions";
@@ -46,6 +47,7 @@ public interface Constants {
     String EVENT_HANDLER_KEY = "event_handler";
     String MESSAGE_ID_KEY = "message_id";
     String EVENT_EXECUTION_ID_KEY = "event_execution_id";
+    String RATE_LIMIT_BUCKET_ID_KEY = "rate_limit_bucket_id";
 
     String ENTITY_TYPE_WORKFLOW = "workflow";
     String ENTITY_TYPE_TASK = "task";

--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/util/Statements.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/util/Statements.java
@@ -23,12 +23,14 @@ import static com.netflix.conductor.cassandra.util.Constants.EVENT_HANDLER_NAME_
 import static com.netflix.conductor.cassandra.util.Constants.HANDLERS_KEY;
 import static com.netflix.conductor.cassandra.util.Constants.MESSAGE_ID_KEY;
 import static com.netflix.conductor.cassandra.util.Constants.PAYLOAD_KEY;
+import static com.netflix.conductor.cassandra.util.Constants.RATE_LIMIT_BUCKET_ID_KEY;
 import static com.netflix.conductor.cassandra.util.Constants.SHARD_ID_KEY;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_EVENT_EXECUTIONS;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_EVENT_HANDLERS;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_TASK_DEFS;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_TASK_DEF_LIMIT;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_TASK_LOOKUP;
+import static com.netflix.conductor.cassandra.util.Constants.TABLE_TASK_RATE_LIMIT;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_WORKFLOWS;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_WORKFLOW_DEFS;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_WORKFLOW_DEFS_INDEX;
@@ -48,6 +50,7 @@ import static com.netflix.conductor.cassandra.util.Constants.WORKFLOW_VERSION_KE
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.gte;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
 
 /**
@@ -123,6 +126,15 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
  *       ('handlers',?,?);
  *   <li>SELECT * FROM conductor.event_handlers WHERE handlers=?;
  *   <li>DELETE FROM conductor.event_handlers WHERE handlers='handlers' AND event_handler_name=?;
+ * </ul>
+ *
+ * <em>RateLimitingDAO</em>
+ *
+ * <ul>
+ *   <li>SELECT count(*) FROM conductor.task_rate_limit WHERE task_def_name=? AND
+ *       rate_limit_bucket_id>=?;
+ *   <li>INSERT INTO conductor.task_rate_limit (task_def_name,rate_limit_bucket_id) VALUES (?,?)
+ *       USING TTL ?;
  * </ul>
  */
 public class Statements {
@@ -599,6 +611,36 @@ public class Statements {
                 .from(keyspace, TABLE_EVENT_HANDLERS)
                 .where(eq(HANDLERS_KEY, HANDLERS_KEY))
                 .and(eq(EVENT_HANDLER_NAME_KEY, bindMarker()))
+                .getQueryString();
+    }
+
+    // RateLimitingDAO
+    // Select Statements
+
+    /**
+     * @return cql query statement to count rate limit bucket entries for a task def within the rate
+     *     limit frequency window from the "task_rate_limit" table
+     */
+    public String getSelectRateLimitCountStatement() {
+        return QueryBuilder.select()
+                .countAll()
+                .from(keyspace, TABLE_TASK_RATE_LIMIT)
+                .where(eq(TASK_DEF_NAME_KEY, bindMarker()))
+                .and(gte(RATE_LIMIT_BUCKET_ID_KEY, bindMarker()))
+                .getQueryString();
+    }
+
+    // Insert Statements
+
+    /**
+     * @return cql query statement to add a rate limit bucket entry, expiring after the rate limit
+     *     frequency window, into the "task_rate_limit" table
+     */
+    public String getInsertRateLimitBucketStatement() {
+        return QueryBuilder.insertInto(keyspace, TABLE_TASK_RATE_LIMIT)
+                .value(TASK_DEF_NAME_KEY, bindMarker())
+                .value(RATE_LIMIT_BUCKET_ID_KEY, bindMarker())
+                .using(QueryBuilder.ttl(bindMarker()))
                 .getQueryString();
     }
 }


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

- `ExecutionDAOFacade` requires a `RateLimitingDAO` bean unconditionally. mysql/postgres/sqlite
  implement it inline; redis has `RedisRateLimitingDAO`. Cassandra had none →
  `APPLICATION FAILED TO START` on every cassandra-backed boot.
- Added `CassandraRateLimitingDAO`, registered in `CassandraConfiguration`.
- New `task_rate_limit` table: one row per execution in the rate-limit window, timeuuid key,
  TTL'd so old rows self-expire — same zset+TTL sliding-window semantics as
  `RedisRateLimitingDAO`, via clustered range read + insert.

Issue #

Alternatives considered
----

- No-op stub (always not-rate-limited) instead of a real implementation — smaller change, but
  silently disables the `rateLimitPerFrequency` feature for cassandra with no signal to the user.
