### PR TITLE
fix(test): pin mcp<2 and gate mcp-testkit readiness

### DIFF
--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/AgentSpanMcpTestkitApiDiscoveryEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/AgentSpanMcpTestkitApiDiscoveryEndToEndTest.java
@@ -12,6 +12,7 @@
  */
 package com.netflix.conductor.test.integration.agent;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +39,8 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 import com.netflix.conductor.ConductorTestApp;
@@ -104,6 +107,11 @@ class AgentSpanMcpTestkitApiDiscoveryEndToEndTest {
             new GenericContainer<>(DockerImageName.parse("redis:6.2-alpine"))
                     .withExposedPorts(6379);
 
+    // mcp-testkit 1.0.3 does not constrain its own `mcp` dependency, and mcp 2.0.0 dropped
+    // mcp.server.fastmcp, which the testkit imports at start-up. Without 'mcp<2' the install
+    // succeeds and the server then dies with ModuleNotFoundError, so nothing ever binds 3001.
+    // The log-message wait is what surfaces that: the default port check is satisfied by Docker's
+    // published-port proxy before the process inside the container has bound anything.
     @SuppressWarnings("resource")
     private static final GenericContainer<?> MCP_TESTKIT =
             new GenericContainer<>(DockerImageName.parse("python:3.12-slim"))
@@ -111,10 +119,15 @@ class AgentSpanMcpTestkitApiDiscoveryEndToEndTest {
                     .withCommand(
                             "sh",
                             "-c",
-                            "pip install --no-cache-dir mcp-testkit==1.0.3"
+                            "pip install --no-cache-dir mcp-testkit==1.0.3 'mcp<2'"
                                     + " && mcp-testkit --transport http --host 0.0.0.0 --port 3001"
                                     + " --auth "
-                                    + TESTKIT_AUTH);
+                                    + TESTKIT_AUTH)
+                    .withLogConsumer(
+                            new Slf4jLogConsumer(org.slf4j.LoggerFactory.getLogger("mcp-testkit")))
+                    .waitingFor(
+                            Wait.forLogMessage(".*Application startup complete.*\\n", 1)
+                                    .withStartupTimeout(Duration.ofMinutes(3)));
 
     @SuppressWarnings("resource")
     private static final LocalStackContainer LOCALSTACK =


### PR DESCRIPTION
`AgentSpanMcpTestkitApiDiscoveryEndToEndTest` is failing on every push and PR since ~14:00 UTC today. It runs in `:conductor-test-harness:test`, so this blocks all PRs, not just the nightly.

## Cause

`mcp-testkit==1.0.3` does not constrain its own `mcp` dependency. **`mcp 2.0.0` was published at `2026-07-28T13:45:28Z`** and dropped `mcp.server.fastmcp`, which the testkit imports at start-up. `--no-cache-dir` means every run resolves `mcp` fresh, so the install succeeds and the server then dies immediately:

```
File "/usr/local/lib/python3.12/site-packages/mcp_test_server/server.py", line 7
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

Nothing ever binds port 3001, so the tests get connection refused on both `127.0.0.1` and `::1` and report as assertion failures.

## Timeline

| When (UTC) | Commit | `test-harness` | Run |
|---|---|---|---|
| 07-28 03:03 | `bf19b22b4` | pass | [30324882788](https://github.com/conductor-oss/conductor/actions/runs/30324882788) |
| 07-28 05:34 | `e4898a62a` | pass | [30332012037](https://github.com/conductor-oss/conductor/actions/runs/30332012037) |
| 07-28 10:13 | `feature/a2a-expose-all` | pass | [30349917249](https://github.com/conductor-oss/conductor/actions/runs/30349917249) |
| **07-28 13:45** | — | **`mcp 2.0.0` published to PyPI** | — |
| 07-28 14:29 | PR #1402 | **fail — 5 methods** | [30366947480](https://github.com/conductor-oss/conductor/actions/runs/30366947480) |
| 07-28 ~15:00 | `e4898a62a` | **fail** | [30371061708](https://github.com/conductor-oss/conductor/actions/runs/30371061708) |
| 07-28 ~15:05 | `b479d83a9` | **fail** | [30372576023](https://github.com/conductor-oss/conductor/actions/runs/30372576023) |

The last two are `workflow_dispatch` runs on commits with and without #1369. Both fail identically, which rules out any recent merge as the cause — the break is the upstream release.

## Fix

- Pin `'mcp<2'` in the install so the testkit resolves a compatible version (verified: `mcp-1.29.0`).
- Wait on the server's own `Application startup complete` log line instead of the default port check — that check is satisfied by Docker's published-port proxy before the process inside the container binds anything, which is why a broken container was reported as "started in 8.4s".
- Attach a `Slf4jLogConsumer` so the container's traceback is visible instead of being lost.

Verified locally: **6 tests, 0 failures** (the 5 that were failing, plus the sixth in the class).

Follow-up worth considering separately: a prebuilt image or vendored wheel would remove the runtime PyPI dependency entirely, so an upstream release can't break CI for the whole repo again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)