### PR TITLE
fix(agentspan): stop emitting DO_WHILE nested inside DO_WHILE for requiredTools

### DIFF
--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/AgentCompiler.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/AgentCompiler.java
@@ -789,8 +789,57 @@ public class AgentCompiler {
         // Prefill tool calls: execute before the loop so results are in LLM context
         allTasks.addAll(prefill.tasks());
 
-        // Required tools enforcement: wrap loop + check in outer DO_WHILE
+        // Required tools enforcement: retry the agent loop until every required tool has
+        // been called (bounded at 3 attempts).
+        //
+        // The retry is an outer DO_WHILE and the agent loop it retries is itself a
+        // DO_WHILE. Conductor does not support a DO_WHILE nested directly inside another
+        // DO_WHILE, so the inner loop is wrapped in a SUB_WORKFLOW — the documented
+        // workaround, and the shape this compiler already uses elsewhere for swarm agents.
         if (config.getRequiredTools() != null && !config.getRequiredTools().isEmpty()) {
+            String innerWfRef = toRef(config.getName()) + "_required_tools_inner";
+
+            // The loop body reads workflow VARIABLES (_agent_state, _last_tool_results,
+            // _stop_requested, _signal_injection, and _human_feedback when approval is
+            // on). Variables are per-workflow, so a sub-workflow starts with none: seed
+            // them from sub-workflow inputs before the loop runs, mirroring the parent's
+            // init_state. Every SET_VARIABLE in this compiler sits OUTSIDE the loop body,
+            // so the loop only reads them — seeding is sufficient and no write-back to
+            // the parent is required.
+            Map<String, Object> seedVars = new LinkedHashMap<>();
+            for (String v : initVars.keySet()) {
+                seedVars.put(v, "${workflow.input." + v + "}");
+            }
+            WorkflowTask seedState = new WorkflowTask();
+            seedState.setType("SET_VARIABLE");
+            seedState.setTaskReferenceName(innerWfRef + "_seed_state");
+            seedState.setInputParameters(seedVars);
+
+            WorkflowDef innerWf = createWorkflow(config);
+            innerWf.setName(config.getName() + "_required_tools_inner");
+            innerWf.setDescription(
+                    "Agent loop for " + config.getName() + " (required-tools retry body)");
+            innerWf.setTasks(List.of(seedState, loop));
+            // Expose the loop output so the check task can see which tools ran.
+            innerWf.setOutputParameters(Map.of("loop", "${" + loopRef + ".output}"));
+            WorkflowTaskUtils.ensureAllTaskNames(innerWf);
+
+            WorkflowTask innerTask = new WorkflowTask();
+            innerTask.setType("SUB_WORKFLOW");
+            innerTask.setName(innerWf.getName());
+            innerTask.setTaskReferenceName(innerWfRef);
+            innerTask.setSubWorkflowParam(new SubWorkflowParams());
+            innerTask.getSubWorkflowParam().setName(innerWf.getName());
+            innerTask.getSubWorkflowParam().setWorkflowDef(innerWf);
+            Map<String, Object> innerInputs = new LinkedHashMap<>();
+            for (String k : WORKFLOW_INPUTS) {
+                innerInputs.put(k, "${workflow.input." + k + "}");
+            }
+            for (String v : initVars.keySet()) {
+                innerInputs.put(v, "${workflow.variables." + v + "}");
+            }
+            innerTask.setInputParameters(innerInputs);
+
             String checkRef = toRef(config.getName()) + "_required_tools_check";
             WorkflowTask checkTask = new WorkflowTask();
             checkTask.setType("INLINE");
@@ -801,7 +850,7 @@ public class AgentCompiler {
                             "expression",
                                     JavaScriptBuilder.requiredToolsCheckScript(
                                             config.getRequiredTools()),
-                            "completedTaskNames", ref(loopRef + ".output")));
+                            "completedTaskNames", ref(innerWfRef + ".output.loop")));
 
             String outerLoopRef = toRef(config.getName()) + "_required_tools_loop";
             String outerCondition =
@@ -814,7 +863,10 @@ public class AgentCompiler {
 
             WorkflowTask outerLoop =
                     buildDoWhile(
-                            outerLoopRef, outerCondition, List.of(loop, checkTask), outerInputs);
+                            outerLoopRef,
+                            outerCondition,
+                            List.of(innerTask, checkTask),
+                            outerInputs);
             allTasks.add(outerLoop);
         } else {
             allTasks.add(loop);

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/AgentCompilerTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/AgentCompilerTest.java
@@ -624,14 +624,73 @@ class AgentCompilerTest {
         assertThat(outerLoop.getType()).isEqualTo("DO_WHILE");
         assertThat(outerLoop.getTaskReferenceName()).isEqualTo("filing_agent_required_tools_loop");
 
-        // Outer loop should contain: inner loop + INLINE check
+        // Outer loop contains the agent loop wrapped in a SUB_WORKFLOW + the INLINE check.
+        // The wrapper is required: Conductor does not support DO_WHILE directly inside
+        // DO_WHILE, so the agent loop cannot be a member of loopOver on its own.
         assertThat(outerLoop.getLoopOver()).hasSize(2);
-        assertThat(outerLoop.getLoopOver().get(0).getType()).isEqualTo("DO_WHILE");
-        assertThat(outerLoop.getLoopOver().get(0).getTaskReferenceName())
-                .isEqualTo("filing_agent_loop");
+        WorkflowTask innerTask = outerLoop.getLoopOver().get(0);
+        assertThat(innerTask.getType()).isEqualTo("SUB_WORKFLOW");
+        assertThat(innerTask.getTaskReferenceName()).isEqualTo("filing_agent_required_tools_inner");
         assertThat(outerLoop.getLoopOver().get(1).getType()).isEqualTo("INLINE");
         assertThat(outerLoop.getLoopOver().get(1).getTaskReferenceName())
                 .isEqualTo("filing_agent_required_tools_check");
+
+        // The agent loop lives inside the embedded sub-workflow definition, preceded by a
+        // SET_VARIABLE that seeds the variables the loop body reads (a sub-workflow starts
+        // with an empty variable scope).
+        WorkflowDef innerWf = innerTask.getSubWorkflowParam().getWorkflowDef();
+        assertThat(innerWf).isNotNull();
+        assertThat(innerWf.getTasks()).hasSize(2);
+        assertThat(innerWf.getTasks().get(0).getType()).isEqualTo("SET_VARIABLE");
+        assertThat(innerWf.getTasks().get(0).getInputParameters())
+                .containsKeys("_agent_state", "_stop_requested", "_signal_injection");
+        assertThat(innerWf.getTasks().get(1).getType()).isEqualTo("DO_WHILE");
+        assertThat(innerWf.getTasks().get(1).getTaskReferenceName()).isEqualTo("filing_agent_loop");
+
+        // The seed values come from the parent's variables, via sub-workflow inputs.
+        assertThat(innerTask.getInputParameters())
+                .containsEntry("_agent_state", "${workflow.variables._agent_state}");
+
+        // The check task reads the loop output through the sub-workflow's output mapping.
+        assertThat(innerWf.getOutputParameters())
+                .containsEntry("loop", "${filing_agent_loop.output}");
+        assertThat(outerLoop.getLoopOver().get(1).getInputParameters())
+                .containsEntry(
+                        "completedTaskNames", "${filing_agent_required_tools_inner.output.loop}");
+
+        // The invariant this whole shape exists to satisfy.
+        assertNoDoWhileNestedInDoWhile(wf);
+    }
+
+    /**
+     * Walks a compiled definition (including embedded sub-workflow definitions) and fails if any
+     * DO_WHILE has another DO_WHILE among its loopOver tasks. Conductor does not support that
+     * nesting.
+     */
+    private static void assertNoDoWhileNestedInDoWhile(WorkflowDef wf) {
+        for (WorkflowTask t : wf.getTasks()) {
+            assertNoDoWhileNestedInDoWhile(t, false);
+        }
+    }
+
+    private static void assertNoDoWhileNestedInDoWhile(WorkflowTask task, boolean insideDoWhile) {
+        boolean isDoWhile = "DO_WHILE".equals(task.getType());
+        if (isDoWhile && insideDoWhile) {
+            throw new AssertionError(
+                    "DO_WHILE '"
+                            + task.getTaskReferenceName()
+                            + "' is nested directly inside another DO_WHILE");
+        }
+        if (task.getLoopOver() != null) {
+            for (WorkflowTask child : task.getLoopOver()) {
+                assertNoDoWhileNestedInDoWhile(child, insideDoWhile || isDoWhile);
+            }
+        }
+        // A SUB_WORKFLOW boundary resets the nesting context — that is the point of it.
+        if (task.getSubWorkflowParam() != null
+                && task.getSubWorkflowParam().getWorkflowDef() != null) {
+            assertNoDoWhileNestedInDoWhile(task.getSubWorkflowParam().getWorkflowDef());
+        }
     }
 
     @Test


### PR DESCRIPTION
> **Draft.** Structurally verified and unit-tested; not yet exercised end-to-end against a live server. See *Not verified* below.

## Problem

Conductor does not support a `DO_WHILE` directly inside another `DO_WHILE`. The `requiredTools` path emitted exactly that — the retry wrapper is a `DO_WHILE`, and the agent's ReAct loop it retries is also a `DO_WHILE`, handed straight to `loopOver`:

```java
WorkflowTask loop = buildDoWhile(loopRef, termCondition, loopTasks, loopInputs);   // DO_WHILE
...
WorkflowTask outerLoop = buildDoWhile(outerLoopRef, outerCondition, List.of(loop, checkTask), outerInputs);
                                                                              // ^^^^ nested DO_WHILE
```

So declaring an agent with `requiredTools` produces an unsupported workflow shape. Nothing in the caller's control causes it — it's emitted by the compiler.

**This is the only place in the compiler that nests loops.** There is a single `DO_WHILE` factory (`buildDoWhile`, the one `setType("DO_WHILE")`), and across all its call sites this is the one that passes a `DO_WHILE` into a loop body. Every other loop body is built from non-loop tasks.

## Fix

Use the supported shape — a `DO_WHILE` inside a `SUB_WORKFLOW` — which this compiler **already uses for swarm agents**. The agent loop is wrapped in a `SUB_WORKFLOW` with an embedded definition, so the outer retry loop sees a `SUB_WORKFLOW` rather than a `DO_WHILE`.

### The subtlety: variable scope

The loop body reads workflow **variables** — `_agent_state`, `_last_tool_results`, `_stop_requested`, `_signal_injection`, and `_human_feedback` when approval is on. A sub-workflow starts with an *empty* variable scope, so a naive wrap would leave those silently reading empty.

The inner definition therefore begins with a `SET_VARIABLE` seeding them from sub-workflow inputs, wired from the parent's variables. **Seeding alone is sufficient** because every `SET_VARIABLE` in this compiler sits *outside* the loop body — the loop only reads these, so nothing needs writing back to the parent.

The check task previously read the inner loop's output directly; it now reads it via the sub-workflow's `outputParameters` mapping.

## Behaviour

Unchanged otherwise — same retry bound of 3, same condition. The `requiredTools`-empty branch already emitted a bare loop and is untouched, so no nesting is introduced there.

## Tests

`testCompileWithRequiredTools` is updated to the new shape and additionally asserts the seeded variables, the input wiring from parent variables, and the output mapping.

It also asserts the invariant the whole shape exists for, via a recursive walk that descends into embedded sub-workflow definitions:

```java
assertNoDoWhileNestedInDoWhile(wf);
```

**I verified that assertion actually bites**: putting the old nesting back (`List.of(loop, checkTask)`) fails the test with *"DO_WHILE 'filing_agent_loop' is nested directly inside another DO_WHILE"*. So it's a real guard, not decoration.

`563 tests pass`, spotless applied.

## Not verified

No end-to-end run against a live server. The compiled shape is asserted structurally, but the runtime semantics of seeded variables across the sub-workflow boundary should be confirmed by the agent e2e suite before this leaves draft. Two things worth watching there specifically:

- whether `_agent_state` seeded per outer-retry-attempt behaves as intended (each attempt re-seeds from the parent's value, so state does not accumulate across attempts — matching the previous behaviour, where the inner loop re-read the same parent variable, but worth confirming)
- the sub-workflow's own timeout, inherited from `createWorkflow` (60s), relative to long agent loops

## Context

This shape is what motivated adding nested-`DO_WHILE` support to the engine in orkes-io/orkes-conductor#3819. If `requiredTools` stops producing it, that engine change may not be needed — which also avoids the task-reference suffix-collision surface raised in review there.
