### PR TITLE
fix(ui): preserve agent filters in generated search code

### DIFF
--- a/ui-next/src/pages/agent/executions/ApiSearchModalIntegration.test.ts
+++ b/ui-next/src/pages/agent/executions/ApiSearchModalIntegration.test.ts
@@ -1,0 +1,19 @@
+import { buildEndpoint } from "./agentSearchCode";
+
+describe("buildEndpoint", () => {
+  it("preserves agent search filters in generated code", () => {
+    expect(
+      buildEndpoint({
+        start: 20,
+        size: 10,
+        sort: "startTime:DESC",
+        freeText: "*",
+        query: "status=RUNNING",
+        classifier: "agent",
+        topLevelOnly: true,
+      }),
+    ).toBe(
+      `${window.location.origin}/api/workflow/search?start=20&size=10&sort=startTime%3ADESC&freeText=*&query=status%3DRUNNING&classifier=agent&topLevelOnly=true`,
+    );
+  });
+});

--- a/ui-next/src/pages/agent/executions/ApiSearchModalIntegration.tsx
+++ b/ui-next/src/pages/agent/executions/ApiSearchModalIntegration.tsx
@@ -2,34 +2,12 @@ import { ApiSearchModal } from "components/ApiSearchModal";
 import { toCodeT, useParamsToSdk } from "shared/CodeModal/hook";
 import { SupportedDisplayTypes } from "shared/CodeModal/types";
 import { curlHeaders } from "shared/CodeModal/curlHeader";
-
-export type BuildQueryOutput = {
-  query: string;
-  freeText: string;
-  start: number;
-  size: number;
-  sort: string;
-};
+import { buildEndpoint, type BuildQueryOutput } from "./agentSearchCode";
 
 interface ApiSearchModalIntegrationProps {
   buildQueryOutput: BuildQueryOutput;
   onClose: () => void;
 }
-
-const buildEndpoint = ({
-  start,
-  size,
-  sort,
-  freeText,
-  query,
-}: BuildQueryOutput) =>
-  `${window.location.origin}/api/workflow/search?${new URLSearchParams({
-    start: String(start),
-    size: String(size),
-    sort,
-    freeText,
-    query,
-  }).toString()}`;
 
 const buildCurlCode = (
   buildQueryOutput: BuildQueryOutput,
@@ -99,3 +77,4 @@ const ApiSearchModalIntegration = ({
 };
 
 export { ApiSearchModalIntegration };
+export type { BuildQueryOutput };

--- a/ui-next/src/pages/agent/executions/agentSearchCode.ts
+++ b/ui-next/src/pages/agent/executions/agentSearchCode.ts
@@ -1,0 +1,31 @@
+export type BuildQueryOutput = {
+  query: string;
+  freeText: string;
+  start: number;
+  size: number;
+  sort: string;
+  classifier: string;
+  topLevelOnly: boolean;
+};
+
+/**
+ * Builds a search URL that preserves the filters applied on the Agent Executions page.
+ */
+export const buildEndpoint = ({
+  start,
+  size,
+  sort,
+  freeText,
+  query,
+  classifier,
+  topLevelOnly,
+}: BuildQueryOutput) =>
+  `${window.location.origin}/api/workflow/search?${new URLSearchParams({
+    start: String(start),
+    size: String(size),
+    sort,
+    freeText,
+    query,
+    classifier,
+    topLevelOnly: String(topLevelOnly),
+  }).toString()}`;

--- a/ui-next/src/pages/agent/executions/workflowSearchComponents/AdvancedSearch.tsx
+++ b/ui-next/src/pages/agent/executions/workflowSearchComponents/AdvancedSearch.tsx
@@ -365,6 +365,8 @@ export default function AdvancedSearch({
                 sort,
                 freeText,
                 query: buildQuery().query,
+                classifier: "agent",
+                topLevelOnly: hideSubWorkflows,
               }}
             />
           )}

--- a/ui-next/src/pages/agent/executions/workflowSearchComponents/BasicSearch.tsx
+++ b/ui-next/src/pages/agent/executions/workflowSearchComponents/BasicSearch.tsx
@@ -413,6 +413,8 @@ export default function BasicSearch({
                 sort,
                 freeText,
                 query: buildQuery().query,
+                classifier: "agent",
+                topLevelOnly: hideSubWorkflows,
               }}
             />
           )}


### PR DESCRIPTION
## Summary
- preserve the agent classifier in Agent Executions generated search requests
- preserve the Hide sub-agent executions setting in generated requests
- add regression coverage for the generated endpoint

Closes #1318

## Test Evidence: ##
<img width="1459" height="909" alt="image" src="https://github.com/user-attachments/assets/03b5361e-8d76-4b26-9fe7-92109b8c62a8" />


## Testing
- `npm test -- --run src/pages/agent/executions/ApiSearchModalIntegration.test.ts`
- `npm run typecheck`
- `npm run lint -- --no-error-on-unmatched-pattern ...`
- `npm run prettier:check -- ...`
- `./gradlew spotlessApply`