### PR TITLE
Prompt Template field + Start Agent event handler action

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/events/EventHandler.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/events/EventHandler.java
@@ -148,7 +148,8 @@ public class EventHandler {
             complete_task,
             fail_task,
             terminate_workflow,
-            update_workflow_variables
+            update_workflow_variables,
+            start_agent
         }
 
         @ProtoField(id = 1)
@@ -171,6 +172,9 @@ public class EventHandler {
 
         @ProtoField(id = 7)
         private UpdateWorkflowVariables update_workflow_variables;
+
+        @ProtoField(id = 8)
+        private StartAgent start_agent;
 
         /**
          * @return the action
@@ -270,6 +274,20 @@ public class EventHandler {
         public void setUpdate_workflow_variables(
                 UpdateWorkflowVariables update_workflow_variables) {
             this.update_workflow_variables = update_workflow_variables;
+        }
+
+        /**
+         * @return the start_agent
+         */
+        public StartAgent getStart_agent() {
+            return start_agent;
+        }
+
+        /**
+         * @param start_agent the start_agent to set
+         */
+        public void setStart_agent(StartAgent start_agent) {
+            this.start_agent = start_agent;
         }
     }
 
@@ -466,6 +484,134 @@ public class EventHandler {
 
         public void setTaskToDomain(Map<String, String> taskToDomain) {
             this.taskToDomain = taskToDomain;
+        }
+    }
+
+    /**
+     * Starts an execution of a previously deployed agent definition, identified by {@link #name}
+     * and optional {@link #version}. Field names mirror {@code AgentStartRequest} so the action
+     * processor can map this directly onto that request.
+     */
+    @ProtoMessage
+    public static class StartAgent {
+
+        @ProtoField(id = 1)
+        private String name;
+
+        @ProtoField(id = 2)
+        private Integer version;
+
+        @ProtoField(id = 3)
+        private String prompt;
+
+        @ProtoField(id = 4)
+        private String sessionId;
+
+        @ProtoField(id = 5)
+        private List<String> media;
+
+        @ProtoField(id = 6)
+        private Map<String, Object> context;
+
+        @ProtoField(id = 7)
+        private String idempotencyKey;
+
+        /**
+         * @return the name of the deployed agent definition to start
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * @param name the name to set
+         */
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        /**
+         * @return the version; the latest version is used when null
+         */
+        public Integer getVersion() {
+            return version;
+        }
+
+        /**
+         * @param version the version to set
+         */
+        public void setVersion(Integer version) {
+            this.version = version;
+        }
+
+        /**
+         * @return the prompt
+         */
+        public String getPrompt() {
+            return prompt;
+        }
+
+        /**
+         * @param prompt the prompt to set
+         */
+        public void setPrompt(String prompt) {
+            this.prompt = prompt;
+        }
+
+        /**
+         * @return the sessionId
+         */
+        public String getSessionId() {
+            return sessionId;
+        }
+
+        /**
+         * @param sessionId the sessionId to set
+         */
+        public void setSessionId(String sessionId) {
+            this.sessionId = sessionId;
+        }
+
+        /**
+         * @return the media
+         */
+        public List<String> getMedia() {
+            return media;
+        }
+
+        /**
+         * @param media the media to set
+         */
+        public void setMedia(List<String> media) {
+            this.media = media;
+        }
+
+        /**
+         * @return the context
+         */
+        public Map<String, Object> getContext() {
+            return context;
+        }
+
+        /**
+         * @param context the context to set
+         */
+        public void setContext(Map<String, Object> context) {
+            this.context = context;
+        }
+
+        /**
+         * @return the idempotencyKey
+         */
+        public String getIdempotencyKey() {
+            return idempotencyKey;
+        }
+
+        /**
+         * @param idempotencyKey the idempotencyKey to set
+         */
+        public void setIdempotencyKey(String idempotencyKey) {
+            this.idempotencyKey = idempotencyKey;
         }
     }
 

--- a/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
+++ b/core/src/main/java/com/netflix/conductor/core/events/SimpleActionProcessor.java
@@ -16,12 +16,15 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.conductoross.conductor.common.metadata.agent.AgentStartRequest;
+import org.conductoross.conductor.common.metadata.agent.AgentStartResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
 import com.netflix.conductor.common.metadata.events.EventHandler.Action;
+import com.netflix.conductor.common.metadata.events.EventHandler.StartAgent;
 import com.netflix.conductor.common.metadata.events.EventHandler.StartWorkflow;
 import com.netflix.conductor.common.metadata.events.EventHandler.TaskDetails;
 import com.netflix.conductor.common.metadata.tasks.TaskResult;
@@ -89,6 +92,8 @@ public class SimpleActionProcessor implements ActionProcessor {
                         TaskModel.Status.FAILED,
                         event,
                         messageId);
+            case start_agent:
+                return startAgent(action, jsonObject, event, messageId);
             default:
                 break;
         }
@@ -250,6 +255,81 @@ public class SimpleActionProcessor implements ActionProcessor {
             Monitors.recordEventActionError(action.getAction().name(), params.getName(), event);
             LOGGER.error(
                     "Error starting workflow: {}, version: {}, for event: {} for message: {}",
+                    params.getName(),
+                    params.getVersion(),
+                    event,
+                    messageId,
+                    e);
+            output.put("error", e.getMessage());
+            throw e;
+        }
+        return output;
+    }
+
+    private Map<String, Object> startAgent(
+            Action action, Object payload, String event, String messageId) {
+        StartAgent params = action.getStart_agent();
+        Map<String, Object> output = new HashMap<>();
+        try {
+            Map<String, Object> paramsMap = new HashMap<>();
+            paramsMap.put("name", params.getName());
+            Optional.ofNullable(params.getPrompt())
+                    .ifPresent(value -> paramsMap.put("prompt", value));
+            Optional.ofNullable(params.getSessionId())
+                    .ifPresent(value -> paramsMap.put("sessionId", value));
+            Optional.ofNullable(params.getIdempotencyKey())
+                    .ifPresent(value -> paramsMap.put("idempotencyKey", value));
+            if (params.getContext() != null) {
+                paramsMap.put("context", params.getContext());
+            }
+            if (params.getMedia() != null) {
+                paramsMap.put("media", params.getMedia());
+            }
+            Map<String, Object> replaced = parametersUtils.replace(paramsMap, payload);
+
+            AgentStartRequest request = new AgentStartRequest();
+            request.setName(
+                    Optional.ofNullable(replaced.get("name"))
+                            .map(Object::toString)
+                            .orElse(params.getName()));
+            request.setVersion(params.getVersion());
+            request.setPrompt(
+                    Optional.ofNullable(replaced.get("prompt")).map(Object::toString).orElse(null));
+            request.setSessionId(
+                    Optional.ofNullable(replaced.get("sessionId"))
+                            .map(Object::toString)
+                            .orElse(null));
+            request.setIdempotencyKey(
+                    Optional.ofNullable(replaced.get("idempotencyKey"))
+                            .map(Object::toString)
+                            .orElse(null));
+            if (replaced.get("context") instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> resolvedContext = (Map<String, Object>) replaced.get("context");
+                request.setContext(resolvedContext);
+            }
+            if (replaced.get("media") instanceof List) {
+                @SuppressWarnings("unchecked")
+                List<String> resolvedMedia = (List<String>) replaced.get("media");
+                request.setMedia(resolvedMedia);
+            }
+
+            AgentStartResponse response = workflowExecutor.startAgentExecution(request);
+
+            output.put("executionId", response.getExecutionId());
+            output.put("agentName", response.getAgentName());
+            LOGGER.debug(
+                    "Started agent: {}/{}/{} for event: {} for message:{}",
+                    params.getName(),
+                    params.getVersion(),
+                    response.getExecutionId(),
+                    event,
+                    messageId);
+
+        } catch (RuntimeException e) {
+            Monitors.recordEventActionError(action.getAction().name(), params.getName(), event);
+            LOGGER.error(
+                    "Error starting agent: {}, version: {}, for event: {} for message: {}",
                     params.getName(),
                     params.getVersion(),
                     event,

--- a/core/src/test/java/com/netflix/conductor/core/events/TestSimpleActionProcessor.java
+++ b/core/src/test/java/com/netflix/conductor/core/events/TestSimpleActionProcessor.java
@@ -13,8 +13,11 @@
 package com.netflix.conductor.core.events;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.conductoross.conductor.common.metadata.agent.AgentStartRequest;
+import org.conductoross.conductor.common.metadata.agent.AgentStartResponse;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,6 +29,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
 import com.netflix.conductor.common.metadata.events.EventHandler.Action;
 import com.netflix.conductor.common.metadata.events.EventHandler.Action.Type;
+import com.netflix.conductor.common.metadata.events.EventHandler.StartAgent;
 import com.netflix.conductor.common.metadata.events.EventHandler.StartWorkflow;
 import com.netflix.conductor.common.metadata.events.EventHandler.TaskDetails;
 import com.netflix.conductor.common.metadata.tasks.TaskResult;
@@ -326,6 +330,56 @@ public class TestSimpleActionProcessor {
                 "testEvent", argumentCaptor.getValue().getOutputData().get("conductor.event.name"));
         assertEquals("workflow_1", argumentCaptor.getValue().getOutputData().get("workflowId"));
         assertEquals("task_1", argumentCaptor.getValue().getOutputData().get("taskId"));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Test
+    public void testStartAgent() throws Exception {
+        StartAgent startAgent = new StartAgent();
+        startAgent.setName("testAgent");
+        startAgent.setVersion(2);
+        startAgent.setPrompt("${userPrompt}");
+        startAgent.setSessionId("${sessionId}");
+        startAgent.setIdempotencyKey("${eventId}");
+        startAgent.setMedia(List.of("${mediaUrl}"));
+        Map<String, Object> context = new HashMap<>();
+        context.put("locale", "${locale}");
+        startAgent.setContext(context);
+
+        Action action = new Action();
+        action.setAction(Type.start_agent);
+        action.setStart_agent(startAgent);
+
+        Object payload =
+                objectMapper.readValue(
+                        "{\"userPrompt\":\"Summarize this\",\"sessionId\":\"session-1\","
+                                + "\"eventId\":\"evt-1\",\"mediaUrl\":\"https://example.com/a.png\","
+                                + "\"locale\":\"en-US\"}",
+                        Object.class);
+
+        AgentStartResponse response =
+                AgentStartResponse.builder().executionId("exec_1").agentName("testAgent").build();
+        when(workflowExecutor.startAgentExecution(any())).thenReturn(response);
+
+        Map<String, Object> output =
+                actionProcessor.execute(action, payload, "testEvent", "testMessage");
+
+        assertNotNull(output);
+        assertEquals("exec_1", output.get("executionId"));
+        assertEquals("testAgent", output.get("agentName"));
+
+        ArgumentCaptor<AgentStartRequest> requestCaptor =
+                ArgumentCaptor.forClass(AgentStartRequest.class);
+        verify(workflowExecutor).startAgentExecution(requestCaptor.capture());
+        AgentStartRequest capturedValue = requestCaptor.getValue();
+
+        assertEquals("testAgent", capturedValue.getName());
+        assertEquals(Integer.valueOf(2), capturedValue.getVersion());
+        assertEquals("Summarize this", capturedValue.getPrompt());
+        assertEquals("session-1", capturedValue.getSessionId());
+        assertEquals("evt-1", capturedValue.getIdempotencyKey());
+        assertEquals(List.of("https://example.com/a.png"), capturedValue.getMedia());
+        assertEquals("en-US", capturedValue.getContext().get("locale"));
     }
 
     @Test

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -278,6 +278,46 @@ public abstract class AbstractProtoMapper {
         return to;
     }
 
+    public EventHandlerPb.EventHandler.StartAgent toProto(EventHandler.StartAgent from) {
+        EventHandlerPb.EventHandler.StartAgent.Builder to = EventHandlerPb.EventHandler.StartAgent.newBuilder();
+        if (from.getName() != null) {
+            to.setName( from.getName() );
+        }
+        if (from.getVersion() != null) {
+            to.setVersion( from.getVersion() );
+        }
+        if (from.getPrompt() != null) {
+            to.setPrompt( from.getPrompt() );
+        }
+        if (from.getSessionId() != null) {
+            to.setSessionId( from.getSessionId() );
+        }
+        to.addAllMedia( from.getMedia() );
+        for (Map.Entry<String, Object> pair : from.getContext().entrySet()) {
+            to.putContext( pair.getKey(), toProto( pair.getValue() ) );
+        }
+        if (from.getIdempotencyKey() != null) {
+            to.setIdempotencyKey( from.getIdempotencyKey() );
+        }
+        return to.build();
+    }
+
+    public EventHandler.StartAgent fromProto(EventHandlerPb.EventHandler.StartAgent from) {
+        EventHandler.StartAgent to = new EventHandler.StartAgent();
+        to.setName( from.getName() );
+        to.setVersion( from.getVersion() );
+        to.setPrompt( from.getPrompt() );
+        to.setSessionId( from.getSessionId() );
+        to.setMedia( from.getMediaList().stream().collect(Collectors.toCollection(ArrayList::new)) );
+        Map<String, Object> contextMap = new HashMap<String, Object>();
+        for (Map.Entry<String, Value> pair : from.getContextMap().entrySet()) {
+            contextMap.put( pair.getKey(), fromProto( pair.getValue() ) );
+        }
+        to.setContext(contextMap);
+        to.setIdempotencyKey( from.getIdempotencyKey() );
+        return to;
+    }
+
     public EventHandlerPb.EventHandler.StartWorkflow toProto(EventHandler.StartWorkflow from) {
         EventHandlerPb.EventHandler.StartWorkflow.Builder to = EventHandlerPb.EventHandler.StartWorkflow.newBuilder();
         if (from.getName() != null) {
@@ -377,6 +417,9 @@ public abstract class AbstractProtoMapper {
         if (from.getUpdate_workflow_variables() != null) {
             to.setUpdateWorkflowVariables( toProto( from.getUpdate_workflow_variables() ) );
         }
+        if (from.getStart_agent() != null) {
+            to.setStartAgent( toProto( from.getStart_agent() ) );
+        }
         return to.build();
     }
 
@@ -399,6 +442,9 @@ public abstract class AbstractProtoMapper {
         if (from.hasUpdateWorkflowVariables()) {
             to.setUpdate_workflow_variables( fromProto( from.getUpdateWorkflowVariables() ) );
         }
+        if (from.hasStartAgent()) {
+            to.setStart_agent( fromProto( from.getStartAgent() ) );
+        }
         return to;
     }
 
@@ -410,6 +456,7 @@ public abstract class AbstractProtoMapper {
             case fail_task: to = EventHandlerPb.EventHandler.Action.Type.FAIL_TASK; break;
             case terminate_workflow: to = EventHandlerPb.EventHandler.Action.Type.TERMINATE_WORKFLOW; break;
             case update_workflow_variables: to = EventHandlerPb.EventHandler.Action.Type.UPDATE_WORKFLOW_VARIABLES; break;
+            case start_agent: to = EventHandlerPb.EventHandler.Action.Type.START_AGENT; break;
             default: throw new IllegalArgumentException("Unexpected enum constant: " + from);
         }
         return to;
@@ -423,6 +470,7 @@ public abstract class AbstractProtoMapper {
             case FAIL_TASK: to = EventHandler.Action.Type.fail_task; break;
             case TERMINATE_WORKFLOW: to = EventHandler.Action.Type.terminate_workflow; break;
             case UPDATE_WORKFLOW_VARIABLES: to = EventHandler.Action.Type.update_workflow_variables; break;
+            case START_AGENT: to = EventHandler.Action.Type.start_agent; break;
             default: throw new IllegalArgumentException("Unexpected enum constant: " + from);
         }
         return to;

--- a/grpc/src/main/proto/model/eventhandler.proto
+++ b/grpc/src/main/proto/model/eventhandler.proto
@@ -18,6 +18,15 @@ message EventHandler {
         string workflow_id = 1;
         string termination_reason = 2;
     }
+    message StartAgent {
+        string name = 1;
+        int32 version = 2;
+        string prompt = 3;
+        string session_id = 4;
+        repeated string media = 5;
+        map<string, google.protobuf.Value> context = 6;
+        string idempotency_key = 7;
+    }
     message StartWorkflow {
         string name = 1;
         int32 version = 2;
@@ -41,6 +50,7 @@ message EventHandler {
             FAIL_TASK = 2;
             TERMINATE_WORKFLOW = 3;
             UPDATE_WORKFLOW_VARIABLES = 4;
+            START_AGENT = 5;
         }
         EventHandler.Action.Type action = 1;
         EventHandler.StartWorkflow start_workflow = 2;
@@ -49,6 +59,7 @@ message EventHandler {
         bool expand_inline_json = 5;
         EventHandler.TerminateWorkflow terminate_workflow = 6;
         EventHandler.UpdateWorkflowVariables update_workflow_variables = 7;
+        EventHandler.StartAgent start_agent = 8;
     }
     string name = 1;
     string event = 2;

--- a/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/LLMChatCompleteTaskForm.test.tsx
+++ b/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/LLMChatCompleteTaskForm.test.tsx
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import { queryClient } from "queryClient";
+import { TaskDef } from "types";
+import { LLMChatCompleteTaskForm } from "./LLMChatCompleteTaskForm";
+
+const fetchWithContext = vi.hoisted(() => vi.fn());
+
+vi.mock("plugins/fetch", () => ({
+  fetchWithContext,
+  fetchContextNonHook: () => ({ stack: "test" }),
+  useFetchContext: () => ({}),
+}));
+
+vi.mock("utils/query", () => ({
+  useAuthHeaders: () => ({}),
+}));
+
+vi.mock("components/FlatMapForm/ConductorAutocompleteVariables", () => ({
+  ConductorAutocompleteVariables: ({
+    label,
+    value,
+    onChange,
+    onFocus,
+  }: any) => (
+    <input
+      aria-label={String(label)}
+      value={value ?? ""}
+      onChange={(event) => onChange(event.target.value)}
+      onFocus={() => onFocus?.()}
+    />
+  ),
+}));
+
+vi.mock("components/PromptVariables", () => ({ default: () => null }));
+vi.mock(
+  "pages/definition/EditorPanel/TaskFormTab/forms/ConductorValueInput",
+  () => ({ ConductorValueInput: () => null }),
+);
+vi.mock(
+  "pages/definition/EditorPanel/TaskFormTab/forms/LLMFormFields/ConductorArrayMapForm",
+  () => ({ ConductorArrayMapFormBase: () => null }),
+);
+vi.mock("./ConductorCacheOutputForm", () => ({
+  ConductorCacheOutput: () => null,
+}));
+vi.mock("./OptionalFieldForm", () => ({ Optional: () => null }));
+
+function Harness({ initialTask }: { initialTask: Partial<TaskDef> }) {
+  const [task, setTask] = useState(initialTask);
+  return (
+    <>
+      <LLMChatCompleteTaskForm task={task} onChange={setTask} />
+      <pre data-testid="task-json">{JSON.stringify(task)}</pre>
+    </>
+  );
+}
+
+const savedTask = (): Partial<TaskDef> =>
+  JSON.parse(screen.getByTestId("task-json").textContent ?? "{}");
+
+describe("LLMChatCompleteTaskForm — Prompt Template field", () => {
+  beforeEach(() => {
+    fetchWithContext.mockReset();
+    fetchWithContext.mockResolvedValue([]);
+    queryClient.clear();
+  });
+
+  it("labels the field Prompt Template, not Prompt Name", async () => {
+    render(<Harness initialTask={{ inputParameters: {} }} />);
+    expect(screen.getByLabelText("Prompt Template")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Prompt Name")).not.toBeInTheDocument();
+    await waitFor(() => expect(fetchWithContext).toHaveBeenCalled());
+  });
+
+  it("writes free text to instructions and sets allowRawPrompts (no registry match — the OSS / raw-text path)", async () => {
+    render(<Harness initialTask={{ inputParameters: {} }} />);
+    await waitFor(() => expect(fetchWithContext).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText("Prompt Template"), {
+      target: { value: "You are a helpful assistant." },
+    });
+
+    expect(savedTask().inputParameters?.instructions).toBe(
+      "You are a helpful assistant.",
+    );
+    // ChatCompletion.getPrompt() returns instructions server-side, so this is
+    // subject to the same checkPromptAccess/allowRawPrompts gate as promptName.
+    expect(savedTask().inputParameters?.allowRawPrompts).toBe(true);
+  });
+
+  it("selecting a known template auto-populates variables/temperature/stopWords and clears allowRawPrompts", async () => {
+    fetchWithContext.mockImplementation((path: string) => {
+      if (path === "/prompts") {
+        return Promise.resolve([
+          {
+            name: "system-greeting",
+            variables: ["audience"],
+            integrations: [],
+            topP: 0.9,
+            stopWords: ["END"],
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    render(<Harness initialTask={{ inputParameters: {} }} />);
+    const field = screen.getByLabelText("Prompt Template");
+
+    await waitFor(() => {
+      fireEvent.focus(field);
+      expect(fetchWithContext).toHaveBeenCalledWith(
+        "/prompts",
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    fireEvent.change(field, { target: { value: "system-greeting" } });
+
+    await waitFor(() =>
+      expect(savedTask().inputParameters).toMatchObject({
+        instructions: "system-greeting",
+        allowRawPrompts: false,
+        topP: 0.9,
+        stopWords: ["END"],
+        promptVariables: { audience: "" },
+      }),
+    );
+  });
+});

--- a/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/LLMChatCompleteTaskForm.tsx
+++ b/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/LLMChatCompleteTaskForm.tsx
@@ -1,17 +1,14 @@
-import { Box, Grid } from "@mui/material";
-import ConductorInput from "components/ui/inputs/ConductorInput";
-import { path as _path } from "lodash/fp";
+import { Box } from "@mui/material";
 import { UiIntegrationsFieldType } from "types/FormFieldTypes";
-import {
-  fieldsToFieldsFieldsComponents,
-  updateField,
-} from "utils/fieldHelpers";
+import { fieldsToFieldsFieldsComponents } from "utils/fieldHelpers";
 import { ConductorCacheOutput } from "./ConductorCacheOutputForm";
 import { LLMFormFields } from "./LLMFormFields/LLMFormFields";
 import LLMFormFieldsWrapper from "./LLMFormFields/LLMFormFieldsWrapper";
 import { Optional } from "./OptionalFieldForm";
 import TaskFormSection from "./TaskFormSection";
 import { TaskFormProps } from "./types";
+
+const promptFields = [UiIntegrationsFieldType.INSTRUCTIONS];
 
 const modelFields = [
   UiIntegrationsFieldType.LLM_PROVIDER,
@@ -29,17 +26,15 @@ const fineTuningFields = [
 
 const outputFields = [UiIntegrationsFieldType.JSON_OUTPUT];
 
+const promptFieldComponents = fieldsToFieldsFieldsComponents(promptFields);
 const modelFieldComponents = fieldsToFieldsFieldsComponents(modelFields);
 const messageFieldComponents = fieldsToFieldsFieldsComponents(messageFields);
 const fineTuningFieldComponents =
   fieldsToFieldsFieldsComponents(fineTuningFields);
 const outputFieldComponents = fieldsToFieldsFieldsComponents(outputFields);
 
-// INSTRUCTIONS is intentionally excluded from allFieldComponents — in OSS, the
-// instructions/system-prompt is a plain textarea (below). Enterprise plugins
-// override this section with a prompt-template picker that resolves promptName
-// against the server's prompt library.
 const allFieldComponents = [
+  ...promptFieldComponents,
   ...modelFieldComponents,
   ...messageFieldComponents,
   ...fineTuningFieldComponents,
@@ -47,8 +42,6 @@ const allFieldComponents = [
 ];
 
 export const LLMChatCompleteTaskForm = ({ task, onChange }: TaskFormProps) => {
-  const instructions = _path("inputParameters.instructions", task) || "";
-
   return (
     <LLMFormFieldsWrapper
       task={task}
@@ -57,30 +50,16 @@ export const LLMChatCompleteTaskForm = ({ task, onChange }: TaskFormProps) => {
     >
       {(actor) => (
         <Box padding={1} width="100%">
-          {/* OSS: plain textarea for system instructions / prompt.
-              Enterprise plugins replace this section with a prompt-template picker. */}
           <TaskFormSection
             accordionAdditionalProps={{ defaultExpanded: true }}
             title="Instructions"
           >
-            <Grid container sx={{ width: "100%" }}>
-              <Grid size={12}>
-                <ConductorInput
-                  label="Instructions"
-                  name="instructions"
-                  value={instructions}
-                  onTextInputChange={(v) =>
-                    onChange(
-                      updateField("inputParameters.instructions", v, task),
-                    )
-                  }
-                  multiline
-                  rows={6}
-                  fullWidth
-                  placeholder="Enter system instructions or prompt for the model..."
-                />
-              </Grid>
-            </Grid>
+            <LLMFormFields
+              task={task}
+              onChange={onChange}
+              fieldFieldComponents={promptFieldComponents}
+              actor={actor}
+            />
           </TaskFormSection>
           <TaskFormSection
             accordionAdditionalProps={{ defaultExpanded: true }}

--- a/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/LLMFormFields/LLMFormFieldsWrapper.tsx
+++ b/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/LLMFormFields/LLMFormFieldsWrapper.tsx
@@ -102,6 +102,14 @@ const LLMFormFieldsWrapper = ({
             );
           }
 
+          // A known registered template is selected — Orkes' prompt-association
+          // check (checkPromptAccess) will find it, so raw-prompt bypass isn't needed.
+          taskWithSelectedPromptName = updateField(
+            `inputParameters.allowRawPrompts`,
+            false,
+            taskWithSelectedPromptName,
+          );
+
           onChange(taskWithSelectedPromptName);
         } else {
           const updatedTask = updateField(
@@ -110,7 +118,16 @@ const LLMFormFieldsWrapper = ({
             event.task,
           );
 
-          onChange(updatedTask);
+          // Free text (or OSS, which has no prompt registry at all) — without this,
+          // Orkes' checkPromptAccess terminates the workflow at runtime because the
+          // value isn't an associated prompt name.
+          const updatedTaskWithRawFlag = updateField(
+            `inputParameters.allowRawPrompts`,
+            true,
+            updatedTask,
+          );
+
+          onChange(updatedTaskWithRawFlag);
         }
       },
       selectInstructions: (
@@ -179,6 +196,14 @@ const LLMFormFieldsWrapper = ({
             );
           }
 
+          // A known registered template is selected — Orkes' prompt-association
+          // check (checkPromptAccess) will find it, so raw-prompt bypass isn't needed.
+          taskWithSelectedPromptName = updateField(
+            `inputParameters.allowRawPrompts`,
+            false,
+            taskWithSelectedPromptName,
+          );
+
           onChange(taskWithSelectedPromptName);
         } else {
           const updatedTask = updateField(
@@ -187,7 +212,17 @@ const LLMFormFieldsWrapper = ({
             event.task,
           );
 
-          onChange(updatedTask);
+          // Free text (or OSS, which has no prompt registry at all) — without this,
+          // Orkes' checkPromptAccess terminates the workflow at runtime because the
+          // value isn't an associated prompt name (ChatCompletion.getPrompt() reads
+          // instructions server-side).
+          const updatedTaskWithRawFlag = updateField(
+            `inputParameters.allowRawPrompts`,
+            true,
+            updatedTask,
+          );
+
+          onChange(updatedTaskWithRawFlag);
         }
       },
     },

--- a/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/LLMTextCompleteTaskForm.test.tsx
+++ b/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/LLMTextCompleteTaskForm.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import { queryClient } from "queryClient";
+import { TaskDef } from "types";
+import { LLMTextCompleteTaskForm } from "./LLMTextCompleteTaskForm";
+
+const fetchWithContext = vi.hoisted(() => vi.fn());
+
+vi.mock("plugins/fetch", () => ({
+  fetchWithContext,
+  fetchContextNonHook: () => ({ stack: "test" }),
+  useFetchContext: () => ({}),
+}));
+
+vi.mock("utils/query", () => ({
+  useAuthHeaders: () => ({}),
+}));
+
+vi.mock("components/FlatMapForm/ConductorAutocompleteVariables", () => ({
+  ConductorAutocompleteVariables: ({
+    label,
+    value,
+    onChange,
+    onFocus,
+  }: any) => (
+    <input
+      aria-label={String(label)}
+      value={value ?? ""}
+      onChange={(event) => onChange(event.target.value)}
+      onFocus={() => onFocus?.()}
+    />
+  ),
+}));
+
+vi.mock("components/PromptVariables", () => ({ default: () => null }));
+vi.mock(
+  "pages/definition/EditorPanel/TaskFormTab/forms/ConductorValueInput",
+  () => ({ ConductorValueInput: () => null }),
+);
+vi.mock("./ConductorCacheOutputForm", () => ({
+  ConductorCacheOutput: () => null,
+}));
+vi.mock("./OptionalFieldForm", () => ({ Optional: () => null }));
+
+function Harness({ initialTask }: { initialTask: Partial<TaskDef> }) {
+  const [task, setTask] = useState(initialTask);
+  return (
+    <>
+      <LLMTextCompleteTaskForm task={task} onChange={setTask} />
+      <pre data-testid="task-json">{JSON.stringify(task)}</pre>
+    </>
+  );
+}
+
+const savedTask = (): Partial<TaskDef> =>
+  JSON.parse(screen.getByTestId("task-json").textContent ?? "{}");
+
+describe("LLMTextCompleteTaskForm — Prompt Template field", () => {
+  beforeEach(() => {
+    fetchWithContext.mockReset();
+    fetchWithContext.mockResolvedValue([]);
+    queryClient.clear();
+  });
+
+  it("labels the field Prompt Template, not Prompt Name", async () => {
+    render(<Harness initialTask={{ inputParameters: {} }} />);
+    expect(screen.getByLabelText("Prompt Template")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Prompt Name")).not.toBeInTheDocument();
+    await waitFor(() => expect(fetchWithContext).toHaveBeenCalled());
+  });
+
+  it("writes free text to promptName and sets allowRawPrompts (no registry match — the OSS / raw-text path)", async () => {
+    render(<Harness initialTask={{ inputParameters: {} }} />);
+    await waitFor(() => expect(fetchWithContext).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText("Prompt Template"), {
+      target: { value: "Summarize: ${workflow.input.doc}" },
+    });
+
+    expect(savedTask().inputParameters?.promptName).toBe(
+      "Summarize: ${workflow.input.doc}",
+    );
+    // Without this, Orkes' checkPromptAccess terminates the workflow at runtime
+    // because free text is never an "associated" prompt name.
+    expect(savedTask().inputParameters?.allowRawPrompts).toBe(true);
+  });
+
+  it("falls back to the legacy prompt key for display when promptName is unset", async () => {
+    render(
+      <Harness
+        initialTask={{ inputParameters: { prompt: "Legacy free text" } }}
+      />,
+    );
+    expect(screen.getByLabelText("Prompt Template")).toHaveValue(
+      "Legacy free text",
+    );
+    await waitFor(() => expect(fetchWithContext).toHaveBeenCalled());
+  });
+
+  it("selecting a known template auto-populates variables/temperature/stopWords and clears allowRawPrompts", async () => {
+    fetchWithContext.mockImplementation((path: string) => {
+      if (path === "/prompts") {
+        return Promise.resolve([
+          {
+            name: "greeting",
+            variables: ["name"],
+            integrations: [],
+            temperature: 0.4,
+            stopWords: ["STOP"],
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    render(<Harness initialTask={{ inputParameters: {} }} />);
+    const field = screen.getByLabelText("Prompt Template");
+
+    // FOCUS_PROMPT_NAME is only handled once the machine reaches IDLE (after the
+    // LLM provider options fetch that's kicked off on mount settles) — retry focus
+    // until the /prompts fetch it should trigger has actually fired.
+    await waitFor(() => {
+      fireEvent.focus(field);
+      expect(fetchWithContext).toHaveBeenCalledWith(
+        "/prompts",
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    fireEvent.change(field, { target: { value: "greeting" } });
+
+    await waitFor(() =>
+      expect(savedTask().inputParameters).toMatchObject({
+        promptName: "greeting",
+        allowRawPrompts: false,
+        temperature: 0.4,
+        stopWords: ["STOP"],
+        promptVariables: { name: "" },
+      }),
+    );
+  });
+});

--- a/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/LLMTextCompleteTaskForm.tsx
+++ b/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/LLMTextCompleteTaskForm.tsx
@@ -1,17 +1,14 @@
-import { Box, Grid } from "@mui/material";
-import ConductorInput from "components/ui/inputs/ConductorInput";
-import { path as _path } from "lodash/fp";
+import { Box } from "@mui/material";
 import { LLMFormFields } from "pages/definition/EditorPanel/TaskFormTab/forms/LLMFormFields";
 import { UiIntegrationsFieldType } from "types/FormFieldTypes";
-import {
-  fieldsToFieldsFieldsComponents,
-  updateField,
-} from "utils/fieldHelpers";
+import { fieldsToFieldsFieldsComponents } from "utils/fieldHelpers";
 import { ConductorCacheOutput } from "./ConductorCacheOutputForm";
 import { Optional } from "./OptionalFieldForm";
 import TaskFormSection from "./TaskFormSection";
 import { TaskFormProps } from "./types";
 import LLMFormFieldsWrapper from "./LLMFormFields/LLMFormFieldsWrapper";
+
+const promptFields = [UiIntegrationsFieldType.PROMPT_NAME];
 
 const modelFields = [
   UiIntegrationsFieldType.LLM_PROVIDER,
@@ -25,20 +22,18 @@ const fineTuningFields = [
   UiIntegrationsFieldType.STOP_WORDS,
 ];
 
+const promptFieldComponents = fieldsToFieldsFieldsComponents(promptFields);
 const modelFieldComponents = fieldsToFieldsFieldsComponents(modelFields);
 const fineTuningFieldComponents =
   fieldsToFieldsFieldsComponents(fineTuningFields);
 
-// prompt is a plain textarea (below), not the saved-prompt picker (PROMPT_NAME).
-// Enterprise plugins override with the saved AI Prompt picker (see conductor-ui).
 const allFieldComponents = [
+  ...promptFieldComponents,
   ...modelFieldComponents,
   ...fineTuningFieldComponents,
 ];
 
 export const LLMTextCompleteTaskForm = ({ task, onChange }: TaskFormProps) => {
-  const prompt = _path("inputParameters.prompt", task) || "";
-
   return (
     <LLMFormFieldsWrapper
       task={task}
@@ -51,22 +46,12 @@ export const LLMTextCompleteTaskForm = ({ task, onChange }: TaskFormProps) => {
             accordionAdditionalProps={{ defaultExpanded: true }}
             title="Prompt"
           >
-            <Grid container sx={{ width: "100%" }}>
-              <Grid size={12}>
-                <ConductorInput
-                  label="Prompt"
-                  name="prompt"
-                  value={prompt}
-                  onTextInputChange={(v) =>
-                    onChange(updateField("inputParameters.prompt", v, task))
-                  }
-                  multiline
-                  rows={6}
-                  fullWidth
-                  placeholder="Enter the text prompt to complete..."
-                />
-              </Grid>
-            </Grid>
+            <LLMFormFields
+              task={task}
+              onChange={onChange}
+              fieldFieldComponents={promptFieldComponents}
+              actor={actor}
+            />
           </TaskFormSection>
           <TaskFormSection
             accordionAdditionalProps={{ defaultExpanded: true }}

--- a/ui-next/src/pages/definition/EventHandler/eventhandlers/FormComponent/ActionForms/StartAgentTask.test.tsx
+++ b/ui-next/src/pages/definition/EventHandler/eventhandlers/FormComponent/ActionForms/StartAgentTask.test.tsx
@@ -1,0 +1,166 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { StartAgentActionForm } from "./StartAgentTask";
+
+const useFetch = vi.hoisted(() => vi.fn());
+
+vi.mock("utils/query", () => ({ useFetch }));
+
+vi.mock("components/ui/inputs", () => ({
+  ConductorAutoComplete: ({ label, value, onChange, onBlur, options }: any) => (
+    <input
+      aria-label={String(label)}
+      value={value ?? ""}
+      data-options={JSON.stringify(options)}
+      onChange={(event) => onChange(event, event.target.value)}
+      onBlur={(event) => onBlur?.(event)}
+    />
+  ),
+}));
+
+vi.mock("components/ui/inputs/ConductorInput", () => ({
+  default: ({ label, value, onTextInputChange, multiline }: any) => {
+    const Tag = multiline ? "textarea" : "input";
+    return (
+      <Tag
+        aria-label={label}
+        value={value ?? ""}
+        onChange={(event: any) => onTextInputChange?.(event.target.value)}
+      />
+    );
+  },
+}));
+
+vi.mock("components/FlatMapForm/ConductorFlatMapForm", () => ({
+  ConductorFlatMapFormBase: ({ onChange, value }: any) => (
+    <button
+      aria-label="Edit context"
+      onClick={() => onChange({ ...value, addedKey: "addedValue" })}
+    >
+      Edit context
+    </button>
+  ),
+}));
+
+function Harness({ initialPayload }: { initialPayload: any }) {
+  const [payload, setPayload] = useState(initialPayload);
+  return (
+    <>
+      <StartAgentActionForm
+        index={0}
+        payload={payload}
+        handleChangeAction={(_index: number, newPayload: any) =>
+          setPayload(newPayload)
+        }
+        onRemove={() => {}}
+      />
+      <pre data-testid="payload-json">{JSON.stringify(payload)}</pre>
+    </>
+  );
+}
+
+const savedPayload = () =>
+  JSON.parse(screen.getByTestId("payload-json").textContent ?? "{}");
+
+const basePayload = {
+  action: "start_agent",
+  expandInlineJSON: false,
+  start_agent: {
+    name: "",
+    version: "",
+    prompt: "",
+    sessionId: "",
+    idempotencyKey: "",
+  },
+};
+
+describe("StartAgentActionForm", () => {
+  beforeEach(() => {
+    useFetch.mockReset();
+    useFetch.mockReturnValue({
+      data: [
+        { name: "researcher", version: 1 },
+        { name: "researcher", version: 2 },
+        { name: "summarizer", version: 5 },
+      ],
+    });
+  });
+
+  it("writes the typed agent name to start_agent.name", () => {
+    render(<Harness initialPayload={basePayload} />);
+
+    fireEvent.change(screen.getByLabelText("Agent name"), {
+      target: { value: "researcher" },
+    });
+
+    expect(savedPayload().start_agent.name).toBe("researcher");
+  });
+
+  it("commits the agent name on blur, mirroring Start Workflow's name field", () => {
+    render(<Harness initialPayload={basePayload} />);
+
+    const field = screen.getByLabelText("Agent name");
+    fireEvent.change(field, { target: { value: "researcher" } });
+    fireEvent.blur(field);
+
+    expect(savedPayload().start_agent.name).toBe("researcher");
+  });
+
+  it("filters the version field's options to the versions of the selected agent", () => {
+    render(<Harness initialPayload={basePayload} />);
+
+    fireEvent.change(screen.getByLabelText("Agent name"), {
+      target: { value: "researcher" },
+    });
+
+    const versionField = screen.getByLabelText("Agent version");
+    expect(
+      JSON.parse(versionField.getAttribute("data-options") ?? "[]"),
+    ).toEqual(["1", "2"]);
+  });
+
+  it("writes prompt, session id, and idempotency key to their respective fields", () => {
+    render(<Harness initialPayload={basePayload} />);
+
+    fireEvent.change(screen.getByLabelText("Prompt"), {
+      target: { value: "Summarize: ${event.payload.doc}" },
+    });
+    fireEvent.change(screen.getByLabelText("Session ID"), {
+      target: { value: "${event.payload.session_id}" },
+    });
+    fireEvent.change(screen.getByLabelText("Idempotency key"), {
+      target: { value: "${event.payload.event_id}" },
+    });
+
+    expect(savedPayload().start_agent).toMatchObject({
+      prompt: "Summarize: ${event.payload.doc}",
+      sessionId: "${event.payload.session_id}",
+      idempotencyKey: "${event.payload.event_id}",
+    });
+  });
+
+  it("splits the media textarea into a trimmed, non-empty string array", () => {
+    render(<Harness initialPayload={basePayload} />);
+
+    fireEvent.change(screen.getByLabelText("Media (one URL per line)"), {
+      target: {
+        value: "https://example.com/a.png\n  \nhttps://example.com/b.png\n",
+      },
+    });
+
+    expect(savedPayload().start_agent.media).toEqual([
+      "https://example.com/a.png",
+      "https://example.com/b.png",
+    ]);
+  });
+
+  it("updates start_agent.context via the flat map editor", () => {
+    render(<Harness initialPayload={basePayload} />);
+
+    fireEvent.click(screen.getByLabelText("Edit context"));
+
+    expect(savedPayload().start_agent.context).toMatchObject({
+      addedKey: "addedValue",
+    });
+  });
+});

--- a/ui-next/src/pages/definition/EventHandler/eventhandlers/FormComponent/ActionForms/StartAgentTask.tsx
+++ b/ui-next/src/pages/definition/EventHandler/eventhandlers/FormComponent/ActionForms/StartAgentTask.tsx
@@ -1,0 +1,250 @@
+import { Grid } from "@mui/material";
+import { ConductorFlatMapFormBase } from "components/FlatMapForm/ConductorFlatMapForm";
+import XCloseIcon from "components/icons/XCloseIcon";
+import IconButton from "components/ui/buttons/MuiIconButton";
+import { ConductorAutoComplete } from "components/ui/inputs";
+import ConductorInput from "components/ui/inputs/ConductorInput";
+import MuiTypography from "components/ui/MuiTypography";
+import _isEmpty from "lodash/isEmpty";
+import _isUndefined from "lodash/isUndefined";
+import { AgentSummary } from "pages/agent/types";
+import { FocusEvent, useMemo } from "react";
+import { useFetch } from "utils/query";
+import { Props } from "./common";
+
+export const StartAgentActionForm = ({
+  onRemove,
+  index,
+  payload,
+  handleChangeAction,
+}: Props) => {
+  const { start_agent } = payload;
+  const { data: agentDefinitions } = useFetch<AgentSummary[]>("/agent/list");
+
+  const namesAndVersions = useMemo(() => {
+    const map = new Map<string, number[]>();
+    (agentDefinitions ?? []).forEach(({ name, version }) => {
+      const versions = map.get(name) ?? [];
+      versions.push(version);
+      map.set(name, versions);
+    });
+    return map;
+  }, [agentDefinitions]);
+
+  const options = useMemo(
+    () => Array.from(namesAndVersions.keys()).sort(),
+    [namesAndVersions],
+  );
+
+  const maybeSelectedAgentName = useMemo(
+    () => (_isEmpty(start_agent?.name) ? undefined : start_agent?.name),
+    [start_agent?.name],
+  );
+
+  const availableVersions: string[] = useMemo(() => {
+    const versions: number[] =
+      namesAndVersions.get(maybeSelectedAgentName) || [];
+
+    return _isUndefined(maybeSelectedAgentName) && !_isEmpty(options)
+      ? []
+      : versions.map((val) => val.toString()).sort();
+  }, [maybeSelectedAgentName, namesAndVersions, options]);
+
+  const mediaText = (start_agent?.media || []).join("\n");
+
+  return (
+    <Grid
+      container
+      spacing={4}
+      my={2}
+      sx={{ width: "100%", position: "relative" }}
+    >
+      <Grid size={12}>
+        <MuiTypography fontWeight={800} fontSize={16}>
+          Start Agent
+        </MuiTypography>
+      </Grid>
+      <Grid
+        size={{
+          xs: 12,
+          sm: 12,
+          md: 9,
+        }}
+      >
+        <ConductorAutoComplete
+          label="Agent name"
+          freeSolo
+          fullWidth
+          value={start_agent?.name}
+          options={options}
+          onChange={(_, value) =>
+            handleChangeAction(index, {
+              ...payload,
+              start_agent: {
+                ...start_agent,
+                name: value,
+              },
+            })
+          }
+          onBlur={(event: FocusEvent<HTMLInputElement>) => {
+            handleChangeAction(index, {
+              ...payload,
+              start_agent: {
+                ...start_agent,
+                name: event.target.value,
+              },
+            });
+          }}
+          conductorInputProps={{
+            placeholder: `\${event.payload.agent_name}`,
+          }}
+        />
+      </Grid>
+      <Grid
+        size={{
+          xs: 12,
+          sm: 12,
+          md: 3,
+        }}
+      >
+        <ConductorAutoComplete
+          label="Agent version"
+          freeSolo
+          fullWidth
+          value={start_agent?.version}
+          options={availableVersions}
+          onChange={(_, value) =>
+            handleChangeAction(index, {
+              ...payload,
+              start_agent: {
+                ...start_agent,
+                version: value,
+              },
+            })
+          }
+          onBlur={(event: FocusEvent<HTMLInputElement>) => {
+            handleChangeAction(index, {
+              ...payload,
+              start_agent: {
+                ...start_agent,
+                version: event.target.value,
+              },
+            });
+          }}
+          conductorInputProps={{
+            placeholder: "latest",
+          }}
+        />
+      </Grid>
+      <Grid size={12}>
+        <ConductorInput
+          fullWidth
+          multiline
+          minRows={3}
+          label="Prompt"
+          placeholder={`\${event.payload.prompt}`}
+          value={start_agent?.prompt}
+          onTextInputChange={(value) =>
+            handleChangeAction(index, {
+              ...payload,
+              start_agent: {
+                ...start_agent,
+                prompt: value,
+              },
+            })
+          }
+        />
+      </Grid>
+      <Grid
+        size={{
+          xs: 12,
+          md: 6,
+        }}
+      >
+        <ConductorInput
+          fullWidth
+          label="Session ID"
+          placeholder={`\${event.payload.session_id}`}
+          value={start_agent?.sessionId}
+          onTextInputChange={(value) =>
+            handleChangeAction(index, {
+              ...payload,
+              start_agent: {
+                ...start_agent,
+                sessionId: value,
+              },
+            })
+          }
+        />
+      </Grid>
+      <Grid
+        size={{
+          xs: 12,
+          md: 6,
+        }}
+      >
+        <ConductorInput
+          fullWidth
+          label="Idempotency key"
+          placeholder={`\${event.payload.event_id}`}
+          value={start_agent?.idempotencyKey}
+          onTextInputChange={(value) =>
+            handleChangeAction(index, {
+              ...payload,
+              start_agent: {
+                ...start_agent,
+                idempotencyKey: value,
+              },
+            })
+          }
+        />
+      </Grid>
+      <Grid size={12}>
+        <ConductorInput
+          fullWidth
+          multiline
+          minRows={2}
+          label="Media (one URL per line)"
+          placeholder={`\${event.payload.media_url}`}
+          value={mediaText}
+          onTextInputChange={(value) =>
+            handleChangeAction(index, {
+              ...payload,
+              start_agent: {
+                ...start_agent,
+                media: value
+                  .split("\n")
+                  .map((line) => line.trim())
+                  .filter((line) => line.length > 0),
+              },
+            })
+          }
+        />
+      </Grid>
+      <Grid size={12}>
+        <ConductorFlatMapFormBase
+          onChange={(newValues) => {
+            handleChangeAction(index, {
+              ...payload,
+              start_agent: {
+                ...start_agent,
+                context: newValues,
+              },
+            });
+          }}
+          value={{ ...start_agent?.context }}
+          title="Context"
+          keyColumnLabel="Key"
+          valueColumnLabel="Value"
+          addItemLabel="Add parameter"
+          showFieldTypes
+          enableAutocomplete={false}
+          autoFocusField={false}
+        />
+      </Grid>
+      <IconButton onClick={onRemove} sx={{ position: "absolute", right: 0 }}>
+        <XCloseIcon size={26} />
+      </IconButton>
+    </Grid>
+  );
+};

--- a/ui-next/src/pages/definition/EventHandler/eventhandlers/FormComponent/EventHandlerForm.tsx
+++ b/ui-next/src/pages/definition/EventHandler/eventhandlers/FormComponent/EventHandlerForm.tsx
@@ -22,6 +22,7 @@ import { colors } from "theme/tokens/variables";
 import { useEventNameSuggestions } from "utils/hooks/useEventNameSuggestions";
 import { CompleteTask } from "./ActionForms/CompleteTask";
 import { FailTask } from "./ActionForms/FailTask";
+import { StartAgentActionForm } from "./ActionForms/StartAgentTask";
 import { StartWorkflowActionForm } from "./ActionForms/StartWorkflowTask";
 import { TerminateWorkflowForm } from "./ActionForms/TerminateWorkflowTask";
 import { UpdateWorkflowForm } from "./ActionForms/UpdateWorkflowTask";
@@ -209,6 +210,11 @@ const EventHandlerForm = ({
                           return renderFormComponent(
                             StartWorkflowActionForm,
                             `startWorkflow`,
+                          );
+                        case Action.START_AGENT:
+                          return renderFormComponent(
+                            StartAgentActionForm,
+                            `startAgent`,
                           );
                         case Action.TERMINATE_WORKFLOW:
                           return renderFormComponent(

--- a/ui-next/src/pages/definition/EventHandler/eventhandlers/FormComponent/state/actions.ts
+++ b/ui-next/src/pages/definition/EventHandler/eventhandlers/FormComponent/state/actions.ts
@@ -1,6 +1,7 @@
 import {
   UPDATE_VARIABLES_ACTION,
   START_WORKFLOW_ACTION,
+  START_AGENT_ACTION,
   TERMINATE_WORKFLOW_ACTION,
   COMPLETE_TASK_ACTION,
   FAIL_TASK_ACTION,
@@ -50,6 +51,11 @@ export const persistNewAction = assign({
         return {
           ...context.eventAsJson,
           actions: [START_WORKFLOW_ACTION, ...actions],
+        };
+      case Action.START_AGENT:
+        return {
+          ...context.eventAsJson,
+          actions: [START_AGENT_ACTION, ...actions],
         };
       default:
         return context.eventAsJson;

--- a/ui-next/src/pages/definition/EventHandler/eventhandlers/FormComponent/state/types.ts
+++ b/ui-next/src/pages/definition/EventHandler/eventhandlers/FormComponent/state/types.ts
@@ -89,6 +89,7 @@ export enum Action {
   UPDATE_WORKFLOW_VARIABLES = "update_workflow_variables",
   FAIL_TASK = "fail_task",
   START_WORKFLOW = "start_workflow",
+  START_AGENT = "start_agent",
 }
 
 export type AddActionEvent = {
@@ -102,6 +103,7 @@ export const actionLabel = {
   update_workflow_variables: "Update Variables",
   fail_task: "Fail Task",
   start_workflow: "Start Workflow",
+  start_agent: "Start Agent",
 } as { [key: string]: string };
 
 export interface EventFormMachineContext {

--- a/ui-next/src/pages/definition/EventHandler/eventhandlers/eventHandlerSchema.ts
+++ b/ui-next/src/pages/definition/EventHandler/eventhandlers/eventHandlerSchema.ts
@@ -2,6 +2,7 @@ import {
   CompleteActionType,
   ConductorEvent,
   FailActionType,
+  StartAgentAction,
   StartWorkflowAction,
   TerminateWorkflowAction,
   UpdateWorkFlowVariableType,
@@ -71,5 +72,17 @@ export const TERMINATE_WORKFLOW_ACTION: TerminateWorkflowAction = {
   terminate_workflow: {
     workflowId: "",
     terminationReason: "",
+  },
+};
+
+export const START_AGENT_ACTION: StartAgentAction = {
+  action: "start_agent",
+  expandInlineJSON: false,
+  start_agent: {
+    name: "",
+    version: "",
+    prompt: "",
+    sessionId: "",
+    idempotencyKey: "",
   },
 };

--- a/ui-next/src/types/Events.ts
+++ b/ui-next/src/types/Events.ts
@@ -57,6 +57,20 @@ export type TerminateWorkflowAction = {
   };
 };
 
+export type StartAgentAction = {
+  action: "start_agent";
+  expandInlineJSON: boolean;
+  start_agent: {
+    name: string;
+    version?: string;
+    prompt?: string;
+    sessionId?: string;
+    idempotencyKey?: string;
+    media?: string[];
+    context?: Record<string, unknown>;
+  };
+};
+
 export type ConductorEvent = {
   name: string;
   description?: string;
@@ -69,6 +83,7 @@ export type ConductorEvent = {
     | UpdateWorkFlowVariableType
     | StartWorkflowAction
     | TerminateWorkflowAction
+    | StartAgentAction
   >;
   active: boolean;
   ownerEmail: string;

--- a/ui-next/src/utils/fieldHelpers.tsx
+++ b/ui-next/src/utils/fieldHelpers.tsx
@@ -20,9 +20,15 @@ import { PromptDef } from "types/Prompts";
 import { ActorRef, State } from "xstate";
 import { MEDIA_TYPE_SUGGESTIONS } from "./constants/httpSuggestions";
 
-/** LLM text complete stores the prompt in promptName; chat complete uses instructions. */
+/**
+ * LLM text complete stores the prompt template name in promptName; chat complete
+ * uses instructions. Legacy text-complete tasks (saved before the Prompt Template
+ * field existed) may only have the deprecated free-text `prompt` key.
+ */
 const selectedPromptNameFromTask = (task: Partial<TaskDef>) =>
-  task?.inputParameters?.promptName ?? task?.inputParameters?.instructions;
+  task?.inputParameters?.promptName ??
+  task?.inputParameters?.instructions ??
+  task?.inputParameters?.prompt;
 
 export type FieldComponentType = FunctionComponent<{
   onChange: (t: Partial<TaskDef>) => void;
@@ -68,6 +74,98 @@ const useSetterGetter = (
   (value: unknown) => updateField(`inputParameters.${type}`, value, task),
   fieldValue(task, type),
 ];
+
+type PromptTemplateFieldConfig = {
+  fieldType:
+    | UiIntegrationsFieldType.PROMPT_NAME
+    | UiIntegrationsFieldType.INSTRUCTIONS;
+  selectEventType:
+    | LLMFormFieldsMachineEventTypes.SELECT_PROMPT_NAME
+    | LLMFormFieldsMachineEventTypes.SELECT_INSTRUCTIONS;
+  /**
+   * Legacy inputParameters key to read from when fieldType's own key is unset.
+   * Back-compat for text-complete tasks saved before this field wrote to promptName.
+   */
+  legacyReadKey?: string;
+};
+
+/**
+ * Shared "Prompt Template" field for LLM_TEXT_COMPLETE (promptName) and
+ * LLM_CHAT_COMPLETE (instructions). Free text always works (ConductorAutocompleteVariables
+ * is freeSolo) and self-fetches known prompt templates via promptNameOptions, which
+ * degrades to an empty list (pure free text) when the server has no /prompts registry
+ * (OSS) and populates a picker when it does (Orkes). Selecting a known template
+ * auto-populates its variables/temperature/topP/stopWords; any other value is treated
+ * as a raw prompt (see allowRawPrompts handling in LLMFormFieldsWrapper).
+ */
+const createPromptTemplateField = ({
+  fieldType,
+  selectEventType,
+  legacyReadKey,
+}: PromptTemplateFieldConfig): FieldComponentType =>
+  function PromptTemplateField({ onChange, task, actor }) {
+    const promptNames = useSelector(
+      actor,
+      (state) => state.context.promptNameOptions,
+    );
+    const options = useMemo(
+      () => promptNames.map(({ name }: { name: string }) => name),
+      [promptNames],
+    );
+
+    const [setValue, ipValue] = useSetterGetter(fieldType, task);
+    const legacyValue = legacyReadKey
+      ? _path(`inputParameters.${legacyReadKey}`, task)
+      : undefined;
+    const displayValue = ipValue || legacyValue || "";
+
+    const currentVariables = task.inputParameters?.promptVariables || {};
+    return (
+      <Grid container spacing={3} sx={{ width: "100%" }}>
+        <Grid size={12}>
+          <MuiTypography sx={{ opacity: 0.5, mb: 3 }}>
+            Enter a prompt, or reference a saved AI Prompt by name —{" "}
+            <Link
+              sx={{ fontWeight: 400 }}
+              target="_blank"
+              href="/ai_prompts/new_ai_prompt_model"
+              rel="noreferrer"
+            >
+              create a new one.
+            </Link>
+          </MuiTypography>
+          <ConductorAutocompleteVariables
+            openOnFocus
+            multiline
+            onChange={(value) => {
+              actor.send({
+                type: selectEventType,
+                task: setValue(value),
+              });
+            }}
+            value={displayValue}
+            otherOptions={options}
+            label="Prompt Template"
+            onFocus={() =>
+              actor.send({
+                type: LLMFormFieldsMachineEventTypes.FOCUS_PROMPT_NAMES,
+                task,
+              })
+            }
+          />
+        </Grid>
+        <MuiTypography sx={{ opacity: 0.5 }}>
+          {`Variables to be used in the prompt (e.g. "What's the weather in {$userLocation}?").`}
+        </MuiTypography>
+        <PromptVariables
+          currentVariables={currentVariables}
+          onChange={onChange}
+          updateField={updateField}
+          task={task}
+        />
+      </Grid>
+    );
+  };
 
 const aiFieldTypes = {
   [UiIntegrationsFieldType.LLM_PROVIDER]: ({ onChange, task, actor }) => {
@@ -191,70 +289,11 @@ const aiFieldTypes = {
       />
     );
   },
-  [UiIntegrationsFieldType.PROMPT_NAME]: ({ onChange, task, actor }) => {
-    const promptNames = useSelector(
-      actor,
-      (state) => state.context.promptNameOptions,
-    );
-    const [options] = useMemo(() => {
-      return [
-        promptNames.map(
-          ({ name }: { name: string }) => name, // Fix types
-        ),
-      ];
-    }, [promptNames]);
-
-    const [setValue, ipValue] = useSetterGetter(
-      UiIntegrationsFieldType.PROMPT_NAME,
-      task,
-    );
-
-    const currentVariables = task.inputParameters?.promptVariables || {};
-    return (
-      <Grid container spacing={3} sx={{ width: "100%" }}>
-        <Grid size={6}>
-          <MuiTypography sx={{ opacity: 0.5, mb: 3 }}>
-            Enter a saved AI Prompt name or{" "}
-            <Link
-              sx={{ fontWeight: 400 }}
-              target="_blank"
-              href="/ai_prompts/new_ai_prompt_model"
-              rel="noreferrer"
-            >
-              create a new one.
-            </Link>
-          </MuiTypography>
-          <ConductorAutocompleteVariables
-            openOnFocus
-            onChange={(value) => {
-              actor.send({
-                type: LLMFormFieldsMachineEventTypes.SELECT_PROMPT_NAME,
-                task: setValue(value),
-              });
-            }}
-            value={ipValue}
-            otherOptions={options}
-            label="Prompt Name"
-            onFocus={() =>
-              actor.send({
-                type: LLMFormFieldsMachineEventTypes.FOCUS_PROMPT_NAMES,
-                task,
-              })
-            }
-          />
-        </Grid>
-        <MuiTypography sx={{ opacity: 0.5 }}>
-          {`Variables to be used in the prompt (e.g. "What's the weather in {$userLocation}?").`}
-        </MuiTypography>
-        <PromptVariables
-          currentVariables={currentVariables}
-          onChange={onChange}
-          updateField={updateField}
-          task={task}
-        />
-      </Grid>
-    );
-  },
+  [UiIntegrationsFieldType.PROMPT_NAME]: createPromptTemplateField({
+    fieldType: UiIntegrationsFieldType.PROMPT_NAME,
+    selectEventType: LLMFormFieldsMachineEventTypes.SELECT_PROMPT_NAME,
+    legacyReadKey: "prompt",
+  }),
   [UiIntegrationsFieldType.TEXT]: ({ onChange, task }) => {
     const [setValue, ipValue] = useSetterGetter(
       UiIntegrationsFieldType.TEXT,
@@ -612,64 +651,10 @@ const aiFieldTypes = {
     );
   },
 
-  [UiIntegrationsFieldType.INSTRUCTIONS]: ({ onChange, task, actor }) => {
-    const options = useSelector(
-      actor,
-      (state: State<LLMFormFieldsMachineContext>) =>
-        state.context.promptNameOptions.map(({ name }) => name),
-    );
-
-    const [setValue, ipValue] = useSetterGetter(
-      UiIntegrationsFieldType.INSTRUCTIONS,
-      task,
-    );
-
-    const currentVariables = task.inputParameters?.promptVariables || {};
-    return (
-      <Grid container spacing={3} sx={{ width: "100%" }}>
-        <Grid size={12}>
-          <MuiTypography sx={{ opacity: 0.5, mb: 3 }}>
-            Enter a saved AI Prompt name or{" "}
-            <Link
-              sx={{ fontWeight: 400 }}
-              target="_blank"
-              href="/ai_prompts/new_ai_prompt_model"
-              rel="noreferrer"
-            >
-              create a new one.
-            </Link>
-          </MuiTypography>
-          <ConductorAutocompleteVariables
-            value={ipValue}
-            otherOptions={options}
-            label="Prompt Name"
-            onChange={(value) => {
-              actor.send({
-                type: LLMFormFieldsMachineEventTypes.SELECT_INSTRUCTIONS,
-                task: setValue(value),
-              });
-            }}
-            onFocus={() =>
-              actor.send({
-                type: LLMFormFieldsMachineEventTypes.FOCUS_PROMPT_NAMES,
-                task,
-              })
-            }
-            openOnFocus
-          />
-        </Grid>
-        <MuiTypography sx={{ opacity: 0.5 }}>
-          {`Variables to be used in the prompt (e.g. "What's the weather in {$userLocation}?").`}
-        </MuiTypography>
-        <PromptVariables
-          currentVariables={currentVariables}
-          onChange={onChange}
-          updateField={updateField}
-          task={task}
-        />
-      </Grid>
-    );
-  },
+  [UiIntegrationsFieldType.INSTRUCTIONS]: createPromptTemplateField({
+    fieldType: UiIntegrationsFieldType.INSTRUCTIONS,
+    selectEventType: LLMFormFieldsMachineEventTypes.SELECT_INSTRUCTIONS,
+  }),
   [UiIntegrationsFieldType.MESSAGES]: ({ onChange, task }) => {
     const [setValue, ipValue] = useSetterGetter(
       UiIntegrationsFieldType.MESSAGES,


### PR DESCRIPTION
## Summary

Two independent items landing together:

### 1. Prompt Template field (rename + fix a live termination bug)

The Prompt Template picker already existed in `fieldHelpers.tsx` (`PROMPT_NAME`/`INSTRUCTIONS` field types) — self-fetching `/prompts` via the existing `fetchForPromptNames` service, degrading to plain free text when the server has no prompt registry (OSS), and showing a picker when it does (Orkes) — but it was disconnected from both LLM task forms, which instead rendered plain textareas.

- Extracted a shared `createPromptTemplateField` factory from the two near-duplicate renderers; renamed the label from "Prompt Name" to "Prompt Template".
- Re-wired `LLMTextCompleteTaskForm` to write `inputParameters.promptName` (previously `.prompt`) and `LLMChatCompleteTaskForm` to the `INSTRUCTIONS` field; removed the plain textareas and the stale "enterprise overrides this" comments (`conductor-ui` only wraps these forms with a Guardrails section — it never overrode the prompt field).
- Added a legacy-read fallback so text-complete tasks saved before this change (`inputParameters.prompt`, no `promptName`) still display their prompt text on open.
- **Fixed a live termination bug**: `LLMFormFieldsWrapper`'s `selectPromptName`/`selectInstructions` actions now set `inputParameters.allowRawPrompts` — `true` for free text, `false` when the value matches a fetched template exactly. Without this, Orkes' `AIModelTaskValidator.checkPromptAccess` terminates the workflow at runtime for any free-text prompt (the default in OSS, which has no `/prompts` registry at all). This is a live bug for chat-complete today (`ChatCompletion.getPrompt()` reads `instructions` server-side) and would become one for text-complete the moment it starts writing `promptName` instead of `prompt`.

### 2. `start_agent` event handler action

Adds a first-class "Start Agent" action to event handlers, so an event can start a registered agent execution directly via `WorkflowExecutor.startAgentExecution(AgentStartRequest)` (already on `origin/main`) — rather than going through `start_workflow` against the agent's underlying workflow definition, which would bypass the agent input contract (`prompt`/`media`/`context`/`session_id`), per-run model/timeout overrides, and idempotency handling.

- `common`: `EventHandler.Action.Type += start_agent`, new flat `Action.StartAgent` payload as `@ProtoField(id = 8)`.
- `core`: `SimpleActionProcessor` case templating the payload against the event (mirroring `startWorkflow`), then calling `startAgentExecution`.
- `grpc`: regenerated by the `:conductor-common:protogen` task wired into `:conductor-grpc`'s build — no hand-written gRPC code.
- `ui-next`: `Action` enum/label/schema template/render-switch/TS type follow the `start_workflow` pattern; new `StartAgentActionForm` (modeled on `StartWorkflowActionForm`) with an agent name/version picker sourced from the existing `/agent/list` endpoint.

**Scope note**: this action is OSS + `ui-next` only in this PR. A mirror in `orkes-conductor` (its own `EventHandler` model + `OrkesActionProcessor` case) is required for it to work on Orkes — that's a separate PR against that repo.

## Testing

- `LLMTextCompleteTaskForm.test.tsx` / `LLMChatCompleteTaskForm.test.tsx`: label rename, free-text → `allowRawPrompts=true`, legacy `prompt`-key fallback, known-template selection → auto-populated variables/temperature/stopWords with `allowRawPrompts=false`.
- `TestSimpleActionProcessor#testStartAgent`: payload templating (`${...}` against the event payload for name/prompt/sessionId/idempotencyKey/media/context) and correct mapping onto `AgentStartRequest`.
- `StartAgentTask.test.tsx`: name/version field wiring (including version-options filtering by selected agent name), prompt/session/idempotency text fields, media newline-splitting, and the context key-value editor.
- Verified: `tsc --noEmit`, `eslint`, `prettier --check`, full `vitest` suite (713 passed), `build:lib` — all clean on `ui-next`. `./gradlew :conductor-common:compileJava :conductor-core:compileJava :conductor-grpc:compileJava` and the affected test suites pass on the Java side.