### PR TITLE
fix(ui): show full execution failure reason in dialog

### DIFF
--- a/ui-next/src/pages/execution/Execution.test.tsx
+++ b/ui-next/src/pages/execution/Execution.test.tsx
@@ -1,0 +1,20 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ReasonForIncompletion } from "./ReasonForIncompletion";
+
+describe("ReasonForIncompletion", () => {
+  it("shows a long failure reason in place instead of navigating away", () => {
+    const reason = `Task failed: ${"details ".repeat(50)}`;
+
+    render(<ReasonForIncompletion reason={reason} />);
+
+    fireEvent.click(screen.getByText("View full message"));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        (_, element) =>
+          element?.tagName === "PRE" && element.textContent === reason,
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui-next/src/pages/execution/Execution.tsx
+++ b/ui-next/src/pages/execution/Execution.tsx
@@ -47,6 +47,7 @@ import ExecutionJson from "./ExecutionJson";
 import ExecutionSummary from "./ExecutionSummary";
 import { isAgentWorkflowExecution } from "./helpers";
 import LeftPanelTabs from "./LeftPanelTabs";
+import { ReasonForIncompletion } from "./ReasonForIncompletion";
 import { RightPanel } from "./RightPanel";
 import { TaskList } from "./TaskList/TaskList";
 import Timeline from "./Timeline";
@@ -209,42 +210,6 @@ const FailureAlert = ({ failedWFLink, alertText }: FailureAlertProps) => {
   );
 };
 
-interface ReasonForIncompletionProps {
-  reason: string;
-  navigate: (path: string) => void;
-  location: { pathname: string };
-}
-
-const ReasonForIncompletion = ({
-  reason,
-  navigate,
-  location,
-}: ReasonForIncompletionProps) => {
-  if (!reason) return null;
-
-  if (reason.length >= 300) {
-    return (
-      <Box>
-        {reason.substr(0, 60)}... [
-        <MuiTypography
-          component="span"
-          color="#1976d2"
-          fontWeight="bold"
-          cursor="pointer"
-          onClick={() => {
-            navigate(`${location.pathname}?tab=summary`);
-          }}
-        >
-          View full message
-        </MuiTypography>
-        ]
-      </Box>
-    );
-  }
-
-  return <>{reason}</>;
-};
-
 interface ExecutionAlertProps {
   execution: WorkflowExecution;
   openedTab: ExecutionTabs;
@@ -258,9 +223,6 @@ const ExecutionAlert = ({
   failedTaskWithReason,
   handleJumpToTask,
 }: ExecutionAlertProps) => {
-  const navigate = usePushHistory();
-  const location = useLocation();
-
   if (
     execution?.rateLimited ||
     (execution?.reasonForIncompletion &&
@@ -283,11 +245,7 @@ const ExecutionAlert = ({
           {execution?.rateLimited ? (
             "This execution is rate limited and will be executed once previous executions are completed."
           ) : (
-            <ReasonForIncompletion
-              reason={execution?.reasonForIncompletion}
-              navigate={navigate}
-              location={location}
-            />
+            <ReasonForIncompletion reason={execution?.reasonForIncompletion} />
           )}
         </Box>
 

--- a/ui-next/src/pages/execution/ReasonForIncompletion.tsx
+++ b/ui-next/src/pages/execution/ReasonForIncompletion.tsx
@@ -1,0 +1,61 @@
+import {
+  Box,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from "@mui/material";
+import { Button } from "components";
+import MuiTypography from "components/ui/MuiTypography";
+import { useState } from "react";
+
+interface ReasonForIncompletionProps {
+  reason: string;
+}
+
+export const ReasonForIncompletion = ({
+  reason,
+}: ReasonForIncompletionProps) => {
+  const [isFullMessageOpen, setIsFullMessageOpen] = useState(false);
+
+  if (!reason) return null;
+
+  if (reason.length >= 300) {
+    return (
+      <>
+        <Box>
+          {reason.substr(0, 60)}... [
+          <MuiTypography
+            component="span"
+            color="#1976d2"
+            fontWeight="bold"
+            cursor="pointer"
+            onClick={() => setIsFullMessageOpen(true)}
+          >
+            View full message
+          </MuiTypography>
+          ]
+        </Box>
+        <Dialog
+          open={isFullMessageOpen}
+          onClose={() => setIsFullMessageOpen(false)}
+          fullWidth
+          maxWidth="md"
+        >
+          <DialogTitle>Failure reason</DialogTitle>
+          <DialogContent dividers>
+            {/* Preserve server-provided newlines so API failures remain readable. */}
+            <Box component="pre" sx={{ m: 0, whiteSpace: "pre-wrap" }}>
+              {reason}
+            </Box>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setIsFullMessageOpen(false)}>Close</Button>
+          </DialogActions>
+        </Dialog>
+      </>
+    );
+  }
+
+  return <>{reason}</>;
+};


### PR DESCRIPTION
## Summary

- open long execution failure reasons in an in-place dialog
- preserve multiline error text for readable API failure details
- add regression coverage for the full-message action

Fixes #1409

## Validation

- `pnpm exec vitest run src/pages/execution/Execution.test.tsx`
- `pnpm typecheck`
- `./gradlew spotlessApply`

Fix Evidence: 

<img width="1430" height="890" alt="image" src="https://github.com/user-attachments/assets/fa153c39-0e43-4a11-9ffa-7654706642cb" />
