### PR TITLE
feat(ui): align agent definitions with workflows

### DIFF
--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentService.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentService.java
@@ -197,8 +197,8 @@ public class AgentService {
         stampAgentDef(metadata, request, config);
         def.setMetadata(metadata);
 
-        // 2. Register workflow definition (upsert)
-        metadataDAO.updateWorkflowDef(def);
+        // 2. Register workflow definition while preserving workflow metadata timestamps.
+        upsertWorkflowDef(def);
 
         // 3. Register task definitions for worker tools
         registerTaskDefinitions(config);
@@ -281,8 +281,8 @@ public class AgentService {
         stampAgentDef(metadata, request, config);
         def.setMetadata(metadata);
 
-        // 2. Register workflow definition (upsert)
-        metadataDAO.updateWorkflowDef(def);
+        // 2. Register workflow definition while preserving workflow metadata timestamps.
+        upsertWorkflowDef(def);
 
         // 3. Register task definitions for worker tools
         registerTaskDefinitions(config);
@@ -873,6 +873,27 @@ public class AgentService {
     }
 
     /**
+     * Persist an agent-generated workflow with the metadata lifecycle used by normal workflow
+     * definitions. Direct DAO updates bypass {@link MetadataService} and leave a newly deployed
+     * agent's create time at zero, which prevents the definitions table from rendering it.
+     */
+    private void upsertWorkflowDef(WorkflowDef def) {
+        Optional<WorkflowDef> existing =
+                metadataDAO.getWorkflowDef(def.getName(), def.getVersion());
+        if (existing.isPresent()) {
+            // Older direct-DAO deployments have no create time; repair it on their next deploy.
+            if (existing.get().getCreateTime() == 0) {
+                def.setCreateTime(System.currentTimeMillis());
+            } else {
+                def.setCreateTime(existing.get().getCreateTime());
+            }
+            metadataService.updateWorkflowDef(def);
+        } else {
+            metadataService.registerWorkflowDef(def);
+        }
+    }
+
+    /**
      * Search for an existing workflow with the given correlationId (idempotency key). Returns the
      * execution ID if a RUNNING or COMPLETED execution exists, null otherwise.
      */
@@ -1144,7 +1165,7 @@ public class AgentService {
 
                 // Compile and register the child agent workflow
                 WorkflowDef childDef = agentCompiler.compile(childConfig);
-                metadataDAO.updateWorkflowDef(childDef);
+                upsertWorkflowDef(childDef);
                 log.info(
                         "Registered agent_tool child workflow: {} for tool '{}'",
                         childDef.getName(),

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentService.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentService.java
@@ -391,6 +391,18 @@ public class AgentService {
                             .updateTime(def.getUpdateTime())
                             .description(def.getDescription())
                             .checksum(checksum)
+                            .schemaVersion(def.getSchemaVersion())
+                            .restartable(def.isRestartable())
+                            .workflowStatusListenerEnabled(def.isWorkflowStatusListenerEnabled())
+                            .ownerEmail(def.getOwnerEmail())
+                            .inputParameters(def.getInputParameters())
+                            .outputParameters(def.getOutputParameters())
+                            .timeoutPolicy(
+                                    def.getTimeoutPolicy() == null
+                                            ? null
+                                            : def.getTimeoutPolicy().name())
+                            .timeoutSeconds(def.getTimeoutSeconds())
+                            .failureWorkflow(def.getFailureWorkflow())
                             .build());
         }
 

--- a/common/src/main/java/org/conductoross/conductor/common/metadata/agent/AgentSummary.java
+++ b/common/src/main/java/org/conductoross/conductor/common/metadata/agent/AgentSummary.java
@@ -13,6 +13,7 @@
 package org.conductoross.conductor.common.metadata.agent;
 
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
@@ -35,4 +36,16 @@ public class AgentSummary {
     private Long updateTime;
     private String description;
     private String checksum;
+
+    // These fields mirror the underlying workflow definition so the agent list can use the same
+    // metadata columns as the workflow definition list.
+    private Integer schemaVersion;
+    private Boolean restartable;
+    private Boolean workflowStatusListenerEnabled;
+    private String ownerEmail;
+    private List<String> inputParameters;
+    private Map<String, Object> outputParameters;
+    private String timeoutPolicy;
+    private Long timeoutSeconds;
+    private String failureWorkflow;
 }

--- a/ui-next/src/pages/agent/AgentDefinitions.test.tsx
+++ b/ui-next/src/pages/agent/AgentDefinitions.test.tsx
@@ -19,11 +19,28 @@ vi.mock("utils/query", () => ({
     isFetching: false,
     refetch: vi.fn(),
   }),
+  useActionWithPath: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("utils/hooks/useCustomPagination", () => ({
+  default: () => [
+    { filterParam: "", pageParam: "", searchParam: "" },
+    {
+      setFilterParam: vi.fn(),
+      setSearchParam: vi.fn(),
+      handlePageChange: vi.fn(),
+    },
+  ],
 }));
 
 vi.mock("components", () => ({
+  Button: ({ children, onClick }: any) => (
+    <button onClick={onClick}>{children}</button>
+  ),
   DataTable: ({ columns, data }: any) => {
-    const nameColumn = columns.find((column: any) => column.id === "name");
+    const nameColumn = columns.find(
+      (column: any) => column.id === "workflow_name",
+    );
     return <>{nameColumn.renderer(data[0].name, data[0])}</>;
   },
   NavLink: ({ children, path }: any) => <a href={path}>{children}</a>,

--- a/ui-next/src/pages/agent/AgentDefinitions.tsx
+++ b/ui-next/src/pages/agent/AgentDefinitions.tsx
@@ -39,7 +39,11 @@ const INTRO_CONTENT = `**Agents** are AI agent definitions compiled and run as n
 No agents deployed yet? Use **Create Agent** for a copy-and-run SDK guide.`;
 
 const toTagDtos = (tags?: string[]): TagDto[] =>
-  (tags || []).map((tag) => ({ key: "capability", value: tag }));
+  (tags || []).map((tag) => ({
+    key: "capability",
+    value: tag,
+    type: "METADATA",
+  }));
 
 export default function AgentDefinitions() {
   const navigate = useNavigate();

--- a/ui-next/src/pages/agent/AgentDefinitions.tsx
+++ b/ui-next/src/pages/agent/AgentDefinitions.tsx
@@ -32,6 +32,7 @@ import { logger } from "utils/logger";
 import { useActionWithPath, useFetch } from "utils/query";
 import { tryToJson } from "utils/utils";
 import TagList from "components/ui/TagList";
+import CloneAgentDialog from "./CloneAgentDialog";
 import { AgentSummary } from "./types";
 
 const INTRO_CONTENT = `**Agents** are AI agent definitions compiled and run as native Conductor workflows by the embedded AgentSpan runtime.
@@ -53,6 +54,7 @@ export default function AgentDefinitions() {
   const { setMessage } = useContext(MessageContext);
   const [toastMessage, setToastMessage] = useState<PopoverMessage | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<AgentSummary | null>(null);
+  const [agentToClone, setAgentToClone] = useState<AgentSummary | null>(null);
   const [
     { filterParam, pageParam, searchParam },
     { setFilterParam, setSearchParam, handlePageChange },
@@ -70,33 +72,6 @@ export default function AgentDefinitions() {
     },
     onError: (error: Error) => {
       setMessage({ severity: "error", text: "Failed to delete agent" });
-      logger.error(error);
-    },
-  });
-
-  const copyAgentAction = useActionWithPath<Record<string, unknown>>({
-    onSuccess: async (definition) => {
-      try {
-        await navigator.clipboard.writeText(
-          JSON.stringify(definition, null, 2),
-        );
-        setToastMessage({
-          text: "Agent definition copied to clipboard",
-          severity: "success",
-        });
-      } catch (error) {
-        setMessage({
-          severity: "error",
-          text: "Failed to copy agent definition",
-        });
-        logger.error(error);
-      }
-    },
-    onError: (error: Error) => {
-      setMessage({
-        severity: "error",
-        text: "Failed to load agent definition",
-      });
       logger.error(error);
     },
   });
@@ -264,16 +239,11 @@ export default function AgentDefinitions() {
                 <PlayIcon size={22} />
               </IconButton>
             </Tooltip>
-            <Tooltip title="Copy agent definition">
+            <Tooltip title="Clone Agent">
               <IconButton
-                id={`copy-${agent.name}-btn`}
+                id={`clone-${agent.name}-btn`}
                 disabled={isTrialExpired}
-                onClick={() =>
-                  copyAgentAction.mutate({
-                    method: "get",
-                    path: `/agent/${encodeURIComponent(agent.name)}?version=${agent.version}`,
-                  })
-                }
+                onClick={() => setAgentToClone(agent)}
                 size="small"
               >
                 <CopyIcon size={20} />
@@ -293,7 +263,7 @@ export default function AgentDefinitions() {
         ),
       },
     ],
-    [copyAgentAction, isTrialExpired, navigate, tagsEnabled],
+    [isTrialExpired, navigate, tagsEnabled],
   );
 
   const handleFilterChange = useCallback(
@@ -312,6 +282,21 @@ export default function AgentDefinitions() {
       <Helmet>
         <title>Agent Definitions</title>
       </Helmet>
+      {agentToClone && (
+        <CloneAgentDialog
+          selectedAgent={agentToClone}
+          agentList={tableData}
+          onClose={() => setAgentToClone(null)}
+          onSuccess={() => {
+            setAgentToClone(null);
+            refetch();
+            setToastMessage({
+              text: "Agent cloned successfully",
+              severity: "success",
+            });
+          }}
+        />
+      )}
       {confirmDelete && (
         <ConfirmChoiceDialog
           handleConfirmationValue={(confirmed) => {
@@ -369,7 +354,7 @@ export default function AgentDefinitions() {
             localStorageKey="agentDefinitionsTable"
             quickSearchEnabled
             quickSearchPlaceholder="Search agent definitions"
-            searchTerm={searchParam}
+            searchTerm={searchParam ?? ""}
             onSearchTermChange={setSearchParam}
             defaultShowColumns={[
               "workflow_name",

--- a/ui-next/src/pages/agent/AgentDefinitions.tsx
+++ b/ui-next/src/pages/agent/AgentDefinitions.tsx
@@ -1,78 +1,301 @@
-import { DataTable, NavLink, Paper } from "components";
-import { ColumnCustomType } from "components/ui/DataTable/types";
-import SectionHeader from "components/layout/SectionHeader";
-import SectionHeaderActions from "components/ui/layout/SectionHeaderActions";
-import AddIcon from "components/icons/AddIcon";
+import { Box, Tooltip } from "@mui/material";
+import {
+  CopySimple as CopyIcon,
+  Trash as DeleteIcon,
+} from "@phosphor-icons/react";
+import { Button, DataTable, IconButton, NavLink, Paper } from "components";
+import { FilterObjectItem } from "components/ui/DataTable/state";
+import { ColumnCustomType, LegacyColumn } from "components/ui/DataTable/types";
 import Header from "components/ui/Header";
 import NoDataComponent from "components/ui/NoDataComponent";
+import { SnackbarMessage } from "components/ui/SnackbarMessage";
+import ConfirmChoiceDialog from "components/ui/dialogs/ConfirmChoiceDialog";
+import SectionHeader from "components/layout/SectionHeader";
+import SectionHeaderActions from "components/ui/layout/SectionHeaderActions";
 import SectionContainer from "components/ui/layout/SectionContainer";
-import { useMemo } from "react";
+import PlayIcon from "components/icons/PlayIcon";
+import { useAuth } from "components/features/auth";
+import { MessageContext } from "components/providers/messageContext";
+import { useCallback, useContext, useMemo, useState } from "react";
 import { Helmet } from "react-helmet";
 import { useNavigate } from "react-router";
-import { AGENT_DEFINITION_URL } from "utils/constants/route";
-import { useFetch } from "utils/query";
+import { PopoverMessage } from "types/Messages";
+import { TagDto } from "types/Tag";
+import {
+  AGENT_DEFINITION_URL,
+  AGENT_EXECUTIONS_URL,
+  RUN_AGENT_URL,
+} from "utils/constants/route";
+import { featureFlags, FEATURES } from "utils/flags";
+import useCustomPagination from "utils/hooks/useCustomPagination";
+import { logger } from "utils/logger";
+import { useActionWithPath, useFetch } from "utils/query";
+import { tryToJson } from "utils/utils";
+import TagList from "components/ui/TagList";
 import { AgentSummary } from "./types";
 
 const INTRO_CONTENT = `**Agents** are AI agent definitions compiled and run as native Conductor workflows by the embedded AgentSpan runtime.
 
 No agents deployed yet? Use **Create Agent** for a copy-and-run SDK guide.`;
 
-export default function AgentDefinitions() {
-  const { data, isFetching, refetch } = useFetch<AgentSummary[]>("/agent/list");
-  const navigate = useNavigate();
+const toTagDtos = (tags?: string[]): TagDto[] =>
+  (tags || []).map((tag) => ({ key: "capability", value: tag }));
 
-  const columns = useMemo(
+export default function AgentDefinitions() {
+  const navigate = useNavigate();
+  const { isTrialExpired } = useAuth();
+  const tagsEnabled = featureFlags.isEnabled(FEATURES.TAG_VISIBILITY);
+  const { data, isFetching, refetch } = useFetch<AgentSummary[]>("/agent/list");
+  const { setMessage } = useContext(MessageContext);
+  const [toastMessage, setToastMessage] = useState<PopoverMessage | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<AgentSummary | null>(null);
+  const [
+    { filterParam, pageParam, searchParam },
+    { setFilterParam, setSearchParam, handlePageChange },
+  ] = useCustomPagination();
+  const filterObj =
+    filterParam === "" ? undefined : tryToJson<FilterObjectItem>(filterParam);
+
+  const deleteAgentAction = useActionWithPath({
+    onSuccess: () => {
+      setToastMessage({
+        text: "Agent deleted successfully",
+        severity: "success",
+      });
+      refetch();
+    },
+    onError: (error: Error) => {
+      setMessage({ severity: "error", text: "Failed to delete agent" });
+      logger.error(error);
+    },
+  });
+
+  const copyAgentAction = useActionWithPath<Record<string, unknown>>({
+    onSuccess: async (definition) => {
+      try {
+        await navigator.clipboard.writeText(
+          JSON.stringify(definition, null, 2),
+        );
+        setToastMessage({
+          text: "Agent definition copied to clipboard",
+          severity: "success",
+        });
+      } catch (error) {
+        setMessage({
+          severity: "error",
+          text: "Failed to copy agent definition",
+        });
+        logger.error(error);
+      }
+    },
+    onError: (error: Error) => {
+      setMessage({
+        severity: "error",
+        text: "Failed to load agent definition",
+      });
+      logger.error(error);
+    },
+  });
+
+  const columns = useMemo<LegacyColumn[]>(
     () => [
       {
-        id: "name",
+        id: "workflow_name",
         name: "name",
-        label: "Agent name",
-        tooltip: "Agent name",
+        label: "Workflow name",
         renderer: (name: string, agent: AgentSummary) => (
           <NavLink
+            data-cy="workflow-link"
             path={`${AGENT_DEFINITION_URL.BASE}/${encodeURIComponent(name.trim())}/${agent.version}`}
+            id={`${name.trim()}-link-btn`}
           >
             {name.trim()}
           </NavLink>
         ),
+        tooltip: "The name of the workflow",
       },
       {
-        id: "version",
-        name: "version",
-        label: "Version",
-        grow: 0.5,
-        tooltip: "Agent version",
-      },
-      {
-        id: "description",
+        id: "workflow_description",
         name: "description",
         label: "Description",
         grow: 2,
-        tooltip: "Agent description",
+        tooltip: "The description of the workflow",
+      },
+      ...(tagsEnabled
+        ? ([
+            {
+              id: "workflow_tags",
+              name: "tags",
+              label: "Tags",
+              searchable: true,
+              searchableFunc: (tags: string[]) => (tags || []).join(", "),
+              renderer: (tags: string[], row: AgentSummary) => (
+                <TagList tags={toTagDtos(tags)} name={row.name} />
+              ),
+              grow: 2,
+              tooltip: "The tags associated with the workflow",
+            },
+          ] as LegacyColumn[])
+        : []),
+      {
+        id: "create_time",
+        name: "createTime",
+        label: "Created time",
+        type: ColumnCustomType.DATE,
+        tooltip: "The time the workflow was created",
       },
       {
-        id: "type",
-        name: "type",
-        label: "Type",
-        tooltip: "Agent workflow type",
+        id: "latest_version",
+        name: "version",
+        label: "Latest version",
+        grow: 0.5,
+        tooltip: "The latest version of the workflow",
       },
       {
-        id: "tags",
-        name: "tags",
-        label: "Tags",
+        id: "schema_version",
+        name: "schemaVersion",
+        label: "Schema version",
+        grow: 0.5,
+        tooltip: "The schema version of the workflow",
+      },
+      {
+        id: "restartable",
+        name: "restartable",
+        label: "Restartable",
+        grow: 0.5,
+        tooltip: "Whether the workflow is restartable",
+      },
+      {
+        id: "status_listener_enabled",
+        name: "workflowStatusListenerEnabled",
+        label: "Status listener enabled",
+        grow: 0.5,
+        tooltip: "Whether the status listener is enabled",
+      },
+      {
+        id: "owner_email",
+        name: "ownerEmail",
+        label: "Owner email",
+        tooltip: "The email of the owner of the workflow",
+      },
+      {
+        id: "input_params",
+        name: "inputParameters",
+        label: "Input params",
         type: ColumnCustomType.JSON,
         sortable: false,
-        tooltip: "Agent tags",
+        tooltip: "The input parameters of the workflow",
       },
       {
-        id: "createTime",
-        name: "createTime",
-        label: "Created",
-        type: ColumnCustomType.DATE,
-        tooltip: "Created time",
+        id: "output_params",
+        name: "outputParameters",
+        label: "Output params",
+        type: ColumnCustomType.JSON,
+        sortable: false,
+        tooltip: "The output parameters of the workflow",
+      },
+      {
+        id: "timeout_policy",
+        name: "timeoutPolicy",
+        label: "Timeout policy",
+        grow: 0.5,
+        tooltip: "The timeout policy of the workflow",
+      },
+      {
+        id: "timeout_seconds",
+        name: "timeoutSeconds",
+        label: "Timeout seconds",
+        grow: 0.5,
+        tooltip: "The timeout seconds of the workflow",
+      },
+      {
+        id: "failure_workflow",
+        name: "failureWorkflow",
+        label: "Failure workflow",
+        grow: 1,
+        tooltip: "The compensation workflow",
+      },
+      {
+        id: "executions_link",
+        name: "name",
+        label: "Executions",
+        sortable: false,
+        searchable: false,
+        grow: 0.5,
+        renderer: (name: string) => (
+          <NavLink
+            path={`${AGENT_EXECUTIONS_URL.BASE}?agentName=${encodeURIComponent(name.trim())}`}
+            newTab
+          >
+            Query
+          </NavLink>
+        ),
+        tooltip: "The executions of the workflow",
+      },
+      {
+        id: "actions",
+        name: "name",
+        label: "Actions",
+        sortable: false,
+        searchable: false,
+        grow: 0.5,
+        minWidth: "180px",
+        tooltip: "Actions you can perform on the workflow",
+        renderer: (_: string, agent: AgentSummary) => (
+          <Box style={{ display: "flex", justifyContent: "space-evenly" }}>
+            <Tooltip title="Run agent">
+              <IconButton
+                id={`run-${agent.name}-btn`}
+                disabled={isTrialExpired}
+                onClick={() =>
+                  navigate(RUN_AGENT_URL, {
+                    state: {
+                      agentName: agent.name,
+                      agentVersion: agent.version,
+                    },
+                  })
+                }
+                size="small"
+              >
+                <PlayIcon size={22} />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Copy agent definition">
+              <IconButton
+                id={`copy-${agent.name}-btn`}
+                disabled={isTrialExpired}
+                onClick={() =>
+                  copyAgentAction.mutate({
+                    method: "get",
+                    path: `/agent/${encodeURIComponent(agent.name)}?version=${agent.version}`,
+                  })
+                }
+                size="small"
+              >
+                <CopyIcon size={20} />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Delete workflow">
+              <IconButton
+                id={`delete-${agent.name}-btn`}
+                disabled={isTrialExpired}
+                onClick={() => setConfirmDelete(agent)}
+                size="small"
+              >
+                <DeleteIcon size={20} />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        ),
       },
     ],
-    [],
+    [copyAgentAction, isTrialExpired, navigate, tagsEnabled],
+  );
+
+  const handleFilterChange = useCallback(
+    (filter?: FilterObjectItem) =>
+      setFilterParam(filter ? JSON.stringify(filter) : ""),
+    [setFilterParam],
   );
 
   const tableData = useMemo<AgentSummary[]>(
@@ -83,14 +306,46 @@ export default function AgentDefinitions() {
   return (
     <>
       <Helmet>
-        <title>Agents</title>
+        <title>Agent Definitions</title>
       </Helmet>
+      {confirmDelete && (
+        <ConfirmChoiceDialog
+          handleConfirmationValue={(confirmed) => {
+            if (confirmed) {
+              deleteAgentAction.mutate({
+                method: "delete",
+                path: `/agent/${encodeURIComponent(confirmDelete.name)}?version=${confirmDelete.version}`,
+              });
+            }
+            setConfirmDelete(null);
+          }}
+          message={
+            <>
+              Are you sure you want to delete{" "}
+              <strong style={{ color: "red" }}>{confirmDelete.name}</strong>{" "}
+              workflow definition? This cannot be undone.
+              <div style={{ marginTop: "15px" }}>
+                Please type <strong>{confirmDelete.name}</strong> to confirm.
+              </div>
+            </>
+          }
+          header="Deletion confirmation"
+          isInputConfirmation
+          valueToBeDeleted={confirmDelete.name}
+        />
+      )}
       <SectionHeader
-        title="Agents"
         _deprecate_marginTop={0}
+        title="Agent Definitions"
         actions={
           <SectionHeaderActions
             buttons={[
+              {
+                label: "Run agent",
+                color: "secondary",
+                onClick: () => navigate(RUN_AGENT_URL),
+                startIcon: <PlayIcon />,
+              },
               {
                 label: "Create Agent",
                 color: "secondary",
@@ -98,35 +353,76 @@ export default function AgentDefinitions() {
                   navigate(
                     `${AGENT_DEFINITION_URL.NEW}?language=python&framework=native`,
                   ),
-                startIcon: <AddIcon />,
               },
             ]}
           />
         }
       />
       <SectionContainer>
-        {/*@ts-ignore*/}
-        <Paper variant="outlined">
+        <Paper id="workflow-definitions-table-wrapper" variant="outlined">
           <Header loading={isFetching} />
           <DataTable
             localStorageKey="agentDefinitionsTable"
             quickSearchEnabled
-            quickSearchPlaceholder="Search agents"
+            quickSearchPlaceholder="Search agent definitions"
+            searchTerm={searchParam}
+            onSearchTermChange={setSearchParam}
+            defaultShowColumns={[
+              "workflow_name",
+              "workflow_description",
+              ...(tagsEnabled ? ["workflow_tags"] : []),
+              "latest_version",
+              "create_time",
+              "owner_email",
+              "executions_link",
+              "actions",
+            ]}
             keyField="name"
+            onFilterChange={handleFilterChange}
+            initialFilterObj={filterObj}
             data={tableData}
             columns={columns}
-            customActions={[]}
+            customActions={[
+              <Tooltip
+                title="Refresh agent definitions"
+                key="refresh-agent-definitions"
+              >
+                <Button
+                  variant="text"
+                  color="inherit"
+                  size="small"
+                  onClick={refetch as () => void}
+                >
+                  Refresh
+                </Button>
+              </Tooltip>,
+            ]}
+            onChangePage={handlePageChange}
+            paginationDefaultPage={pageParam ? Number(pageParam) : 1}
             noDataComponent={
               <NoDataComponent
-                title="Agents"
+                title="Agent Definition"
                 description={INTRO_CONTENT}
-                buttonText="Refresh"
-                buttonHandler={() => refetch()}
+                buttonText="Create Agent"
+                buttonHandler={() =>
+                  navigate(
+                    `${AGENT_DEFINITION_URL.NEW}?language=python&framework=native`,
+                  )
+                }
               />
             }
           />
         </Paper>
       </SectionContainer>
+      {toastMessage && (
+        <SnackbarMessage
+          autoHideDuration={3000}
+          id="agent-definitions-toast-message"
+          message={toastMessage.text}
+          severity={toastMessage.severity}
+          onDismiss={() => setToastMessage(null)}
+        />
+      )}
     </>
   );
 }

--- a/ui-next/src/pages/agent/CloneAgentDialog.tsx
+++ b/ui-next/src/pages/agent/CloneAgentDialog.tsx
@@ -1,0 +1,161 @@
+import { yupResolver } from "@hookform/resolvers/yup";
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Grid,
+} from "@mui/material";
+import ActionButton from "components/ui/buttons/ActionButton";
+import Button from "components/ui/buttons/MuiButton";
+import ReactHookFormDropdown from "components/ui/react-hook-form/ReactHookFormDropdown";
+import ReactHookFormInput from "components/ui/react-hook-form/ReactHookFormInput";
+import { useMemo } from "react";
+import { DefaultValues, SubmitHandler, useForm } from "react-hook-form";
+import { WORKFLOW_NAME_ERROR_MESSAGE } from "utils/constants/common";
+import { WORKFLOW_NAME_REGEX } from "utils/constants/regex";
+import { useActionWithPath, useFetch } from "utils/query";
+import { getSequentiallySuffix } from "utils/strings";
+import * as yup from "yup";
+import { AgentSummary } from "./types";
+
+interface DialogData {
+  name: string;
+  version: number;
+}
+
+interface CloneAgentDialogProps {
+  selectedAgent: AgentSummary;
+  agentList: AgentSummary[];
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+/**
+ * Mirrors the workflow clone dialog while deploying the source agent definition under a new name.
+ */
+export default function CloneAgentDialog({
+  selectedAgent,
+  agentList,
+  onClose,
+  onSuccess,
+}: CloneAgentDialogProps) {
+  const { data: agentDefinitions = [] } = useFetch<AgentSummary[]>(
+    "/metadata/workflow?short=true&metadata=true&classifier=agent",
+  );
+  const agentNames = useMemo(
+    () => Array.from(new Set(agentList.map((agent) => agent.name))),
+    [agentList],
+  );
+  const { name: suffixedAgentName } = getSequentiallySuffix({
+    name: selectedAgent.name,
+    refNames: agentNames,
+  });
+  const agentVersions = useMemo(() => {
+    const versions = agentDefinitions
+      .filter((agent) => agent.name === selectedAgent.name)
+      .map((agent) => agent.version);
+    return versions.length > 0 ? versions : [selectedAgent.version];
+  }, [agentDefinitions, selectedAgent]);
+  const formSchema: yup.ObjectSchema<DialogData> = yup.object().shape({
+    name: yup
+      .string()
+      .required("Name cannot be blank.")
+      .matches(WORKFLOW_NAME_REGEX, WORKFLOW_NAME_ERROR_MESSAGE)
+      .notOneOf(agentNames, "This name is existing."),
+    version: yup
+      .number()
+      .required("Version cannot be blank.")
+      .typeError("Version cannot be blank."),
+  });
+  const defaultValues: DefaultValues<DialogData> = {
+    name: suffixedAgentName,
+    version: selectedAgent.version,
+  };
+  const {
+    control,
+    handleSubmit,
+    watch,
+    formState: { errors: formErrors, isValid },
+  } = useForm<DialogData>({
+    mode: "onChange",
+    resolver: yupResolver(formSchema),
+    defaultValues,
+  });
+  const selectedVersion = watch("version");
+  const { data: sourceDefinition, isFetching } = useFetch<
+    Record<string, unknown>
+  >(
+    `/agent/${encodeURIComponent(selectedAgent.name)}?version=${selectedVersion}`,
+    { when: Number.isInteger(selectedVersion) },
+  );
+  const deployAgentAction = useActionWithPath({ onSuccess });
+  const onSubmit: SubmitHandler<DialogData> = ({ name }) => {
+    if (!sourceDefinition) {
+      return;
+    }
+    deployAgentAction.mutate({
+      method: "post",
+      path: "/agent/deploy",
+      body: JSON.stringify({ agentConfig: { ...sourceDefinition, name } }),
+    });
+  };
+
+  return (
+    <Dialog fullWidth maxWidth="sm" open onClose={onClose}>
+      <DialogTitle>Clone Agent Confirmation</DialogTitle>
+      <DialogContent>
+        <Grid container sx={{ width: "100%" }} spacing={5} pt={5}>
+          <Grid size={12}>
+            <ReactHookFormInput
+              id="agent-name-field"
+              name="name"
+              control={control}
+              fullWidth
+              label="Agent name"
+              required
+              error={!!formErrors?.name?.message}
+              helperText={formErrors?.name?.message}
+              spellCheck={false}
+            />
+          </Grid>
+          <Grid size={12}>
+            <ReactHookFormDropdown
+              id="agent-version-field"
+              name="version"
+              control={control}
+              fullWidth
+              label="Version"
+              required
+              getOptionLabel={(option) => option?.toString()}
+              options={agentVersions}
+              error={!!formErrors?.version?.message}
+              helperText={formErrors?.version?.message}
+            />
+          </Grid>
+        </Grid>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          id="cancel-btn"
+          variant="contained"
+          color="secondary"
+          onClick={onClose}
+        >
+          Cancel
+        </Button>
+        <ActionButton
+          id="confirm-clone-btn"
+          variant="contained"
+          color="primary"
+          sx={{ fontSize: 14, lineHeight: 1.5 }}
+          onClick={() => handleSubmit(onSubmit)()}
+          disabled={!isValid || isFetching}
+          progress={deployAgentAction.isLoading}
+        >
+          Clone
+        </ActionButton>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/ui-next/src/pages/agent/RunAgent.tsx
+++ b/ui-next/src/pages/agent/RunAgent.tsx
@@ -9,7 +9,7 @@ import ConductorInput from "components/ui/inputs/ConductorInput";
 import SectionContainer from "components/ui/layout/SectionContainer";
 import { useState } from "react";
 import { Helmet } from "react-helmet";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { AGENT_EXECUTIONS_URL } from "utils/constants/route";
 import { useAction, useFetch } from "utils/query";
 import { useLocalStorage } from "utils";
@@ -33,8 +33,16 @@ type AgentRunHistory = {
 /** Starts a deployed agent through POST /api/agent/start. */
 export default function RunAgent() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const selectedAgent = location.state as {
+    agentName?: string;
+    agentVersion?: number;
+  } | null;
   const { data: agents = [] } = useFetch<AgentSummary[]>("/agent/list");
-  const [agentName, setAgentName] = useState("");
+  const [agentName, setAgentName] = useState(selectedAgent?.agentName || "");
+  const [agentVersion, setAgentVersion] = useState<number | undefined>(
+    selectedAgent?.agentVersion,
+  );
   const [model, setModel] = useState("");
   const [prompt, setPrompt] = useState("");
   const [started, setStarted] = useState<AgentStartResponse>();
@@ -77,6 +85,7 @@ export default function RunAgent() {
 
   const reset = () => {
     setAgentName("");
+    setAgentVersion(undefined);
     setModel("");
     setPrompt("");
     setStarted(undefined);
@@ -91,6 +100,7 @@ export default function RunAgent() {
     startAgent({
       body: JSON.stringify({
         name: agentName,
+        version: agentVersion,
         model: model.trim() || undefined,
         prompt,
       }),
@@ -179,9 +189,10 @@ export default function RunAgent() {
                     label="Agent"
                     options={agentNames}
                     value={agentName}
-                    onChange={(_: unknown, value: string | null) =>
-                      setAgentName(value || "")
-                    }
+                    onChange={(_: unknown, value: string | null) => {
+                      setAgentName(value || "");
+                      setAgentVersion(undefined);
+                    }}
                     required
                     autoFocus
                   />

--- a/ui-next/src/pages/agent/types.ts
+++ b/ui-next/src/pages/agent/types.ts
@@ -12,6 +12,15 @@ export interface AgentSummary {
   updateTime?: number;
   description?: string;
   checksum?: string;
+  schemaVersion?: number;
+  restartable?: boolean;
+  workflowStatusListenerEnabled?: boolean;
+  ownerEmail?: string;
+  inputParameters?: string[];
+  outputParameters?: Record<string, unknown>;
+  timeoutPolicy?: string;
+  timeoutSeconds?: number;
+  failureWorkflow?: string;
 }
 
 export interface AgentExecutionSummary {

--- a/ui-next/src/pages/definitions/Workflow.tsx
+++ b/ui-next/src/pages/definitions/Workflow.tsx
@@ -65,7 +65,7 @@ export default function WorkflowDefinitions() {
   const isPlayground = featureFlags.isEnabled(FEATURES.PLAYGROUND);
   const tagsEnabled = featureFlags.isEnabled(FEATURES.TAG_VISIBILITY);
   const { data, isFetching, refetch }: UseQueryResult<WorkflowDef[]> =
-    useWorkflowDefs();
+    useWorkflowDefs({}, "workflow");
   const [showAddTagDialog, setShowAddTagDialog] = useState(false);
   const [addTagDialogData, setAddTagDialogData] =
     useState<TagDialogProps | null>(null);

--- a/ui-next/src/pages/definitions/Workflow.tsx
+++ b/ui-next/src/pages/definitions/Workflow.tsx
@@ -494,7 +494,7 @@ export default function WorkflowDefinitions() {
               localStorageKey="workflowsTable"
               quickSearchEnabled
               quickSearchPlaceholder="Search workflow definitions"
-              searchTerm={searchParam}
+              searchTerm={searchParam ?? ""}
               onSearchTermChange={setSearchParam}
               defaultShowColumns={[
                 "workflow_name",

--- a/ui-next/src/utils/query.ts
+++ b/ui-next/src/utils/query.ts
@@ -463,8 +463,12 @@ export function useUsersListing(includeApps = false) {
 
 export function useWorkflowDefs(
   optionsOverride: Partial<UseQueryOptions<WorkflowDef[], FetchError>> = {},
+  classifier?: "workflow" | "agent",
 ): UseQueryResult<WorkflowDef[], FetchError> {
-  return useFetch<WorkflowDef[]>(WORKFLOW_METADATA_SHORT_URL, {
+  const path = classifier
+    ? `${WORKFLOW_METADATA_SHORT_URL}&classifier=${classifier}`
+    : WORKFLOW_METADATA_SHORT_URL;
+  return useFetch<WorkflowDef[]>(path, {
     staleTime: DEFAULT_STALE_TIME,
     ...optionsOverride,
   });


### PR DESCRIPTION
## Summary
- Make **Agent Definitions** match the **Workflow Definitions** experience: the same default columns, filtering, pagination, refresh control, and table layout.
- Surface the compiled workflow metadata needed by those shared columns, including creation time; agent registrations now preserve a real creation timestamp.
- Add matching row actions: run the selected agent version, clone through the workflow-style clone dialog, and confirm deletion.
- Keep the pages correctly separated by classifier: agent definitions no longer appear in Workflow Definitions.

Fixes #1305
Fixes orkes-io/orkes-conductor#3846

## Manual UI evidence
Captured in headless Chromium against the local UI (`http://localhost:1234`) on 2026-07-28. Upload the screenshots below in order by replacing each placeholder.

### 1. Play triggers an agent workflow
The Play action opened the run form and triggered a real `greeter` execution. The execution view displayed the generated workflow/execution ID and a running agent task.

<img width="1600" height="1000" alt="01-play-agent-execution" src="https://github.com/user-attachments/assets/0255379c-9645-40e7-83f6-4176d4e5afe0" />


### 2. Clone opens the dialog

<img width="1600" height="1000" alt="02-clone-dialog" src="https://github.com/user-attachments/assets/b5980cc3-004e-4567-a764-5c2fe4e496f9" />


### 3. Clone creates the agent definition
The clone operation created `greeter_1`, which appeared in Agent Definitions.

<img width="1600" height="1000" alt="03-clone-created" src="https://github.com/user-attachments/assets/4857e897-ca57-4692-92a4-44ceba004f96" />

### 4. Delete removes the agent definition
Deleting `greeter_1` displayed the success toast and removed it from the table, leaving only the original `greeter`.

<img width="1600" height="1000" alt="04-delete-agent-definition" src="https://github.com/user-attachments/assets/b983f6d3-cf03-4bb7-ac09-c2a441e338b4" />

### 5. Workflow Definitions excludes agent definitions
Workflow Definitions no longer contains agent-classified definitions.

<img width="1777" height="615" alt="image" src="https://github.com/user-attachments/assets/cdf68a7c-14ea-4124-8bf6-ab17205cf57c" />


## Validation
- `./gradlew spotlessApply`
- `./gradlew :conductor-agentspan:test --tests "*AgentService*"`
- `pnpm --dir ui-next test --run src/pages/agent/AgentDefinitions.test.tsx`
- `pnpm --dir ui-next typecheck`
- `pnpm --dir ui-next lint`