### PR TITLE
Add test-harness coverage of system-task poll/execute path

### DIFF
--- a/test-harness/src/test/groovy/com/netflix/conductor/test/base/AbstractSystemTaskWorkerSpecification.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/base/AbstractSystemTaskWorkerSpecification.groovy
@@ -34,10 +34,15 @@ import com.netflix.conductor.core.execution.tasks.SystemTaskWorker
  * namespace, so both contexts read and write the same physical queues. Isolation comes from the
  * setup()/cleanup() lifecycle below, which arms the worker only for the duration of a feature.
  */
+// systemTaskWorkerThreadCount must be comfortably above 1: SystemTaskWorker shares a single
+// ExecutionConfig (thread pool + semaphore) across every async system-task queue, so a task that
+// blocks in start() holds a permit for its whole invocation. With only 2 permits, the remaining one
+// is contended by all ~26 pollers and a queued message can sit undelivered for tens of seconds,
+// which silently turns redelivery tests into false passes.
 @TestPropertySource(properties = [
         "conductor.system-task-workers.enabled=true",
-        "conductor.app.systemTaskWorkerThreadCount=2",
-        "conductor.app.systemTaskMaxPollCount=2",
+        "conductor.app.systemTaskWorkerThreadCount=10",
+        "conductor.app.systemTaskMaxPollCount=10",
         "conductor.app.systemTaskWorkerPollInterval=50ms",
         "conductor.app.systemTaskQueuePopTimeout=100ms"
 ])

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/base/AbstractSystemTaskWorkerSpecification.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/base/AbstractSystemTaskWorkerSpecification.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.test.base
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.TestPropertySource
+
+import com.netflix.conductor.core.execution.tasks.SystemTaskWorker
+
+/**
+ * Restores test-harness coverage of the async system-task poll/execute path: SystemTaskWorker polls
+ * the task queue and AsyncSystemTaskExecutor reserves and executes.
+ *
+ * The default harness config disables the worker ({@code conductor.system-task-workers.enabled=false}
+ * in application-integrationtest.properties) and every existing spec hand-drives
+ * {@code asyncSystemTaskExecutor.execute(...)} with a task id it looked up directly. That is
+ * deterministic, but it bought determinism by hand-driving the executor: the poll/reserve/execute
+ * path — where issues #1321 and #1322 (duplicate async system-task execution) live — is never
+ * exercised. Specs extending this class cover it.
+ *
+ * Overriding the property here changes the merged @TestPropertySource set, so these specs get their
+ * own Spring application context. That alone does NOT isolate them from the other specs: the Redis
+ * Testcontainer in AbstractSpecification is static and every context shares the same integtest queue
+ * namespace, so both contexts read and write the same physical queues. Isolation comes from the
+ * setup()/cleanup() lifecycle below, which arms the worker only for the duration of a feature.
+ */
+@TestPropertySource(properties = [
+        "conductor.system-task-workers.enabled=true",
+        "conductor.app.systemTaskWorkerThreadCount=2",
+        "conductor.app.systemTaskMaxPollCount=2",
+        "conductor.app.systemTaskWorkerPollInterval=50ms",
+        "conductor.app.systemTaskQueuePopTimeout=100ms"
+])
+abstract class AbstractSystemTaskWorkerSpecification extends AbstractSpecification {
+
+    @Autowired
+    SystemTaskWorker systemTaskWorker
+
+    /**
+     * The Redis Testcontainer in AbstractSpecification is static and both contexts share the
+     * integtest queue namespace, and Spring caches contexts without closing them. Left running,
+     * this context's worker threads would keep popping messages that belong to workflows created
+     * by the hand-driven specs. Arm the worker only for the duration of a feature.
+     */
+    def setup() {
+        systemTaskWorker.start()
+    }
+
+    def cleanup() {
+        systemTaskWorker.stop()
+    }
+}

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/AsyncSystemTaskDuplicateExecutionSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/AsyncSystemTaskDuplicateExecutionSpec.groovy
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.test.integration
+
+import org.springframework.beans.factory.annotation.Autowired
+
+import com.netflix.conductor.common.metadata.tasks.Task
+import com.netflix.conductor.dao.QueueDAO
+import com.netflix.conductor.test.base.AbstractSystemTaskWorkerSpecification
+import com.netflix.conductor.test.utils.BlockingSystemTask
+
+import spock.lang.Shared
+
+/**
+ * An async system task must never be executed twice under the same task id.
+ *
+ * SystemTaskWorker acks (removes) the queue message at poll, and AsyncSystemTaskExecutor then invokes
+ * a blocking start() without persisting anything first. For the whole invocation the task is therefore
+ * SCHEDULED with no queue message — the state WorkflowSweeper's repair treats as a lost message and
+ * re-pushes, which hands the task straight back to the worker for a second concurrent invocation.
+ */
+class AsyncSystemTaskDuplicateExecutionSpec extends AbstractSystemTaskWorkerSpecification {
+
+    @Autowired
+    QueueDAO queueDAO
+
+    @Shared
+    def BLOCKING_SYSTEM_TASK_WORKFLOW = 'test_blocking_system_task_workflow'
+
+    def setup() {
+        BlockingSystemTask.reset()
+        workflowTestUtil.registerWorkflows('blocking_system_task_workflow_integration_test.json')
+    }
+
+    def cleanup() {
+        BlockingSystemTask.release()
+    }
+
+    def "a blocked async system task is not executed twice when repair re-queues its message"() {
+        when: "the workflow is started and the worker picks up the blocking system task"
+        def workflowId = startWorkflow(BLOCKING_SYSTEM_TASK_WORKFLOW, 1, 'duplicate_execution', [:], null)
+
+        then: "start() has been entered exactly once and is still blocked"
+        BlockingSystemTask.awaitFirstInvocation(15)
+        BlockingSystemTask.invocationCount() == 1
+
+        and: "the task is SCHEDULED and its queue message was removed at poll"
+        String taskId = null
+        conditions.eventually {
+            def task = workflowExecutionService.getExecutionStatus(workflowId, true).tasks
+                    .find { it.taskType == BlockingSystemTask.NAME }
+            task != null
+            task.status == Task.Status.SCHEDULED
+            taskId = task.taskId
+        }
+
+        when: "the sweeper repairs the workflow while the invocation is still in flight"
+        sweep(workflowId)
+        // The worker polls this queue every 50ms, so 5s is ~100 poll cycles. Against the pre-fix
+        // behaviour the second invocation was observed within ~2s of the repair.
+        Thread.sleep(5000)
+
+        then: "the message is still reserved, so start() was not invoked a second time"
+        queueDAO.containsMessage(BlockingSystemTask.NAME, taskId)
+        BlockingSystemTask.invocationCount() == 1
+
+        cleanup:
+        BlockingSystemTask.release()
+    }
+}

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/AsyncSystemTaskDuplicateExecutionSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/AsyncSystemTaskDuplicateExecutionSpec.groovy
@@ -22,7 +22,7 @@ import com.netflix.conductor.test.utils.BlockingSystemTask
 import spock.lang.Shared
 
 /**
- * An async system task must never be executed twice under the same task id.
+ * An async system task shouldn't be executed twice under the same task id.
  *
  * SystemTaskWorker acks (removes) the queue message at poll, and AsyncSystemTaskExecutor then invokes
  * a blocking start() without persisting anything first. For the whole invocation the task is therefore

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/AsyncSystemTaskWorkerSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/AsyncSystemTaskWorkerSpec.groovy
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.test.integration
+
+import org.springframework.beans.factory.annotation.Autowired
+
+import com.netflix.conductor.common.metadata.tasks.Task
+import com.netflix.conductor.common.run.Workflow
+import com.netflix.conductor.dao.QueueDAO
+import com.netflix.conductor.test.base.AbstractSystemTaskWorkerSpecification
+
+import spock.lang.Shared
+
+import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_SUB_WORKFLOW
+
+/**
+ * Restores test-harness coverage of the async system-task poll/execute path, driven by the real
+ * SystemTaskWorker.
+ *
+ * Every other sub-workflow spec obtains the SCHEDULED SUB_WORKFLOW task id itself and calls
+ * asyncSystemTaskExecutor.execute(...) directly — it bought determinism by hand-driving the
+ * executor, and as a result the queue hop is never exercised. Nothing here touches
+ * asyncSystemTaskExecutor: the worker must find the message on its own.
+ */
+class AsyncSystemTaskWorkerSpec extends AbstractSystemTaskWorkerSpecification {
+
+    @Autowired
+    QueueDAO queueDAO
+
+    @Shared
+    def WORKFLOW_WITH_SUBWORKFLOW = 'integration_test_wf_with_sub_wf'
+
+    @Shared
+    def SUB_WORKFLOW = 'sub_workflow'
+
+    def setup() {
+        workflowTestUtil.registerWorkflows('simple_one_task_sub_workflow_integration_test.json',
+                'workflow_with_sub_workflow_1_integration_test.json')
+    }
+
+    def "the real system task worker polls and starts the SUB_WORKFLOW task"() {
+        given: "a parent workflow whose second task is a SUB_WORKFLOW"
+        def input = ['param1': 'p1 value', 'param2': 'p2 value', 'subwf': SUB_WORKFLOW]
+
+        when: "the parent workflow is started"
+        def rootWorkflowId = startWorkflow(WORKFLOW_WITH_SUBWORKFLOW, 1, 'worker_poll_execute', input, null)
+
+        then: "the first task is scheduled"
+        conditions.eventually {
+            with(workflowExecutionService.getExecutionStatus(rootWorkflowId, true)) {
+                status == Workflow.WorkflowStatus.RUNNING
+                tasks.size() == 1
+                tasks[0].taskType == 'integration_task_1'
+                tasks[0].status == Task.Status.SCHEDULED
+            }
+        }
+
+        when: "the first task completes - and nothing else is driven by hand"
+        workflowTestUtil.pollAndCompleteTask('integration_task_1', 'task1.integration.worker', ['op': 'task1.done'])
+
+        then: "the SystemTaskWorker pops the SUB_WORKFLOW message and starts the child workflow"
+        String subWorkflowId = null
+        conditions.eventually {
+            with(workflowExecutionService.getExecutionStatus(rootWorkflowId, true)) {
+                tasks.size() == 2
+                tasks[1].taskType == TASK_TYPE_SUB_WORKFLOW
+                tasks[1].status == Task.Status.IN_PROGRESS
+                tasks[1].subWorkflowId != null
+            }
+            subWorkflowId = workflowExecutionService.getExecutionStatus(rootWorkflowId, true).tasks[1].subWorkflowId
+        }
+
+        and: "the child workflow is running its own first task"
+        conditions.eventually {
+            with(workflowExecutionService.getExecutionStatus(subWorkflowId, true)) {
+                status == Workflow.WorkflowStatus.RUNNING
+                tasks.size() == 1
+                tasks[0].taskType == 'simple_task_in_sub_wf'
+            }
+        }
+    }
+
+    def "repeated sweeps do not duplicate an in-flight SUB_WORKFLOW task"() {
+        given: "a parent workflow whose SUB_WORKFLOW task the worker has already started"
+        def input = ['param1': 'p1 value', 'param2': 'p2 value', 'subwf': SUB_WORKFLOW]
+        def rootWorkflowId = startWorkflow(WORKFLOW_WITH_SUBWORKFLOW, 1, 'worker_no_duplicate', input, null)
+
+        conditions.eventually {
+            with(workflowExecutionService.getExecutionStatus(rootWorkflowId, true)) {
+                tasks.size() == 1
+                tasks[0].status == Task.Status.SCHEDULED
+            }
+        }
+        workflowTestUtil.pollAndCompleteTask('integration_task_1', 'task1.integration.worker', ['op': 'task1.done'])
+
+        String subWorkflowId = null
+        String subWorkflowTaskId = null
+        conditions.eventually {
+            with(workflowExecutionService.getExecutionStatus(rootWorkflowId, true)) {
+                tasks.size() == 2
+                tasks[1].taskType == TASK_TYPE_SUB_WORKFLOW
+                tasks[1].status == Task.Status.IN_PROGRESS
+                tasks[1].subWorkflowId != null
+            }
+            def subWorkflowTask = workflowExecutionService.getExecutionStatus(rootWorkflowId, true).tasks[1]
+            subWorkflowId = subWorkflowTask.subWorkflowId
+            subWorkflowTaskId = subWorkflowTask.taskId
+        }
+
+        when: "the parent is swept repeatedly while the SUB_WORKFLOW task is in flight"
+        5.times { sweep(rootWorkflowId) }
+
+        then: "exactly one child workflow exists - repair did not re-queue the running task"
+        workflowExecutionService.getRunningWorkflows(SUB_WORKFLOW, 1).size() == 1
+
+        and: "the parent still holds a single SUB_WORKFLOW task pointing at the same child"
+        with(workflowExecutionService.getExecutionStatus(rootWorkflowId, true)) {
+            tasks.findAll { it.taskType == TASK_TYPE_SUB_WORKFLOW }.size() == 1
+            tasks.find { it.taskType == TASK_TYPE_SUB_WORKFLOW }.subWorkflowId == subWorkflowId
+        }
+
+        and: "the in-flight task has no queue message, and repair left it that way (#202, #630)"
+        !queueDAO.containsMessage(TASK_TYPE_SUB_WORKFLOW, subWorkflowTaskId)
+    }
+}

--- a/test-harness/src/test/java/com/netflix/conductor/test/utils/BlockingSystemTask.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/utils/BlockingSystemTask.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.test.utils;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.stereotype.Component;
+
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.core.execution.tasks.WorkflowSystemTask;
+import com.netflix.conductor.model.TaskModel;
+import com.netflix.conductor.model.WorkflowModel;
+
+/**
+ * Async system task whose {@code start()} blocks until the test releases it, and which counts how
+ * many times it was invoked.
+ *
+ * <p>A blocking {@code start()} is what makes duplicate async system-task execution observable: the
+ * task stays SCHEDULED in the store for the whole invocation, so anything that re-delivers its
+ * queue message during that window causes a second, concurrent invocation under the same task id.
+ */
+@Component(BlockingSystemTask.NAME)
+public class BlockingSystemTask extends WorkflowSystemTask {
+
+    public static final String NAME = "BLOCKING_SYSTEM_TASK";
+
+    private static final AtomicInteger INVOCATIONS = new AtomicInteger();
+    private static volatile CountDownLatch entered = new CountDownLatch(1);
+    private static volatile CountDownLatch release = new CountDownLatch(1);
+
+    public BlockingSystemTask() {
+        super(NAME);
+    }
+
+    /** Must be called from the test's setup, before the workflow is started. */
+    public static void reset() {
+        INVOCATIONS.set(0);
+        entered = new CountDownLatch(1);
+        release = new CountDownLatch(1);
+    }
+
+    public static int invocationCount() {
+        return INVOCATIONS.get();
+    }
+
+    /** Blocks until {@code start()} has been entered at least once. */
+    public static boolean awaitFirstInvocation(long timeoutSeconds) throws InterruptedException {
+        return entered.await(timeoutSeconds, TimeUnit.SECONDS);
+    }
+
+    /** Unblocks every in-flight invocation. Safe to call more than once. */
+    public static void release() {
+        release.countDown();
+    }
+
+    @Override
+    public void start(WorkflowModel workflow, TaskModel task, WorkflowExecutor executor) {
+        INVOCATIONS.incrementAndGet();
+        entered.countDown();
+        try {
+            release.await(30, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        task.setStatus(TaskModel.Status.COMPLETED);
+    }
+
+    @Override
+    public boolean isAsync() {
+        return true;
+    }
+}

--- a/test-harness/src/test/resources/blocking_system_task_workflow_integration_test.json
+++ b/test-harness/src/test/resources/blocking_system_task_workflow_integration_test.json
@@ -1,0 +1,29 @@
+{
+  "name": "test_blocking_system_task_workflow",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "blocking_system_task",
+      "taskReferenceName": "blocking_system_task",
+      "inputParameters": {},
+      "type": "BLOCKING_SYSTEM_TASK",
+      "decisionCases": {},
+      "defaultCase": [],
+      "forkTasks": [],
+      "startDelay": 0,
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopOver": []
+    }
+  ],
+  "inputParameters": [],
+  "outputParameters": {},
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false,
+  "timeoutPolicy": "ALERT_ONLY",
+  "timeoutSeconds": 0,
+  "ownerEmail": "test@harness.com"
+}


### PR DESCRIPTION
Followup of #1369 -  Test-harness only.

> **CI is expected to fail on main branch.** `AsyncSystemTaskDuplicateExecutionSpec` is a reproduction of duplicate async system-task execution: it fails on `main` and passes once the in-flight queue message is reserved at poll (#1369). Merge this after #1369.

## Why

`conductor.system-task-workers.enabled=false` in the test-harness, so the real `poll → execute` path for async system tasks is NOT exercised.

No `SystemTaskWorker` runs and every spec starts async system tasks by hand instead — 123 call sites across 26 specs. They look up the SCHEDULED task id themselves and invoke the executor directly, e.g. `SubWorkflowSpec.groovy:96`:

```groovy
when: "the subworkflow task is started by issuing a system task call"
def rootSubWfTask = workflowExecutionService.getExecutionStatus(workflowInstanceId, true)
        .tasks.find { it.taskType == TASK_TYPE_SUB_WORKFLOW && it.status == Task.Status.SCHEDULED }
if (rootSubWfTask) {
    asyncSystemTaskExecutor.execute(subWorkflowTask, rootSubWfTask.taskId)
}
```

The queue hop never happens, so a change to `SystemTaskWorker` or `AsyncSystemTaskExecutor` can regress that path with a green `test-harness` job.

## What this adds

- `AbstractSystemTaskWorkerSpecification` — turns the worker on. Overriding the property changes the merged `@TestPropertySource` set, so these specs get their own Spring context and the 1**23 existing call sites are untouched**.
- `AsyncSystemTaskWorkerSpec` — two tests, neither of which calls the executor by hand:
  - the worker picks up the `SUB_WORKFLOW` message and starts the child workflow on its own;
  - sweeping the parent repeatedly while the child is running still leaves exactly one child workflow.
- `AsyncSystemTaskDuplicateExecutionSpec` + `BlockingSystemTask` — the reproduction described above.

## The duplicate-execution reproduction

`SystemTaskWorker` acks (removes) the queue message at poll, and `AsyncSystemTaskExecutor` then invokes a blocking `start()` without persisting anything first. For the whole invocation the task is `SCHEDULED` with no queue message — which `WorkflowSweeper`'s repair reads as a lost message and re-pushes, handing the task back to the worker for a second concurrent invocation under the same task id.

`BLOCKING_SYSTEM_TASK` blocks in `start()` and counts invocations, so the window is deterministic. Observed:

| | `containsMessage` | invocations |
|---|---|---|
| `main` | `true` → `false` | 1 → **2** |
| with #1369 | `true` throughout | 1 |

Confirmed by the sweeper's own log line on `main`:

```
Going to repair the task 76bdb58c… / blocking_system_task, with status SCHEDULED, workflow = 0f3bbef5…
```

## Review notes

**Why the worker is started and stopped per feature.** Every spec shares one Redis container (`AbstractSpecification` holds it in a `static` field) and one set of queue names, so there is a single physical `SUB_WORKFLOW` queue for the whole test run. Enabling the property gives these specs their own Spring context, but that separates only the beans — not the queue. Spring also caches test contexts instead of closing them, so the worker's polling threads would keep running for the rest of the JVM's life, including while the 123 hand-driven call sites run later, taking messages those specs intend to execute themselves. That is what broke `HierarchicalForkJoinSubworkflowRerunSpec` on an earlier iteration of this branch. `setup()` starts the worker and `cleanup()` stops it; `SystemTaskWorker.pollAndExecute` checks `isRunning()` before each poll.

**Why `systemTaskWorkerThreadCount=10`.** `SystemTaskWorker` shares a single `ExecutionConfig` — thread pool *and* semaphore — across every async system-task queue. A task blocked in `start()` holds a permit for its whole invocation, so with only 2 permits the remaining one is contended by all ~26 pollers and a re-queued message can sit undelivered for tens of seconds. An earlier version of the reproduction passed against the bug for exactly that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
