### PR TITLE
fix(ui): handle prompt template agent instructions

### DIFF
--- a/ui-next/src/components/ErrorBoundary.test.tsx
+++ b/ui-next/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes, useNavigate } from "react-router";
+import ErrorBoundary from "./ErrorBoundary";
+
+vi.mock("utils", () => ({
+  reportErrorToLogRocket: vi.fn(),
+  isLogRocketEnabled: vi.fn(() => false),
+}));
+
+function ThrowError({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error("Agent diagram failed to render");
+  }
+
+  return <div>Recovered content</div>;
+}
+
+function RouteRecoveryFixture() {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <button onClick={() => navigate("/healthy")}>Navigate away</button>
+      <ErrorBoundary>
+        <Routes>
+          <Route path="/broken" element={<ThrowError shouldThrow />} />
+          <Route path="/healthy" element={<div>Healthy page</div>} />
+        </Routes>
+      </ErrorBoundary>
+    </>
+  );
+}
+
+describe("ErrorBoundary", () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it("shows the captured error message and retries rendering its children", () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <ErrorBoundary>
+          <ThrowError shouldThrow />
+        </ErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Agent diagram failed to render",
+    );
+
+    rerender(
+      <MemoryRouter>
+        <ErrorBoundary>
+          <ThrowError shouldThrow={false} />
+        </ErrorBoundary>
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(screen.getByText("Recovered content")).toBeInTheDocument();
+  });
+
+  it("recovers automatically when navigation changes the route", () => {
+    render(
+      <MemoryRouter initialEntries={["/broken"]}>
+        <RouteRecoveryFixture />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Navigate away" }));
+
+    expect(screen.getByText("Healthy page")).toBeInTheDocument();
+  });
+});

--- a/ui-next/src/components/ErrorBoundary.tsx
+++ b/ui-next/src/components/ErrorBoundary.tsx
@@ -1,25 +1,26 @@
 import { Component, ErrorInfo, ReactNode } from "react";
-import { Box } from "@mui/material";
+import { Box, Button } from "@mui/material";
+import { useLocation } from "react-router";
 // import { reportErrorToHeap, isHeapEnabled } from "utils";
 
 import { reportErrorToLogRocket, isLogRocketEnabled } from "utils";
 interface Props {
   children?: ReactNode;
-  location?: any;
+  locationKey: string;
 }
 
 interface State {
-  hasError: boolean;
+  error: Error | null;
 }
 
-class ErrorBoundary extends Component<Props, State> {
+class ErrorBoundaryContent extends Component<Props, State> {
   public state: State = {
-    hasError: false,
+    error: null,
   };
 
-  public static getDerivedStateFromError(_: Error): State {
+  public static getDerivedStateFromError(error: Error): State {
     // Update state so the next render will show the fallback UI.
-    return { hasError: true };
+    return { error };
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
@@ -34,15 +35,21 @@ class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (prevProps?.location?.pathname !== this.props.location?.pathname) {
-      this.setState({ hasError: false });
+    if (
+      prevProps.locationKey !== this.props.locationKey &&
+      this.state.error !== null
+    ) {
+      this.setState({ error: null });
     }
   }
 
+  private handleRetry = () => this.setState({ error: null });
+
   public render() {
-    if (this.state.hasError) {
+    if (this.state.error) {
       return (
         <Box
+          role="alert"
           sx={{
             width: "100%",
             height: "100%",
@@ -59,9 +66,16 @@ class ErrorBoundary extends Component<Props, State> {
           >
             There was an error performing this action. Please try again.
           </Box>
+          <Box sx={{ fontSize: "1rem", mt: 1 }}>
+            {this.state.error.message || "An unexpected error occurred."}
+          </Box>
+          <Button sx={{ mt: 2 }} onClick={this.handleRetry} variant="contained">
+            Try again
+          </Button>
           <Box
             sx={{
               fontSize: "1rem",
+              mt: 2,
             }}
           >
             Contact support if the error persists.
@@ -74,4 +88,14 @@ class ErrorBoundary extends Component<Props, State> {
   }
 }
 
-export default ErrorBoundary;
+/** Resets the boundary when the active route changes. */
+export default function ErrorBoundary({ children }: { children?: ReactNode }) {
+  const location = useLocation();
+  const locationKey = `${location.pathname}${location.search}${location.hash}`;
+
+  return (
+    <ErrorBoundaryContent locationKey={locationKey}>
+      {children}
+    </ErrorBoundaryContent>
+  );
+}

--- a/ui-next/src/pages/execution/AgentExecution/AgentDefinitionView.test.tsx
+++ b/ui-next/src/pages/execution/AgentExecution/AgentDefinitionView.test.tsx
@@ -1,6 +1,27 @@
 import { render, screen } from "@testing-library/react";
-import { AgentDefinitionView } from "./AgentDefinitionView";
+import { vi } from "vitest";
+import {
+  AgentDefinitionDiagram,
+  AgentDefinitionView,
+} from "./AgentDefinitionView";
 import { WorkflowExecution } from "types/Execution";
+
+vi.mock("reaflow", () => ({
+  Canvas: ({
+    nodes,
+  }: {
+    nodes: Array<{ id: string; data: { sublabel?: string } }>;
+  }) => (
+    <div>
+      {nodes.map((node) => (
+        <span key={node.id}>{node.data.sublabel}</span>
+      ))}
+    </div>
+  ),
+  CanvasPosition: { CENTER: "center" },
+  Edge: () => null,
+  Node: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
 
 describe("AgentDefinitionView", () => {
   it("shows a fallback message when the workflow definition has no agentDef metadata", () => {
@@ -12,6 +33,37 @@ describe("AgentDefinitionView", () => {
 
     expect(
       screen.getByText("No agent definition found in workflow metadata"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders prompt-template instruction references without crashing", () => {
+    render(
+      <AgentDefinitionDiagram
+        agentDef={{
+          name: "Publisher",
+          instructions: {
+            type: "prompt_template",
+            name: "content-publisher",
+            version: 2,
+          },
+          agents: [
+            {
+              name: "Editor",
+              instructions: {
+                type: "prompt_template",
+                name: "editorial-style",
+              },
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText("Prompt template: content-publisher (v2)"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Prompt template: editorial-style"),
     ).toBeInTheDocument();
   });
 });

--- a/ui-next/src/pages/execution/AgentExecution/AgentDefinitionView.tsx
+++ b/ui-next/src/pages/execution/AgentExecution/AgentDefinitionView.tsx
@@ -94,6 +94,38 @@ function getItemDescription(t: unknown): string | undefined {
   return undefined;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function truncateText(text: string, maxLength: number): string {
+  return text.length > maxLength ? `${text.slice(0, maxLength)}…` : text;
+}
+
+/**
+ * Produces a safe diagram label for either inline instructions or a prompt-template reference.
+ * Agent definitions accept both shapes, so only strings are sliced directly.
+ */
+function instructionSnippet(
+  instructions: unknown,
+  maxLength = 55,
+): string | undefined {
+  if (typeof instructions === "string") {
+    return instructions ? truncateText(instructions, maxLength) : undefined;
+  }
+
+  if (!isRecord(instructions)) return undefined;
+
+  const templateName = instructions.name;
+  if (typeof templateName !== "string" || !templateName) return undefined;
+
+  const version = instructions.version;
+  const templateLabel = `Prompt template: ${templateName}${
+    typeof version === "number" ? ` (v${version})` : ""
+  }`;
+  return truncateText(templateLabel, maxLength);
+}
+
 function toolCat(
   t: Record<string, unknown>,
 ): "agent" | "tool" | "guardrail" | "http" | "mcp" | "rag" {
@@ -467,9 +499,7 @@ function buildDefDiagram(agentDef: Record<string, unknown>) {
   const agentName = (agentDef.name as string | undefined) ?? "Agent";
   const strategy = agentDef.strategy as string | undefined;
   const maxTurns = agentDef.maxTurns as number | undefined;
-  const instructions = (agentDef.instructions ?? agentDef.description) as
-    | string
-    | undefined;
+  const instructions = agentDef.instructions ?? agentDef.description;
 
   // Sub-agents from the agents[] field (orchestrator pattern)
   const agentsList =
@@ -496,7 +526,7 @@ function buildDefDiagram(agentDef: Record<string, unknown>) {
     ...agentsList.map((a) => ({
       name: getItemName(a),
       model: a.model as string | undefined,
-      instructions: a.instructions as string | undefined,
+      instructions: a.instructions,
       strategy: a.strategy as string | undefined,
       maxTurns: a.maxTurns as number | undefined,
       subAgentCount: ((a.agents as unknown[]) ?? []).length,
@@ -507,9 +537,10 @@ function buildDefDiagram(agentDef: Record<string, unknown>) {
       model: ((t.config as any)?.agentConfig?.model ?? t.model) as
         | string
         | undefined,
-      instructions: (t.config as any)?.agentConfig?.instructions as
-        | string
-        | undefined,
+      instructions:
+        isRecord(t.config) && isRecord(t.config.agentConfig)
+          ? t.config.agentConfig.instructions
+          : undefined,
       strategy: t.strategy as string | undefined,
       maxTurns: undefined as number | undefined,
       subAgentCount: 0,
@@ -517,9 +548,7 @@ function buildDefDiagram(agentDef: Record<string, unknown>) {
     })),
   ];
 
-  const instSnippet = instructions
-    ? instructions.slice(0, 55) + (instructions.length > 55 ? "…" : "")
-    : undefined;
+  const instSnippet = instructionSnippet(instructions);
 
   // ── Root agent node ──────────────────────────────────────────────────────────
   nodes.push({
@@ -554,10 +583,7 @@ function buildDefDiagram(agentDef: Record<string, unknown>) {
     for (let i = 0; i < allSubAgents.length; i++) {
       const sa = allSubAgents[i];
       const id = `subagent-${i}`;
-      const instSub = sa.instructions
-        ? sa.instructions.slice(0, 55) +
-          (sa.instructions.length > 55 ? "…" : "")
-        : undefined;
+      const instSub = instructionSnippet(sa.instructions);
       nodes.push({
         id,
         width: W,


### PR DESCRIPTION
## Summary
- safely format prompt-template instruction references in the shared agent definition diagram
- repair the existing shared `ErrorBoundary` so it recovers after navigation
- display captured exception messages and provide a retry action
- add regression coverage for both failure paths

## What was already there

The application already had an `ErrorBoundary`. Both the OSS and enterprise `AuthGuard` components wrap their authenticated route `<Outlet>` with this shared boundary, so no new boundary or route wrapper is being introduced by this PR.

## What was broken

There were two separate problems:

### 1. The agent diagram caused the original exception

Agent instructions can be either inline strings or prompt-template objects. The diagram cast every instruction to a string and called `.slice()`. For definitions such as `content_publishing_platform`, that produced:

```text
TypeError: sa.instructions.slice is not a function
```

### 2. The existing error boundary could catch the exception but could not recover

The boundary attempted to reset when `location.pathname` changed, but `location` was an optional prop and neither AuthGuard supplied it:

```tsx
<ErrorBoundary>
  <Outlet />
</ErrorBoundary>
```

Consequently, both the previous and current `location` values were `undefined`. Navigating to another page never cleared the boundary state, leaving the authenticated content area stuck on its fallback until the application was reloaded. The fallback also hid the captured exception behind a generic message and had no retry action.

## Before/after evidence

<table>
  <tr>
    <th width="50%">Before — render failure</th>
    <th width="50%">After — diagram renders</th>
  </tr>
  <tr>
    <td valign="top"><img src="https://github.com/user-attachments/assets/2a78b0d4-5d20-48b6-b149-65f3df45128c" alt="Before: agent definition page displays a render error" /></td>
    <td valign="top"><img src="https://github.com/user-attachments/assets/1f32c7c4-bd24-4b83-be45-d0bcdde9e46d" alt="After: agent definition diagram renders successfully" /></td>
  </tr>
  <tr>
    <td align="center"><sub>Prompt-template instructions crash the agent definition view.</sub></td>
    <td align="center"><sub>The definition diagram renders and page navigation remains usable.</sub></td>
  </tr>
</table>

## Fix

- Handle instruction values as `unknown` and only truncate actual strings.
- Render prompt-template references as `Prompt template: <name> (v<version>)`.
- Have the existing boundary obtain the active route internally with `useLocation`; callers do not need to pass location state.
- Reset its captured error when pathname, search, or hash changes.
- Show the captured exception message, preserve existing console/LogRocket reporting, and provide **Try again**.

This keeps the implementation in the shared OSS UI. It does not duplicate the agent-definition page or require changes in `conductor-ui`.

## Regression coverage

- prompt-template instructions on root agents and sub-agents render without throwing
- captured error messages are displayed
- retry clears the boundary state
- navigation clears the boundary and renders the destination page

## Verification

- `pnpm exec vitest run src/components/ErrorBoundary.test.tsx src/pages/execution/AgentExecution/AgentDefinitionView.test.tsx`
- `pnpm exec eslint src/components/ErrorBoundary.tsx src/components/ErrorBoundary.test.tsx --quiet`
- `pnpm typecheck`
- verified `/agents/content_publishing_platform/1` through the enterprise UI with zero browser errors and no error fallback