### PR TITLE
refactor(ai): consolidate Conductor-Agents configuration

### DIFF
--- a/agentspan/build.gradle
+++ b/agentspan/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compileOnly 'org.springframework.boot:spring-boot-starter'
-    // Needed to compile A2A push-notification callback controller and AgentSpan activation glue;
+    // Needed to compile A2A push-notification callback controller and Conductor-Agents activation glue;
     // supplied by the server at runtime.
     compileOnly 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.springframework.boot:spring-boot-autoconfigure'
@@ -12,7 +12,7 @@ dependencies {
     // Exercise the adapters against a real persisted backend rather than mocked DAOs.
     testImplementation project(':conductor-sqlite-persistence')
 
-    // AgentSpan's real event listener depends on its SSE registry at test runtime.
+    // Conductor-Agents' real event listener depends on its SSE registry at test runtime.
     testImplementation 'org.springframework:spring-webmvc'
 
     testImplementation 'org.graalvm.polyglot:polyglot:25.0.2'
@@ -20,11 +20,11 @@ dependencies {
 
 }
 
-// AgentSpan spans three test JVMs: focused module tests, deterministic real-engine coverage, and
-// a mandatory live-provider suite. Merge their execution files while reporting only AgentSpan
+// Conductor-Agents spans three test JVMs: focused module tests, deterministic real-engine coverage, and
+// a mandatory live-provider suite. Merge their execution files while reporting only Conductor-Agents
 // production classes so the coverage number reflects deploy/start/MCP and actual model-tool turns.
 tasks.register('agentspanEndToEndCoverage', JacocoReport) {
-    description = 'Reports AgentSpan coverage from module, deterministic, and live real-E2E test runs'
+    description = 'Reports Conductor-Agents coverage from module, deterministic, and live real-E2E test runs'
     group = 'verification'
     dependsOn test, ':conductor-test-harness:agentspanDeterministicE2E', ':conductor-test-harness:agentspanRealE2E'
 

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/ConductorAgentSpanConfiguration.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/ConductorAgentSpanConfiguration.java
@@ -31,7 +31,8 @@ public class ConductorAgentSpanConfiguration {
     private final ObjectMapper objectMapper = new ObjectMapperProvider().getObjectMapper();
 
     /**
-     * Bridges AgentSpan's skill-metadata SPI to Conductor's per-backend {@code SkillMetadataDAO}.
+     * Bridges Conductor-Agents' skill-metadata SPI to Conductor's per-backend {@code
+     * SkillMetadataDAO}.
      */
     @Bean
     public SkillMetadataDAO agentSpanSkillMetadataDAO(

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/SkillMetadataDaoAdapter.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/SkillMetadataDaoAdapter.java
@@ -22,10 +22,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
- * Bridges AgentSpan's {@link SkillMetadataDAO} SPI onto Conductor's backend-agnostic {@link
+ * Bridges Conductor-Agents' {@link SkillMetadataDAO} SPI onto Conductor's backend-agnostic {@link
  * org.conductoross.conductor.dao.SkillMetadataDAO}. The {@link SkillDetail} manifest is serialized
- * to JSON for storage so the persistence layer carries no dependency on AgentSpan model types; it
- * is rehydrated on read.
+ * to JSON for storage so the persistence layer carries no dependency on Conductor-Agents model
+ * types; it is rehydrated on read.
  *
  * <p>OSS Conductor is single-tenant, so skills share one global namespace and neither side of the
  * adapter is owner-scoped.

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/SkillPackageStoreAdapter.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/SkillPackageStoreAdapter.java
@@ -17,7 +17,7 @@ import org.conductoross.conductor.ai.agentspan.runtime.spi.StoredSkillPackage;
 import org.conductoross.conductor.dao.SkillPackageDAO;
 
 /**
- * Bridges AgentSpan's {@link SkillPackageStore} SPI onto Conductor's backend-agnostic {@link
+ * Bridges Conductor-Agents' {@link SkillPackageStore} SPI onto Conductor's backend-agnostic {@link
  * SkillPackageDAO}, so skill package bytes persist through whichever Conductor backend is
  * configured (Postgres, MySQL, SQLite, Redis).
  *

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/listener/AgentSpanCompositeTaskStatusListener.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/listener/AgentSpanCompositeTaskStatusListener.java
@@ -25,12 +25,11 @@ import com.netflix.conductor.model.TaskModel;
  * A {@link TaskStatusListener} that fans every callback out to all other {@code TaskStatusListener}
  * beans in the context.
  *
- * <p>The motivation mirrors {@link AgentSpanCompositeWorkflowStatusListener}: Conductor injects a
- * <b>single</b> {@code TaskStatusListener} bean, so the embedded {@code conductor-agentspan}
- * library's {@code @Primary AgentEventListener} would otherwise shadow an operator-configured
- * {@code task_publisher}. Registering this composite as the sole {@code @Primary} listener and
- * re-broadcasting to every registered listener lets agentspan's SSE listener and the configured
- * publisher coexist.
+ * <p>The motivation mirrors the workflow-status composite: Conductor injects a <b>single</b> {@code
+ * TaskStatusListener} bean, so the embedded {@code conductor-agentspan} library's {@code @Primary
+ * AgentEventListener} would otherwise shadow an operator-configured {@code task_publisher}.
+ * Registering this composite as the sole {@code @Primary} listener and re-broadcasting to every
+ * registered listener lets agentspan's SSE listener and the configured publisher coexist.
  *
  * <p>Each callback delegates to the <b>same</b> method on every other listener so each delegate
  * keeps its own gating semantics. The composite excludes itself to avoid recursion and isolates

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/listener/AgentSpanListenerCoexistenceConfiguration.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/listener/AgentSpanListenerCoexistenceConfiguration.java
@@ -37,17 +37,13 @@ import com.netflix.conductor.core.listener.WorkflowStatusListener;
  * conductor.integrations.ai.enabled} defaults to {@code true}, so this would affect default
  * servers.
  *
- * <p>Active only in embedded mode ({@code agentspan.embedded=true}, which {@code
- * application.properties} derives from {@code conductor.integrations.ai.enabled}), this
- * configuration:
+ * <p>Active only when {@code conductor.integrations.ai.enabled=true}, this configuration:
  *
  * <ol>
  *   <li>demotes agentspan's {@code AgentEventListener} from {@code @Primary} (via a {@link
  *       BeanFactoryPostProcessor} that edits the bean definition before instantiation), and
- *   <li>registers composite {@code @Primary} listeners ({@link
- *       AgentSpanCompositeWorkflowStatusListener}, {@link AgentSpanCompositeTaskStatusListener})
- *       that fan every callback out to <i>all</i> registered listeners — agentspan's listener and
- *       the configured publisher alike.
+ *   <li>registers composite {@code @Primary} listeners that fan every callback out to <i>all</i>
+ *       registered listeners — agentspan's listener and the configured publisher alike.
  * </ol>
  *
  * <p>The composite becomes the sole {@code @Primary} candidate, so the single-bean injection points
@@ -55,7 +51,7 @@ import com.netflix.conductor.core.listener.WorkflowStatusListener;
  * receives every event.
  */
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnProperty(name = "agentspan.embedded", havingValue = "true")
+@ConditionalOnProperty(name = "conductor.integrations.ai.enabled", havingValue = "true")
 public class AgentSpanListenerCoexistenceConfiguration {
 
     private static final Logger LOGGER =

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/ai/AgentChatCompleteTaskMapper.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/ai/AgentChatCompleteTaskMapper.java
@@ -453,7 +453,8 @@ public class AgentChatCompleteTaskMapper extends AIModelTaskMapper<ChatCompletio
                     String toolRefName = toolCall.getTaskReferenceName();
                     List<TaskModel> toolModels =
                             refNameToTask.getOrDefault(toolRefName, new ArrayList<>());
-                    // AgentSpan dispatches tool calls with FORK_JOIN_DYNAMIC. The LLM gives the
+                    // Conductor-Agents dispatches tool calls with FORK_JOIN_DYNAMIC. The LLM gives
+                    // the
                     // logical call ref (for example, toolu_abc); Conductor assigns each dynamic
                     // branch a stable descendant ref (toolu_abc_0). Match those descendants so
                     // the next LLM turn receives the tool response instead of retrying the call.

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/ai/AgentspanAIModelProvider.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/ai/AgentspanAIModelProvider.java
@@ -94,8 +94,8 @@ public class AgentspanAIModelProvider extends AIModelProvider {
 
     /**
      * Spring constructor. The native credential resolution service is <em>optional</em>: when
-     * {@code agentspan.embedded=true} it is gated off (the host delivers secrets), so it resolves
-     * to {@code null} here and native resolution is skipped.
+     * {@code conductor.integrations.ai.enabled=true} it is gated off (the host delivers secrets),
+     * so it resolves to {@code null} here and native resolution is skipped.
      */
     @Autowired
     public AgentspanAIModelProvider(

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/MultiAgentCompiler.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/MultiAgentCompiler.java
@@ -2406,7 +2406,7 @@ public class MultiAgentCompiler {
         routerWf.setInputParameters(List.of("conversation"));
         routerWf.setTasks(List.of(llm));
         routerWf.setOutputParameters(Map.of("result", ref(taskRef + "_llm.output.result")));
-        // Routers are implementation details of an AgentSpan execution.  Stamping the inline
+        // Routers are implementation details of a Conductor-Agents execution. Stamping the inline
         // definition preserves that identity in the execution index, where parentWorkflowId
         // distinguishes this generated child from the top-level agent run.
         agentCompiler.stampAgentMetadata(routerWf, parentAgent);

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/ToolCompiler.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/ToolCompiler.java
@@ -175,7 +175,7 @@ public class ToolCompiler {
             spec.put("name", tool.getName());
             spec.put("type", conductorType);
             spec.put("description", tool.getDescription());
-            // Every AgentSpan spec is complete as compiled (name + description
+            // Every Conductor-Agents spec is complete as compiled (name + description
             // + inputSchema inline). The marker tells spec consumers — notably
             // orkes-conductor's OrkesLLM — to hand it to the LLM as-is and
             // never resolve/replace it by name against integration stores.

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/config/AgentSpanAutoConfiguration.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/config/AgentSpanAutoConfiguration.java
@@ -18,26 +18,25 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 
 /**
- * Registers the AgentSpan beans by component-scanning the {@code
+ * Registers the Conductor-Agents beans by component-scanning the {@code
  * org.conductoross.conductor.ai.agentspan.runtime} namespace — agent domain, compilers, services,
  * controllers, system tasks, and whichever SPI implementations are present on the classpath.
  *
  * <p>Loaded via {@code
  * META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports}, so an
  * embedding host (e.g. the Conductor server, orkes-conductor) gets the beans without adding the
- * AgentSpan runtime packages to its own component scan.
+ * Conductor-Agents runtime packages to its own component scan.
  *
  * <p><b>Activation contract.</b> Merely having this library on the classpath must not change a host
- * application's behavior. The configuration activates only when the host explicitly opts in with
- * {@code agentspan.embedded=true} (the Conductor server derives this from {@code
- * conductor.integrations.ai.enabled}). Without the flag, the host runs as stock Conductor — no
- * AgentSpan beans, controllers, or system-task overrides are registered.
+ * application's behavior. The configuration activates only when the host explicitly enables {@code
+ * conductor.integrations.ai.enabled=true}. Without the flag, the host runs as stock Conductor — no
+ * Conductor-Agents beans, controllers, or system-task overrides are registered.
  *
  * <p>Excludes this class from the scan, since it is processed directly as an auto-configuration
  * rather than as a component-scanned candidate.
  */
 @AutoConfiguration
-@ConditionalOnProperty(name = "agentspan.embedded", havingValue = "true")
+@ConditionalOnProperty(name = "conductor.integrations.ai.enabled", havingValue = "true")
 @ComponentScan(
         basePackages = "org.conductoross.conductor.ai.agentspan.runtime",
         excludeFilters = {

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/context/RequestContext.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/context/RequestContext.java
@@ -22,10 +22,10 @@ import lombok.NoArgsConstructor;
 /**
  * Per-request principal context stored in a ThreadLocal for the duration of each request.
  *
- * <p>Carries the resolved {@code userId} used for per-user secret scoping. AgentSpan defines no
- * identity model of its own — the host populates this: the standalone server's {@code AuthFilter}
- * sets an anonymous id, while an embedding application (e.g. orkes-conductor) supplies its own
- * principal id.
+ * <p>Carries the resolved {@code userId} used for per-user secret scoping. Conductor-Agents defines
+ * no identity model of its own — the host populates this: the standalone server's {@code
+ * AuthFilter} sets an anonymous id, while an embedding application (e.g. orkes-conductor) supplies
+ * its own principal id.
  */
 @Data
 @Builder

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/controller/AgentController.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/controller/AgentController.java
@@ -40,7 +40,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping({"/api/agent"})
 @RequiredArgsConstructor
-@ConditionalOnProperty(name = "agentspan.embedded", havingValue = "true")
+@ConditionalOnProperty(name = "conductor.integrations.ai.enabled", havingValue = "true")
 public class AgentController {
 
     private final AgentService agentService;

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/controller/ProviderController.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/controller/ProviderController.java
@@ -54,7 +54,7 @@ import okhttp3.Response;
 @RestController
 @RequestMapping("/api/providers")
 @RequiredArgsConstructor
-@ConditionalOnProperty(name = "agentspan.embedded", havingValue = "true")
+@ConditionalOnProperty(name = "conductor.integrations.ai.enabled", havingValue = "true")
 public class ProviderController {
 
     /** Providers surfaced in status, aligned with the docs' provider list. */

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/controller/SecretController.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/controller/SecretController.java
@@ -49,7 +49,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/secrets")
 @RequiredArgsConstructor
-@ConditionalOnProperty(name = "agentspan.embedded", havingValue = "true")
+@ConditionalOnProperty(name = "conductor.integrations.ai.enabled", havingValue = "true")
 public class SecretController {
 
     private static final Logger log = LoggerFactory.getLogger(SecretController.class);

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/controller/SkillController.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/controller/SkillController.java
@@ -40,7 +40,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/skills")
 @RequiredArgsConstructor
 @ConditionalOnProperty(
-        name = {"agentspan.embedded", "agentspan.skills.enabled"},
+        name = {"conductor.integrations.ai.enabled", "agentspan.skills.enabled"},
         havingValue = "true")
 public class SkillController {
 

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/credentials/CredentialResolutionService.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/credentials/CredentialResolutionService.java
@@ -47,7 +47,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * os.environ} fallback when {@code secret_strict_mode=false}.
  */
 @Service
-@ConditionalOnProperty(name = "agentspan.embedded", havingValue = "true")
+@ConditionalOnProperty(name = "conductor.integrations.ai.enabled", havingValue = "true")
 public class CredentialResolutionService {
 
     private static final Logger log = LoggerFactory.getLogger(CredentialResolutionService.class);

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/credentials/KnownProviderEnvVars.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/credentials/KnownProviderEnvVars.java
@@ -15,16 +15,13 @@ package org.conductoross.conductor.ai.agentspan.runtime.credentials;
 import java.util.List;
 
 /**
- * Single source of truth for the well-known LLM/tool provider environment variables that AgentSpan
- * auto-seeds into the credential store on startup.
+ * Single source of truth for the well-known LLM/tool provider environment variables that
+ * Conductor-Agents auto-seeds into the credential store on startup.
  *
  * <p>Shared so every deployment seeds the same set: the standalone server's {@code
  * CredentialEnvSeeder} and any embedding host (e.g. orkes-conductor) reference this list instead of
  * maintaining their own copies. Keeping one list avoids drift between standalone and embedded
  * behavior.
- *
- * <p>{@code AGENTSPAN_MASTER_KEY} is intentionally excluded — it is the encryption master key and
- * must never be stored as a credential.
  */
 public final class KnownProviderEnvVars {
 

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentEventListener.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentEventListener.java
@@ -41,7 +41,7 @@ import io.micrometer.core.instrument.MeterRegistry;
  */
 @Component
 @Primary
-@ConditionalOnProperty(name = "agentspan.embedded", havingValue = "true")
+@ConditionalOnProperty(name = "conductor.integrations.ai.enabled", havingValue = "true")
 public class AgentEventListener implements TaskStatusListener, WorkflowStatusListener {
 
     private static final Logger logger = LoggerFactory.getLogger(AgentEventListener.class);

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentHumanTask.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentHumanTask.java
@@ -36,11 +36,11 @@ import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_HUM
  * {@code start()} to emit the SSE event directly.
  *
  * <p>Registered as the {@code HUMAN} system task by {@link AgentHumanTaskConfig}, which is gated on
- * {@code agentspan.embedded=true}. It is intentionally not a {@code @Component}: two beans named
- * {@code HUMAN} (this one and Conductor's {@code Human}) would collide during component scanning,
- * and both would land in {@code SystemTaskRegistry}'s taskType→task map as duplicate keys. The
- * config's {@code @Bean("HUMAN")} instead <em>overrides</em> Conductor's default so exactly one
- * {@code HUMAN} bean exists.
+ * {@code conductor.integrations.ai.enabled=true}. It is intentionally not a {@code @Component}: two
+ * beans named {@code HUMAN} (this one and Conductor's {@code Human}) would collide during component
+ * scanning, and both would land in {@code SystemTaskRegistry}'s taskType→task map as duplicate
+ * keys. The config's {@code @Bean("HUMAN")} instead <em>overrides</em> Conductor's default so
+ * exactly one {@code HUMAN} bean exists.
  */
 public class AgentHumanTask extends WorkflowSystemTask {
 

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentHumanTaskConfig.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentHumanTaskConfig.java
@@ -21,7 +21,7 @@ import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_HUM
 
 /**
  * Registers {@link AgentHumanTask} as the {@code HUMAN} system task when running in embedded mode
- * ({@code agentspan.embedded=true}).
+ * ({@code conductor.integrations.ai.enabled=true}).
  *
  * <p>The {@code @Bean("HUMAN")} definition <em>overrides</em> Conductor's default {@code Human}
  * component (enabled via {@code spring.main.allow-bean-definition-overriding=true}), so exactly one
@@ -29,11 +29,11 @@ import static com.netflix.conductor.common.metadata.tasks.TaskType.TASK_TYPE_HUM
  * duplicate taskType key in {@code SystemTaskRegistry} that would otherwise result from having two
  * {@code WorkflowSystemTask}s both reporting the {@code HUMAN} type.
  *
- * <p>When {@code agentspan.embedded} is unset (the standalone OSS server), this configuration is
- * skipped and Conductor's default {@code Human} task remains in effect.
+ * <p>When {@code conductor.integrations.ai.enabled} is disabled, this configuration is skipped and
+ * Conductor's default {@code Human} task remains in effect.
  */
 @Configuration
-@ConditionalOnProperty(name = "agentspan.embedded", havingValue = "true")
+@ConditionalOnProperty(name = "conductor.integrations.ai.enabled", havingValue = "true")
 public class AgentHumanTaskConfig {
 
     @Bean(TASK_TYPE_HUMAN)

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentService.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentService.java
@@ -56,7 +56,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor
-@ConditionalOnProperty(name = "agentspan.embedded", havingValue = "true")
+@ConditionalOnProperty(name = "conductor.integrations.ai.enabled", havingValue = "true")
 @Slf4j
 public class AgentService {
 
@@ -353,7 +353,8 @@ public class AgentService {
         for (WorkflowDef def : allDefs) {
             Map<String, Object> metadata = def.getMetadata();
             // A def is an agent when its derived classifier resolves to "agent": either the
-            // AgentSpan stamp (agent_sdk/agentDef) is present, or the def carries an explicit
+            // Conductor-Agents stamp (agent_sdk/agentDef) is present, or the def carries an
+            // explicit
             // metadata.classifier=agent tag. An explicit non-agent classifier excludes a def
             // even if it still carries a stamp.
             if (!WorkflowClassifiers.isAgent(metadata)) {

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/ServiceConductorAgentClient.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/ServiceConductorAgentClient.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * HTTP calls through {@code AgentController}.
  */
 @Component
-@ConditionalOnProperty(name = "agentspan.embedded", havingValue = "true")
+@ConditionalOnProperty(name = "conductor.integrations.ai.enabled", havingValue = "true")
 public class ServiceConductorAgentClient implements ConductorAgentClient {
 
     private final AgentService agentService;

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/SkillRegistryService.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/SkillRegistryService.java
@@ -57,7 +57,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Component
-@ConditionalOnProperty(name = "agentspan.embedded", havingValue = "true")
+@ConditionalOnProperty(name = "conductor.integrations.ai.enabled", havingValue = "true")
 public class SkillRegistryService {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/util/EmbeddedMode.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/util/EmbeddedMode.java
@@ -16,10 +16,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
- * Captures whether AgentSpan is running embedded in a host (e.g. orkes-conductor) into a static
- * flag, so compile-time code reached through plain (non-Spring) helpers — e.g. {@code ToolCompiler}
- * — can branch on it. Populated once at startup from the {@code agentspan.embedded} property
- * (default {@code false} for the standalone server). Compilation is request-driven, so the value is
+ * Captures whether Conductor-Agents is running embedded in a host (e.g. orkes-conductor) into a
+ * static flag, so compile-time code reached through plain (non-Spring) helpers — e.g. {@code
+ * ToolCompiler} — can branch on it. Populated once at startup from the {@code
+ * conductor.integrations.ai.enabled} property. Compilation is request-driven, so the value is
  * always set before any compile runs.
  */
 @Component
@@ -27,8 +27,8 @@ public class EmbeddedMode {
 
     private static volatile boolean embedded = false;
 
-    @Value("${agentspan.embedded:false}")
-    public void setEmbedded(boolean value) {
+    @Value("${conductor.integrations.ai.enabled:false}")
+    public void setAiIntegrationEnabled(boolean value) {
         embedded = value;
     }
 

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/util/JavaScriptBuilder.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/util/JavaScriptBuilder.java
@@ -461,8 +461,8 @@ public class JavaScriptBuilder {
     }
 
     /**
-     * Normalize a framework/custom guardrail worker result into AgentSpan's internal guardrail
-     * contract.
+     * Normalize a framework/custom guardrail worker result into Conductor-Agents' internal
+     * guardrail contract.
      */
     public static String customGuardrailNormalizeScript() {
         return iife(
@@ -1279,7 +1279,8 @@ public class JavaScriptBuilder {
                             + "    specs.push({name: t.name, type: 'CALL_MCP_TOOL',"
                             + "      description: t.description || '',"
                             + "      inputSchema: _json(t.inputSchema || {type:'object',properties:{}}),"
-                            // Keep the dynamic MCP path equivalent to static AgentSpan tool specs.
+                            // Keep the dynamic MCP path equivalent to static Conductor-Agents tool
+                            // specs.
                             + "      selfDescribing: true,"
                             + "      configParams: {mcpServer: s.serverUrl, headers: s.headers || {}, selfDescribing: true}});"
                             + "    mcpCfg[t.name] = {mcpServer: s.serverUrl, headers: s.headers || {}};"

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/util/WorkflowClassifiers.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/util/WorkflowClassifiers.java
@@ -20,15 +20,15 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
  * Derives the <b>classifier</b> of a workflow definition from its {@code metadata} map.
  *
  * <p>The classifier distinguishes kinds of definitions/executions: an untagged def is a plain
- * <b>workflow</b>; AgentSpan-compiled defs are tagged <b>agent</b>. A def may also carry any
+ * <b>workflow</b>; Conductor-Agents-compiled defs are tagged <b>agent</b>. A def may also carry any
  * explicit {@code metadata.classifier} value, enabling future kinds without code changes.
  *
  * <p>Resolution order:
  *
  * <ol>
  *   <li>explicit {@code metadata.classifier} (non-blank) — wins;
- *   <li>otherwise {@code "agent"} when the AgentSpan stamp is present ({@code metadata.agent_sdk}
- *       or {@code metadata.agentDef});
+ *   <li>otherwise {@code "agent"} when the Conductor-Agents stamp is present ({@code
+ *       metadata.agent_sdk} or {@code metadata.agentDef});
  *   <li>otherwise {@code "workflow"} (a normal, untagged workflow).
  * </ol>
  *

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/ConductorAgentSpanConfigurationIntegrationTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/ConductorAgentSpanConfigurationIntegrationTest.java
@@ -44,8 +44,8 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 /**
- * Integration coverage for the AgentSpan host configuration and both persistence adapters. The
- * tests cross the complete adapter boundary into a real SQLite database; no DAO is mocked.
+ * Integration coverage for the Conductor-Agents host configuration and both persistence adapters.
+ * The tests cross the complete adapter boundary into a real SQLite database; no DAO is mocked.
  */
 class ConductorAgentSpanConfigurationIntegrationTest {
 

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/listener/AgentSpanListenerCoexistenceConfigurationIntegrationTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/listener/AgentSpanListenerCoexistenceConfigurationIntegrationTest.java
@@ -30,8 +30,8 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Boots the coexistence configuration with AgentSpan's real primary listener and proves that the
- * composite becomes the injection target while both real listeners still receive callbacks.
+ * Boots the coexistence configuration with Conductor-Agents' real primary listener and proves that
+ * the composite becomes the injection target while both real listeners still receive callbacks.
  */
 class AgentSpanListenerCoexistenceConfigurationIntegrationTest {
 
@@ -39,7 +39,7 @@ class AgentSpanListenerCoexistenceConfigurationIntegrationTest {
     void embeddedContextDemotesAgentListenerAndSelectsCompositesAsPrimary() {
         try (AnnotationConfigApplicationContext context =
                 new AnnotationConfigApplicationContext()) {
-            TestPropertyValues.of("agentspan.embedded=true").applyTo(context);
+            TestPropertyValues.of("conductor.integrations.ai.enabled=true").applyTo(context);
             context.register(AgentSpanListenerCoexistenceConfiguration.class);
             context.registerBean(AgentStreamRegistry.class);
             context.registerBean(MeterRegistry.class, SimpleMeterRegistry::new);
@@ -74,7 +74,7 @@ class AgentSpanListenerCoexistenceConfigurationIntegrationTest {
     void nonEmbeddedContextDoesNotRegisterCoexistenceBeans() {
         try (AnnotationConfigApplicationContext context =
                 new AnnotationConfigApplicationContext()) {
-            TestPropertyValues.of("agentspan.embedded=false").applyTo(context);
+            TestPropertyValues.of("conductor.integrations.ai.enabled=false").applyTo(context);
             context.register(AgentSpanListenerCoexistenceConfiguration.class);
             context.refresh();
 

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/Issue1323GuardrailToolCallBindingTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/Issue1323GuardrailToolCallBindingTest.java
@@ -23,7 +23,8 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * REPRODUCES ISSUE #1323 (compiler half) - AgentSpan output guardrails misfire on tool-call turns.
+ * REPRODUCES ISSUE #1323 (compiler half) - Conductor-Agents output guardrails misfire on tool-call
+ * turns.
  *
  * <p>The runtime misfire (see {@code Issue1323GuardrailToolCallMisfireTest}) is only fixable if the
  * compiled INLINE guardrail task is actually fed the LLM turn's tool calls. Today {@link

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/ToolCompilerTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/ToolCompilerTest.java
@@ -468,7 +468,7 @@ class ToolCompilerTest {
 
     @Test
     void testCompileToolSpecs_everySpecIsSelfDescribing() {
-        // Every AgentSpan-compiled tool spec is complete (name + description +
+        // Every Conductor-Agents-compiled tool spec is complete (name + description +
         // inputSchema inline), so every spec must carry the selfDescribing
         // marker that tells OrkesLLM to skip integration resolution.
         List<ToolConfig> tools =

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/WorkerRuntimeMetadataTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/WorkerRuntimeMetadataTest.java
@@ -27,13 +27,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Pure compiler invariants for worker credential declarations. Registration and persistence are
- * verified by {@code AgentSpanDeploymentContractEndToEndTest} using the real metadata service.
+ * verified by the deployment contract test using the real metadata service.
  */
 class WorkerRuntimeMetadataTest {
 
     @AfterEach
-    void resetEmbedded() {
-        new EmbeddedMode().setEmbedded(false);
+    void resetAiIntegrationEnabled() {
+        new EmbeddedMode().setAiIntegrationEnabled(false);
     }
 
     @Test
@@ -46,9 +46,9 @@ class WorkerRuntimeMetadataTest {
                         .config(Map.of("credentials", List.of("GITHUB_TOKEN")))
                         .build();
 
-        new EmbeddedMode().setEmbedded(true);
+        new EmbeddedMode().setAiIntegrationEnabled(true);
         String embedded = enrichScript(tool);
-        new EmbeddedMode().setEmbedded(false);
+        new EmbeddedMode().setAiIntegrationEnabled(false);
         String standalone = enrichScript(tool);
 
         assertThat(embedded).doesNotContain("__resolved_credentials__");

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/credentials/NativeSecretGatingTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/credentials/NativeSecretGatingTest.java
@@ -35,13 +35,13 @@ class NativeSecretGatingTest {
                     .withUserConfiguration(NativeBeans.class);
 
     @Test
-    void nativeResolutionIsAbsentWhenEmbeddedModeIsNotEnabled() {
+    void nativeResolutionIsAbsentWhenAiIntegrationIsDisabled() {
         runner.run(ctx -> assertThat(ctx).doesNotHaveBean(CredentialResolutionService.class));
     }
 
     @Test
-    void nativeResolutionUsesTheConcreteSecretBackendWhenEmbeddedModeIsEnabled() {
-        runner.withPropertyValues("agentspan.embedded=true")
+    void nativeResolutionUsesTheConcreteSecretBackendWhenAiIntegrationIsEnabled() {
+        runner.withPropertyValues("conductor.integrations.ai.enabled=true")
                 .run(ctx -> assertThat(ctx).hasSingleBean(CredentialResolutionService.class));
     }
 }

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/util/Issue1323GuardrailToolCallMisfireTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/util/Issue1323GuardrailToolCallMisfireTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * REPRODUCES ISSUE #1323 - AgentSpan output guardrails misfire on tool-call turns.
+ * REPRODUCES ISSUE #1323 - Conductor-Agents output guardrails misfire on tool-call turns.
  *
  * <p>This test executes the ACTUAL guardrail script produced by {@link
  * JavaScriptBuilder#regexGuardrailScript} through the same GraalJS engine that the compiled INLINE

--- a/ai/build.gradle
+++ b/ai/build.gradle
@@ -63,7 +63,7 @@ sourceSets.main.resources.srcDir(downloadSqliteVec)
 
 dependencies {
     compileOnly 'org.springframework.boot:spring-boot-starter'
-    // Needed to compile A2A push-notification callback controller and AgentSpan activation glue;
+    // Needed to compile A2A push-notification callback controller and Conductor-Agents activation glue;
     // supplied by the server at runtime.
     compileOnly 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.springframework.boot:spring-boot-autoconfigure'

--- a/ai/examples/README.md
+++ b/ai/examples/README.md
@@ -112,16 +112,16 @@ by registering them with `metadata.a2a.enabled=true` and `conductor.a2a.server.e
 
 Conductor running an agent on its **embedded agentspan runtime** via the `AGENT` task with
 `agentType: "conductor"`. These require the server to run with the embedded agentspan runtime
-enabled (`agentspan.embedded=true`) and at least one agent registered with it (example 33 needs
+enabled (`conductor.integrations.ai.enabled=true`) and at least one agent registered with it (example 33 needs
 two: `planner` and `researcher`). The `AGENT` task is non-blocking — it starts the run and polls
 until it reaches a terminal (or `WAITING`) state.
 
 | File | Workflow name | Description | Requirements |
 |------|---------------|-------------|--------------|
-| `31-conductor-agent-basic.json` | `conductor_agent_basic` | Single agent run to completion (poll mode) | `agentspan.embedded=true`, a registered agent |
-| `32-conductor-agent-human-in-loop.json` | `conductor_agent_human_in_loop` | Waiting run resumed via a `HUMAN` task and `executionId` | `agentspan.embedded=true`, a registered agent |
-| `33-conductor-agent-multi-agent.json` | `conductor_agent_multi_agent` | Two agent branches via `FORK_JOIN` -> `JOIN` | `agentspan.embedded=true`, two registered agents |
-| `34-conductor-agent-cancel.json` | `conductor_agent_cancel` | Start a long agent run, then cancel it (`CANCELED` mapping) | `agentspan.embedded=true`, a registered agent |
+| `31-conductor-agent-basic.json` | `conductor_agent_basic` | Single agent run to completion (poll mode) | `conductor.integrations.ai.enabled=true`, a registered agent |
+| `32-conductor-agent-human-in-loop.json` | `conductor_agent_human_in_loop` | Waiting run resumed via a `HUMAN` task and `executionId` | `conductor.integrations.ai.enabled=true`, a registered agent |
+| `33-conductor-agent-multi-agent.json` | `conductor_agent_multi_agent` | Two agent branches via `FORK_JOIN` -> `JOIN` | `conductor.integrations.ai.enabled=true`, two registered agents |
+| `34-conductor-agent-cancel.json` | `conductor_agent_cancel` | Start a long agent run, then cancel it (`CANCELED` mapping) | `conductor.integrations.ai.enabled=true`, a registered agent |
 
 ---
 
@@ -499,7 +499,7 @@ curl -X POST 'http://localhost:8080/api/workflow/multi_turn_chain' \
 ### 31. Conductor Agent (Basic)
 
 ```bash
-# Requires agentspan.embedded=true and a registered 'planner' agent
+# Requires conductor.integrations.ai.enabled=true and a registered 'planner' agent
 
 # Register
 curl -X POST 'http://localhost:8080/api/metadata/workflow' \
@@ -519,7 +519,7 @@ transient poll-failure cap, default 30) input parameters on the `AGENT` task.
 ### 32. Conductor Agent (Human-in-the-Loop)
 
 ```bash
-# Requires agentspan.embedded=true and a registered 'planner' agent
+# Requires conductor.integrations.ai.enabled=true and a registered 'planner' agent
 
 # Register
 curl -X POST 'http://localhost:8080/api/metadata/workflow' \
@@ -536,7 +536,7 @@ curl -X POST 'http://localhost:8080/api/workflow/conductor_agent_human_in_loop' 
 ### 33. Conductor Agent (Multi-Agent)
 
 ```bash
-# Requires agentspan.embedded=true and two registered agents: 'planner' and 'researcher'
+# Requires conductor.integrations.ai.enabled=true and two registered agents: 'planner' and 'researcher'
 
 # Register
 curl -X POST 'http://localhost:8080/api/metadata/workflow' \
@@ -552,7 +552,7 @@ curl -X POST 'http://localhost:8080/api/workflow/conductor_agent_multi_agent' \
 ### 34. Conductor Agent (Cancel)
 
 ```bash
-# Requires agentspan.embedded=true and a registered 'planner' agent
+# Requires conductor.integrations.ai.enabled=true and a registered 'planner' agent
 
 # Register
 curl -X POST 'http://localhost:8080/api/metadata/workflow' \

--- a/ai/src/main/java/org/conductoross/conductor/ai/agent/AgentEventStream.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/agent/AgentEventStream.java
@@ -17,8 +17,8 @@ import org.conductoross.conductor.common.metadata.agent.AgentSSEEvent;
 /**
  * Transport-neutral stream of agent lifecycle events.
  *
- * <p>The HTTP client adapts SSE to this contract while embedded AgentSpan implementations subscribe
- * directly to the in-process event registry.
+ * <p>The HTTP client adapts SSE to this contract while embedded Conductor-Agents implementations
+ * subscribe directly to the in-process event registry.
  */
 public interface AgentEventStream extends AutoCloseable {
 

--- a/ai/src/main/java/org/conductoross/conductor/ai/agent/ConductorAgentClient.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/agent/ConductorAgentClient.java
@@ -15,8 +15,8 @@ package org.conductoross.conductor.ai.agent;
 /**
  * Agent control-plane client used by portable Conductor workers.
  *
- * <p>The boundary uses only AI-module DTOs. AgentSpan injects an in-process implementation and
- * translates those models to its service layer; external workers inject an SDK-backed adapter.
+ * <p>The boundary uses only AI-module DTOs. Conductor-Agents injects an in-process implementation
+ * and translates those models to its service layer; external workers inject an SDK-backed adapter.
  */
 public interface ConductorAgentClient extends AutoCloseable {
 

--- a/ai/src/main/java/org/conductoross/conductor/ai/model/ToolSpec.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/model/ToolSpec.java
@@ -29,7 +29,7 @@ public class ToolSpec {
     /**
      * When true, this spec is complete as delivered: pass it to the LLM as-is. Consumers must not
      * resolve, enrich, or replace it by name against integrations, services, or task definitions.
-     * Set by producers that compile full inline tool specs (e.g. AgentSpan).
+     * Set by producers that compile full inline tool specs (e.g. Conductor-Agents).
      */
     private boolean selfDescribing;
 }

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowClassifier.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowClassifier.java
@@ -18,16 +18,16 @@ import java.util.Map;
  * Derives the <b>classifier</b> of a workflow definition from its {@code metadata} map.
  *
  * <p>The classifier is a tag used to distinguish kinds of definitions/executions: an untagged def
- * is a plain <b>workflow</b> (classifier {@link #WORKFLOW}); AgentSpan-compiled defs are tagged
- * {@link #AGENT}. The scheme is open-ended — a def may carry any explicit {@code
+ * is a plain <b>workflow</b> (classifier {@link #WORKFLOW}); Conductor-Agents-compiled defs are
+ * tagged {@link #AGENT}. The scheme is open-ended — a def may carry any explicit {@code
  * metadata.classifier} value, enabling future kinds without schema/code changes.
  *
  * <p>Resolution order:
  *
  * <ol>
  *   <li>explicit {@code metadata.classifier} (non-blank) — wins;
- *   <li>otherwise {@code "agent"} when the AgentSpan stamp is present ({@code metadata.agent_sdk}
- *       or {@code metadata.agentDef});
+ *   <li>otherwise {@code "agent"} when the Conductor-Agents stamp is present ({@code
+ *       metadata.agent_sdk} or {@code metadata.agentDef});
  *   <li>otherwise {@code "workflow"} (a normal, untagged workflow).
  * </ol>
  *

--- a/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
+++ b/common/src/main/java/com/netflix/conductor/common/run/WorkflowSummary.java
@@ -105,7 +105,7 @@ public class WorkflowSummary {
 
     /**
      * Classifier of the workflow definition this execution was started from (e.g. {@code workflow}
-     * for a plain workflow, {@code agent} for AgentSpan agents). Derived via {@link
+     * for a plain workflow, {@code agent} for Conductor-Agents agents). Derived via {@link
      * WorkflowClassifier} at index time.
      */
     @ProtoField(id = 23)

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
@@ -39,11 +39,11 @@ public class Join extends WorkflowSystemTask {
     @VisibleForTesting static final double EVALUATION_OFFSET_BASE = 1.2;
 
     /**
-     * Keys propagated from fork-branch outputs into the JOIN output for AgentSpan agent executions.
-     * Only these are copied so the JOIN payload stays small for multi-agent merges — full fork
-     * outputs are read directly from the individual tool tasks by the agent message builder, so
-     * duplicating them in JOIN is unnecessary. This mirrors AgentSpan's own JOIN task; for
-     * non-agent workflows the full fork output is copied as before.
+     * Keys propagated from fork-branch outputs into the JOIN output for Conductor-Agents agent
+     * executions. Only these are copied so the JOIN payload stays small for multi-agent merges —
+     * full fork outputs are read directly from the individual tool tasks by the agent message
+     * builder, so duplicating them in JOIN is unnecessary. This mirrors the Conductor-Agents JOIN
+     * task; for non-agent workflows the full fork output is copied as before.
      */
     private static final Set<String> AGENT_PROPAGATED_KEYS = Set.of("_state_updates", "state");
 
@@ -84,7 +84,8 @@ public class Join extends WorkflowSystemTask {
 
             TaskModel.Status taskStatus = forkedTask.getStatus();
 
-            // Only add to task output if it's not empty. For AgentSpan agent executions, copy
+            // Only add to task output if it's not empty. For Conductor-Agents agent executions,
+            // copy
             // only the agent merge keys (compact) to keep the JOIN payload small; otherwise copy
             // the full fork output (default Conductor behavior).
             if (!forkedTask.getOutputData().isEmpty()) {
@@ -154,9 +155,9 @@ public class Join extends WorkflowSystemTask {
 
     /**
      * Returns the compact state output for an agent fork, or a namespaced observation for a
-     * dynamically generated AgentSpan tool. The latter is the only durable way an AgentSpan ReAct
-     * loop can make a dynamic HTTP/MCP/HUMAN result available to its next model turn: dynamic task
-     * reference names are not known when the workflow is compiled.
+     * dynamically generated Conductor-Agents tool. The latter is the only durable way a
+     * Conductor-Agents ReAct loop can make a dynamic HTTP/MCP/HUMAN result available to its next
+     * model turn: dynamic task reference names are not known when the workflow is compiled.
      */
     private static Map<String, Object> compactAgentOutput(TaskModel forkedTask) {
         Map<String, Object> output = forkedTask.getOutputData();

--- a/core/src/main/java/org/conductoross/conductor/dao/SkillMetadataDAO.java
+++ b/core/src/main/java/org/conductoross/conductor/dao/SkillMetadataDAO.java
@@ -16,14 +16,14 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Persistence for AgentSpan skill <b>metadata</b>: the per-version manifest plus a per-skill
+ * Persistence for Conductor-Agents skill <b>metadata</b>: the per-version manifest plus a per-skill
  * "latest" pointer. Skill package <b>bytes</b> are stored separately via {@link SkillPackageDAO}.
  *
- * <p>This DAO is the Conductor-native backing store for AgentSpan's {@code
+ * <p>This DAO is the Conductor-native backing store for Conductor-Agents' {@code
  * dev.agentspan.runtime.spi.SkillMetadataDAO} SPI; an adapter in the {@code conductor-ai} module
  * bridges the two so skills persist through whichever Conductor backend is configured (Postgres,
  * MySQL, SQLite, Redis). It deliberately stores the manifest as an opaque JSON document ({@code
- * detailJson}) so the persistence layer carries no dependency on AgentSpan model types.
+ * detailJson}) so the persistence layer carries no dependency on Conductor-Agents model types.
  *
  * <p>Skills share a single global namespace (OSS Conductor is single-tenant). Authorization
  * (whether the caller may read a given skill) is the caller's concern, not this DAO's. Implemented

--- a/core/src/main/java/org/conductoross/conductor/dao/SkillPackageDAO.java
+++ b/core/src/main/java/org/conductoross/conductor/dao/SkillPackageDAO.java
@@ -13,11 +13,11 @@
 package org.conductoross.conductor.dao;
 
 /**
- * Persistence for AgentSpan skill package <b>bytes</b> (the zipped {@code SKILL.md} package),
- * addressed by an opaque {@code handle}. Skill <b>metadata</b> is stored separately via {@link
- * SkillMetadataDAO}.
+ * Persistence for Conductor-Agents skill package <b>bytes</b> (the zipped {@code SKILL.md}
+ * package), addressed by an opaque {@code handle}. Skill <b>metadata</b> is stored separately via
+ * {@link SkillMetadataDAO}.
  *
- * <p>This DAO is the Conductor-native backing store for AgentSpan's {@code
+ * <p>This DAO is the Conductor-native backing store for Conductor-Agents' {@code
  * dev.agentspan.runtime.spi.SkillPackageStore} SPI; an adapter in the {@code conductor-ai} module
  * bridges the two. Implementations store the bytes through whichever Conductor backend is
  * configured (Postgres, MySQL, SQLite, Redis). Bytes are persisted Base64-encoded so the value

--- a/docs/design/backfill-method-removal-architecture.md
+++ b/docs/design/backfill-method-removal-architecture.md
@@ -43,7 +43,7 @@ resolution. No new behavior is introduced.
 - Java 21, Gradle multi-module build.
 - Modules touched: `agentspan` (production) and `test-harness` (integration test).
 - Spring Boot component model; `AgentService` is a `@Component` gated by
-  `@ConditionalOnProperty(name = "agentspan.embedded", havingValue = "true")`
+  `@ConditionalOnProperty(name = "conductor.integrations.ai.enabled", havingValue = "true")`
   and uses Lombok `@RequiredArgsConstructor`.
 - JUnit 5 (`org.junit.jupiter`) for the affected test.
 

--- a/docs/devguide/ai/conductor-agents.md
+++ b/docs/devguide/ai/conductor-agents.md
@@ -16,16 +16,16 @@ Both values drive the same `AGENT` task type with one consistent input/output co
 
 With `agentType: "conductor"`, the `AGENT` task runs a registered agent on Conductor's embedded agentspan runtime instead of calling out to a remote agent. Like the A2A branch, it is **non-blocking**: a fast reply completes immediately; a long-running run moves to `IN_PROGRESS` and is polled at a cadence (no worker thread is held), so the call survives a server crash, restart, or redeploy and resumes from persisted state.
 
-This branch requires the embedded runtime, enabled with:
+This branch requires the AI integration, enabled with:
 
 ```properties
-agentspan.embedded=true
+conductor.integrations.ai.enabled=true
 ```
 
 On a deployment without it, the runtime bean is absent and any `agentType: "conductor"` task fails terminally with:
 
 ```
-Conductor agents require the embedded agentspan runtime (agentspan.embedded=true)
+Conductor agents require conductor.integrations.ai.enabled=true
 ```
 
 
@@ -109,7 +109,7 @@ A single `AGENT` task that runs an embedded agent to completion:
 }
 ```
 
-Register and run it (the embedded runtime must be enabled — `agentspan.embedded=true`):
+Register and run it (the AI integration must be enabled — `conductor.integrations.ai.enabled=true`):
 
 ```bash
 # register

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation project(':conductor-rest')
     implementation project(':conductor-grpc-server')
     implementation project(':conductor-ai')
-    // Embedded AgentSpan runtime (REST controllers, agent services); activated only when
+    // Embedded Conductor-Agents runtime (REST controllers, agent services); activated only when
     // conductor.integrations.ai.enabled=true.
     implementation project(':conductor-agentspan')
 

--- a/server/src/main/java/com/netflix/conductor/server/AgentSpanUiContextController.java
+++ b/server/src/main/java/com/netflix/conductor/server/AgentSpanUiContextController.java
@@ -27,14 +27,14 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.servlet.http.HttpServletResponse;
 
 /**
- * Serves the UI runtime config {@code /context.js} so the embedded AgentSpan agent pages are gated
+ * Serves the UI runtime config {@code /context.js} so the embedded Conductor-Agents pages are gated
  * by the server's {@code conductor.integrations.ai.enabled} flag.
  *
  * <p>Mirrors orkes-conductor's {@code UIContextGenerator}: a controller mapping takes precedence
  * over the bundled static {@code /static/context.js}, so we serve the bundled file (preserving all
- * other feature flags) and append a runtime override of {@code AGENTSPAN_ENABLED}. The UI reads
- * {@code window.conductor.AGENTSPAN_ENABLED} to show/hide the Agents, Executions, Skills and
- * Secrets pages. Only active when UI serving is enabled.
+ * other feature flags) and append a runtime override of {@code CONDUCTOR_INTEGRATIONS_AI_ENABLED}.
+ * The UI reads {@code window.conductor.CONDUCTOR_INTEGRATIONS_AI_ENABLED} to show/hide the Agents,
+ * Executions, Skills and Secrets pages. Only active when UI serving is enabled.
  *
  * <p>Writes directly to the response to avoid content-negotiation on {@code
  * application/javascript}.
@@ -46,11 +46,11 @@ import jakarta.servlet.http.HttpServletResponse;
         matchIfMissing = true)
 public class AgentSpanUiContextController {
 
-    private final boolean agentSpanEnabled;
+    private final boolean aiIntegrationEnabled;
 
     public AgentSpanUiContextController(
-            @Value("${conductor.integrations.ai.enabled:false}") boolean agentSpanEnabled) {
-        this.agentSpanEnabled = agentSpanEnabled;
+            @Value("${conductor.integrations.ai.enabled:false}") boolean aiIntegrationEnabled) {
+        this.aiIntegrationEnabled = aiIntegrationEnabled;
     }
 
     @GetMapping("/context.js")
@@ -74,7 +74,9 @@ public class AgentSpanUiContextController {
         // Runtime override driven by the server configuration.
         js.append("\n// Injected by Conductor server (conductor.integrations.ai.enabled)\n");
         js.append("window.conductor = window.conductor || {};\n");
-        js.append("window.conductor.AGENTSPAN_ENABLED = ").append(agentSpanEnabled).append(";\n");
+        js.append("window.conductor.CONDUCTOR_INTEGRATIONS_AI_ENABLED = ")
+                .append(aiIntegrationEnabled)
+                .append(";\n");
 
         response.getWriter().write(js.toString());
     }

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -196,15 +196,11 @@ management.jmx.metrics.export.enabled=false
 conductor.metrics-logger.enabled=false
 # Start AI Workers
 conductor.integrations.ai.enabled=true
-# External MCP servers and AgentSpan OpenAPI discovery are default-deny. Configure exact origins
+# External MCP servers and Conductor-Agents OpenAPI discovery are default-deny. Configure exact origins
 # (for example, https://tools.example.com) before using those integrations. Private addresses stay
 # denied even when their origin is listed unless the development-only allow-private-networks flag is set.
 #conductor.ai.outbound.allowed-origins=https://tools.example.com
 #conductor.ai.outbound.allow-private-networks=false
-# Run the embedded AgentSpan library in embedded mode whenever the AI integration is on. Its
-# auto-configuration activates on this flag; keeping it in lock-step with the flag above avoids
-# shadowing Conductor's native HTTP/HUMAN/JOIN task beans. Override explicitly to decouple.
-agentspan.embedded=${conductor.integrations.ai.enabled:false}
 spring.main.allow-bean-definition-overriding=true
 
 # Vector store: with SQLite persistence + AI both enabled (as above), Conductor

--- a/test-harness/build.gradle
+++ b/test-harness/build.gradle
@@ -75,7 +75,7 @@ tasks.withType(Test)  {
     maxParallelForks = 1
 }
 
-// AgentSpan's deterministic suite uses real Conductor services plus Testcontainers. The live
+// Conductor-Agents' deterministic suite uses real Conductor services plus Testcontainers. The live
 // suite additionally calls a configured LLM provider and is deliberately separate from the
 // default test task so local contributors do not need provider credentials to run unit tests.
 tasks.named('test') {

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/AgentSpanDeploymentContractEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/AgentSpanDeploymentContractEndToEndTest.java
@@ -101,9 +101,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Real persistence contract for AgentSpan deployment. These assertions intentionally use the same
- * compiler, metadata service, and Redis-backed task-definition registry as production rather than
- * inspecting calls made to mocked collaborators.
+ * Real persistence contract for Conductor-Agents deployment. These assertions intentionally use the
+ * same compiler, metadata service, and Redis-backed task-definition registry as production rather
+ * than inspecting calls made to mocked collaborators.
  */
 @Tag("agentspan-deterministic-e2e")
 @SpringBootTest(
@@ -118,7 +118,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
             "conductor.app.sweeperThreadCount=1",
             "conductor.app.sweeper.sweepBatchSize=1",
             "conductor.integrations.ai.enabled=true",
-            "agentspan.embedded=true",
             "agentspan.skills.enabled=true",
             "conductor.ai.outbound.allow-private-networks=true",
             "conductor.external-payload-storage.type=s3",

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/AgentSpanMcpTestkitApiDiscoveryEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/AgentSpanMcpTestkitApiDiscoveryEndToEndTest.java
@@ -73,7 +73,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Exercises AgentSpan API discovery and MCP calls through the real Conductor engine and
+ * Exercises Conductor-Agents API discovery and MCP calls through the real Conductor engine and
  * mcp-testkit's HTTP transport. The server exposes a deterministic authenticated OpenAPI document
  * and MCP protocol surface, so this catches routing and durability regressions that a hand-built
  * JSON fixture cannot.
@@ -89,7 +89,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
             "conductor.app.sweeperThreadCount=1",
             "conductor.app.sweeper.sweepBatchSize=1",
             "conductor.integrations.ai.enabled=true",
-            "agentspan.embedded=true",
             "conductor.ai.outbound.allow-private-networks=true",
             "conductor.external-payload-storage.type=s3",
             "conductor.external-payload-storage.s3.bucketName="

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/AgentSpanRegistrationEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/AgentSpanRegistrationEndToEndTest.java
@@ -70,7 +70,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * End-to-end test of the <b>real</b> AgentSpan registration/compilation pipeline — not the
+ * End-to-end test of the <b>real</b> Conductor-Agents registration/compilation pipeline — not the
  * hand-rolled {@code metadata.agentDef}-stamped {@link WorkflowDef}s in {@link
  * ConductorAgentEndToEndTest}. Every agent here is registered through {@code
  * AgentService.deploy(AgentStartRequest)} (the same call {@code POST /api/agent/deploy} makes) with
@@ -80,10 +80,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p>Requires a live LLM. The dedicated {@code agentspanRealE2E} Gradle task fails before running
  * the suite unless {@code ANTHROPIC_API_KEY} or {@code OPENAI_API_KEY} is set. It picks whichever
- * key is present (Anthropic preferred) rather than running the provider-agnostic AgentSpan pipeline
- * twice — these tests exercise the compiler/dispatch machinery, not provider-specific quirks, so
- * there is nothing to gain from a two-provider matrix, only 2x the LLM spend on every CI run once a
- * key is configured.
+ * key is present (Anthropic preferred) rather than running the provider-agnostic Conductor-Agents
+ * pipeline twice — these tests exercise the compiler/dispatch machinery, not provider-specific
+ * quirks, so there is nothing to gain from a two-provider matrix, only 2x the LLM spend on every CI
+ * run once a key is configured.
  *
  * <p>LLM output wording is inherently non-deterministic, so assertions favor <b>structural</b>
  * proof (a real {@code HTTP} task ran with {@code statusCode=200}; a real {@code HUMAN} task paused
@@ -102,7 +102,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
             "conductor.app.sweeper.sweepBatchSize=1",
             "conductor.app.sweeper.queuePopTimeout=750",
             "conductor.integrations.ai.enabled=true",
-            "agentspan.embedded=true",
             "conductor.external-payload-storage.type=s3",
             "conductor.external-payload-storage.s3.bucketName="
                     + AgentSpanRegistrationEndToEndTest.PAYLOAD_BUCKET,
@@ -461,7 +460,7 @@ class AgentSpanRegistrationEndToEndTest {
                 "the completed interview must preserve a terminal result: " + resultText);
     }
 
-    // ── AgentSpan registration ─────────────────────────────────────────────
+    // ── Conductor-Agents registration ──────────────────────────────────────
 
     private void deployAgent(AgentConfig config) {
         AgentStartResponse response =

--- a/ui-next/e2e/integration/workflows.spec.ts
+++ b/ui-next/e2e/integration/workflows.spec.ts
@@ -42,6 +42,11 @@ function makeWorkflowDef(suffix: string): WorkflowDef {
 const WF_LIST = makeWorkflowDef("list");
 const WF_EDITOR = makeWorkflowDef("editor");
 
+// Monaco loads its editor runtime asynchronously from the CDN. The integration
+// suite uses the production bundle and a real browser, so allow the same
+// network window as navigation rather than Playwright's 5-second default.
+const MONACO_CONTENT_TIMEOUT_MS = 30_000;
+
 test.beforeAll(async () => {
   await createWorkflowDef(WF_LIST);
   await createWorkflowDef(WF_EDITOR);
@@ -167,7 +172,7 @@ test("switching to the Code tab shows the workflow JSON editor", async ({
   // workflow definition JSON is actually present in the editor content.
   await expect(
     page.locator("#editor-panel-tab-content #code-tab"),
-  ).toContainText("SET_VARIABLE");
+  ).toContainText("SET_VARIABLE", { timeout: MONACO_CONTENT_TIMEOUT_MS });
 });
 
 test("navigating to /newWorkflowDef opens an empty editor", async ({
@@ -198,5 +203,5 @@ test("navigating to /newWorkflowDef opens an empty editor", async ({
   // that no task reference names snuck in from a previously loaded definition.
   await expect(
     page.locator("#editor-panel-tab-content #code-tab"),
-  ).toContainText('"tasks": []');
+  ).toContainText('"tasks": []', { timeout: MONACO_CONTENT_TIMEOUT_MS });
 });

--- a/ui-next/public/context.js
+++ b/ui-next/public/context.js
@@ -30,9 +30,9 @@ window.conductor = {
   SENDGRID_TASK_ENABLED: false,
   SKU_ENABLED: false,
 
-  // Embedded AgentSpan agent UI. Default off here; the Conductor server overrides
+  // Embedded Conductor-Agents UI. Default off here; the Conductor server overrides
   // /context.js at runtime with the value of conductor.integrations.ai.enabled.
-  AGENTSPAN_ENABLED: true,
+  CONDUCTOR_INTEGRATIONS_AI_ENABLED: true,
 
   // UI Configuration
   PLAYGROUND: false,

--- a/ui-next/src/components/providers/sidebar/__tests__/sidebarCoreItems.test.tsx
+++ b/ui-next/src/components/providers/sidebar/__tests__/sidebarCoreItems.test.tsx
@@ -19,7 +19,7 @@ vi.mock("utils", () => ({
     PLAYGROUND: "PLAYGROUND",
     SHOW_FEEDBACK_FORM: "SHOW_FEEDBACK_FORM",
     SCHEDULER: "SCHEDULER",
-    AGENTSPAN_ENABLED: "AGENTSPAN_ENABLED",
+    CONDUCTOR_INTEGRATIONS_AI_ENABLED: "CONDUCTOR_INTEGRATIONS_AI_ENABLED",
   },
   featureFlags: {
     isEnabled: vi.fn((feature: string) => feature === "SCHEDULER"),

--- a/ui-next/src/components/providers/sidebar/sidebarCoreItems.tsx
+++ b/ui-next/src/components/providers/sidebar/sidebarCoreItems.tsx
@@ -37,7 +37,9 @@ import {
 const isPlayground = featureFlags.isEnabled(FEATURES.PLAYGROUND);
 const hideFeedbackForm = !featureFlags.isEnabled(FEATURES.SHOW_FEEDBACK_FORM);
 const hideScheduler = !featureFlags.isEnabled(FEATURES.SCHEDULER);
-const hideAgentspan = !featureFlags.isEnabled(FEATURES.AGENTSPAN_ENABLED);
+const hideAgentspan = !featureFlags.isEnabled(
+  FEATURES.CONDUCTOR_INTEGRATIONS_AI_ENABLED,
+);
 
 /**
  * Core sidebar position constants. Root and submenus both use 100, 200, 300, ...
@@ -131,7 +133,7 @@ export function getCoreSidebarItems(open: boolean): MenuItemType[] {
         },
       ],
     },
-    // Agents submenu (embedded AgentSpan) - hidden unless AGENTSPAN_ENABLED
+    // Agents submenu (embedded Conductor-Agents) - hidden unless CONDUCTOR_INTEGRATIONS_AI_ENABLED
     {
       id: "agentspanSubMenu",
       title: "Agents",

--- a/ui-next/src/pages/agent/executions/workflowSearchComponents/AdvancedSearch.tsx
+++ b/ui-next/src/pages/agent/executions/workflowSearchComponents/AdvancedSearch.tsx
@@ -210,7 +210,7 @@ export default function AdvancedSearch({
       query: queryFT.query,
       freeText: queryFT.freeText,
       // Scope results to a single classifier: "workflow" for plain workflow
-      // executions, "agent" for AgentSpan agent runs on the Agents pages.
+      // executions, "agent" for Conductor-Agents runs on the Agents pages.
       classifier: "agent",
       topLevelOnly: hideSubWorkflows,
     },

--- a/ui-next/src/pages/agent/executions/workflowSearchComponents/BasicSearch.tsx
+++ b/ui-next/src/pages/agent/executions/workflowSearchComponents/BasicSearch.tsx
@@ -280,7 +280,7 @@ export default function BasicSearch({
       query: queryFT.query,
       freeText: queryFT.freeText,
       // Scope results to a single classifier: "workflow" for plain workflow
-      // executions, "agent" for AgentSpan agent runs on the Agents pages.
+      // executions, "agent" for Conductor-Agents runs on the Agents pages.
       classifier: "agent",
       topLevelOnly: hideSubWorkflows,
     },

--- a/ui-next/src/pages/agent/guides/dotnet/native.md
+++ b/ui-next/src/pages/agent/guides/dotnet/native.md
@@ -11,7 +11,7 @@ export CONDUCTOR_SERVER_URL={{CONDUCTOR_SERVER_URL}}
 # For authenticated Conductor servers:
 # export CONDUCTOR_AUTH_KEY=<YOUR_AUTH_KEY>
 # export CONDUCTOR_AUTH_SECRET=<YOUR_AUTH_SECRET>
-export AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini
+export CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
 ```
 
 ## 3. Run an agent

--- a/ui-next/src/pages/agent/guides/java/google-adk.md
+++ b/ui-next/src/pages/agent/guides/java/google-adk.md
@@ -12,7 +12,7 @@ export CONDUCTOR_SERVER_URL={{CONDUCTOR_SERVER_URL}}
 # For authenticated Conductor servers:
 # export CONDUCTOR_AUTH_KEY=<YOUR_AUTH_KEY>
 # export CONDUCTOR_AUTH_SECRET=<YOUR_AUTH_SECRET>
-export AGENTSPAN_LLM_MODEL=google_gemini/gemini-2.0-flash
+export CONDUCTOR_AGENT_LLM_MODEL=google_gemini/gemini-2.0-flash
 ```
 
 ```java

--- a/ui-next/src/pages/agent/guides/java/native.md
+++ b/ui-next/src/pages/agent/guides/java/native.md
@@ -13,7 +13,7 @@ export CONDUCTOR_SERVER_URL={{CONDUCTOR_SERVER_URL}}
 # For authenticated Conductor servers:
 # export CONDUCTOR_AUTH_KEY=<YOUR_AUTH_KEY>
 # export CONDUCTOR_AUTH_SECRET=<YOUR_AUTH_SECRET>
-export AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini
+export CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
 ```
 
 ## 3. Run an agent

--- a/ui-next/src/pages/agent/guides/java/openai.md
+++ b/ui-next/src/pages/agent/guides/java/openai.md
@@ -12,7 +12,7 @@ export CONDUCTOR_SERVER_URL={{CONDUCTOR_SERVER_URL}}
 # For authenticated Conductor servers:
 # export CONDUCTOR_AUTH_KEY=<YOUR_AUTH_KEY>
 # export CONDUCTOR_AUTH_SECRET=<YOUR_AUTH_SECRET>
-export AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini
+export CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
 ```
 
 ```java

--- a/ui-next/src/pages/agent/guides/manifest.test.ts
+++ b/ui-next/src/pages/agent/guides/manifest.test.ts
@@ -31,6 +31,7 @@ describe("agent guide manifest", () => {
       expect(markdown).toContain("CONDUCTOR_AUTH_KEY");
       expect(markdown).toContain("CONDUCTOR_AUTH_SECRET");
       expect(markdown).not.toContain("AGENTSPAN_SERVER_URL");
+      expect(markdown).not.toContain("AGENTSPAN_LLM_MODEL");
       expect(markdown).not.toMatch(
         /export (?:OPENAI|ANTHROPIC|GOOGLE_GEMINI)_API_KEY=/,
       );

--- a/ui-next/src/pages/agent/guides/python/google-adk.md
+++ b/ui-next/src/pages/agent/guides/python/google-adk.md
@@ -6,7 +6,7 @@ export CONDUCTOR_SERVER_URL={{CONDUCTOR_SERVER_URL}}
 # For authenticated Conductor servers:
 # export CONDUCTOR_AUTH_KEY=<YOUR_AUTH_KEY>
 # export CONDUCTOR_AUTH_SECRET=<YOUR_AUTH_SECRET>
-export AGENTSPAN_LLM_MODEL=google_gemini/gemini-2.0-flash
+export CONDUCTOR_AGENT_LLM_MODEL=google_gemini/gemini-2.0-flash
 ```
 
 ## 2. Run the ADK agent

--- a/ui-next/src/pages/agent/guides/python/langchain.md
+++ b/ui-next/src/pages/agent/guides/python/langchain.md
@@ -6,7 +6,7 @@ export CONDUCTOR_SERVER_URL={{CONDUCTOR_SERVER_URL}}
 # For authenticated Conductor servers:
 # export CONDUCTOR_AUTH_KEY=<YOUR_AUTH_KEY>
 # export CONDUCTOR_AUTH_SECRET=<YOUR_AUTH_SECRET>
-export AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini
+export CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
 ```
 
 ## 2. Run the agent

--- a/ui-next/src/pages/agent/guides/python/langgraph.md
+++ b/ui-next/src/pages/agent/guides/python/langgraph.md
@@ -6,7 +6,7 @@ export CONDUCTOR_SERVER_URL={{CONDUCTOR_SERVER_URL}}
 # For authenticated Conductor servers:
 # export CONDUCTOR_AUTH_KEY=<YOUR_AUTH_KEY>
 # export CONDUCTOR_AUTH_SECRET=<YOUR_AUTH_SECRET>
-export AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini
+export CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
 ```
 
 ## 2. Run the graph

--- a/ui-next/src/pages/agent/guides/python/native.md
+++ b/ui-next/src/pages/agent/guides/python/native.md
@@ -13,7 +13,7 @@ export CONDUCTOR_SERVER_URL={{CONDUCTOR_SERVER_URL}}
 # For authenticated Conductor servers:
 # export CONDUCTOR_AUTH_KEY=<YOUR_AUTH_KEY>
 # export CONDUCTOR_AUTH_SECRET=<YOUR_AUTH_SECRET>
-export AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini
+export CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
 ```
 
 ## 3. Save as `hello.py` and run

--- a/ui-next/src/pages/agent/guides/python/openai.md
+++ b/ui-next/src/pages/agent/guides/python/openai.md
@@ -6,7 +6,7 @@ export CONDUCTOR_SERVER_URL={{CONDUCTOR_SERVER_URL}}
 # For authenticated Conductor servers:
 # export CONDUCTOR_AUTH_KEY=<YOUR_AUTH_KEY>
 # export CONDUCTOR_AUTH_SECRET=<YOUR_AUTH_SECRET>
-export AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini
+export CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
 ```
 
 ## 2. Change one import

--- a/ui-next/src/pages/agent/guides/typescript/google-adk.md
+++ b/ui-next/src/pages/agent/guides/typescript/google-adk.md
@@ -6,7 +6,7 @@ export CONDUCTOR_SERVER_URL={{CONDUCTOR_SERVER_URL}}
 # For authenticated Conductor servers:
 # export CONDUCTOR_AUTH_KEY=<YOUR_AUTH_KEY>
 # export CONDUCTOR_AUTH_SECRET=<YOUR_AUTH_SECRET>
-export AGENTSPAN_LLM_MODEL=google_gemini/gemini-2.5-flash
+export CONDUCTOR_AGENT_LLM_MODEL=google_gemini/gemini-2.5-flash
 ```
 
 ## 2. Run the agent

--- a/ui-next/src/pages/agent/guides/typescript/langchain.md
+++ b/ui-next/src/pages/agent/guides/typescript/langchain.md
@@ -6,7 +6,7 @@ export CONDUCTOR_SERVER_URL={{CONDUCTOR_SERVER_URL}}
 # For authenticated Conductor servers:
 # export CONDUCTOR_AUTH_KEY=<YOUR_AUTH_KEY>
 # export CONDUCTOR_AUTH_SECRET=<YOUR_AUTH_SECRET>
-export AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini
+export CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
 ```
 
 ## 2. Hand your executor to Conductor

--- a/ui-next/src/pages/agent/guides/typescript/langgraph.md
+++ b/ui-next/src/pages/agent/guides/typescript/langgraph.md
@@ -6,7 +6,7 @@ export CONDUCTOR_SERVER_URL={{CONDUCTOR_SERVER_URL}}
 # For authenticated Conductor servers:
 # export CONDUCTOR_AUTH_KEY=<YOUR_AUTH_KEY>
 # export CONDUCTOR_AUTH_SECRET=<YOUR_AUTH_SECRET>
-export AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini
+export CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
 ```
 
 ## 2. Run the graph

--- a/ui-next/src/pages/agent/guides/typescript/native.md
+++ b/ui-next/src/pages/agent/guides/typescript/native.md
@@ -11,7 +11,7 @@ export CONDUCTOR_SERVER_URL={{CONDUCTOR_SERVER_URL}}
 # For authenticated Conductor servers:
 # export CONDUCTOR_AUTH_KEY=<YOUR_AUTH_KEY>
 # export CONDUCTOR_AUTH_SECRET=<YOUR_AUTH_SECRET>
-export AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini
+export CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
 ```
 
 ## 3. Save as `my-agent.ts` and run

--- a/ui-next/src/pages/agent/guides/typescript/openai.md
+++ b/ui-next/src/pages/agent/guides/typescript/openai.md
@@ -6,7 +6,7 @@ export CONDUCTOR_SERVER_URL={{CONDUCTOR_SERVER_URL}}
 # For authenticated Conductor servers:
 # export CONDUCTOR_AUTH_KEY=<YOUR_AUTH_KEY>
 # export CONDUCTOR_AUTH_SECRET=<YOUR_AUTH_SECRET>
-export AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini
+export CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
 ```
 
 ## 2. Run the agent

--- a/ui-next/src/pages/agent/guides/typescript/vercel-ai.md
+++ b/ui-next/src/pages/agent/guides/typescript/vercel-ai.md
@@ -6,7 +6,7 @@ export CONDUCTOR_SERVER_URL={{CONDUCTOR_SERVER_URL}}
 # For authenticated Conductor servers:
 # export CONDUCTOR_AUTH_KEY=<YOUR_AUTH_KEY>
 # export CONDUCTOR_AUTH_SECRET=<YOUR_AUTH_SECRET>
-export AGENTSPAN_LLM_MODEL=openai/gpt-4o-mini
+export CONDUCTOR_AGENT_LLM_MODEL=openai/gpt-4o-mini
 ```
 
 ## 2. Run with the Vercel tool

--- a/ui-next/src/pages/agent/types.ts
+++ b/ui-next/src/pages/agent/types.ts
@@ -1,5 +1,5 @@
 /**
- * Wire types for the embedded AgentSpan REST API (conductor-agentspan).
+ * Wire types for the embedded Conductor-Agents REST API (conductor-agentspan).
  * Kept local to the agent pages; mirror the server DTOs.
  */
 

--- a/ui-next/src/pages/execution/AgentExecution/HumanInputPanel.tsx
+++ b/ui-next/src/pages/execution/AgentExecution/HumanInputPanel.tsx
@@ -5,7 +5,7 @@
  *   1. Tool approval  (@tool(approval_required=True)) — approve/reject buttons
  *   2. MANUAL strategy agent selection — dropdown + confirm button
  *
- * Talks to the embedded AgentSpan REST API (conductor-agentspan module,
+ * Talks to the embedded Conductor-Agents REST API (conductor-agentspan module,
  * gated by conductor.integrations.ai.enabled) — /api/agent/:id/status and
  * /api/agent/:id/respond.
  */

--- a/ui-next/src/pages/execution/Execution.tsx
+++ b/ui-next/src/pages/execution/Execution.tsx
@@ -473,7 +473,7 @@ export default function Execution() {
               (isAgentWorkflowExecution(execution) ? (
                 // Relabeled "Agent Definition" in LeftPanelTabs for agent
                 // executions — a graph of the agent's static structure
-                // (model/sub-agents/tools/guardrails), matching AgentSpan's
+                // (model/sub-agents/tools/guardrails), matching Conductor-Agents'
                 // own UI, instead of the plain Conductor execution summary.
                 <AgentDefinitionView execution={execution} />
               ) : (

--- a/ui-next/src/pages/execution/LeftPanelTabs.tsx
+++ b/ui-next/src/pages/execution/LeftPanelTabs.tsx
@@ -34,7 +34,7 @@ export default function LeftPanelTabs({
   const isAgentWorkflow = isAgentWorkflowExecution(execution);
 
   // Agent-classified executions get a curated tab set that matches
-  // AgentSpan's own UI 1:1: Agent Execution, Workflow View (Diagram, relabeled),
+  // Conductor-Agents' UI 1:1: Agent Execution, Workflow View (Diagram, relabeled),
   // Task List, Timeline, Agent Definition (Summary, relabeled), JSON — no
   // Workflow Input/Output, Variables, or Tasks to Domain. Regular workflows
   // keep the full Conductor tab set unchanged.
@@ -118,7 +118,7 @@ export default function LeftPanelTabs({
       ];
 
   // Add Workflow Introspection tab only if the feature flag is enabled —
-  // inserted right after "Timeline" in either tab set (matches AgentSpan's
+  // inserted right after "Timeline" in either tab set (matches Conductor-Agents'
   // own splice position for the agent set, and the pre-existing position
   // for the regular set).
   if (isWorkflowIntrospectionEnabled) {

--- a/ui-next/src/pages/execution/helpers.ts
+++ b/ui-next/src/pages/execution/helpers.ts
@@ -7,7 +7,7 @@ type SeqResult = {
 };
 
 /**
- * Whether a workflow execution is an AgentSpan-compiled agent run (carries
+ * Whether a workflow execution is a Conductor-Agents-compiled agent run (carries
  * the `agentDef`/`agent_sdk` metadata stamp on its workflow definition), as
  * opposed to a plain Conductor workflow. Drives: which tab the execution page
  * defaults to, which sidebar nav item stays highlighted, and which route

--- a/ui-next/src/pages/execution/state/guards.ts
+++ b/ui-next/src/pages/execution/state/guards.ts
@@ -38,7 +38,7 @@ export const isAgentExecutionTab = ({ currentTab }: ExecutionMachineContext) =>
 
 /**
  * Gate for the "Agent Execution" debugger tab — only agent-classified
- * executions (AgentSpan-compiled workflows) get the tab/default-tab treatment;
+ * executions (Conductor-Agents-compiled workflows) get the tab/default-tab treatment;
  * regular workflows keep Diagram as the default view.
  */
 export const isAgentWorkflowExecution = (context: ExecutionMachineContext) =>

--- a/ui-next/src/pages/execution/state/machine.ts
+++ b/ui-next/src/pages/execution/state/machine.ts
@@ -217,7 +217,7 @@ export const executionMachine = createMachine<
                     target: "diagram",
                   },
                   {
-                    // Agent-classified executions (AgentSpan-compiled workflows)
+                    // Agent-classified executions (Conductor-Agents-compiled workflows)
                     // default to the Agent Execution debugger tab; regular
                     // workflows keep Diagram as the default view.
                     cond: "isAgentWorkflowExecution",

--- a/ui-next/src/pages/executions/workflowSearchComponents/AdvancedSearch.tsx
+++ b/ui-next/src/pages/executions/workflowSearchComponents/AdvancedSearch.tsx
@@ -212,7 +212,7 @@ export default function AdvancedSearch({
       query: queryFT.query,
       freeText: queryFT.freeText,
       // Scope results to a single classifier: "workflow" for plain workflow
-      // executions, "agent" for AgentSpan agent runs on the Agents pages.
+      // executions, "agent" for Conductor-Agents runs on the Agents pages.
       classifier,
     },
     {},

--- a/ui-next/src/pages/executions/workflowSearchComponents/BasicSearch.tsx
+++ b/ui-next/src/pages/executions/workflowSearchComponents/BasicSearch.tsx
@@ -303,7 +303,7 @@ export default function BasicSearch({
       query: queryFT.query,
       freeText: queryFT.freeText,
       // Scope results to a single classifier: "workflow" for plain workflow
-      // executions, "agent" for AgentSpan agent runs on the Agents pages.
+      // executions, "agent" for Conductor-Agents runs on the Agents pages.
       classifier,
     },
     {},

--- a/ui-next/src/routes/__tests__/router.test.tsx
+++ b/ui-next/src/routes/__tests__/router.test.tsx
@@ -18,7 +18,7 @@ vi.mock("utils", async (importOriginal) => {
       PLAYGROUND: "PLAYGROUND",
       SHOW_GET_STARTED_PAGE: "SHOW_GET_STARTED_PAGE",
       TASK_INDEXING: "TASK_INDEXING",
-      AGENTSPAN_ENABLED: "AGENTSPAN_ENABLED",
+      CONDUCTOR_INTEGRATIONS_AI_ENABLED: "CONDUCTOR_INTEGRATIONS_AI_ENABLED",
     },
   };
 });
@@ -244,7 +244,7 @@ describe("router (OSS)", () => {
     expect(router).toBeDefined();
   });
 
-  describe("AgentSpan gating (AGENTSPAN_ENABLED)", () => {
+  describe("Conductor AI integration gating", () => {
     const AGENT_PATHS = [
       "/agents",
       "/agents/new",
@@ -255,15 +255,15 @@ describe("router (OSS)", () => {
       "/agentSecrets",
     ];
 
-    it("omits agent routes when AGENTSPAN_ENABLED is off", () => {
+    it("omits agent routes when the AI integration is off", () => {
       mockFeatureFlags.isEnabled.mockReturnValue(false);
       const paths = collectPaths(getRoutes());
       AGENT_PATHS.forEach((p) => expect(paths).not.toContain(p));
     });
 
-    it("includes agent routes when AGENTSPAN_ENABLED is on", () => {
+    it("includes agent routes when the AI integration is on", () => {
       mockFeatureFlags.isEnabled.mockImplementation(
-        (feature: string) => feature === "AGENTSPAN_ENABLED",
+        (feature: string) => feature === "CONDUCTOR_INTEGRATIONS_AI_ENABLED",
       );
       const paths = collectPaths(getRoutes());
       AGENT_PATHS.forEach((p) => expect(paths).toContain(p));
@@ -271,7 +271,7 @@ describe("router (OSS)", () => {
 
     it("registers the create-agent route before the agent detail route", () => {
       mockFeatureFlags.isEnabled.mockImplementation(
-        (feature: string) => feature === "AGENTSPAN_ENABLED",
+        (feature: string) => feature === "CONDUCTOR_INTEGRATIONS_AI_ENABLED",
       );
       const paths = collectPaths(getRoutes());
 

--- a/ui-next/src/routes/routes.tsx
+++ b/ui-next/src/routes/routes.tsx
@@ -207,9 +207,9 @@ const getCoreAuthenticatedRoutes = () => [
     element: <CreatorFlags />,
   },
 
-  // Embedded AgentSpan pages (registered only when AGENTSPAN_ENABLED, i.e.
+  // Embedded Conductor-Agents pages (registered only when CONDUCTOR_INTEGRATIONS_AI_ENABLED, i.e.
   // the server's conductor.integrations.ai.enabled is true).
-  ...(featureFlags.isEnabled(FEATURES.AGENTSPAN_ENABLED)
+  ...(featureFlags.isEnabled(FEATURES.CONDUCTOR_INTEGRATIONS_AI_ENABLED)
     ? [
         { path: AGENT_DEFINITION_URL.BASE, element: <AgentDefinitions /> },
         { path: AGENT_DEFINITION_URL.NEW, element: <CreateAgentGuide /> },

--- a/ui-next/src/utils/constants/route.ts
+++ b/ui-next/src/utils/constants/route.ts
@@ -37,7 +37,7 @@ export const SCHEDULER_DEFINITION_URL = {
 
 export const SCHEDULER_EXECUTION_URL = "/schedulerExecs";
 
-// Embedded AgentSpan agent pages (gated by AGENTSPAN_ENABLED / conductor.integrations.ai.enabled)
+// Embedded Conductor-Agents pages, gated by conductor.integrations.ai.enabled.
 export const AGENT_DEFINITION_URL = {
   BASE: "/agents",
   NEW: "/agents/new",

--- a/ui-next/src/utils/flags.ts
+++ b/ui-next/src/utils/flags.ts
@@ -92,8 +92,8 @@ export const FEATURES = Object.freeze({
   SHOW_AGENT: "SHOW_AGENT",
   ENABLE_AGENT_AUDIO_INPUT: "ENABLE_AGENT_AUDIO_INPUT",
   // Driven by the server's conductor.integrations.ai.enabled (injected via /context.js).
-  // Gates the embedded AgentSpan agent pages (Agents, Executions, Skills, Secrets).
-  AGENTSPAN_ENABLED: "AGENTSPAN_ENABLED",
+  // Gates the embedded Conductor-Agents pages (Agents, Executions, Skills, Secrets).
+  CONDUCTOR_INTEGRATIONS_AI_ENABLED: "CONDUCTOR_INTEGRATIONS_AI_ENABLED",
   AI_CODER_WORKER: "AI_CODER_WORKER",
   AI_CODER_CLOUD_WORKER: "AI_CODER_CLOUD_WORKER",
   TAG_VISIBILITY: "TAG_VISIBILITY",


### PR DESCRIPTION
## Summary

- Make `conductor.integrations.ai.enabled` the single configuration switch for Conductor-Agents.
- Remove the redundant `agentspan.embedded` property and migrate all backend conditional wiring, tests, examples, and documentation to the canonical property.
- Replace the UI-only `AGENTSPAN_ENABLED` runtime flag with `CONDUCTOR_INTEGRATIONS_AI_ENABLED`, injected from the same server property through the `context.js` runtime configuration.
- Update stale quickstart model-variable guidance to use `CONDUCTOR_AGENT_LLM_MODEL`, and refresh human-facing comments to use the Conductor-Agents name.

## Verification

- Focused Conductor-Agents gating tests
- Server module compilation
- Spotless formatting
- UI route and sidebar tests
- UI typecheck

## Screenshot evidence

Replace each `<upload-image-url>` placeholder after dragging the matching screenshot into this PR comment or editing this PR description.

### 1. Enabled startup — `conductor.integrations.ai.enabled=true`

**Server startup — AGENT and CANCEL_AGENT listeners are initialized**

<img width="1280" height="720" alt="1-enabled-startup" src="https://github.com/user-attachments/assets/dc4fd13a-6479-4d5b-b299-e419f44ab24d" />

### 2. Enabled UI — `conductor.integrations.ai.enabled=true`

**UI — Agents navigation and Create Agent are rendered**

<img width="1280" height="720" alt="2-enabled-ui" src="https://github.com/user-attachments/assets/e4fb8acb-b5f0-4d0e-bbe1-59db872c8fe5" />

### 3. Disabled startup — `conductor.integrations.ai.enabled=false`

**Server startup — agent listeners/model-provider initialization are absent; runtime context reports false**

<img width="1280" height="720" alt="3-disabled-startup" src="https://github.com/user-attachments/assets/30edf745-7ec2-437d-857f-cfd2208a8554" />

### 4. Disabled UI — `conductor.integrations.ai.enabled=false`

**UI — Agent components and navigation are not rendered**

<img width="1280" height="720" alt="4-disabled-ui" src="https://github.com/user-attachments/assets/1fc338c9-c185-4cd8-bf99-6e6bf7f181fd" />
