### PR TITLE
fix(guardrail): preserve serialized custom rejection

### DIFF
--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/util/JavaScriptBuilder.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/util/JavaScriptBuilder.java
@@ -490,6 +490,22 @@ public class JavaScriptBuilder {
                         + "            fixed_output: null, guardrail_name: guardrailName,"
                         + "            should_continue: false};"
                         + "  }"
+                        // Worker SDKs may serialize a custom guardrail response into the result
+                        // envelope. Decode it before applying the guardrail contract; otherwise a
+                        // valid {passed:false,on_fail:'raise'} response falls through as a pass.
+                        + "  if (typeof raw === 'object' && raw.result !== undefined"
+                        + "      && raw.on_fail === undefined && raw.onFail === undefined"
+                        + "      && raw.passed === undefined && raw.output === undefined) {"
+                        + "    raw = raw.result;"
+                        + "  }"
+                        + "  if (typeof raw === 'object' && raw.output !== undefined"
+                        + "      && raw.on_fail === undefined && raw.onFail === undefined"
+                        + "      && raw.passed === undefined) {"
+                        + "    raw = raw.output;"
+                        + "  }"
+                        + "  if (typeof raw === 'string') {"
+                        + "    try { raw = JSON.parse(raw); } catch (ignored) {}"
+                        + "  }"
                         + "  if (typeof raw === 'object' && raw.result !== undefined"
                         + "      && raw.on_fail === undefined && raw.onFail === undefined"
                         + "      && raw.tripwire_triggered === undefined && raw.tripwireTriggered === undefined"

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/util/GuardrailEscalationScriptTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/util/GuardrailEscalationScriptTest.java
@@ -165,6 +165,44 @@ class GuardrailEscalationScriptTest {
         assertThat(result.getMember("passed").asBoolean()).isTrue();
     }
 
+    @Test
+    void serializedCustomGuardrailRejectionPreservesRaise() {
+        Value result =
+                normalize(
+                        "{worker_output: {result: '{\\\"passed\\\":false,\\\"on_fail\\\":\\\"raise\\\",\\\"message\\\":\\\"blocked\\\"}'}, "
+                                + "guardrail_name: 'g', default_on_fail: 'retry', "
+                                + "iteration: 1, max_retries: 3}");
+
+        assertThat(result.getMember("passed").asBoolean()).isFalse();
+        assertThat(result.getMember("on_fail").asString()).isEqualTo("raise");
+        assertThat(result.getMember("message").asString()).isEqualTo("blocked");
+    }
+
+    @Test
+    void serializedCustomGuardrailRetryEscalatesAtMaxRetries() {
+        Value result =
+                normalize(
+                        "{worker_output: {result: '{\\\"passed\\\":false,\\\"on_fail\\\":\\\"retry\\\"}'}, "
+                                + "guardrail_name: 'g', default_on_fail: 'retry', "
+                                + "iteration: 3, max_retries: 3}");
+
+        assertThat(result.getMember("passed").asBoolean()).isFalse();
+        assertThat(result.getMember("on_fail").asString()).isEqualTo("raise");
+        assertThat(result.getMember("should_continue").asBoolean()).isFalse();
+    }
+
+    @Test
+    void outputEnvelopeCustomGuardrailRejectionPreservesRaise() {
+        Value result =
+                normalize(
+                        "{worker_output: {output: {passed: false, on_fail: 'raise', message: 'blocked'}}, "
+                                + "guardrail_name: 'g', default_on_fail: 'retry', "
+                                + "iteration: 1, max_retries: 3}");
+
+        assertThat(result.getMember("passed").asBoolean()).isFalse();
+        assertThat(result.getMember("on_fail").asString()).isEqualTo("raise");
+    }
+
     // ── composition with the tool-call-turn short-circuit (Issue #1323 / PR #1352) ──
     //
     // compileGuardrailTasks binds both toolCalls (short-circuit, #1352) and

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/ConductorAgentEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/ConductorAgentEndToEndTest.java
@@ -201,9 +201,7 @@ class ConductorAgentEndToEndTest {
                         .getFirst();
         // The production compiler resolves this from the surrounding agent loop. This focused
         // workflow has a single synthetic turn, so provide that turn number directly.
-        guardrailTask
-                .getTasks()
-                .forEach(task -> task.getInputParameters().put("iteration", 1));
+        guardrailTask.getTasks().forEach(task -> task.getInputParameters().put("iteration", 1));
         GuardrailCompiler.GuardrailRoutingResult routing =
                 compiler.compileGuardrailRouting(
                         guardrail,

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/ConductorAgentEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/ConductorAgentEndToEndTest.java
@@ -21,6 +21,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.awaitility.Awaitility;
+import org.conductoross.conductor.ai.agentspan.runtime.compiler.GuardrailCompiler;
+import org.conductoross.conductor.common.metadata.agent.GuardrailConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -168,6 +170,114 @@ class ConductorAgentEndToEndTest {
         Workflow agentExecution = executionService.getExecutionStatus(executionId, true);
         assertEquals(Workflow.WorkflowStatus.COMPLETED, agentExecution.getStatus());
         assertEquals(agentName, agentExecution.getWorkflowName());
+    }
+
+    /**
+     * A rejecting custom tool-input guardrail must take the generated {@code raise} branch before
+     * the guarded tool is reached. This deliberately uses the compiler's real {@code SIMPLE ->
+     * INLINE normalizer -> SWITCH -> SIMPLE} shape and the real server executor rather than
+     * duplicating the routing decision in the test.
+     */
+    @Test
+    void customToolInputGuardrailRaiseFailsBeforeGuardedToolExecutes() {
+        String guardrailWorker = "tin_custom_raise_guardrail_" + UUID.randomUUID();
+        String guardedTool = "tin_custom_raise_tool_" + UUID.randomUUID();
+        String workflowName = "tin_custom_raise_workflow_" + UUID.randomUUID();
+        ensureTaskDef(guardrailWorker);
+        ensureTaskDef(guardedTool);
+
+        GuardrailConfig guardrail =
+                GuardrailConfig.builder()
+                        .name("tin_custom_raise")
+                        .guardrailType("custom")
+                        .position("input")
+                        .taskName(guardrailWorker)
+                        .onFail("raise")
+                        .build();
+        GuardrailCompiler compiler = new GuardrailCompiler();
+        GuardrailCompiler.GuardrailTaskResult guardrailTask =
+                compiler.compileToolGuardrailTasks(
+                                List.of(guardrail), "tin_custom_raise", "tool input")
+                        .getFirst();
+        // The production compiler resolves this from the surrounding agent loop. This focused
+        // workflow has a single synthetic turn, so provide that turn number directly.
+        guardrailTask
+                .getTasks()
+                .forEach(task -> task.getInputParameters().put("iteration", 1));
+        GuardrailCompiler.GuardrailRoutingResult routing =
+                compiler.compileGuardrailRouting(
+                        guardrail,
+                        guardrailTask.getRefName(),
+                        "tool input",
+                        "tin_custom_raise",
+                        "_tg",
+                        guardrailTask.isInline());
+        WorkflowTask guardedToolTask = new WorkflowTask();
+        guardedToolTask.setName(guardedTool);
+        guardedToolTask.setTaskReferenceName("guarded_tool");
+        guardedToolTask.setType("SIMPLE");
+        guardedToolTask.setInputParameters(Map.of());
+        guardrailTask.getTasks().forEach(this::populateTaskNames);
+        populateTaskNames(routing.getSwitchTask());
+
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setName(workflowName);
+        workflowDef.setVersion(1);
+        workflowDef.setOwnerEmail("conductor-agent-e2e@conductor.test");
+        // Tool guardrails are compiled for the agent's DO_WHILE turn loop and resolve their
+        // iteration from ${tin_custom_raise_loop.output.iteration}. Exercise that real shape so
+        // the workflow definition is valid and the routing behaviour is tested at execution time.
+        List<WorkflowTask> loopTasks = new ArrayList<>(guardrailTask.getTasks());
+        loopTasks.add(routing.getSwitchTask());
+        loopTasks.add(guardedToolTask);
+        WorkflowTask loop = new WorkflowTask();
+        loop.setName("DO_WHILE");
+        loop.setType("DO_WHILE");
+        loop.setTaskReferenceName("tin_custom_raise_loop");
+        loop.setLoopCondition(
+                "if ($.tin_custom_raise_loop['iteration'] < 1) { true; } else { false; }");
+        loop.setLoopOver(loopTasks);
+        loop.setInputParameters(Map.of("tin_custom_raise_loop", "${tin_custom_raise_loop}"));
+        workflowDef.setTasks(List.of(loop));
+        metadataService.updateWorkflowDef(List.of(workflowDef));
+
+        String workflowId = startWorkflow(workflowName);
+        String guardrailTaskId = awaitPolledTask(workflowId, guardrailWorker);
+
+        TaskResult rejection = new TaskResult();
+        rejection.setTaskId(guardrailTaskId);
+        rejection.setWorkflowInstanceId(workflowId);
+        rejection.setStatus(TaskResult.Status.COMPLETED);
+        // This is the worker result shape emitted by SDK workers that serialize their guardrail
+        // response into TaskResult.outputData.result.
+        rejection.setOutputData(
+                Map.of(
+                        "result",
+                        "{\"passed\":false,\"on_fail\":\"raise\",\"message\":\"blocked\"}"));
+        workflowExecutor.updateTask(rejection);
+
+        Workflow failed = awaitTerminal(workflowId);
+        assertEquals(Workflow.WorkflowStatus.FAILED, failed.getStatus());
+        Task normalizedGuardrail =
+                failed.getTasks().stream()
+                        .filter(
+                                task ->
+                                        "INLINE".equals(task.getTaskType())
+                                                && task.getReferenceTaskName()
+                                                        .startsWith(guardrailTask.getRefName()))
+                        .findFirst()
+                        .orElseThrow();
+        assertTrue(normalizedGuardrail.getOutputData().get("result") instanceof Map<?, ?>);
+        Map<?, ?> normalizedResult = (Map<?, ?>) normalizedGuardrail.getOutputData().get("result");
+        assertEquals(false, normalizedResult.get("passed"));
+        assertEquals("raise", normalizedResult.get("on_fail"));
+        assertTrue(
+                failed.getTasks().stream()
+                        .noneMatch(task -> guardedTool.equals(task.getTaskType())),
+                "guarded tool must never be scheduled after custom guardrail rejection");
+        assertTrue(
+                queueDAO.pop(guardedTool, 1, 100).isEmpty(),
+                "guarded tool must not be available for a worker to poll");
     }
 
     /**
@@ -1123,6 +1233,39 @@ class ConductorAgentEndToEndTest {
             metadataService.registerTaskDef(List.of(td));
         } catch (Exception ignored) {
             // already registered by a prior test
+        }
+    }
+
+    private String awaitPolledTask(String workflowId, String taskType) {
+        return Awaitility.await()
+                .atMost(15, TimeUnit.SECONDS)
+                .pollInterval(100, TimeUnit.MILLISECONDS)
+                .until(
+                        () -> {
+                            workflowExecutor.decide(workflowId);
+                            List<String> taskIds = queueDAO.pop(taskType, 1, 100);
+                            return taskIds.isEmpty() ? null : taskIds.get(0);
+                        },
+                        java.util.Objects::nonNull);
+    }
+
+    /**
+     * Compiler-generated structural tasks receive names when the full agent definition is built.
+     */
+    private void populateTaskNames(WorkflowTask task) {
+        if (task.getName() == null) {
+            task.setName(task.getType());
+        }
+        if (task.getDecisionCases() != null) {
+            task.getDecisionCases()
+                    .values()
+                    .forEach(tasks -> tasks.forEach(this::populateTaskNames));
+        }
+        if (task.getDefaultCase() != null) {
+            task.getDefaultCase().forEach(this::populateTaskNames);
+        }
+        if (task.getForkTasks() != null) {
+            task.getForkTasks().forEach(tasks -> tasks.forEach(this::populateTaskNames));
         }
     }
 }


### PR DESCRIPTION
## Summary

- [x] Bugfix

Custom tool-input guardrails can return a valid rejection as JSON serialized inside `TaskResult.outputData.result`. The generated normalizer previously only recognized object-shaped results, so it treated that rejection as a pass. The guardrail switch then took its default path, scheduled the guarded tool, and the workflow could complete instead of failing.

This PR unwraps standard worker result/output envelopes and parses serialized JSON before normalizing the guardrail contract. A `{ passed: false, on_fail: "raise" }` rejection now reaches the generated `raise` branch, terminates the workflow as `FAILED`, and prevents the guarded tool from being scheduled.

## How the custom-result normalizer works

The compiler routes on the normalizer output, not the raw worker output. It expects a guardrail object such as:

```json
{ "passed": false, "on_fail": "raise", "message": "blocked" }
```

Some SDK workers send that result as a JSON string inside a standard envelope instead:

```json
{ "result": "{\"passed\":false,\"on_fail\":\"raise\",\"message\":\"blocked\"}" }
```

Previously that string was not decoded, so the normalizer used its pass default and the generated `SWITCH` took its default branch. The new JavaScript unwraps `result` or `output`, then safely applies `JSON.parse` when the value is a string. It can therefore preserve `passed: false` and `on_fail: "raise"`; the existing generated `raise` route runs `TERMINATE` with `FAILED` before tool dispatch.

## Retry escalation

Retry handling remains separate from the `raise` fix. Added coverage proves that a serialized custom `on_fail: "retry"` result still escalates to `raise` when `iteration >= maxRetries`.

## Tests

- `./gradlew :conductor-agentspan:test --tests org.conductoross.conductor.ai.agentspan.runtime.util.GuardrailEscalationScriptTest --tests org.conductoross.conductor.ai.agentspan.runtime.compiler.GuardrailCompilerTest`
- `./gradlew :conductor-test-harness:test --tests com.netflix.conductor.test.integration.agent.ConductorAgentEndToEndTest.customToolInputGuardrailRaiseFailsBeforeGuardedToolExecutes`
- `./gradlew :conductor-agentspan:spotlessApply :conductor-test-harness:spotlessApply`

## Workflow shape

No generated-workflow shape changed: the route still reads the custom normalizer output at `...output.result.on_fail`. The fix preserves that contract and ensures serialized worker results are normalized into it.