### PR TITLE
fix(engine): support nested DO_WHILE iteration chains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ server/*.db*
 *.db-shm
 *.db-wal
 docs/superpowers
+.codex/

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -32,6 +32,7 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.common.utils.ExternalPayloadStorage.Operation;
 import com.netflix.conductor.common.utils.ExternalPayloadStorage.PayloadType;
+import com.netflix.conductor.common.utils.TaskUtils;
 import com.netflix.conductor.core.exception.TerminateWorkflowException;
 import com.netflix.conductor.core.execution.mapper.TaskMapper;
 import com.netflix.conductor.core.execution.mapper.TaskMapperContext;
@@ -536,7 +537,7 @@ public class DeciderService {
 
         String taskReferenceName =
                 task.isLoopOverTask()
-                        ? LoopTaskUtils.removeIterationSuffixChain(task.getReferenceTaskName())
+                        ? TaskUtils.removeIterationFromTaskRefName(task.getReferenceTaskName())
                         : task.getReferenceTaskName();
         WorkflowTask taskToSchedule = workflowDef.getNextTask(taskReferenceName);
         while (isTaskSkipped(taskToSchedule, workflow)) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/DeciderService.java
@@ -32,13 +32,13 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.common.utils.ExternalPayloadStorage.Operation;
 import com.netflix.conductor.common.utils.ExternalPayloadStorage.PayloadType;
-import com.netflix.conductor.common.utils.TaskUtils;
 import com.netflix.conductor.core.exception.TerminateWorkflowException;
 import com.netflix.conductor.core.execution.mapper.TaskMapper;
 import com.netflix.conductor.core.execution.mapper.TaskMapperContext;
 import com.netflix.conductor.core.execution.tasks.SystemTaskRegistry;
 import com.netflix.conductor.core.utils.ExternalPayloadStorageUtils;
 import com.netflix.conductor.core.utils.IDGenerator;
+import com.netflix.conductor.core.utils.LoopTaskUtils;
 import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.metrics.Monitors;
@@ -240,10 +240,13 @@ public class DeciderService {
                     && pendingTask.getStatus().isTerminal()) {
                 pendingTask.setExecuted(true);
                 List<TaskModel> nextTasks = getNextTask(workflow, pendingTask);
-                if (pendingTask.isLoopOverTask()
-                        && !TaskType.DO_WHILE.name().equals(pendingTask.getTaskType())
-                        && !nextTasks.isEmpty()) {
-                    nextTasks = filterNextLoopOverTasks(nextTasks, pendingTask, workflow);
+                if (!nextTasks.isEmpty()) {
+                    String suffixChain = LoopTaskUtils.getIterationSuffixChain(pendingTask);
+                    if (!suffixChain.isEmpty()) {
+                        nextTasks =
+                                filterNextLoopOverTasks(
+                                        nextTasks, suffixChain, pendingTask, workflow);
+                    }
                 }
                 nextTasks.forEach(
                         nextTask ->
@@ -319,14 +322,25 @@ public class DeciderService {
     @VisibleForTesting
     List<TaskModel> filterNextLoopOverTasks(
             List<TaskModel> tasks, TaskModel pendingTask, WorkflowModel workflow) {
+        return filterNextLoopOverTasks(
+                tasks, LoopTaskUtils.getIterationSuffixChain(pendingTask), pendingTask, workflow);
+    }
 
-        // Update the task reference name and iteration
+    @VisibleForTesting
+    List<TaskModel> filterNextLoopOverTasks(
+            List<TaskModel> tasks,
+            String suffixChain,
+            TaskModel pendingTask,
+            WorkflowModel workflow) {
+
+        int iteration = LoopTaskUtils.getIterationFromSuffixChain(suffixChain);
         tasks.forEach(
                 nextTask -> {
-                    nextTask.setReferenceTaskName(
-                            TaskUtils.appendIteration(
-                                    nextTask.getReferenceTaskName(), pendingTask.getIteration()));
-                    nextTask.setIteration(pendingTask.getIteration());
+                    nextTask.setReferenceTaskName(nextTask.getReferenceTaskName() + suffixChain);
+                    if (iteration > 0) {
+                        nextTask.setIteration(iteration);
+                    }
+                    nextTask.setLoopTaskId(pendingTask.getLoopTaskId());
                 });
 
         List<String> tasksInWorkflow =
@@ -522,13 +536,16 @@ public class DeciderService {
 
         String taskReferenceName =
                 task.isLoopOverTask()
-                        ? TaskUtils.removeIterationFromTaskRefName(task.getReferenceTaskName())
+                        ? LoopTaskUtils.removeIterationSuffixChain(task.getReferenceTaskName())
                         : task.getReferenceTaskName();
         WorkflowTask taskToSchedule = workflowDef.getNextTask(taskReferenceName);
         while (isTaskSkipped(taskToSchedule, workflow)) {
             taskToSchedule = workflowDef.getNextTask(taskToSchedule.getTaskReferenceName());
         }
         if (taskToSchedule != null && TaskType.DO_WHILE.name().equals(taskToSchedule.getType())) {
+            if (taskToSchedule.has(taskReferenceName)) {
+                return Collections.emptyList();
+            }
             // check if already has this DO_WHILE task, ignore it if it already exists
             String nextTaskReferenceName = taskToSchedule.getTaskReferenceName();
             if (workflow.getTasks().stream()

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
@@ -48,6 +48,7 @@ import com.netflix.conductor.core.listener.WorkflowStatusListener;
 import com.netflix.conductor.core.listener.WorkflowStatusListener.WorkflowEventType;
 import com.netflix.conductor.core.metadata.MetadataMapperService;
 import com.netflix.conductor.core.utils.IDGenerator;
+import com.netflix.conductor.core.utils.LoopTaskUtils;
 import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.core.utils.QueueUtils;
 import com.netflix.conductor.core.utils.Utils;
@@ -2468,12 +2469,15 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
                         loopTask.getRetryCount(),
                         null);
         setTaskDomains(scheduledLoopOverTasks, workflow);
+        String loopSuffixChain = LoopTaskUtils.getIterationSuffixChain(loopTask);
         scheduledLoopOverTasks.forEach(
                 t -> {
                     t.setReferenceTaskName(
                             TaskUtils.appendIteration(
-                                    t.getReferenceTaskName(), loopTask.getIteration()));
+                                    t.getReferenceTaskName() + loopSuffixChain,
+                                    loopTask.getIteration()));
                     t.setIteration(loopTask.getIteration());
+                    t.setLoopTaskId(loopTask.getTaskId());
                 });
         scheduleTask(workflow, scheduledLoopOverTasks);
         workflow.getTasks().addAll(scheduledLoopOverTasks);

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
@@ -27,6 +27,7 @@ import com.netflix.conductor.common.utils.TaskUtils;
 import com.netflix.conductor.core.dal.ExecutionDAOFacade;
 import com.netflix.conductor.core.events.ScriptEvaluator;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.core.utils.LoopTaskUtils;
 import com.netflix.conductor.core.utils.ParametersUtils;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
@@ -64,14 +65,18 @@ public class DoWhile extends WorkflowSystemTask {
          * Get the latest set of tasks (the ones that have the highest retry count). We don't want to evaluate any tasks
          * that have already failed if there is a more current one (a later retry count).
          */
+        String currentIterationChain =
+                TaskUtils.appendIteration(
+                        LoopTaskUtils.getIterationSuffixChain(doWhileTaskModel),
+                        doWhileTaskModel.getIteration());
         Map<String, TaskModel> relevantTasks = new LinkedHashMap<>();
         TaskModel relevantTask;
         for (TaskModel t : workflow.getTasks()) {
             if (doWhileTaskModel
                             .getWorkflowTask()
-                            .has(TaskUtils.removeIterationFromTaskRefName(t.getReferenceTaskName()))
+                            .has(LoopTaskUtils.removeIterationSuffixChain(t.getReferenceTaskName()))
                     && !doWhileTaskModel.getReferenceTaskName().equals(t.getReferenceTaskName())
-                    && doWhileTaskModel.getIteration() == t.getIteration()) {
+                    && currentIterationChain.equals(LoopTaskUtils.getIterationSuffixChain(t))) {
                 relevantTask = relevantTasks.get(t.getReferenceTaskName());
                 if (relevantTask == null || t.getRetryCount() > relevantTask.getRetryCount()) {
                     relevantTasks.put(t.getReferenceTaskName(), t);
@@ -122,7 +127,7 @@ public class DoWhile extends WorkflowSystemTask {
                 failureReason.append(loopOverTask.getReasonForIncompletion()).append(" ");
             }
             output.put(
-                    TaskUtils.removeIterationFromTaskRefName(loopOverTask.getReferenceTaskName()),
+                    LoopTaskUtils.removeIterationSuffixChain(loopOverTask.getReferenceTaskName()),
                     loopOverTask.getOutputData());
             if (hasFailures) {
                 break;
@@ -221,13 +226,13 @@ public class DoWhile extends WorkflowSystemTask {
                 keepLastN);
 
         // Find and remove tasks from old iterations
-        List<TaskModel> tasksToRemove =
+        Set<String> taskIdsToRemove =
                 workflow.getTasks().stream()
                         .filter(
                                 task -> {
                                     // Check if this task belongs to the DO_WHILE loop
                                     String taskRefWithoutIteration =
-                                            TaskUtils.removeIterationFromTaskRefName(
+                                            LoopTaskUtils.removeIterationSuffixChain(
                                                     task.getReferenceTaskName());
                                     boolean belongsToLoop =
                                             doWhileTaskModel
@@ -244,10 +249,27 @@ public class DoWhile extends WorkflowSystemTask {
 
                                     return belongsToLoop && isOldIteration;
                                 })
-                        .collect(Collectors.toList());
+                        .map(TaskModel::getTaskId)
+                        .collect(Collectors.toSet());
+
+        boolean changed = !taskIdsToRemove.isEmpty();
+        while (changed) {
+            changed = false;
+            for (TaskModel task : workflow.getTasks()) {
+                if (!taskIdsToRemove.contains(task.getTaskId())
+                        && task.getLoopTaskId() != null
+                        && taskIdsToRemove.contains(task.getLoopTaskId())) {
+                    taskIdsToRemove.add(task.getTaskId());
+                    changed = true;
+                }
+            }
+        }
 
         // Remove each task from the database
-        for (TaskModel taskToRemove : tasksToRemove) {
+        for (TaskModel taskToRemove : workflow.getTasks()) {
+            if (!taskIdsToRemove.contains(taskToRemove.getTaskId())) {
+                continue;
+            }
             try {
                 LOGGER.debug(
                         "Removing task {} (iteration {}) from workflow {}",
@@ -265,10 +287,9 @@ public class DoWhile extends WorkflowSystemTask {
                 // Continue with other tasks even if one fails
             }
         }
-
         LOGGER.info(
                 "Removed {} tasks from {} old iterations for DO_WHILE task {} in workflow {}",
-                tasksToRemove.size(),
+                taskIdsToRemove.size(),
                 iterationsToRemove,
                 doWhileTaskModel.getReferenceTaskName(),
                 workflow.getWorkflowId());
@@ -287,11 +308,13 @@ public class DoWhile extends WorkflowSystemTask {
         List<WorkflowTask> workflowTasksInsideDoWhile =
                 doWhileTaskModel.getWorkflowTask().getLoopOver();
         int iteration = doWhileTaskModel.getIteration();
+        String currentIterationChain =
+                TaskUtils.appendIteration(
+                        LoopTaskUtils.getIterationSuffixChain(doWhileTaskModel), iteration);
         boolean allTasksTerminal = true;
         for (WorkflowTask workflowTaskInsideDoWhile : workflowTasksInsideDoWhile) {
             String taskReferenceName =
-                    TaskUtils.appendIteration(
-                            workflowTaskInsideDoWhile.getTaskReferenceName(), iteration);
+                    workflowTaskInsideDoWhile.getTaskReferenceName() + currentIterationChain;
             if (referenceNameToModel.containsKey(taskReferenceName)) {
                 TaskModel taskModel = referenceNameToModel.get(taskReferenceName);
                 if (!taskModel.getStatus().isTerminal()) {
@@ -329,7 +352,7 @@ public class DoWhile extends WorkflowSystemTask {
         for (TaskModel task : referenceNameToModel.values()) {
             if (task.getStatus().isTerminal()) {
                 String refNameWithoutIteration =
-                        TaskUtils.removeIterationFromTaskRefName(task.getReferenceTaskName());
+                        LoopTaskUtils.removeIterationSuffixChain(task.getReferenceTaskName());
                 WorkflowTask nextWorkflowTask =
                         doWhileTaskModel.getWorkflowTask().next(refNameWithoutIteration, null);
                 // A non-null next task that is still within the DO_WHILE hierarchy (i.e. not the
@@ -341,8 +364,7 @@ public class DoWhile extends WorkflowSystemTask {
                                 .getWorkflowTask()
                                 .has(nextWorkflowTask.getTaskReferenceName())) {
                     String nextTaskRef =
-                            TaskUtils.appendIteration(
-                                    nextWorkflowTask.getTaskReferenceName(), iteration);
+                            nextWorkflowTask.getTaskReferenceName() + currentIterationChain;
                     if (!referenceNameToModel.containsKey(nextTaskRef)) {
                         // Successor task not yet scheduled — iteration is not complete.
                         return false;
@@ -515,7 +537,9 @@ public class DoWhile extends WorkflowSystemTask {
                         workflow,
                         task.getTaskId(),
                         taskDefinition);
-        conditionInput.put(task.getReferenceTaskName(), task.getOutputData());
+        conditionInput.put(
+                LoopTaskUtils.removeIterationSuffixChain(task.getReferenceTaskName()),
+                task.getOutputData());
         List<TaskModel> loopOver =
                 workflow.getTasks().stream()
                         .filter(
@@ -532,7 +556,7 @@ public class DoWhile extends WorkflowSystemTask {
 
         for (TaskModel loopOverTask : loopOver) {
             conditionInput.put(
-                    TaskUtils.removeIterationFromTaskRefName(loopOverTask.getReferenceTaskName()),
+                    LoopTaskUtils.removeIterationSuffixChain(loopOverTask.getReferenceTaskName()),
                     loopOverTask.getOutputData());
         }
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
@@ -74,7 +74,7 @@ public class DoWhile extends WorkflowSystemTask {
         for (TaskModel t : workflow.getTasks()) {
             if (doWhileTaskModel
                             .getWorkflowTask()
-                            .has(LoopTaskUtils.removeIterationSuffixChain(t.getReferenceTaskName()))
+                            .has(TaskUtils.removeIterationFromTaskRefName(t.getReferenceTaskName()))
                     && !doWhileTaskModel.getReferenceTaskName().equals(t.getReferenceTaskName())
                     && currentIterationChain.equals(LoopTaskUtils.getIterationSuffixChain(t))) {
                 relevantTask = relevantTasks.get(t.getReferenceTaskName());
@@ -127,7 +127,7 @@ public class DoWhile extends WorkflowSystemTask {
                 failureReason.append(loopOverTask.getReasonForIncompletion()).append(" ");
             }
             output.put(
-                    LoopTaskUtils.removeIterationSuffixChain(loopOverTask.getReferenceTaskName()),
+                    TaskUtils.removeIterationFromTaskRefName(loopOverTask.getReferenceTaskName()),
                     loopOverTask.getOutputData());
             if (hasFailures) {
                 break;
@@ -232,7 +232,7 @@ public class DoWhile extends WorkflowSystemTask {
                                 task -> {
                                     // Check if this task belongs to the DO_WHILE loop
                                     String taskRefWithoutIteration =
-                                            LoopTaskUtils.removeIterationSuffixChain(
+                                            TaskUtils.removeIterationFromTaskRefName(
                                                     task.getReferenceTaskName());
                                     boolean belongsToLoop =
                                             doWhileTaskModel
@@ -352,7 +352,7 @@ public class DoWhile extends WorkflowSystemTask {
         for (TaskModel task : referenceNameToModel.values()) {
             if (task.getStatus().isTerminal()) {
                 String refNameWithoutIteration =
-                        LoopTaskUtils.removeIterationSuffixChain(task.getReferenceTaskName());
+                        TaskUtils.removeIterationFromTaskRefName(task.getReferenceTaskName());
                 WorkflowTask nextWorkflowTask =
                         doWhileTaskModel.getWorkflowTask().next(refNameWithoutIteration, null);
                 // A non-null next task that is still within the DO_WHILE hierarchy (i.e. not the
@@ -538,7 +538,7 @@ public class DoWhile extends WorkflowSystemTask {
                         task.getTaskId(),
                         taskDefinition);
         conditionInput.put(
-                LoopTaskUtils.removeIterationSuffixChain(task.getReferenceTaskName()),
+                TaskUtils.removeIterationFromTaskRefName(task.getReferenceTaskName()),
                 task.getOutputData());
         String currentIterationChain =
                 TaskUtils.appendIteration(
@@ -549,8 +549,8 @@ public class DoWhile extends WorkflowSystemTask {
                                 t ->
                                         (task.getWorkflowTask()
                                                         .has(
-                                                                LoopTaskUtils
-                                                                        .removeIterationSuffixChain(
+                                                                TaskUtils
+                                                                        .removeIterationFromTaskRefName(
                                                                                 t
                                                                                         .getReferenceTaskName()))
                                                 && !task.getReferenceTaskName()
@@ -561,7 +561,7 @@ public class DoWhile extends WorkflowSystemTask {
 
         for (TaskModel loopOverTask : loopOver) {
             conditionInput.put(
-                    LoopTaskUtils.removeIterationSuffixChain(loopOverTask.getReferenceTaskName()),
+                    TaskUtils.removeIterationFromTaskRefName(loopOverTask.getReferenceTaskName()),
                     loopOverTask.getOutputData());
         }
 

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
@@ -540,18 +540,23 @@ public class DoWhile extends WorkflowSystemTask {
         conditionInput.put(
                 LoopTaskUtils.removeIterationSuffixChain(task.getReferenceTaskName()),
                 task.getOutputData());
+        String currentIterationChain =
+                TaskUtils.appendIteration(
+                        LoopTaskUtils.getIterationSuffixChain(task), task.getIteration());
         List<TaskModel> loopOver =
                 workflow.getTasks().stream()
                         .filter(
                                 t ->
                                         (task.getWorkflowTask()
                                                         .has(
-                                                                TaskUtils
-                                                                        .removeIterationFromTaskRefName(
+                                                                LoopTaskUtils
+                                                                        .removeIterationSuffixChain(
                                                                                 t
                                                                                         .getReferenceTaskName()))
                                                 && !task.getReferenceTaskName()
-                                                        .equals(t.getReferenceTaskName())))
+                                                        .equals(t.getReferenceTaskName())
+                                                && currentIterationChain.equals(
+                                                        LoopTaskUtils.getIterationSuffixChain(t))))
                         .collect(Collectors.toList());
 
         for (TaskModel loopOverTask : loopOver) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/ExclusiveJoin.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/ExclusiveJoin.java
@@ -19,8 +19,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.netflix.conductor.common.utils.TaskUtils;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.core.utils.LoopTaskUtils;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
 
@@ -48,12 +48,8 @@ public class ExclusiveJoin extends WorkflowSystemTask {
         TaskModel.Status taskStatus;
         List<String> joinOn = (List<String>) task.getInputData().get("joinOn");
         if (task.isLoopOverTask()) {
-            // If exclusive join is part of loop over task, wait for specific iteration to get
-            // complete
-            joinOn =
-                    joinOn.stream()
-                            .map(name -> TaskUtils.appendIteration(name, task.getIteration()))
-                            .collect(Collectors.toList());
+            String suffixChain = LoopTaskUtils.getIterationSuffixChain(task);
+            joinOn = joinOn.stream().map(name -> name + suffixChain).collect(Collectors.toList());
         }
         TaskModel exclusiveTask = null;
         for (String joinOnRef : joinOn) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
@@ -25,9 +25,9 @@ import org.springframework.stereotype.Component;
 import com.netflix.conductor.annotations.VisibleForTesting;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
-import com.netflix.conductor.common.utils.TaskUtils;
 import com.netflix.conductor.core.config.ConductorProperties;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.core.utils.LoopTaskUtils;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
 
@@ -63,11 +63,8 @@ public class Join extends WorkflowSystemTask {
         boolean agentExecution = isAgentExecution(workflow);
         List<String> joinOn = (List<String>) task.getInputData().get("joinOn");
         if (task.isLoopOverTask()) {
-            // If join is part of loop over task, wait for specific iteration to get complete
-            joinOn =
-                    joinOn.stream()
-                            .map(name -> TaskUtils.appendIteration(name, task.getIteration()))
-                            .toList();
+            String suffixChain = LoopTaskUtils.getIterationSuffixChain(task);
+            joinOn = joinOn.stream().map(name -> name + suffixChain).toList();
         }
 
         boolean allTasksTerminal =

--- a/core/src/main/java/com/netflix/conductor/core/utils/LoopTaskUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/LoopTaskUtils.java
@@ -24,10 +24,6 @@ public final class LoopTaskUtils {
 
     private LoopTaskUtils() {}
 
-    public static String removeIterationSuffixChain(String referenceTaskName) {
-        return ITERATION_SUFFIX_CHAIN.matcher(referenceTaskName).replaceAll("");
-    }
-
     /**
      * Returns the runtime iteration suffixes relative to the definition-time reference name. A
      * nested task has one {@code __<iteration>} suffix for each enclosing DO_WHILE.

--- a/core/src/main/java/com/netflix/conductor/core/utils/LoopTaskUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/LoopTaskUtils.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.utils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.netflix.conductor.model.TaskModel;
+
+public final class LoopTaskUtils {
+
+    private static final Pattern ITERATION_SUFFIX_CHAIN = Pattern.compile("(__\\d+)+$");
+    private static final Pattern LAST_ITERATION = Pattern.compile("__(\\d+)$");
+
+    private LoopTaskUtils() {}
+
+    public static String removeIterationSuffixChain(String referenceTaskName) {
+        return ITERATION_SUFFIX_CHAIN.matcher(referenceTaskName).replaceAll("");
+    }
+
+    /**
+     * Returns the runtime iteration suffixes relative to the definition-time reference name. A
+     * nested task has one {@code __<iteration>} suffix for each enclosing DO_WHILE.
+     */
+    public static String getIterationSuffixChain(TaskModel task) {
+        String runtimeRefName = task.getReferenceTaskName();
+        if (task.getWorkflowTask() != null) {
+            String definitionRefName = task.getWorkflowTask().getTaskReferenceName();
+            if (definitionRefName != null && runtimeRefName.startsWith(definitionRefName)) {
+                String chain = runtimeRefName.substring(definitionRefName.length());
+                if (ITERATION_SUFFIX_CHAIN.matcher(chain).matches()) {
+                    return chain;
+                }
+                if (chain.isEmpty()
+                        && task.getIteration() > 0
+                        && !"DO_WHILE".equals(task.getTaskType())) {
+                    return "__" + task.getIteration();
+                }
+                if (chain.isEmpty()) {
+                    return "";
+                }
+            }
+        }
+        if (!task.isLoopOverTask()) {
+            return "";
+        }
+        Matcher matcher = ITERATION_SUFFIX_CHAIN.matcher(runtimeRefName);
+        if (matcher.find()) {
+            return matcher.group();
+        }
+        if (task.getIteration() > 0 && !"DO_WHILE".equals(task.getTaskType())) {
+            return "__" + task.getIteration();
+        }
+        return "";
+    }
+
+    public static int getIterationFromSuffixChain(String suffixChain) {
+        Matcher matcher = LAST_ITERATION.matcher(suffixChain);
+        return matcher.find() ? Integer.parseInt(matcher.group(1)) : -1;
+    }
+}

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestDeciderService.java
@@ -1976,6 +1976,35 @@ public class TestDeciderService {
         return workflow;
     }
 
+    @Test
+    public void testFilterNextLoopOverTasksPreservesFullParentSuffixChain() {
+        WorkflowModel workflow = new WorkflowModel();
+
+        WorkflowTask innerDefinition = new WorkflowTask();
+        innerDefinition.setTaskReferenceName("inner_loop");
+        TaskModel completedInnerLoop = new TaskModel();
+        completedInnerLoop.setWorkflowTask(innerDefinition);
+        completedInnerLoop.setReferenceTaskName("inner_loop__3__2");
+        completedInnerLoop.setTaskId("inner-id");
+        completedInnerLoop.setLoopTaskId("parent-loop-id");
+        completedInnerLoop.setIteration(7);
+        completedInnerLoop.setStatus(TaskModel.Status.COMPLETED);
+
+        TaskModel sibling = new TaskModel();
+        sibling.setReferenceTaskName("sibling_check");
+        sibling.setStatus(TaskModel.Status.SCHEDULED);
+        workflow.getTasks().add(completedInnerLoop);
+
+        List<TaskModel> result =
+                deciderService.filterNextLoopOverTasks(
+                        Arrays.asList(sibling), "__3__2", completedInnerLoop, workflow);
+
+        assertEquals(1, result.size());
+        assertEquals("sibling_check__3__2", result.get(0).getReferenceTaskName());
+        assertEquals(2, result.get(0).getIteration());
+        assertEquals("parent-loop-id", result.get(0).getLoopTaskId());
+    }
+
     private WorkflowDef createNestedWorkflow() {
 
         WorkflowDef workflowDef = new WorkflowDef();

--- a/core/src/test/java/com/netflix/conductor/core/utils/LoopTaskUtilsTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/utils/LoopTaskUtilsTest.java
@@ -15,6 +15,7 @@ package com.netflix.conductor.core.utils;
 import org.junit.Test;
 
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.common.utils.TaskUtils;
 import com.netflix.conductor.model.TaskModel;
 
 import static org.junit.Assert.assertEquals;
@@ -23,10 +24,8 @@ public class LoopTaskUtilsTest {
 
     @Test
     public void removesTheWholeIterationSuffixChain() {
-        assertEquals("task", LoopTaskUtils.removeIterationSuffixChain("task__1"));
-        assertEquals("task", LoopTaskUtils.removeIterationSuffixChain("task__2__14"));
-        assertEquals("a__b", LoopTaskUtils.removeIterationSuffixChain("a__b"));
-        assertEquals("a__1b", LoopTaskUtils.removeIterationSuffixChain("a__1b__2"));
+        assertEquals("task", TaskUtils.removeIterationFromTaskRefName("task__1"));
+        assertEquals("task", TaskUtils.removeIterationFromTaskRefName("task__2__14"));
     }
 
     @Test

--- a/core/src/test/java/com/netflix/conductor/core/utils/LoopTaskUtilsTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/utils/LoopTaskUtilsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.utils;
+
+import org.junit.Test;
+
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.model.TaskModel;
+
+import static org.junit.Assert.assertEquals;
+
+public class LoopTaskUtilsTest {
+
+    @Test
+    public void removesTheWholeIterationSuffixChain() {
+        assertEquals("task", LoopTaskUtils.removeIterationSuffixChain("task__1"));
+        assertEquals("task", LoopTaskUtils.removeIterationSuffixChain("task__2__14"));
+        assertEquals("a__b", LoopTaskUtils.removeIterationSuffixChain("a__b"));
+        assertEquals("a__1b", LoopTaskUtils.removeIterationSuffixChain("a__1b__2"));
+    }
+
+    @Test
+    public void computesSuffixChainAgainstDefinitionName() {
+        TaskModel topLevelLoop = task("loop", "loop", 3);
+        topLevelLoop.setTaskType("DO_WHILE");
+        assertEquals("", LoopTaskUtils.getIterationSuffixChain(topLevelLoop));
+        assertEquals("__2", LoopTaskUtils.getIterationSuffixChain(task("inner__2", "inner", 2)));
+        assertEquals(
+                "__2__1", LoopTaskUtils.getIterationSuffixChain(task("body__2__1", "body", 1)));
+        assertEquals("", LoopTaskUtils.getIterationSuffixChain(task("my__2", "my__2", 0)));
+        assertEquals("__1", LoopTaskUtils.getIterationSuffixChain(task("my__2__1", "my__2", 1)));
+    }
+
+    @Test
+    public void returnsInnermostIteration() {
+        assertEquals(1, LoopTaskUtils.getIterationFromSuffixChain("__1"));
+        assertEquals(14, LoopTaskUtils.getIterationFromSuffixChain("__2__14"));
+        assertEquals(-1, LoopTaskUtils.getIterationFromSuffixChain(""));
+    }
+
+    private TaskModel task(String runtimeRefName, String definitionRefName, int iteration) {
+        WorkflowTask workflowTask = new WorkflowTask();
+        workflowTask.setTaskReferenceName(definitionRefName);
+        TaskModel task = new TaskModel();
+        task.setReferenceTaskName(runtimeRefName);
+        task.setWorkflowTask(workflowTask);
+        task.setIteration(iteration);
+        return task;
+    }
+}

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/DoWhileSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/DoWhileSpec.groovy
@@ -59,8 +59,11 @@ class DoWhileSpec extends AbstractSpecification {
             status == Workflow.WorkflowStatus.COMPLETED
             taskRefs.containsAll([
                     'inner_loop__1',
+                    'inner_loop__2',
                     'inner_body__1__1',
                     'inner_body__2__1',
+                    'inner_body__1__2',
+                    'inner_body__2__2',
                     'outer_sibling__1',
                     'outer_sibling__2'
             ])

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/DoWhileSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/DoWhileSpec.groovy
@@ -45,7 +45,26 @@ class DoWhileSpec extends AbstractSpecification {
                 'do_while_system_tasks.json',
                 'do_while_with_decision_task.json',
                 'do_while_set_variable_fix.json',
-                'do_while_high_iteration_test.json')
+                'do_while_high_iteration_test.json',
+                'do_while_nested_full_support.json')
+    }
+
+    def "nested DO_WHILE preserves every iteration suffix and completes"() {
+        when:
+        def workflowId = startWorkflow('do_while_nested_full_support', 1, 'nested-full', new HashMap(), null)
+
+        then:
+        with(workflowExecutionService.getExecutionStatus(workflowId, true)) {
+            def taskRefs = tasks*.referenceTaskName
+            status == Workflow.WorkflowStatus.COMPLETED
+            taskRefs.containsAll([
+                    'inner_loop__1',
+                    'inner_body__1__1',
+                    'inner_body__2__1',
+                    'outer_sibling__1',
+                    'outer_sibling__2'
+            ])
+        }
     }
 
     def "Test workflow with 2 iterations of five tasks"() {

--- a/test-harness/src/test/resources/do_while_nested_full_support.json
+++ b/test-harness/src/test/resources/do_while_nested_full_support.json
@@ -1,0 +1,40 @@
+{
+  "name": "do_while_nested_full_support",
+  "description": "Verifies nested DO_WHILE suffix chains and a trailing sibling task",
+  "version": 1,
+  "schemaVersion": 2,
+  "tasks": [
+    {
+      "name": "outer_loop",
+      "taskReferenceName": "outer_loop",
+      "type": "DO_WHILE",
+      "loopCondition": "if ($.outer_loop['iteration'] < 2) { true; } else { false; }",
+      "loopOver": [
+        {
+          "name": "inner_loop",
+          "taskReferenceName": "inner_loop",
+          "type": "DO_WHILE",
+          "loopCondition": "if ($.inner_loop['iteration'] < 2) { true; } else { false; }",
+          "loopOver": [
+            {
+              "name": "inner_body",
+              "taskReferenceName": "inner_body",
+              "type": "LAMBDA",
+              "inputParameters": {
+                "scriptExpression": "return {ok: true}"
+              }
+            }
+          ]
+        },
+        {
+          "name": "outer_sibling",
+          "taskReferenceName": "outer_sibling",
+          "type": "LAMBDA",
+          "inputParameters": {
+            "scriptExpression": "return {ok: true}"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- port the completed nested `DO_WHILE` engine fix from orkes-io/orkes-conductor#3819
- preserve the full `__<iteration>` suffix chain across nested loop scheduling and sibling transitions
- make `DO_WHILE`, `JOIN`, and `EXCLUSIVE_JOIN` resolve the correct nested task instances
- propagate loop ownership for recursive `keepLastN` cleanup
- key nested loop-condition inputs by definition-time task names
- add unit coverage plus a deterministic two-level integration workflow

## Context
Fixes #1256.

This is a new, broader port of the completed Orkes implementation. It intentionally leaves #1336 unchanged. #1336 fixes the immediate sibling-after-nested-loop reproduction using a single extracted parent iteration; this draft additionally handles arbitrary nesting depth, nested loop bodies, joins, cleanup, and condition evaluation.

Orkes counterpart: orkes-io/orkes-conductor#3819.

## Validation
- `./gradlew :conductor-core:test spotlessCheck --no-daemon`
- `./gradlew :conductor-test-harness:test --tests com.netflix.conductor.test.integration.DoWhileSpec --no-daemon`

Both pass locally.