### PR TITLE
fix(ui-next): show each agent's own strategy in Agent Execution view,…

### DIFF
--- a/ui-next/src/pages/execution/AgentExecution/AgentExecutionDiagram.tsx
+++ b/ui-next/src/pages/execution/AgentExecution/AgentExecutionDiagram.tsx
@@ -985,7 +985,7 @@ function buildTurnNodes(
       modelName: sub.model,
       sublabel:
         agentValuePreview(sub.output, 55) ?? sub.failureReason?.slice(0, 55),
-      strategy: turn.strategy,
+      strategy: sub.strategy,
       ts: toTS(sub.status),
       subAgentRun: sub,
     });
@@ -1288,7 +1288,7 @@ function buildTurnNodes(
           sublabel:
             agentValuePreview(sub.output, 55) ??
             sub.failureReason?.slice(0, 55),
-          strategy: turn.strategy,
+          strategy: sub.strategy,
           ts: toTS(sub.status),
           subAgentRun: sub,
         },
@@ -1325,7 +1325,7 @@ function buildTurnNodes(
           sublabel:
             agentValuePreview(sub.output, 55) ??
             sub.failureReason?.slice(0, 55),
-          strategy: turn.strategy,
+          strategy: sub.strategy,
           ts: toTS(sub.status),
           subAgentRun: sub,
         });

--- a/ui-next/src/pages/execution/AgentExecution/agentExecutionUtils.test.ts
+++ b/ui-next/src/pages/execution/AgentExecution/agentExecutionUtils.test.ts
@@ -8,7 +8,7 @@ import {
   timelineItemKind,
   transformWorkflowExecutionToAgentRun,
 } from "./agentExecutionUtils";
-import { AgentStatus, AgentTimelineKind } from "./types";
+import { AgentStatus, AgentStrategy, AgentTimelineKind } from "./types";
 
 function task(overrides: Record<string, unknown>) {
   return {
@@ -339,5 +339,109 @@ describe("transformWorkflowExecutionToAgentRun timeline", () => {
     );
 
     expect(computeMetrics(run).totalTurns).toBe(1);
+  });
+
+  // Regression coverage for issue #1454: sub-agent nodes were labelled with the
+  // PARENT's invocation strategy instead of their own defined strategy — a
+  // router-strategy sub-agent rendered as "handoff" (whatever spawned it)
+  // instead of "router" (how it orchestrates its own children).
+  it("gives each sub-agent its own defined strategy, not the parent's", () => {
+    const run = transformWorkflowExecutionToAgentRun(
+      execution(
+        [
+          task({
+            referenceTaskName: "researcher__1",
+            taskType: "SUB_WORKFLOW",
+            outputData: { subWorkflowId: "wf-researcher", result: "done" },
+          }),
+        ],
+        {
+          workflowDefinition: {
+            metadata: {
+              agentDef: {
+                name: "agent",
+                strategy: "handoff",
+                agents: [
+                  {
+                    name: "researcher",
+                    strategy: "router",
+                    agents: [{ name: "web_search" }, { name: "arxiv" }],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ),
+    );
+
+    const researcher = run.turns
+      .flatMap((turn) => turn.subAgents)
+      .find((sub) => sub.agentName === "researcher");
+
+    expect(researcher?.strategy).toBe(AgentStrategy.ROUTER);
+  });
+
+  it("shows no strategy for a leaf sub-agent (no nested agents of its own)", () => {
+    // Task runs inside a DO_WHILE iteration so it goes through the
+    // handoff/loop sub-agent path, which used to hardcode strategy=SINGLE
+    // for every sub-agent regardless of its own definition.
+    const run = transformWorkflowExecutionToAgentRun(
+      execution(
+        [
+          task({
+            referenceTaskName: "writer__1",
+            taskType: "SUB_WORKFLOW",
+            loopOverTask: true,
+            outputData: { subWorkflowId: "wf-writer", result: "done" },
+          }),
+        ],
+        {
+          workflowDefinition: {
+            metadata: {
+              agentDef: {
+                name: "agent",
+                strategy: "handoff",
+                agents: [{ name: "writer", strategy: "single" }],
+              },
+            },
+          },
+        },
+      ),
+    );
+
+    const writer = run.turns
+      .flatMap((turn) => turn.subAgents)
+      .find((sub) => sub.agentName === "writer");
+
+    expect(writer?.strategy).toBeUndefined();
+  });
+
+  it("derives the root agent's own strategy from its definition, not the runtime shape", () => {
+    const run = transformWorkflowExecutionToAgentRun(
+      execution(
+        [
+          task({
+            referenceTaskName: "researcher__1",
+            taskType: "SUB_WORKFLOW",
+            outputData: { subWorkflowId: "wf-researcher", result: "done" },
+          }),
+        ],
+        {
+          workflowName: "agent",
+          workflowDefinition: {
+            metadata: {
+              agentDef: {
+                name: "agent",
+                strategy: "router",
+                agents: [{ name: "researcher" }],
+              },
+            },
+          },
+        },
+      ),
+    );
+
+    expect(run.strategy).toBe(AgentStrategy.ROUTER);
   });
 });

--- a/ui-next/src/pages/execution/AgentExecution/agentExecutionUtils.ts
+++ b/ui-next/src/pages/execution/AgentExecution/agentExecutionUtils.ts
@@ -428,6 +428,45 @@ function isChainWorkflow(tasks: ExecutionTask[]): boolean {
   );
 }
 
+function parseAgentStrategy(raw: unknown): AgentStrategy | undefined {
+  if (typeof raw !== "string") return undefined;
+  const normalized = raw.toLowerCase();
+  return (Object.values(AgentStrategy) as string[]).includes(normalized)
+    ? (normalized as AgentStrategy)
+    : undefined;
+}
+
+/**
+ * Recursively index each agent definition's OWN strategy by name, mirroring how
+ * the Definition tab walks agentDef.agents[]. Only agents that actually have
+ * their own sub-agents get an entry — leaves are intentionally left unindexed
+ * so the Execution view shows no strategy badge for them (issue #1454).
+ */
+function indexAgentDefStrategies(
+  agentDef: Record<string, unknown> | undefined,
+  index: Map<string, AgentStrategy> = new Map(),
+): Map<string, AgentStrategy> {
+  if (!agentDef) return index;
+  const children =
+    (agentDef.agents as Array<Record<string, unknown>> | undefined) ?? [];
+  if (children.length > 0) {
+    const name = agentDef.name as string | undefined;
+    const strategy = parseAgentStrategy(agentDef.strategy);
+    if (name && strategy) index.set(name.toLowerCase(), strategy);
+  }
+  for (const child of children) {
+    indexAgentDefStrategies(child, index);
+  }
+  return index;
+}
+
+function lookupOwnStrategy(
+  index: Map<string, AgentStrategy>,
+  name: string | undefined,
+): AgentStrategy | undefined {
+  return name ? index.get(name.toLowerCase()) : undefined;
+}
+
 /**
  * Transform a sequential chain workflow into AgentRunData.
  * Each step becomes a "turn" whose only sub-agent is the step agent.
@@ -469,6 +508,11 @@ function transformChainWorkflowToAgentRun(
   // Grab the per-step agent configs from the definition metadata for gate label info
   const agentsDef = ((execution.workflowDefinition?.metadata?.agentDef as any)
     ?.agents ?? []) as Array<Record<string, unknown>>;
+  const strategyIndex = indexAgentDefStrategies(
+    execution.workflowDefinition?.metadata?.agentDef as
+      | Record<string, unknown>
+      | undefined,
+  );
 
   const turns: AgentTurn[] = sortedSteps.map(
     ([stepN, task], idx): AgentTurn => {
@@ -513,7 +557,7 @@ function transformChainWorkflowToAgentRun(
         status: mapTaskStatus(task.status),
         totalTokens: ZERO_TOKENS,
         totalDurationMs: durationMs,
-        strategy: AgentStrategy.SINGLE,
+        strategy: lookupOwnStrategy(strategyIndex, agentName),
         agentType: task.inputData?.agentType as string | undefined,
         invocationStrategy: AgentStrategy.SEQUENTIAL,
         input: task.inputData?.workflowInput ?? task.inputData,
@@ -672,6 +716,7 @@ export function transformWorkflowExecutionToAgentRun(
   const agentDefMeta = execution.workflowDefinition?.metadata?.agentDef as
     | Record<string, unknown>
     | undefined;
+  const strategyIndex = indexAgentDefStrategies(agentDefMeta);
   const guardrailFnNames = new Set<string>();
   for (const gList of [
     (agentDefMeta?.input_guardrails as
@@ -871,7 +916,7 @@ export function transformWorkflowExecutionToAgentRun(
             status: mapTaskStatus(task.status),
             totalTokens: ZERO_TOKENS,
             totalDurationMs: durationMs,
-            strategy: AgentStrategy.SINGLE,
+            strategy: lookupOwnStrategy(strategyIndex, agentName),
             agentType: task.inputData?.agentType as string | undefined,
             invocationStrategy: AgentStrategy.HANDOFF,
             input: agentInput,
@@ -1302,6 +1347,7 @@ export function transformWorkflowExecutionToAgentRun(
       totalTokens: ZERO_TOKENS,
       totalDurationMs: dur,
       agentType: task.inputData?.agentType as string | undefined,
+      strategy: lookupOwnStrategy(strategyIndex, agentName),
       invocationStrategy:
         rootSubWorkflows.length > 1
           ? AgentStrategy.PARALLEL
@@ -1751,11 +1797,12 @@ export function transformWorkflowExecutionToAgentRun(
     totalDurationMs,
     finishReason,
     strategy:
-      rootSubWorkflows.length > 1
+      lookupOwnStrategy(strategyIndex, rootAgentName) ??
+      (rootSubWorkflows.length > 1
         ? AgentStrategy.PARALLEL
         : sortedIters.length > 0
           ? AgentStrategy.HANDOFF
-          : AgentStrategy.SINGLE,
+          : AgentStrategy.SINGLE),
     input: agentInput,
     output: execution.output ?? finalOutput,
   };


### PR DESCRIPTION
Sub-agent nodes in the Agent Execution diagram were labelled with the parent turn's invocation strategy (e.g. HANDOFF) instead of their own defined strategy, contradicting the Definition tab. Look up each agent's own strategy from its definition, only assigning a badge to agents that actually orchestrate their own children.

Fixes #1454

Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Sub-agent nodes in the Agent Execution diagram showed the parent's invocation strategy (e.g. HANDOFF) instead of their own — contradicting the Definition tab. A ROUTER sub-agent could render as HANDOFF just because of how it was invoked.

Root cause: agentExecutionUtils.ts hardcoded/omitted each sub-agent's strategy, and AgentExecutionDiagram.tsx rendered node badges from turn.strategy (the parent's) instead of sub.strategy (its own).

Fix:

Added indexAgentDefStrategies() to read each agent's own strategy from its definition — only agents with their own children get a badge; leaves show none.
Wired this into all sub-agent construction sites (chain, handoff/loop, root) and into the root agent's strategy, replacing a runtime-shape guess.
AgentExecutionDiagram.tsx: individual nodes use sub.strategy; the collapsed group node still uses turn.strategy (correct — it summarizes the batch invocation, not one agent).
Added 3 regression tests: nested ROUTER sub-agent under a HANDOFF parent, leaf sub-agent with no strategy, and root strategy from definition vs. task shape.
Verified: tsc/eslint clean, full suite passing, manually checked in UI with mock data.

Out of scope: the "4 vs 8 nodes" count issue also in #1454 is a separate, larger fix (#1452 — deeper tree levels aren't fetched until drill-in).

Alternatives considered
----
Considered inferring each sub-agent's strategy purely from its runtime
task shape (as the code did for the root agent), but that's exactly the
heuristic that caused the mismatch with the Definition tab — the
Definition tab is the source of truth for "what strategy did the user
configure," so the Execution view should read from the same place rather
than re-deriving it from execution shape.

Before Fix:
----
<img width="1400" height="420" alt="image" src="https://github.com/user-attachments/assets/c3e724ca-853a-49cb-846b-1f70574f3f91" />

After Fix:
----
<img width="1400" height="420" alt="after" src="https://github.com/user-attachments/assets/866c92b9-b3b8-4330-89e5-16e743249afb" />


