### PR TITLE
Pin compatible OpenAI Agents quickstart version

### DIFF
--- a/ui-next/src/pages/agent/guides/manifest.test.ts
+++ b/ui-next/src/pages/agent/guides/manifest.test.ts
@@ -57,5 +57,11 @@ describe("agent guide manifest", () => {
     javaGuides.forEach(({ markdown }) => {
       expect(markdown).not.toContain("org.conductoross:conductor-ai:");
     });
+
+    const typescriptOpenAiGuide = getAgentGuide(
+      getAgentGuideLanguage("typescript"),
+      "openai",
+    );
+    expect(typescriptOpenAiGuide.markdown).toContain("@openai/agents@0.2.1");
   });
 });

--- a/ui-next/src/pages/agent/guides/typescript/openai.md
+++ b/ui-next/src/pages/agent/guides/typescript/openai.md
@@ -1,7 +1,7 @@
 ## 1. Install and configure
 
 ```bash
-npm install @io-orkes/conductor-javascript@4.0.0-rc4 @openai/agents
+npm install @io-orkes/conductor-javascript@4.0.0-rc4 @openai/agents@0.2.1
 export CONDUCTOR_SERVER_URL={{CONDUCTOR_SERVER_URL}}
 # For authenticated Conductor servers:
 # export CONDUCTOR_AUTH_KEY=<YOUR_AUTH_KEY>


### PR DESCRIPTION
## Summary

The TypeScript OpenAI quickstart merged in #1432 left `@openai/agents` unpinned. The current npm release (`0.14.1`) requires Zod 4, while `@io-orkes/conductor-javascript@4.0.0-rc4` requires Zod 3, so the documented command now fails with `ERESOLVE`.

Pin `@openai/agents@0.2.1`, the newest release whose peer range accepts Zod 3, and add a manifest regression assertion for that integration pin.

## Exact console evidence

### Merged command — fails

```console
$ npm install @io-orkes/conductor-javascript@4.0.0-rc4 @openai/agents
npm error code ERESOLVE
npm error ERESOLVE could not resolve
npm error
npm error While resolving: @io-orkes/conductor-javascript@4.0.0-rc4
npm error Found: zod@4.4.3
npm error node_modules/zod
npm error   peer zod@"^4.0.0" from @openai/agents@0.14.1
npm error   node_modules/@openai/agents
npm error     @openai/agents@"*" from the root project
npm error
npm error Could not resolve dependency:
npm error peerOptional zod@"^3.22.0" from @io-orkes/conductor-javascript@4.0.0-rc4
```

### Corrected guide command — resolves

```console
$ npm install @io-orkes/conductor-javascript@4.0.0-rc4 @openai/agents@0.2.1

added 106 packages in 3s
openai@1.0.0 /tmp/conductor-ts-proof.PUeJt0/openai
├── @io-orkes/conductor-javascript@4.0.0-rc4
└── @openai/agents@0.2.1
```

### Documented imports and `Agent` construction

```console
$ node --input-type=module -e 'import { Agent, setTracingDisabled } from "@openai/agents"; setTracingDisabled(true); const agent = new Agent({name:"openai_greeter", model:"gpt-4o-mini", instructions:"You are friendly and concise."}); console.log(agent.name)'
openai_greeter
```

### UI tests

```console
Test Files  70 passed (70)
     Tests  700 passed | 1 skipped (701)
  Duration  29.45s
```
