### PR TITLE
fix(ai): default agentType(); fix agent-client registration and OkHttpClient wiring

### DIFF
--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AzureFoundryAgentClient.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AzureFoundryAgentClient.java
@@ -30,6 +30,7 @@ import org.conductoross.conductor.ai.agent.credentials.OAuthTokenProvider;
 import org.conductoross.conductor.ai.agentspan.runtime.credentials.CredentialResolutionService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -57,8 +58,11 @@ import okhttp3.Response;
  *   <li>{@code endpoint} - the agentsEndpointUri for the AI Foundry project (optional if
  *       AZURE_FOUNDRY_ENDPOINT secret is set)
  * </ul>
+ *
+ * <p>Activated by {@code conductor.integrations.ai.enabled=true}, like the other agent clients.
  */
 @Component
+@ConditionalOnProperty(name = "conductor.integrations.ai.enabled", havingValue = "true")
 public class AzureFoundryAgentClient implements ConductorAgentClient {
 
     private static final Logger log = LoggerFactory.getLogger(AzureFoundryAgentClient.class);

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AzureFoundryAgentClient.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AzureFoundryAgentClient.java
@@ -30,6 +30,7 @@ import org.conductoross.conductor.ai.agent.credentials.OAuthTokenProvider;
 import org.conductoross.conductor.ai.agentspan.runtime.credentials.CredentialResolutionService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
@@ -60,6 +61,9 @@ import okhttp3.Response;
  * </ul>
  *
  * <p>Activated by {@code conductor.integrations.ai.enabled=true}, like the other agent clients.
+ * Credentials are resolved per request from {@code credentialRef}, so the client registers whether
+ * or not Azure Foundry is configured; an unconfigured runtime fails only if a workflow routes to
+ * it.
  */
 @Component
 @ConditionalOnProperty(name = "conductor.integrations.ai.enabled", havingValue = "true")
@@ -77,7 +81,8 @@ public class AzureFoundryAgentClient implements ConductorAgentClient {
             new ConcurrentHashMap<>();
 
     public AzureFoundryAgentClient(
-            CredentialResolutionService credentialResolutionService, OkHttpClient httpClient) {
+            CredentialResolutionService credentialResolutionService,
+            @Qualifier("conductorAiHttpClient") OkHttpClient httpClient) {
         this.credentialResolutionService = credentialResolutionService;
         this.httpClient = httpClient;
     }

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/BedrockAgentClient.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/BedrockAgentClient.java
@@ -51,6 +51,9 @@ import software.amazon.awssdk.services.bedrockagentruntime.model.SessionState;
  * {@link ExecutionState}. Subsequent {@code getAgentStatus} calls read from that state.
  *
  * <p>Activated by {@code conductor.integrations.ai.enabled=true}, like the other agent clients.
+ * Credentials are resolved per request from {@code credentialRef}, falling back to the default AWS
+ * credential chain, so the client registers whether or not Bedrock is configured; an unconfigured
+ * runtime fails only if a workflow routes to it.
  */
 @Component
 @ConditionalOnProperty(name = "conductor.integrations.ai.enabled", havingValue = "true")

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/BedrockAgentClient.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/BedrockAgentClient.java
@@ -30,6 +30,7 @@ import org.conductoross.conductor.ai.agent.ConductorAgentStatusResponse;
 import org.conductoross.conductor.ai.agentspan.runtime.credentials.CredentialResolutionService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -49,9 +50,10 @@ import software.amazon.awssdk.services.bedrockagentruntime.model.SessionState;
  * {@code startAgent} or {@code respond} streams the response and buffers it into an in-memory
  * {@link ExecutionState}. Subsequent {@code getAgentStatus} calls read from that state.
  *
- * <p>Activated by {@code conductor.ai.bedrock-agent.enabled=true}.
+ * <p>Activated by {@code conductor.integrations.ai.enabled=true}, like the other agent clients.
  */
 @Component
+@ConditionalOnProperty(name = "conductor.integrations.ai.enabled", havingValue = "true")
 public class BedrockAgentClient implements ConductorAgentClient {
 
     private static final Logger log = LoggerFactory.getLogger(BedrockAgentClient.class);

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/service/ExternalAgentClientGatingTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/service/ExternalAgentClientGatingTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.agentspan.runtime.service;
+
+import org.conductoross.conductor.ai.a2a.A2AService;
+import org.conductoross.conductor.ai.agentspan.runtime.credentials.CredentialResolutionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import com.netflix.conductor.core.secrets.NoopSecretsDAO;
+
+import okhttp3.OkHttpClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The external agent clients register together with {@link CredentialResolutionService}, which they
+ * both require, and neither needs credentials to be configured — a deployment using only Bedrock,
+ * only Azure Foundry, both, or neither picks a runtime per workflow via {@code agentType}.
+ *
+ * <p>Guards the wiring rather than the runtimes: before this was gated, the clients registered
+ * while the credential service did not, so a host that component-scanned this package failed to
+ * start.
+ */
+class ExternalAgentClientGatingTest {
+
+    @Configuration
+    @Import({
+        BedrockAgentClient.class,
+        AzureFoundryAgentClient.class,
+        CredentialResolutionService.class
+    })
+    static class ExternalAgentBeans {}
+
+    private final ApplicationContextRunner runner =
+            new ApplicationContextRunner()
+                    .withPropertyValues("conductor.secrets.type=noop")
+                    .withBean(NoopSecretsDAO.class, NoopSecretsDAO::new)
+                    .withBean("conductorAiHttpClient", OkHttpClient.class, OkHttpClient::new)
+                    .withUserConfiguration(ExternalAgentBeans.class);
+
+    @Test
+    void clientsAreAbsentWhenAiIntegrationIsDisabled() {
+        runner.run(
+                ctx -> {
+                    assertThat(ctx).doesNotHaveBean(BedrockAgentClient.class);
+                    assertThat(ctx).doesNotHaveBean(AzureFoundryAgentClient.class);
+                    assertThat(ctx).doesNotHaveBean(CredentialResolutionService.class);
+                });
+    }
+
+    @Test
+    void clientsRegisterWithTheirCredentialServiceWhenAiIntegrationIsEnabled() {
+        runner.withPropertyValues("conductor.integrations.ai.enabled=true")
+                .run(
+                        ctx -> {
+                            assertThat(ctx).hasSingleBean(BedrockAgentClient.class);
+                            assertThat(ctx).hasSingleBean(AzureFoundryAgentClient.class);
+                            assertThat(ctx).hasSingleBean(CredentialResolutionService.class);
+                        });
+    }
+
+    /** No credentials are configured here, so construction must not depend on them. */
+    @Test
+    void clientsReportDistinctAgentTypesWithoutAnyCredentials() {
+        runner.withPropertyValues("conductor.integrations.ai.enabled=true")
+                .run(
+                        ctx -> {
+                            assertThat(ctx.getBean(BedrockAgentClient.class).agentType())
+                                    .isEqualTo(A2AService.AGENT_TYPE_BEDROCK);
+                            assertThat(ctx.getBean(AzureFoundryAgentClient.class).agentType())
+                                    .isEqualTo(A2AService.AGENT_TYPE_AZURE_FOUNDRY);
+                        });
+    }
+
+    /** A second OkHttpClient bean must not make the Azure Foundry injection ambiguous. */
+    @Test
+    void azureFoundryResolvesItsHttpClientAlongsideAnotherOkHttpClientBean() {
+        runner.withPropertyValues("conductor.integrations.ai.enabled=true")
+                .withBean("someOtherHttpClient", OkHttpClient.class, OkHttpClient::new)
+                .run(ctx -> assertThat(ctx).hasSingleBean(AzureFoundryAgentClient.class));
+    }
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/agent/ConductorAgentClient.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/agent/ConductorAgentClient.java
@@ -20,8 +20,16 @@ package org.conductoross.conductor.ai.agent;
  */
 public interface ConductorAgentClient extends AutoCloseable {
 
-    /** Agent type string that routes requests to this client (e.g. "conductor", "bedrock"). */
-    String agentType();
+    /**
+     * Agent type string that routes requests to this client (e.g. "conductor", "bedrock").
+     *
+     * <p>Defaults to {@code "conductor"} — the value of {@code A2AService.AGENT_TYPE_CONDUCTOR},
+     * inlined to keep this boundary interface free of imports — so existing implementations of the
+     * Conductor control plane keep compiling. Clients backing any other runtime must override.
+     */
+    default String agentType() {
+        return "conductor";
+    }
 
     ConductorAgentStartResponse startAgent(ConductorAgentStartRequest request);
 

--- a/ai/src/main/java/org/conductoross/conductor/ai/tasks/worker/A2AWorkers.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/tasks/worker/A2AWorkers.java
@@ -117,13 +117,32 @@ public class A2AWorkers implements AnnotatedSystemTaskWorker, TaskCancellationHa
             String callbackUrl) {
         this.a2aService = a2aService;
         this.applicationContext = null;
-        conductorAgentClients.forEach(c -> agentClients.put(c.agentType().toLowerCase(), c));
+        conductorAgentClients.forEach(this::register);
         this.agentClientsLoaded = true;
         this.callbackUrl = StringUtils.trimToNull(callbackUrl);
     }
 
     public A2AWorkers(A2AService a2aService, List<ConductorAgentClient> conductorAgentClients) {
         this(a2aService, conductorAgentClients, (String) null);
+    }
+
+    /**
+     * Index a client by its agent type. Two clients claiming the same type would otherwise
+     * last-one-wins on discovery order, silently shadowing one of them; {@code agentType()}
+     * defaults to {@code "conductor"}, so an implementation that forgets to override collides with
+     * the built-in client. Keep the first and say so rather than swapping it out invisibly.
+     */
+    private void register(ConductorAgentClient client) {
+        String agentType = client.agentType().toLowerCase();
+        ConductorAgentClient existing = agentClients.putIfAbsent(agentType, client);
+        if (existing != null && existing != client) {
+            log.warn(
+                    "Ignoring agent client {} — agentType '{}' is already served by {}. "
+                            + "Override agentType() so both are reachable.",
+                    client.getClass().getName(),
+                    agentType,
+                    existing.getClass().getName());
+        }
     }
 
     private Map<String, ConductorAgentClient> clients() {
@@ -133,7 +152,7 @@ public class A2AWorkers implements AnnotatedSystemTaskWorker, TaskCancellationHa
                     applicationContext
                             .getBeansOfType(ConductorAgentClient.class)
                             .values()
-                            .forEach(c -> agentClients.put(c.agentType().toLowerCase(), c));
+                            .forEach(this::register);
                     agentClientsLoaded = true;
                 }
             }

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/ConductorAgentEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/ConductorAgentEndToEndTest.java
@@ -81,8 +81,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
             "conductor.app.sweeperThreadCount=1",
             "conductor.app.sweeper.sweepBatchSize=1",
             "conductor.app.sweeper.queuePopTimeout=750",
-            "conductor.integrations.ai.enabled=true",
-            "agentspan.embedded=true"
+            "conductor.integrations.ai.enabled=true"
         })
 class ConductorAgentEndToEndTest {
 


### PR DESCRIPTION
Three fixes for API and wiring problems introduced by #1358, plus one dead property left by #1413. **6 files, +143/−8** — five fixes and a test.

## 1. `ConductorAgentClient.agentType()` is a breaking interface change

#1358 added `agentType()` as an **abstract** method on the public `ConductorAgentClient` interface. That's source- and binary-breaking in a minor release: every external implementation — SDK-backed worker adapters, and any host supplying its own agent control plane — stops compiling until it adds the method, even though `"conductor"` is the only value such an implementation could reasonably return.

Now defaulted to `"conductor"`; clients backing another runtime override. The literal is inlined rather than referencing `A2AService.AGENT_TYPE_CONDUCTOR` (same value, asserted in the javadoc) to keep this boundary interface import-free, as it is today.

## 2. `BedrockAgentClient` / `AzureFoundryAgentClient` can register without their dependency

Both were added as plain `@Component` with no condition, unlike `ServiceConductorAgentClient` which is gated on `conductor.integrations.ai.enabled`. All three require `CredentialResolutionService`, which carries that flag — so leaving two unconditional means a client can exist while the service it needs does not.

On a stock server it's masked: `AgentSpanAutoConfiguration`'s scan shares the flag, so the clients are only discovered when the service also exists. It stops being masked for a host that component-scans the runtime package itself:

```
azureFoundryAgentClient
  -> NoSuchBeanDefinitionException: ...credentials.CredentialResolutionService
```

Both now carry the same condition as `ServiceConductorAgentClient`. Stock behaviour is unchanged — they activate exactly when they do today — and no new property is introduced, so every combination stays reachable: **bedrock only, azure-foundry only, both, or neither**, decided by a workflow's `agentType` rather than by configuration.

That works because neither client resolves credentials at construction. Bedrock reads `credentialRef` inside `buildRuntimeClient` (falling back to the default AWS credential chain), Azure Foundry inside its token exchange — both per request. A missing key cannot break startup; it surfaces only if a workflow actually routes to that runtime. Both javadocs now say so, since "why is this bean registered when I never configured Bedrock" is the obvious question.

`BedrockAgentClient`'s javadoc claimed activation by `conductor.ai.bedrock-agent.enabled`, a property that appears nowhere else in the repo and was never wired; it now names the flag actually used. Real per-runtime opt-in flags would be a reasonable follow-up, but they'd need config metadata and docs, and they aren't required to make the combinations work.

## 3. Unqualified `OkHttpClient` in `AzureFoundryAgentClient`

The one thing that could still break the both-registered case. Only one such bean exists on a stock server (`conductorAiHttpClient`), so it resolves today — but any host defining a second `OkHttpClient` bean fails that client with `NoUniqueBeanDefinitionException`, taking the whole context down rather than just that runtime. Now bound explicitly to `conductorAiHttpClient`, the client the AI module publishes for this purpose.

## 4. Dead `agentspan.embedded` property in a test

#1413 folded `agentspan.embedded` into `conductor.integrations.ai.enabled`. `ConductorAgentEndToEndTest` still set the old flag alongside the new one — the last reference in the repo to a property nothing reads. Removed; `git grep agentspan.embedded` is now empty.

## Verification

- `./gradlew :conductor-agentspan:test :conductor-ai:test` — **0 failures**
- `:conductor-test-harness:compileTestJava` clean
- Spotless clean
- End-to-end downstream check: published this branch to a local Maven repo and consumed it from a host that component-scans the runtime package. Before, that host needed a scan exclusion for both clients *and* its own `agentType()` override; with this PR it compiles and boots clean with **neither**, under AI enabled and disabled.

## 5. `agentType` collisions were silent

`A2AWorkers` indexed clients with `agentClients.put(agentType, client)`, so two clients claiming one type last-one-wins on discovery order and one vanishes with no signal. Before #1358 the single-client injection raised `NoUniqueBeanDefinitionException` — so that traded a loud failure for an invisible one, and **fix 1 above makes it easier to hit**, since an implementation that forgets to override `agentType()` now matches the built-in client. Keeps the first registration and logs which client was ignored, on both the Spring and SDK paths.

## Resolved, not changed

The `"AGENT (conductor) requires 'name'"` validation #1358 dropped from `ConductorAgentDelegate` is **deliberate and stays dropped**: the delegate now also serves bedrock and azure-foundry, whose identity comes from `rawConfig` / `assistantId` rather than a name — which is why the remaining messages were genericised to `"AGENT requires 'prompt'"`. Flagging it here so it isn't mistaken for an oversight.

## Verification

**New test.** `ExternalAgentClientGatingTest` covers the two external clients, which had none: absent when the AI integration is off; registered together with `CredentialResolutionService` when on; reporting their own agent types with **no credentials configured anywhere**; and Azure Foundry still resolving its `OkHttpClient` when a second `OkHttpClient` bean exists. That last case was confirmed to fail without the qualifier (`NoUniqueBeanDefinitionException ... found 2`) and pass with it — so it guards the fix rather than just accompanying it.

**Suites.** `:conductor-agentspan:test` 560 tests, `:conductor-ai:test` 750 tests, **0 failures**. `:conductor-test-harness:compileTestJava` clean. Spotless clean. CI runs `unit-test`, `build` and `test-harness` (~18 min, boots real servers and exercises agent registration / deployment / MCP discovery).

**Downstream, against this exact revision.** Published to a local Maven repo and consumed from a host that component-scans the runtime package. Before this PR that host needed a component-scan exclusion for both clients *and* its own `agentType()` override; with this PR it compiles across all modules and boots a full Spring context with **neither**, under AI integrations both enabled and disabled.

**Not covered:** no test exercises Bedrock or Azure Foundry against the real services — that needs credentials. This PR only changes when those beans register and how their HTTP client is bound, not their request paths.

