### PR TITLE
fix(agentspan): map handoff toolType to INLINE instead of silent SIMPLE default

### DIFF
--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/ToolCompiler.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/ToolCompiler.java
@@ -150,6 +150,7 @@ public class ToolCompiler {
                     Map.entry("generate_video", "GENERATE_VIDEO"),
                     Map.entry("rag_index", "LLM_INDEX_TEXT"),
                     Map.entry("rag_search", "LLM_SEARCH_INDEX"),
+                    Map.entry("handoff", "INLINE"),
                     Map.entry("pull_workflow_messages", "PULL_WORKFLOW_MESSAGES"));
 
     // ── Public API ───────────────────────────────────────────────────────
@@ -169,6 +170,14 @@ public class ToolCompiler {
 
         for (ToolConfig tool : tools) {
             String toolType = tool.getToolType() != null ? tool.getToolType() : "worker";
+            if (!TYPE_MAP.containsKey(toolType)) {
+                logger.warn(
+                        "Unrecognized tool type '{}' for tool '{}' — defaulting to SIMPLE. "
+                                + "If this is a new compiler-owned control-signal type, add it to "
+                                + "ToolCompiler.TYPE_MAP instead of relying on this fallback.",
+                        toolType,
+                        tool.getName());
+            }
             String conductorType = TYPE_MAP.getOrDefault(toolType, "SIMPLE");
 
             Map<String, Object> spec = new LinkedHashMap<>();

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/SwarmHandoffCompilerContractTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/SwarmHandoffCompilerContractTest.java
@@ -72,7 +72,7 @@ class SwarmHandoffCompilerContractTest {
             for (Object rawTool : tools) {
                 if (rawTool instanceof Map<?, ?> tool
                         && String.valueOf(tool.get("name")).contains("_transfer_to_")) {
-                    assertThat(tool.get("type")).isEqualTo("SIMPLE");
+                    assertThat(tool.get("type")).isEqualTo("INLINE");
                     assertThat(tool.get("inputSchema"))
                             .as("generated transfer message schema")
                             .isInstanceOf(Map.class);

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/ToolCompilerTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/ToolCompilerTest.java
@@ -199,6 +199,35 @@ class ToolCompilerTest {
     }
 
     @Test
+    void testCompileToolSpecs_Handoff() {
+        ToolConfig tool =
+                ToolConfig.builder()
+                        .name("swarm_agent_a_transfer_to_swarm_agent_b")
+                        .description("Transfer the conversation to swarm_agent_b.")
+                        .toolType("handoff")
+                        .build();
+
+        ToolCompiler tc = new ToolCompiler();
+        List<Map<String, Object>> specs = tc.compileToolSpecs(List.of(tool));
+
+        assertThat(specs).hasSize(1);
+        assertThat(specs.get(0).get("type")).isEqualTo("INLINE");
+    }
+
+    @Test
+    void testCompileToolSpecs_compilerOwnedToolTypesHaveExplicitMappings() {
+        assertThat(specType("worker")).isEqualTo("SIMPLE");
+        assertThat(specType("agent_tool")).isEqualTo("SUB_WORKFLOW");
+        assertThat(specType("handoff")).isEqualTo("INLINE");
+    }
+
+    private String specType(String toolType) {
+        ToolConfig tool =
+                ToolConfig.builder().name("probe").description("probe").toolType(toolType).build();
+        return (String) new ToolCompiler().compileToolSpecs(List.of(tool)).get(0).get("type");
+    }
+
+    @Test
     void testCompileToolSpecs_AgentTool() {
         ToolConfig tool =
                 ToolConfig.builder()


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

**Bug:** `ToolCompiler.TYPE_MAP` has no entry for `toolType="handoff"` (the SWARM/hybrid transfer
tool's type since PR #1356). `compileToolSpecs` silently falls through to its `"SIMPLE"` default,
so every `{source}_transfer_to_{peer}` tool's LLM-facing spec says `"type": "SIMPLE"` — directly
contradicting the "deliberately not a worker" comment on the same `.toolType("handoff")` call.

**Impact:** cosmetic to the server's own dispatch (transfer calls are intercepted by the INLINE
`checkTransferTask`/`toolRouter` before dynamic-fork dispatch ever runs), but it's the field
client SDKs read to decide "does this tool need a local worker" — and it's wrong. One half of the
fix for #1363 (stateful SWARM handoffs hanging forever); paired python-sdk PR fixes the client
side that this bug misleads.

**Fix:**
- `TYPE_MAP`: add `"handoff" → "INLINE"`, matching how `handoff_check`/`check_transfer` are
  already typed.
- `compileToolSpecs`: WARN-log unrecognized `toolType`s instead of silently defaulting to
  `"SIMPLE"` — a silent default to the one type that implies "needs a worker" is exactly what let
  this regress unnoticed for 9+ days.
- Tests: new `testCompileToolSpecs_Handoff` (direct coverage) and
  `testCompileToolSpecs_compilerOwnedToolTypesHaveExplicitMappings` (pins all 3 compiler-owned
  toolTypes so a future unmapped one is caught here). Fixed one pre-existing
  `SwarmHandoffCompilerContractTest` assertion that had hardcoded this bug (`"SIMPLE"`) as expected
  behavior.

**Not fixed by this PR alone:** `requiredWorkers` (computed from
`WorkflowDef#collectSimpleTaskNames()`, which reads the compiled *graph* task's type, not the LLM
tool spec) already excluded these names, confirmed live both before and after this change. This PR
only fixes the LLM-facing spec field.

Issue #1363

Alternatives considered
----

- Restore server-side `TaskDef` registration for the transfer tool — rejected: the transfer task
  is never dynamically forked/scheduled in the first place (`checkTransferTask`/`toolRouter`
  interception), so a registered `TaskDef` would just be dead clutter.
- Introduce a new task-type marker instead of reusing `"INLINE"` — rejected: `INLINE` is already
  what `handoff_check`/`check_transfer` use for "resolved server-side, no worker."
