### PR TITLE
fix(azure-foundry): scan content parts for text instead of assuming content[0] is text

### DIFF
--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AzureFoundryAgentClient.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AzureFoundryAgentClient.java
@@ -277,7 +277,13 @@ public class AzureFoundryAgentClient implements ConductorAgentClient {
                     get(ctx.endpoint + "/threads/" + threadId + "/messages", token, ctx.apiVersion);
             for (JsonNode msg : messages.path("data")) {
                 if ("assistant".equals(msg.path("role").asText())) {
-                    String text = msg.path("content").path(0).path("text").path("value").asText("");
+                    String text = "";
+                    for (JsonNode part : msg.path("content")) {
+                        if ("text".equals(part.path("type").asText())) {
+                            text = part.path("text").path("value").asText("");
+                            break;
+                        }
+                    }
                     output = Map.of("result", text);
                     break;
                 }

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AzureFoundryAgentClient.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AzureFoundryAgentClient.java
@@ -277,14 +277,7 @@ public class AzureFoundryAgentClient implements ConductorAgentClient {
                     get(ctx.endpoint + "/threads/" + threadId + "/messages", token, ctx.apiVersion);
             for (JsonNode msg : messages.path("data")) {
                 if ("assistant".equals(msg.path("role").asText())) {
-                    String text = "";
-                    for (JsonNode part : msg.path("content")) {
-                        if ("text".equals(part.path("type").asText())) {
-                            text = part.path("text").path("value").asText("");
-                            break;
-                        }
-                    }
-                    output = Map.of("result", text);
+                    output = Map.of("result", extractText(msg.path("content")));
                     break;
                 }
             }
@@ -428,6 +421,21 @@ public class AzureFoundryAgentClient implements ConductorAgentClient {
     private String resolveApiVersion(ConductorAgentStartRequest request) {
         String v = rawConfig(request, "apiVersion");
         return StringUtils.isBlank(v) ? DEFAULT_API_VERSION : v;
+    }
+
+    /**
+     * Returns the text value from the first content part with {@code "type": "text"}.
+     *
+     * <p>Assistants with code interpreter may return an {@code image_file} part before the text
+     * part, so we cannot assume {@code content[0]} is text.
+     */
+    private static String extractText(JsonNode contentArray) {
+        for (JsonNode part : contentArray) {
+            if ("text".equals(part.path("type").asText())) {
+                return part.path("text").path("value").asText("");
+            }
+        }
+        return "";
     }
 
     private static String rawConfig(ConductorAgentStartRequest request, String key) {

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AzureFoundryAgentClient.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AzureFoundryAgentClient.java
@@ -423,12 +423,9 @@ public class AzureFoundryAgentClient implements ConductorAgentClient {
         return StringUtils.isBlank(v) ? DEFAULT_API_VERSION : v;
     }
 
-    /**
-     * Returns the text value from the first content part with {@code "type": "text"}.
-     *
-     * <p>Assistants with code interpreter may return an {@code image_file} part before the text
-     * part, so we cannot assume {@code content[0]} is text.
-     */
+    // Returns the text value from the first content part with "type": "text".
+    // Assistants with code interpreter may return an image_file part before the text part,
+    // so content[0] is not always text.
     private static String extractText(JsonNode contentArray) {
         for (JsonNode part : contentArray) {
             if ("text".equals(part.path("type").asText())) {


### PR DESCRIPTION
## Problem

Assistants with code interpreter enabled (e.g. analyst agents) return multiple content parts in the assistant message — an `image_file` part (the generated chart) followed by the `text` part. The previous code always took `content[0].text.value`, which was empty for these assistants since `content[0]` is an `image_file`, not text.

## Fix

Iterate content parts and return the first one with `type = "text"` instead of blindly indexing `content[0]`.

## Test plan

- [x] Greeter agent (text only) — still returns text correctly
- [x] Summarizer agent (text only) — still returns text correctly
- [x] Analyst agent (code interpreter, returns image_file + text) — now returns text analysis instead of empty string