### PR TITLE
fix(ui): open API Docs in new tab and fix back navigation loading loop

### DIFF
--- a/ui-next/src/components/providers/sidebar/__tests__/sidebarCoreItems.test.tsx
+++ b/ui-next/src/components/providers/sidebar/__tests__/sidebarCoreItems.test.tsx
@@ -216,5 +216,12 @@ describe("getCoreSidebarItems", () => {
       expect(childIds).toContain("eventHandlerDefItem");
       expect(childIds).toContain("schedulerDefItem");
     });
+
+    it("returns swaggerItem configured to open in a new tab", () => {
+      const swaggerItem = findItem(items, "swaggerItem");
+      expect(swaggerItem).toBeDefined();
+      expect(swaggerItem?.linkTo).toBe("/api-reference");
+      expect(swaggerItem?.isOpenNewTab).toBe(true);
+    });
   });
 });

--- a/ui-next/src/components/providers/sidebar/sidebarCoreItems.tsx
+++ b/ui-next/src/components/providers/sidebar/sidebarCoreItems.tsx
@@ -318,6 +318,7 @@ export function getCoreSidebarItems(open: boolean): MenuItemType[] {
       hotkeys: "",
       hidden: false,
       position: R.swaggerItem,
+      isOpenNewTab: true,
     },
   ];
 }

--- a/ui-next/src/pages/apiDocs/ApiReferencePage.tsx
+++ b/ui-next/src/pages/apiDocs/ApiReferencePage.tsx
@@ -13,8 +13,7 @@ const getSwaggerUrl = () =>
 
 export default function ApiReferencePage() {
   useEffect(() => {
-    // Redirect to Swagger UI
-    window.location.href = getSwaggerUrl();
+    window.location.replace(getSwaggerUrl());
   }, []);
 
   return (

--- a/ui-next/src/pages/apiDocs/__tests__/ApiReferencePage.test.tsx
+++ b/ui-next/src/pages/apiDocs/__tests__/ApiReferencePage.test.tsx
@@ -1,0 +1,26 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import ApiReferencePage from "../ApiReferencePage";
+
+describe("ApiReferencePage", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("replaces location with swagger url on mount", () => {
+    const replaceMock = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        host: "localhost:5000",
+        replace: replaceMock,
+      },
+    });
+
+    render(<ApiReferencePage />);
+
+    expect(replaceMock).toHaveBeenCalledWith(
+      "//localhost:5000/swagger-ui/index.html?configUrl=/api-docs/swagger-config#/",
+    );
+  });
+});


### PR DESCRIPTION
Fixes #1316

## Description
Fixes an issue where clicking **API Docs** in the sidebar opened in the same tab, and navigating back via browser history caused an infinite redirect loop / loading spinner hang on `/api-reference`.

## Changes Made
- Set `isOpenNewTab: true` on `swaggerItem` in `sidebarCoreItems.tsx` to force sidebar link to render with `target="_blank"`.
- Replaced `window.location.href = ...` with `window.location.replace(...)` in `ApiReferencePage.tsx` so the redirect replaces the current history entry rather than pushing a new entry on the history stack.
- Added unit tests for `sidebarCoreItems` and `ApiReferencePage`.
