### PR TITLE
fix #1322 — first-terminal-write-wins guard on updateTask

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/dal/ExecutionDAOFacade.java
+++ b/core/src/main/java/com/netflix/conductor/core/dal/ExecutionDAOFacade.java
@@ -550,6 +550,20 @@ public class ExecutionDAOFacade {
      *     payload fails.
      */
     public void updateTask(TaskModel taskModel) {
+        doUpdateTask(taskModel, false);
+    }
+
+    /**
+     * Same as {@link #updateTask(TaskModel)} but bypasses the first-terminal-write-wins guard. Only
+     * for trusted engine state-machine paths that legitimately re-write a terminal task.
+     *
+     * @param taskModel the task to be updated in the data store
+     */
+    public void forceUpdateTask(TaskModel taskModel) {
+        doUpdateTask(taskModel, true);
+    }
+
+    private void doUpdateTask(TaskModel taskModel, boolean force) {
         if (taskModel.getStatus() != null) {
             if (!taskModel.getStatus().isTerminal()
                     || (taskModel.getStatus().isTerminal() && taskModel.getUpdateTime() == 0)) {
@@ -560,7 +574,11 @@ public class ExecutionDAOFacade {
             }
         }
         externalizeTaskData(taskModel);
-        executionDAO.updateTask(taskModel);
+        if (force) {
+            executionDAO.forceUpdateTask(taskModel);
+        } else {
+            executionDAO.updateTask(taskModel);
+        }
         try {
             /*
              * Indexing a task for every update adds a lot of volume. That is ok but if async indexing
@@ -586,6 +604,10 @@ public class ExecutionDAOFacade {
 
     public void updateTasks(List<TaskModel> tasks) {
         tasks.forEach(this::updateTask);
+    }
+
+    public void forceUpdateTasks(List<TaskModel> tasks) {
+        tasks.forEach(this::forceUpdateTask);
     }
 
     public void removeTask(String taskId) {

--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
@@ -329,7 +329,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
             subWorkflowTask.setSubworkflowChanged(true);
             subWorkflowTask.setStatus(IN_PROGRESS);
             subWorkflowTask.setReasonForIncompletion(null);
-            executionDAOFacade.updateTask(subWorkflowTask);
+            executionDAOFacade.forceUpdateTask(subWorkflowTask);
 
             // add an execution log
             String currentWorkflowIdentifier = workflow.toShortString();
@@ -379,20 +379,20 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
                             task.setStatus(IN_PROGRESS);
                             task.setReasonForIncompletion(null);
                             task.setSubworkflowChanged(true);
-                            executionDAOFacade.updateTask(task);
+                            executionDAOFacade.forceUpdateTask(task);
                         } else if (child.getTasks().stream().anyMatch(UNSUCCESSFUL_TERMINAL_TASK)) {
                             retry(child);
                             task.setStatus(IN_PROGRESS);
                             task.setReasonForIncompletion(null);
                             task.setSubworkflowChanged(true);
-                            executionDAOFacade.updateTask(task);
+                            executionDAOFacade.forceUpdateTask(task);
                         }
                     }
                 } else if (task.getStatus() == CANCELED) {
                     if (task.getTaskType().equalsIgnoreCase(TaskType.JOIN.toString())
                             || task.getTaskType().equalsIgnoreCase(TaskType.DO_WHILE.toString())) {
                         task.setStatus(IN_PROGRESS);
-                        executionDAOFacade.updateTask(task);
+                        executionDAOFacade.forceUpdateTask(task);
                     } else {
                         task.setRetryCount(task.getRetryCount() + 1);
                         task.setReasonForIncompletion(null);
@@ -404,7 +404,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
                         task.setRetried(false);
                         task.setExecuted(false);
                         task.setStatus(SCHEDULED);
-                        executionDAOFacade.updateTask(task);
+                        executionDAOFacade.forceUpdateTask(task);
                         addTaskToQueue(task);
                     }
                 }
@@ -441,7 +441,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
                                 task.setStatus(TaskModel.Status.IN_PROGRESS);
                                 addTaskToQueue(task);
                             })
-                    .forEach(executionDAOFacade::updateTask);
+                    .forEach(executionDAOFacade::forceUpdateTask);
         }
     }
 
@@ -526,7 +526,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
         // Note: updateTasks before updateWorkflow might fail when Workflow is archived
         // and doesn't
         // exist in primary store.
-        executionDAOFacade.updateTasks(workflow.getTasks());
+        executionDAOFacade.forceUpdateTasks(workflow.getTasks());
         scheduleTask(workflow, retriableTasks);
         // Push AFTER tasks are reset so async decider sees SCHEDULED/IN_PROGRESS, not stale state
         queueDAO.push(
@@ -1350,7 +1350,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
                 }
 
                 if (!outcome.tasksToBeUpdated.isEmpty() || !tasksToBeScheduled.isEmpty()) {
-                    executionDAOFacade.updateTasks(tasksToBeUpdated);
+                    executionDAOFacade.forceUpdateTasks(tasksToBeUpdated);
                 }
 
                 if (stateChanged) {
@@ -1425,7 +1425,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
             // reset the flag
             TaskModel subWorkflowTask = changedSubWorkflowTask.get();
             subWorkflowTask.setSubworkflowChanged(false);
-            executionDAOFacade.updateTask(subWorkflowTask);
+            executionDAOFacade.forceUpdateTask(subWorkflowTask);
 
             LOGGER.info(
                     "{} reset subworkflowChanged flag for {}",
@@ -2160,7 +2160,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
             }
         }
         if (terminateWorkflowException.getTask() != null) {
-            executionDAOFacade.updateTask(terminateWorkflowException.getTask());
+            executionDAOFacade.forceUpdateTask(terminateWorkflowException.getTask());
         }
         return terminateWorkflow(
                 workflow,
@@ -2265,7 +2265,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
                     && !TaskType.TASK_TYPE_SUB_WORKFLOW.equalsIgnoreCase(
                             rerunFromTask.getTaskType())) {
                 rerunFromTask.setStatus(SCHEDULED);
-                executionDAOFacade.updateTask(rerunFromTask);
+                executionDAOFacade.forceUpdateTask(rerunFromTask);
             }
             updateAndPushParents(workflow, "reran");
             notifyWorkflowStatusListener(workflow, WorkflowEventType.RETRIED);
@@ -2290,7 +2290,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
                 rerunFromTask.setPollCount(0);
                 rerunFromTask.setStatus(IN_PROGRESS);
                 rerunFromTask.setReasonForIncompletion(null);
-                executionDAOFacade.updateTask(rerunFromTask);
+                executionDAOFacade.forceUpdateTask(rerunFromTask);
                 // Push AFTER task reset so async decider sees IN_PROGRESS, not stale FAILED state
                 queueDAO.push(
                         DECIDER_QUEUE,
@@ -2305,7 +2305,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
             // workflows; exclude rerunFromTask, which is updated individually below — writing its
             // stale FAILED state here would race with the sweeper and can re-terminate the parent
             final String rerunTaskId = rerunFromTask.getTaskId();
-            executionDAOFacade.updateTasks(
+            executionDAOFacade.forceUpdateTasks(
                     workflow.getTasks().stream()
                             .filter(t -> !t.getTaskId().equals(rerunTaskId))
                             .collect(Collectors.toList()));
@@ -2337,7 +2337,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
                     // start() hit a transient error — fall back to async queue processing.
                     addTaskToQueue(rerunFromTask);
                 }
-                executionDAOFacade.updateTask(rerunFromTask);
+                executionDAOFacade.forceUpdateTask(rerunFromTask);
                 finalizeRerun(workflow, rerunFromTask);
                 return true;
             }
@@ -2389,7 +2389,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
             }
             // Write the new state to DB before queueing so any async worker sees SCHEDULED,
             // not the stale CANCELED/FAILED state that was in the DB before this rerun.
-            executionDAOFacade.updateTask(rerunFromTask);
+            executionDAOFacade.forceUpdateTask(rerunFromTask);
             if (rerunFromTask.getStatus() == SCHEDULED) {
                 addTaskToQueue(rerunFromTask);
             }
@@ -2473,7 +2473,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
                         });
         // Write SCHEDULED to DB before queueing so async workers (e.g. SystemTaskWorker)
         // never read a stale CANCELED/FAILED state and silently drop the queue entry.
-        executionDAOFacade.updateTasks(workflow.getTasks());
+        executionDAOFacade.forceUpdateTasks(workflow.getTasks());
         tasksToQueue.forEach(this::addTaskToQueue);
         // Push AFTER all sibling tasks are reset so async decider never sees stale CANCELED/FAILED
         queueDAO.push(
@@ -2554,7 +2554,7 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
             return;
         }
         executeSubworkflowTaskAndSyncData(subWorkflow, subWorkflowTask);
-        executionDAOFacade.updateTask(subWorkflowTask);
+        executionDAOFacade.forceUpdateTask(subWorkflowTask);
         if (subWorkflowTask.getStatus().isTerminal()) {
             // This fork branch's sub-workflow just finished; a sibling JOIN waiting on it may now
             // be satisfiable. Nudge it off its exponential-backoff poll so the parent completes

--- a/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowRepairService.java
+++ b/core/src/main/java/com/netflix/conductor/core/reconciliation/WorkflowRepairService.java
@@ -200,6 +200,6 @@ public class WorkflowRepairService {
                 break;
         }
         task.addOutput(subWorkflow.getOutput());
-        executionDAO.updateTask(task);
+        executionDAO.forceUpdateTask(task);
     }
 }

--- a/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/ExecutionDAO.java
@@ -48,9 +48,27 @@ public interface ExecutionDAO {
     List<TaskModel> createTasks(List<TaskModel> tasks);
 
     /**
+     * Updates the persisted task. Semantics are first-terminal-write-wins: once the stored task for
+     * a given taskId is terminal ({@link TaskModel.Status#isTerminal()}), implementations MUST
+     * atomically reject (drop, logged) any later write for that taskId. Non-terminal writes and the
+     * first terminal write always apply. Trusted engine state-machine paths that legitimately need
+     * to re-write an already-terminal task (rerun/retry reopen, decide() re-persist, sub-workflow
+     * sync, reconciliation) must call {@link #forceUpdateTask(TaskModel)} instead.
+     *
      * @param task Task to be updated
      */
     void updateTask(TaskModel task);
+
+    /**
+     * Unconditional write that bypasses the first-terminal-write-wins guard. Only for trusted
+     * engine state-machine paths (rerun/retry reopen, decide() re-persist, sub-workflow sync,
+     * reconciliation).
+     *
+     * @param task Task to be updated
+     */
+    default void forceUpdateTask(TaskModel task) {
+        updateTask(task);
+    }
 
     /**
      * Checks if the number of tasks in progress for the given taskDef will exceed the limit if the

--- a/core/src/main/java/org/conductoross/conductor/core/execution/WorkflowSweeper.java
+++ b/core/src/main/java/org/conductoross/conductor/core/execution/WorkflowSweeper.java
@@ -324,7 +324,7 @@ public class WorkflowSweeper extends LifecycleAwareComponent {
                 return;
         }
         task.addOutput(subWorkflow.getOutput());
-        executionDAO.updateTask(task);
+        executionDAO.forceUpdateTask(task);
     }
 
     private void forceSetLastTaskAsNotExecuted(WorkflowModel workflow) {

--- a/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/TestWorkflowExecutor.java
@@ -1203,7 +1203,7 @@ public class TestWorkflowExecutor {
                             return null;
                         })
                 .when(executionDAOFacade)
-                .updateTasks(any());
+                .forceUpdateTasks(any());
 
         AtomicInteger updateTaskCalledCounter = new AtomicInteger(0);
         doAnswer(
@@ -1212,7 +1212,7 @@ public class TestWorkflowExecutor {
                             return null;
                         })
                 .when(executionDAOFacade)
-                .updateTask(any());
+                .forceUpdateTask(any());
 
         // add 2 failed task in 2 forks and 1 cancelled in the 3rd fork
         TaskModel task_1_1 = new TaskModel();
@@ -1665,7 +1665,7 @@ public class TestWorkflowExecutor {
                             return null;
                         })
                 .when(executionDAOFacade)
-                .updateTasks(any());
+                .forceUpdateTasks(any());
         // end of setup
 
         // when
@@ -2403,7 +2403,7 @@ public class TestWorkflowExecutor {
 
         workflowExecutor.updateParentWorkflowTask(subWorkflow);
         ArgumentCaptor<TaskModel> argumentCaptor = ArgumentCaptor.forClass(TaskModel.class);
-        verify(executionDAOFacade, times(1)).updateTask(argumentCaptor.capture());
+        verify(executionDAOFacade, times(1)).forceUpdateTask(argumentCaptor.capture());
         assertEquals(TaskModel.Status.COMPLETED, argumentCaptor.getAllValues().get(0).getStatus());
         assertEquals(workflowId, argumentCaptor.getAllValues().get(0).getSubWorkflowId());
     }

--- a/core/src/test/java/com/netflix/conductor/core/reconciliation/TestWorkflowRepairService.java
+++ b/core/src/test/java/com/netflix/conductor/core/reconciliation/TestWorkflowRepairService.java
@@ -259,7 +259,7 @@ public class TestWorkflowRepairService {
         verify(queueDAO, never()).push(anyString(), anyString(), anyLong());
         // Verify
         ArgumentCaptor<TaskModel> argumentCaptor = ArgumentCaptor.forClass(TaskModel.class);
-        verify(executionDAO, times(1)).updateTask(argumentCaptor.capture());
+        verify(executionDAO, times(1)).forceUpdateTask(argumentCaptor.capture());
         assertEquals(taskId, argumentCaptor.getValue().getTaskId());
         assertEquals(subWorkflowId, argumentCaptor.getValue().getSubWorkflowId());
         assertEquals(TaskModel.Status.CANCELED, argumentCaptor.getValue().getStatus());

--- a/core/src/test/java/org/conductoross/conductor/core/execution/WorkflowSweeperTest.java
+++ b/core/src/test/java/org/conductoross/conductor/core/execution/WorkflowSweeperTest.java
@@ -180,7 +180,7 @@ public class WorkflowSweeperTest {
 
         workflowSweeper.sweep(WORKFLOW_ID);
 
-        verify(executionDAO).updateTask(subWorkflowTask);
+        verify(executionDAO).forceUpdateTask(subWorkflowTask);
         verify(workflowExecutor, times(2)).decide(WORKFLOW_ID);
         verify(queueDAO, never()).push(anyString(), anyString(), anyLong());
         verify(executionLockService).releaseLock(WORKFLOW_ID);

--- a/docs/design/2026-07-27-issue-1322-first-terminal-write-wins.md
+++ b/docs/design/2026-07-27-issue-1322-first-terminal-write-wins.md
@@ -1,0 +1,151 @@
+# Issue #1322 — First-terminal-write-wins for `ExecutionDAO.updateTask`
+
+Status: WIP. Stacked on #1369 (`fix/system-task-poll-reserve`).
+
+## Problem
+
+A system task can be executed twice — e.g. queue redelivery while a long-running task is still
+in flight, or the timed-out-overrun path introduced by #1369. Both attempts load the task while
+it is non-terminal, both run, and both persist their result through
+`AsyncSystemTaskExecutor`'s `finally { executionDAOFacade.updateTask(task); }`.
+
+Every `ExecutionDAO.updateTask` implementation is last-write-wins, so the second ("zombie")
+completion overwrites the `output`, `endTime`, and `finishReason` of an already-terminal task —
+values the workflow (and any downstream task) already consumed. For AI/agent loops that rebuild
+LLM message history from prior task records, this corrupts the reconstructed conversation
+(spurious assistant turns, missing tool exchanges, timestamps after workflow completion).
+
+Root cause: `updateTask` has no terminal-state protection, and its contract documents no
+concurrency semantics.
+
+## Design
+
+### Contract change
+
+`ExecutionDAO.updateTask` is now specified as **first-terminal-write-wins**: once the stored task
+for a `taskId` is terminal (`TaskModel.Status.isTerminal()`), a later `updateTask` for that
+`taskId` MUST be rejected atomically (dropped, logged). Non-terminal writes and the first
+terminal write always apply.
+
+The engine legitimately re-writes already-terminal tasks on the same `taskId` in several trusted
+state-machine paths (rerun/retry reopen, the `decide()` re-persist of terminal tasks, sub-workflow
+sync, reconciliation). Those must not be blocked, so a sibling method is added:
+
+```java
+default void forceUpdateTask(TaskModel task) { updateTask(task); }
+```
+
+`forceUpdateTask` bypasses the guard. It is a `default` on the interface, so only the Redis
+backend overrides it in this change; all other backends keep today's behaviour. `updateTask`
+stays `void` — rejections are logged, not signalled to callers.
+
+### Redis enforcement (atomic, no TOCTOU)
+
+A naive `getTask()`-then-`set()` check would race. Instead the Redis backend uses a Lua script
+executed via `EVALSHA`, keyed on the task payload key plus a companion **terminal-marker** key:
+
+```
+marker = "{" + nsKey(TASK, taskId) + "}.TERM"
+```
+
+The `{...}` hash tag makes the marker hash to the **same cluster slot** as the task key (the tag
+content is the full task key), so the two-key script is safe on Redis Cluster without changing the
+existing task-key format.
+
+Script (`KEYS=[taskKey, markerKey]`, `ARGV=[payload, isTerminal, bypass]`):
+
+```lua
+if ARGV[3] == '0' and redis.call('EXISTS', KEYS[2]) == 1 then
+    return 0
+end
+redis.call('SET', KEYS[1], ARGV[1])
+if ARGV[2] == '1' then
+    redis.call('SET', KEYS[2], '1')
+elseif ARGV[3] == '1' then
+    redis.call('DEL', KEYS[2])
+end
+return 1
+```
+
+- Guarded write (`bypass=0`): if the marker exists → reject (return 0). Otherwise write the
+  payload; if the incoming status is terminal, set the marker.
+- Bypass write (`bypass=1`): always write the payload; set the marker when terminal, **delete**
+  it when non-terminal. The delete-on-reopen is what lets rerun/retry reopen a terminal task and
+  have its later re-completion accepted by the guarded path.
+
+The marker has no TTL; it is deleted/expired alongside the task key in `removeTask` and
+`removeTaskWithExpiry` (the only two sites that touch the task key). The marker key is never read
+as a task (`getTask` reads the task key directly).
+
+Fallbacks: the in-memory Jedis backend used in single-process dev/tests makes scripting a no-op
+(`scriptLoad` returns empty) — detected and downgraded to a plain `set` (the guard is inert there;
+real deployments run the Lua). A `NOSCRIPT` reply (e.g. a freshly restarted node) triggers a
+one-shot reload-and-retry.
+
+### Call-site classification
+
+Only duplicate-prone completion entry points stay on the guarded `updateTask`
+(`AsyncSystemTaskExecutor`, worker completion — the latter also already self-guards in memory).
+Every path that deliberately re-writes a possibly-terminal task on the same `taskId` is switched
+to `forceUpdateTask`/`forceUpdateTasks`:
+
+- `WorkflowExecutorOps`: `updateAndPushParents`, `resetUnsuccessfulJoinTasks`, `retry(...)`,
+  the `decide()` re-persist loop, `adjustStateIfSubWorkflowChanged`, `terminate`, `rerunWF`,
+  `finalizeRerun`, `updateParentWorkflowTask`.
+- Reconciliation: `WorkflowSweeper.repairSubWorkflowTask`, `WorkflowRepairService.repairSubWorkflowTask`.
+
+The `decide()` re-persist fires on nearly every workflow (it flips `executed`/`retried` flags and
+`FAILED → COMPLETED_WITH_ERRORS` on terminal tasks); leaving it on the guarded path would drop
+those writes, which is why it uses the bypass.
+
+## Marker lifecycle
+
+1. Create (IN_PROGRESS): payload written, no marker.
+2. First completion (terminal): marker absent → write + set marker.
+3. `decide()` re-persist (bypass, terminal): marker stays set (idempotent).
+4. **Zombie duplicate (guarded, terminal): marker present → rejected + logged. Bug fixed.**
+5. rerun/retry reopen (bypass, non-terminal): marker deleted → reopened.
+6. Re-completion after reopen (guarded, terminal): marker absent → accepted.
+7. `removeTask`/`removeWorkflow`: marker deleted/expired with the task.
+
+## Backend rollout
+
+Only Redis enforces the guard in this change. Postgres/MySQL/SQLite/Cassandra inherit the
+unguarded `default forceUpdateTask == updateTask` and keep last-write-wins for now. Follow-ups:
+
+- SQL: an atomic conditional upsert, e.g. `... ON CONFLICT (task_id) DO UPDATE ... WHERE
+  <table>.status NOT IN (<terminal statuses>)`.
+- Cassandra: a lightweight transaction (`UPDATE ... IF status IN (<non-terminal>)`), or a
+  documented limitation if LWT cost is unacceptable.
+
+## Alternatives considered
+
+- **Block only non-terminal-over-terminal / monotonic-timestamp guard:** does not stop a duplicate
+  *terminal* completion overwriting output — i.e. does not fix #1322.
+- **Reject all writes to terminal tasks (no bypass):** breaks rerun/retry and the `decide()`
+  re-persist, which legitimately re-write terminal tasks on the same `taskId`.
+- **Java `getTask()`-then-`set()` check:** a TOCTOU race under concurrent duplicates; the whole
+  point is to make the check-and-set atomic.
+
+## Accepted limitation
+
+Because `updateTask` stays `void`, a rejected write still lets the facade re-index the stale task
+summary when synchronous indexing is enabled. The authoritative version is re-indexed by the
+immediately following `decide()`, and the production default (async indexing) only indexes at
+workflow-terminal, so this is cosmetic. Fixing it would require a non-`void` contract, which is
+out of scope here.
+
+## Testing
+
+`RedisExecutionDAOTest` (real Redis via Testcontainers — the guard cannot be exercised on the
+in-memory backend, where scripting is a no-op):
+
+- `testFirstTerminalWriteWins` — a second terminal write does not overwrite the first; marker set.
+- `testNonTerminalWritesNotBlocked` — repeated non-terminal writes all apply; no marker.
+- `testForceUpdateOverwritesTerminalThenReopenClearsMarker` — bypass overwrites a terminal task;
+  reopening to a non-terminal status clears the marker; re-completion is then accepted.
+- `testRemoveTaskClearsMarker` — `removeTask` deletes the marker.
+- `testConcurrentTerminalWrites` — concurrent terminal writes yield one intact value and one marker.
+
+Regression: `TestWorkflowExecutor`, `TestDeciderService`, `AsyncSystemTaskExecutorTest`,
+`WorkflowServiceTest`, `WorkflowBulkServiceTest` (rerun/retry/decide paths now use the bypass).

--- a/redis-persistence/src/main/java/com/netflix/conductor/redis/dao/RedisExecutionDAO.java
+++ b/redis-persistence/src/main/java/com/netflix/conductor/redis/dao/RedisExecutionDAO.java
@@ -12,6 +12,7 @@
  */
 package com.netflix.conductor.redis.dao;
 
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -62,6 +63,23 @@ public class RedisExecutionDAO extends BaseDynoDAO
     private static final String EVENT_EXECUTION = "EVENT_EXECUTION";
     private final int ttlEventExecutionSeconds;
     private final QueueDAO queueDAO;
+
+    // First-terminal-write-wins guard for the TASK payload: KEYS=[taskKey, markerKey],
+    // ARGV=[payload, isTerminal "1"/"0", bypass "1"/"0"]. Marker present + not bypassing => reject.
+    private static final String TERMINAL_WRITE_GUARD_SCRIPT =
+            "if ARGV[3] == '0' and redis.call('EXISTS', KEYS[2]) == 1 then\n"
+                    + "    return 0\n"
+                    + "end\n"
+                    + "redis.call('SET', KEYS[1], ARGV[1])\n"
+                    + "if ARGV[2] == '1' then\n"
+                    + "    redis.call('SET', KEYS[2], '1')\n"
+                    + "elseif ARGV[3] == '1' then\n"
+                    + "    redis.call('DEL', KEYS[2])\n"
+                    + "end\n"
+                    + "return 1";
+
+    private volatile String scriptSha;
+    private volatile boolean scriptingUnsupported;
 
     public RedisExecutionDAO(
             JedisProxy jedisProxy,
@@ -197,7 +215,57 @@ public class RedisExecutionDAO extends BaseDynoDAO
     @Override
     public void updateTask(TaskModel task) {
         Optional<TaskDef> taskDefinition = task.getTaskDefinition();
+        String payload = toJson(task);
+        recordRedisDaoPayloadSize(
+                "updateTask",
+                payload.length(),
+                taskDefinition.map(TaskDef::getName).orElse("n/a"),
+                task.getWorkflowType());
+        recordRedisDaoRequests("updateTask", task.getTaskType(), task.getWorkflowType());
 
+        boolean terminal = task.getStatus() != null && task.getStatus().isTerminal();
+        boolean written = writeTaskPayload(task.getTaskId(), payload, terminal, false);
+        if (!written) {
+            LOGGER.warn(
+                    "Rejected update to already-terminal task with taskId: {}, workflowId: {}, taskType: {} (first-terminal-write-wins); use forceUpdateTask to bypass",
+                    task.getTaskId(),
+                    task.getWorkflowInstanceId(),
+                    task.getTaskType());
+            return;
+        }
+        LOGGER.debug(
+                "Workflow task payload saved to TASK with taskKey: {}, workflowId: {}, taskId: {}, taskType: {} during updateTask",
+                nsKey(TASK, task.getTaskId()),
+                task.getWorkflowInstanceId(),
+                task.getTaskId(),
+                task.getTaskType());
+        updateTaskBookkeeping(task, taskDefinition, terminal);
+    }
+
+    @Override
+    public void forceUpdateTask(TaskModel task) {
+        Optional<TaskDef> taskDefinition = task.getTaskDefinition();
+        String payload = toJson(task);
+        recordRedisDaoPayloadSize(
+                "updateTask",
+                payload.length(),
+                taskDefinition.map(TaskDef::getName).orElse("n/a"),
+                task.getWorkflowType());
+        recordRedisDaoRequests("updateTask", task.getTaskType(), task.getWorkflowType());
+
+        boolean terminal = task.getStatus() != null && task.getStatus().isTerminal();
+        writeTaskPayload(task.getTaskId(), payload, terminal, true);
+        LOGGER.debug(
+                "Workflow task payload saved to TASK with taskKey: {}, workflowId: {}, taskId: {}, taskType: {} during forceUpdateTask",
+                nsKey(TASK, task.getTaskId()),
+                task.getWorkflowInstanceId(),
+                task.getTaskId(),
+                task.getTaskType());
+        updateTaskBookkeeping(task, taskDefinition, terminal);
+    }
+
+    private void updateTaskBookkeeping(
+            TaskModel task, Optional<TaskDef> taskDefinition, boolean terminal) {
         if (taskDefinition.isPresent() && taskDefinition.get().concurrencyLimit() > 0) {
 
             if (task.getStatus() != null && task.getStatus().equals(TaskModel.Status.IN_PROGRESS)) {
@@ -229,7 +297,7 @@ public class RedisExecutionDAO extends BaseDynoDAO
                         task.getTaskId(),
                         task.getTaskType(),
                         task.getStatus().name());
-                if (task.getStatus() != null && task.getStatus().isTerminal()) {
+                if (terminal) {
                     String queueName = QueueUtils.getQueueName(task);
                     List<String> nextIds = queueDAO.peekFirstIds(queueName, 1);
                     if (nextIds != null && !nextIds.isEmpty()) {
@@ -243,22 +311,7 @@ public class RedisExecutionDAO extends BaseDynoDAO
             }
         }
 
-        String payload = toJson(task);
-        recordRedisDaoPayloadSize(
-                "updateTask",
-                payload.length(),
-                taskDefinition.map(TaskDef::getName).orElse("n/a"),
-                task.getWorkflowType());
-
-        recordRedisDaoRequests("updateTask", task.getTaskType(), task.getWorkflowType());
-        jedisProxy.set(nsKey(TASK, task.getTaskId()), payload);
-        LOGGER.debug(
-                "Workflow task payload saved to TASK with taskKey: {}, workflowId: {}, taskId: {}, taskType: {} during updateTask",
-                nsKey(TASK, task.getTaskId()),
-                task.getWorkflowInstanceId(),
-                task.getTaskId(),
-                task.getTaskType());
-        if (task.getStatus() != null && task.getStatus().isTerminal()) {
+        if (terminal) {
             jedisProxy.srem(nsKey(IN_PROGRESS_TASKS, task.getTaskDefName()), task.getTaskId());
             LOGGER.debug(
                     "Workflow Task removed from TASKS_IN_PROGRESS_STATUS with tasksInProgressKey: {}, workflowId: {}, taskId: {}, taskType: {}, taskStatus: {} during updateTask",
@@ -274,6 +327,80 @@ public class RedisExecutionDAO extends BaseDynoDAO
         if (!taskIds.contains(task.getTaskId())) {
             correlateTaskToWorkflowInDS(task.getTaskId(), task.getWorkflowInstanceId());
         }
+    }
+
+    private String termMarkerKey(String taskId) {
+        return "{" + nsKey(TASK, taskId) + "}.TERM";
+    }
+
+    // Atomically applies the first-terminal-write-wins guard (or bypasses it) for the TASK
+    // payload. Returns false only when the write was rejected (marker present, bypass=false).
+    private boolean writeTaskPayload(
+            String taskId, String payload, boolean terminal, boolean bypass) {
+        if (scriptingUnsupported) {
+            jedisProxy.set(nsKey(TASK, taskId), payload);
+            return true;
+        }
+
+        String sha = ensureScriptLoaded(taskId);
+        if (sha == null) {
+            jedisProxy.set(nsKey(TASK, taskId), payload);
+            return true;
+        }
+
+        List<String> keys = Arrays.asList(nsKey(TASK, taskId), termMarkerKey(taskId));
+        List<String> args = Arrays.asList(payload, terminal ? "1" : "0", bypass ? "1" : "0");
+        try {
+            return isAccepted(jedisProxy.evalsha(sha, keys, args));
+        } catch (RuntimeException e) {
+            if (e.getMessage() == null || !e.getMessage().contains("NOSCRIPT")) {
+                throw e;
+            }
+            String reloadedSha = reloadScript(taskId);
+            if (reloadedSha == null) {
+                jedisProxy.set(nsKey(TASK, taskId), payload);
+                return true;
+            }
+            return isAccepted(jedisProxy.evalsha(reloadedSha, keys, args));
+        }
+    }
+
+    private boolean isAccepted(Object evalResult) {
+        return ((Long) evalResult) == 1L;
+    }
+
+    private String ensureScriptLoaded(String taskId) {
+        String sha = scriptSha;
+        if (sha != null) {
+            return sha;
+        }
+        synchronized (this) {
+            if (scriptSha == null) {
+                scriptSha = loadScript(taskId);
+            }
+            return scriptSha;
+        }
+    }
+
+    private String reloadScript(String taskId) {
+        synchronized (this) {
+            scriptSha = loadScript(taskId);
+            return scriptSha;
+        }
+    }
+
+    // Returns null (and sets scriptingUnsupported) when the backend's scriptLoad is a no-op,
+    // i.e. the InMemory backend used in single-process dev/test; the guard is inert there.
+    private String loadScript(String taskId) {
+        byte[] sha =
+                jedisProxy.scriptLoad(
+                        TERMINAL_WRITE_GUARD_SCRIPT.getBytes(StandardCharsets.UTF_8),
+                        nsKey(TASK, taskId).getBytes(StandardCharsets.UTF_8));
+        if (sha == null || sha.length == 0) {
+            scriptingUnsupported = true;
+            return null;
+        }
+        return new String(sha, StandardCharsets.UTF_8);
     }
 
     @Override
@@ -354,6 +481,7 @@ public class RedisExecutionDAO extends BaseDynoDAO
         removeTaskMappings(task);
 
         jedisProxy.del(nsKey(TASK, task.getTaskId()));
+        jedisProxy.del(termMarkerKey(task.getTaskId()));
         recordRedisDaoRequests("removeTask", task.getTaskType(), task.getWorkflowType());
         return true;
     }
@@ -367,6 +495,7 @@ public class RedisExecutionDAO extends BaseDynoDAO
         removeTaskMappingsWithExpiry(task);
 
         jedisProxy.expire(nsKey(TASK, task.getTaskId()), ttlSeconds);
+        jedisProxy.expire(termMarkerKey(task.getTaskId()), ttlSeconds);
         recordRedisDaoRequests("removeTask", task.getTaskType(), task.getWorkflowType());
         return true;
     }

--- a/redis-persistence/src/test/java/com/netflix/conductor/redis/dao/RedisExecutionDAOTest.java
+++ b/redis-persistence/src/test/java/com/netflix/conductor/redis/dao/RedisExecutionDAOTest.java
@@ -15,9 +15,15 @@ package com.netflix.conductor.redis.dao;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.AfterClass;
@@ -430,5 +436,160 @@ public class RedisExecutionDAOTest extends ExecutionDAOTest {
 
         verify(queueDAO, never()).peekFirstIds(anyString(), anyInt());
         verify(queueDAO, never()).resetOffsetTime(anyString(), anyString());
+    }
+
+    // ---- #1322: first-terminal-write-wins guard ----
+
+    private TaskModel newTask(String taskId, String workflowId, TaskModel.Status status) {
+        TaskModel task = new TaskModel();
+        task.setTaskDefName("task_type");
+        task.setTaskType("task_type");
+        task.setReferenceTaskName("ref");
+        task.setTaskId(taskId);
+        task.setWorkflowInstanceId(workflowId);
+        task.setStatus(status);
+        return task;
+    }
+
+    private Set<String> markerKeys() {
+        try (Jedis jedis = jedisPool.getResource()) {
+            return jedis.keys("*}.TERM");
+        }
+    }
+
+    @Test
+    public void testFirstTerminalWriteWins() {
+        WorkflowModel workflow = createRunningWorkflow();
+        executionDAO.createWorkflow(workflow);
+        String taskId = UUID.randomUUID().toString();
+        TaskModel task = newTask(taskId, workflow.getWorkflowId(), TaskModel.Status.SCHEDULED);
+        executionDAO.createTasks(List.of(task));
+
+        // First terminal write with output A.
+        task.setStatus(TaskModel.Status.COMPLETED);
+        task.setOutputData(new HashMap<>(Map.of("result", "A")));
+        executionDAO.updateTask(task);
+        assertFalse("marker must be set after a terminal write", markerKeys().isEmpty());
+
+        // Zombie duplicate terminal write with output B must be rejected.
+        TaskModel zombie = executionDAO.getTask(taskId);
+        zombie.setStatus(TaskModel.Status.COMPLETED);
+        zombie.setOutputData(new HashMap<>(Map.of("result", "B")));
+        executionDAO.updateTask(zombie);
+
+        TaskModel stored = executionDAO.getTask(taskId);
+        assertEquals("first terminal write must win", "A", stored.getOutputData().get("result"));
+    }
+
+    @Test
+    public void testNonTerminalWritesNotBlocked() {
+        WorkflowModel workflow = createRunningWorkflow();
+        executionDAO.createWorkflow(workflow);
+        String taskId = UUID.randomUUID().toString();
+        TaskModel task = newTask(taskId, workflow.getWorkflowId(), TaskModel.Status.SCHEDULED);
+        executionDAO.createTasks(List.of(task));
+
+        for (int i = 0; i < 3; i++) {
+            task.setStatus(TaskModel.Status.IN_PROGRESS);
+            task.setOutputData(new HashMap<>(Map.of("result", "v" + i)));
+            executionDAO.updateTask(task);
+        }
+
+        assertEquals("v2", executionDAO.getTask(taskId).getOutputData().get("result"));
+        assertTrue("non-terminal writes must not set a marker", markerKeys().isEmpty());
+    }
+
+    @Test
+    public void testForceUpdateOverwritesTerminalThenReopenClearsMarker() {
+        WorkflowModel workflow = createRunningWorkflow();
+        executionDAO.createWorkflow(workflow);
+        String taskId = UUID.randomUUID().toString();
+        TaskModel task = newTask(taskId, workflow.getWorkflowId(), TaskModel.Status.SCHEDULED);
+        executionDAO.createTasks(List.of(task));
+
+        // Terminal via the guarded path.
+        task.setStatus(TaskModel.Status.COMPLETED);
+        task.setOutputData(new HashMap<>(Map.of("result", "A")));
+        executionDAO.updateTask(task);
+
+        // forceUpdateTask bypasses the guard and overwrites a terminal task.
+        TaskModel forced = executionDAO.getTask(taskId);
+        forced.setStatus(TaskModel.Status.COMPLETED);
+        forced.setOutputData(new HashMap<>(Map.of("result", "B")));
+        executionDAO.forceUpdateTask(forced);
+        assertEquals("B", executionDAO.getTask(taskId).getOutputData().get("result"));
+        assertFalse("marker stays set on terminal force-update", markerKeys().isEmpty());
+
+        // Reopening to a non-terminal status via forceUpdateTask clears the marker (rerun/retry).
+        TaskModel reopened = executionDAO.getTask(taskId);
+        reopened.setStatus(TaskModel.Status.SCHEDULED);
+        executionDAO.forceUpdateTask(reopened);
+        assertTrue("reopen must clear the marker", markerKeys().isEmpty());
+
+        // Re-completion after reopen is accepted by the guarded path.
+        TaskModel recompleted = executionDAO.getTask(taskId);
+        recompleted.setStatus(TaskModel.Status.COMPLETED);
+        recompleted.setOutputData(new HashMap<>(Map.of("result", "C")));
+        executionDAO.updateTask(recompleted);
+        assertEquals("C", executionDAO.getTask(taskId).getOutputData().get("result"));
+    }
+
+    @Test
+    public void testRemoveTaskClearsMarker() {
+        WorkflowModel workflow = createRunningWorkflow();
+        executionDAO.createWorkflow(workflow);
+        String taskId = UUID.randomUUID().toString();
+        TaskModel task = newTask(taskId, workflow.getWorkflowId(), TaskModel.Status.SCHEDULED);
+        executionDAO.createTasks(List.of(task));
+        task.setStatus(TaskModel.Status.COMPLETED);
+        executionDAO.updateTask(task);
+        assertFalse(markerKeys().isEmpty());
+
+        executionDAO.removeTask(taskId);
+
+        assertNull(executionDAO.getTask(taskId));
+        assertTrue("removeTask must clear the marker", markerKeys().isEmpty());
+    }
+
+    @Test
+    public void testConcurrentTerminalWrites() throws InterruptedException {
+        WorkflowModel workflow = createRunningWorkflow();
+        executionDAO.createWorkflow(workflow);
+        String taskId = UUID.randomUUID().toString();
+        executionDAO.createTasks(
+                List.of(newTask(taskId, workflow.getWorkflowId(), TaskModel.Status.SCHEDULED)));
+
+        int threads = 8;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        Set<String> candidates = new HashSet<>();
+        for (int i = 0; i < threads; i++) {
+            String value = "v" + i;
+            candidates.add(value);
+            pool.submit(
+                    () -> {
+                        TaskModel t =
+                                newTask(
+                                        taskId,
+                                        workflow.getWorkflowId(),
+                                        TaskModel.Status.COMPLETED);
+                        t.setOutputData(new HashMap<>(Map.of("result", value)));
+                        try {
+                            start.await();
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            return;
+                        }
+                        executionDAO.updateTask(t);
+                    });
+        }
+        start.countDown();
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS));
+
+        // Exactly one write wins; the stored value is one intact candidate, not a torn write.
+        Object stored = executionDAO.getTask(taskId).getOutputData().get("result");
+        assertTrue("stored value must be one intact candidate", candidates.contains(stored));
+        assertEquals("exactly one terminal marker for the task", 1, markerKeys().size());
     }
 }


### PR DESCRIPTION
Defense-in-depth for #1322. 

**#1369 removed the main cause** - duplicate execution of async system tasks. The worker/REST path already rejects terminal updates (`WorkflowExecutorOps.java:944`). 

What's left is a narrow race: `AsyncSystemTaskExecutor` checks `isTerminal()` when it loads the task (`:91`) but its `finally { updateTask(task) }` (`:245`) is unguarded — so when #1369's overrun branch marks a task `TIMED_OUT` while the original blocking `start()` is still running, that run's late return overwrites the terminal record.

## What changed

`ExecutionDAO.updateTask` becomes first-terminal-write-wins: once the stored task for a `taskId` is terminal, later writes are rejected atomically. Engine paths that legitimately re-write a terminal task — rerun/retry, the `decide()` re-persist, sub-workflow sync, reconciliation — use a new `forceUpdateTask` bypass. Redis enforces it with a Lua script plus a hash-tagged marker key; the bypass clears the marker on a non-terminal write so rerun/retry can reopen a task.

**Redis only.** Postgres/MySQL/SQLite/Cassandra inherit an unguarded default and keep last-write-wins.

## How to test

`./gradlew :conductor-core:test :conductor-redis-persistence:test` — `RedisExecutionDAOTest` covers the guard against a real `redis:7-alpine` container (the in-memory backend no-ops scripting, so the guard is inert there).

## Notes

- `decide()` uses the bypass deliberately: it re-persists terminal tasks on nearly every workflow, so guarding it would drop those writes.
- `updateTask` stays `void` — rejections are logged, not signalled to callers.
- Design doc: `docs/design/2026-07-27-issue-1322-first-terminal-write-wins.md`.

**Open question:** with #1369 already covering the main cause, is this worth landing at all? If yes, does the Postgres guard land here or as a follow-up?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
