### PR TITLE
fix(ci): fix comma-joined report_paths hiding AgentSpan E2E results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,9 @@ jobs:
         uses: mikepenz/action-junit-report@v6
         if: always()
         with:
-          report_paths: "test-harness/build/test-results/agentspanDeterministicE2E/TEST-*.xml,test-harness/build/test-results/agentspanRealE2E/TEST-*.xml"
+          report_paths: |
+            test-harness/build/test-results/agentspanDeterministicE2E/TEST-*.xml
+            test-harness/build/test-results/agentspanRealE2E/TEST-*.xml
           check_name: AgentSpan E2E Test Report
       - name: Upload AgentSpan E2E reports
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

- `report_paths` was a single comma-joined string, but `mikepenz/action-junit-report` splits on newlines, not commas — so it matched zero files and the Checks tab always showed "0 ran 0 passed", even though the AgentSpan E2E suite actually ran and passed.
- Switched `report_paths` to a YAML block scalar (one glob per line) so both test result globs are picked up correctly.

Issue #

Alternatives considered
----

None — this matches the input format the action expects.
