### PR TITLE
ci: publish named test-result checks for unit-test, test-harness and e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,13 @@ jobs:
         uses: mikepenz/action-junit-report@v6
         if: always()
         with:
+          check_name: "Test-Harness tests"
+          check_title_template: "{{SUITE_NAME}} | {{TEST_NAME}} | {{CLASS_NAME}}"
           report_paths: "test-harness/build/test-results/test/TEST-*.xml"
+          check_retries: true
+          detailed_summary: true
+          include_passed: false
+          flaky_summary: true
       - name: Upload test-harness reports
         uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,11 @@ jobs:
           path: "**/build/reports/tests"
   test-harness:
     runs-on: ubuntu-latest
+    # checks: write is required for the test-result check below; without it the
+    # default read-only token fails with "Resource not accessible by integration".
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,9 @@ jobs:
   unit-test:
     needs: detect-changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -180,8 +183,13 @@ jobs:
         uses: mikepenz/action-junit-report@v6
         if: always()
         with:
+          check_name: "Unit Test results"
+          check_title_template: "{{SUITE_NAME}} | {{TEST_NAME}} | {{CLASS_NAME}}"
           report_paths: "**/build/test-results/test/TEST-*.xml"
-          check_name: Unit Test Report
+          check_retries: true
+          detailed_summary: true
+          include_passed: false
+          flaky_summary: true
       - name: Upload unit-test reports
         uses: actions/upload-artifact@v7
         if: always()
@@ -251,7 +259,7 @@ jobs:
         uses: mikepenz/action-junit-report@v6
         if: always()
         with:
-          check_name: "Test-Harness tests"
+          check_name: "Test-Harness results"
           check_title_template: "{{SUITE_NAME}} | {{TEST_NAME}} | {{CLASS_NAME}}"
           report_paths: "test-harness/build/test-results/test/TEST-*.xml"
           check_retries: true
@@ -348,6 +356,9 @@ jobs:
     needs: generate-e2e-matrix
     if: ${{ needs.generate-e2e-matrix.outputs.matrix != '{"include":[]}' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-e2e-matrix.outputs.matrix) }}
@@ -380,7 +391,13 @@ jobs:
         uses: mikepenz/action-junit-report@v6
         if: always()
         with:
+          check_name: "E2E results (${{ matrix.name }})"
+          check_title_template: "{{SUITE_NAME}} | {{TEST_NAME}} | {{CLASS_NAME}}"
           report_paths: "e2e/build/test-results/test/TEST-*.xml"
+          check_retries: true
+          detailed_summary: true
+          include_passed: false
+          flaky_summary: true
       - name: Generate test summary table
         if: always()
         shell: python3 {0}


### PR DESCRIPTION
Test results were never published as checks, so the only signal about which test failed was Gradle's exit code. The action was already computing the summary — it just couldn't post it:

```
Unit Test Report - 2802 tests run, 2713 passed, 89 skipped, 0 failed.
Failed to create checks using the provided token.
(HttpError: Resource not accessible by integration)
```

`ci.yml` declared no `permissions`, so these jobs ran with the default read-only token and every check run was rejected. `fail_on_failure` defaults to false, so the steps still went green and the error was easy to miss.

Grants `checks: write` to the three jobs that run tests, and names each check plus enables the per-suite summary. `e2e` is a matrix, so its check name carries `matrix.name` — otherwise the legs overwrite each other's check. The `build` job is left alone: it runs with `-x test`.

Verified on this PR: **Test-Harness results — 335 tests run, 304 passed, 31 skipped, 0 failed.**

Two limits: if the org caps default workflow permissions at read-only without letting jobs request more, the `permissions` block can't escalate; and PRs from forks always get a read-only token, so they won't produce checks either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)