### PR TITLE
fix(agentspan): make host-supplied skill storage optional

### DIFF
--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/SkillRegistryService.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/SkillRegistryService.java
@@ -44,6 +44,7 @@ import org.conductoross.conductor.common.metadata.agent.SkillDetail;
 import org.conductoross.conductor.common.metadata.agent.SkillFileContent;
 import org.conductoross.conductor.common.metadata.agent.SkillFileEntry;
 import org.conductoross.conductor.common.metadata.agent.SkillSummary;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -111,17 +112,32 @@ public class SkillRegistryService {
             @Value("${agentspan.skills.max-uncompressed-bytes:209715200}")
                     long maxUncompressedBytes,
             @Value("${agentspan.skills.max-file-count:2000}") int maxFileCount,
-            SkillPackageStore packageStore,
-            SkillMetadataDAO metadataDao) {
+            ObjectProvider<SkillPackageStore> packageStore,
+            ObjectProvider<SkillMetadataDAO> metadataDao) {
         this.maxPackageBytes = maxPackageBytes;
         this.maxPreviewBytes = maxPreviewBytes;
         this.maxUncompressedBytes = maxUncompressedBytes;
         this.maxFileCount = maxFileCount;
-        this.packageStore = packageStore;
-        this.metadataDao = metadataDao;
+        this.packageStore = packageStore.getIfAvailable();
+        this.metadataDao = metadataDao.getIfAvailable();
+    }
+
+    /** Whether a host supplied skill storage. */
+    public boolean isSkillStorageAvailable() {
+        return packageStore != null && metadataDao != null;
+    }
+
+    private void requireSkillStorage() {
+        if (!isSkillStorageAvailable()) {
+            throw new UnsupportedOperationException(
+                    "Skills are unavailable: no SkillPackageStore/SkillMetadataDAO is configured for"
+                            + " this backend. Agents run without skills; supply both beans to enable"
+                            + " skill registration and lookup.");
+        }
     }
 
     public synchronized SkillDetail register(String manifestJson, MultipartFile packageFile) {
+        requireSkillStorage();
         if (packageFile == null || packageFile.isEmpty()) {
             throw new IllegalArgumentException("Skill package is required");
         }
@@ -206,6 +222,9 @@ public class SkillRegistryService {
     }
 
     public List<SkillSummary> list(boolean allVersions) {
+        if (!isSkillStorageAvailable()) {
+            return List.of();
+        }
         List<SkillSummary> summaries = new ArrayList<>();
         for (SkillDetail detail : metadataDao.list(allVersions)) {
             addSummary(summaries, detail);
@@ -217,6 +236,7 @@ public class SkillRegistryService {
     }
 
     public SkillDetail get(String name, String version) {
+        requireSkillStorage();
         String resolvedVersion = resolveVersion(name, version);
         SkillDetail detail =
                 metadataDao
@@ -232,11 +252,13 @@ public class SkillRegistryService {
     }
 
     public byte[] packageBytes(String name, String version) {
+        requireSkillStorage();
         SkillDetail detail = get(name, version);
         return packageBytes(detail);
     }
 
     public SkillFileContent readFile(String name, String version, String path) {
+        requireSkillStorage();
         if (path == null || path.isBlank()) {
             throw new IllegalArgumentException("File path is required");
         }
@@ -280,6 +302,7 @@ public class SkillRegistryService {
 
     @SuppressWarnings("unchecked")
     public Map<String, Object> resolveRawConfig(Map<String, Object> skillRef) {
+        requireSkillStorage();
         if (skillRef == null) {
             throw new IllegalArgumentException("skillRef is required");
         }
@@ -323,6 +346,7 @@ public class SkillRegistryService {
     }
 
     public synchronized void delete(String name, String version) {
+        requireSkillStorage();
         String resolvedVersion = resolveVersion(name, version);
         metadataDao
                 .find(name, resolvedVersion)

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/service/OptionalSkillStorageTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/service/OptionalSkillStorageTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.agentspan.runtime.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Skill storage is host-supplied, and not every backend has an implementation — a host may run
+ * Postgres stores and nothing for MySQL, for example. Requiring it made the whole agent runtime
+ * un-startable on such a backend, since {@link SkillRegistryService} took both stores as mandatory
+ * constructor arguments. Skills are a capability, not a precondition for running an agent.
+ */
+class OptionalSkillStorageTest {
+
+    @Configuration
+    @Import(SkillRegistryService.class)
+    static class NoSkillStorage {}
+
+    private final ApplicationContextRunner runner =
+            new ApplicationContextRunner()
+                    .withPropertyValues("conductor.integrations.ai.enabled=true")
+                    .withUserConfiguration(NoSkillStorage.class);
+
+    @Test
+    void registryStartsWithNoSkillStorage() {
+        runner.run(
+                ctx -> {
+                    assertThat(ctx).hasNotFailed();
+                    assertThat(ctx).hasSingleBean(SkillRegistryService.class);
+                    assertThat(ctx.getBean(SkillRegistryService.class).isSkillStorageAvailable())
+                            .isFalse();
+                });
+    }
+
+    /** "Which skills exist" has a correct answer without storage: none. */
+    @Test
+    void listDegradesToEmptyWithNoSkillStorage() {
+        runner.run(ctx -> assertThat(ctx.getBean(SkillRegistryService.class).list(true)).isEmpty());
+    }
+
+    /** Anything needing the bytes fails loudly rather than with an NPE. */
+    @Test
+    void skillLookupFailsClearlyWithNoSkillStorage() {
+        runner.run(
+                ctx ->
+                        assertThatThrownBy(
+                                        () ->
+                                                ctx.getBean(SkillRegistryService.class)
+                                                        .get("some-skill", "1"))
+                                .isInstanceOf(UnsupportedOperationException.class)
+                                .hasMessageContaining("Skills are unavailable"));
+    }
+}


### PR DESCRIPTION
`SkillRegistryService` takes both skill stores as **mandatory** constructor arguments:

```java
public SkillRegistryService(..., SkillPackageStore packageStore, SkillMetadataDAO metadataDao)
```

Skill storage is host-supplied, and a host may not have an implementation for every backend it supports. When it doesn't, the whole agent runtime becomes un-startable:

```
agentService -> skillRegistryService
  -> NoSuchBeanDefinitionException: ...agentspan.runtime.spi.SkillPackageStore
```

Skills are a capability, not a precondition for running an agent.

## The change

Both parameters become `ObjectProvider`:

- `list()` degrades to an empty list — "which skills exist" has a correct answer without storage: none
- everything needing the package bytes throws a clear `UnsupportedOperationException` instead of an NPE
- `isSkillStorageAvailable()` lets callers branch

## Why it matters in practice

A host with Postgres skill stores and nothing for MySQL currently has two options, both bad:

1. **Write a second backend-specific DAO pair** — a few hundred lines of dialect SQL per backend, for a capability that host may not even want on it.
2. **Disable the AI integration on that backend** — which also removes unrelated AI surface, since other components are gated on the same flag. In our case it took out the prompt API and broke `PromptResourceE2ETest`.

With this change the host supplies stores where it has them, and agents simply run without skills elsewhere.

## Verification

- `OptionalSkillStorageTest` (new): registry starts with no storage, `list()` returns empty, lookup fails clearly
- `:conductor-agentspan:test` and `:conductor-ai:test` — **0 failures**
- Spotless clean

No behaviour change where storage is present: `getIfAvailable()` resolves the same bean the constructor previously required.