### PR TITLE
fix: slot release must not wake popped-but-unacked messages (floor-restricted peek)

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
@@ -97,6 +97,15 @@ public class ConductorProperties {
     @DurationUnit(ChronoUnit.SECONDS)
     private Duration taskExecutionPostponeDuration = Duration.ofSeconds(60);
 
+    /**
+     * Only queue messages postponed at least this far into the future are woken up when a
+     * concurrency-limited task frees a slot. Must exceed every unack/visibility window in use
+     * (default system-task and worker pop windows are 30s): on queues that keep in-flight messages
+     * visible, a smaller value could wake a message another worker is still executing.
+     */
+    @DurationUnit(ChronoUnit.SECONDS)
+    private Duration concurrencySlotReleaseMinDelay = Duration.ofSeconds(35);
+
     /** Used to enable/disable the indexing of tasks. */
     private boolean taskIndexingEnabled = true;
 
@@ -379,6 +388,14 @@ public class ConductorProperties {
 
     public void setTaskExecutionPostponeDuration(Duration taskExecutionPostponeDuration) {
         this.taskExecutionPostponeDuration = taskExecutionPostponeDuration;
+    }
+
+    public Duration getConcurrencySlotReleaseMinDelay() {
+        return concurrencySlotReleaseMinDelay;
+    }
+
+    public void setConcurrencySlotReleaseMinDelay(Duration concurrencySlotReleaseMinDelay) {
+        this.concurrencySlotReleaseMinDelay = concurrencySlotReleaseMinDelay;
     }
 
     public boolean isTaskExecLogIndexingEnabled() {

--- a/core/src/main/java/com/netflix/conductor/core/dal/ExecutionDAOFacade.java
+++ b/core/src/main/java/com/netflix/conductor/core/dal/ExecutionDAOFacade.java
@@ -613,7 +613,16 @@ public class ExecutionDAOFacade {
 
         String queueName = QueueUtils.getQueueName(taskModel);
         try {
-            List<String> nextIds = queueDAO.peekFirstIds(queueName, 1);
+            // Floor-restricted peek: on queues that keep popped-but-unacked messages visible
+            // (the Redis single-zset design), a floor-less peek can select a message another
+            // worker is executing RIGHT NOW, and resetting it would cause an immediate duplicate
+            // delivery. Only genuinely postponed messages are eligible; a sibling whose remaining
+            // postpone is already below the floor is left to expire naturally (bounded wait).
+            List<String> nextIds =
+                    queueDAO.peekPostponedIds(
+                            queueName,
+                            properties.getConcurrencySlotReleaseMinDelay().toMillis(),
+                            1);
             if (nextIds == null || nextIds.isEmpty()) {
                 return;
             }

--- a/core/src/main/java/com/netflix/conductor/dao/QueueDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/QueueDAO.java
@@ -202,4 +202,21 @@ public interface QueueDAO {
     default List<String> peekFirstIds(String queueName, int count) {
         return List.of();
     }
+
+    /**
+     * Returns up to {@code count} message ids whose delivery time is at least {@code
+     * minDelayMillis} in the future — i.e. messages that are genuinely postponed, as opposed to due
+     * or popped-but-unacked. Callers that intend to {@link #resetOffsetTime} a message they did not
+     * pop (e.g. releasing a concurrency-limited successor) MUST use this instead of {@link
+     * #peekFirstIds}: on queue implementations that keep in-flight messages visible (the Redis
+     * single-zset design bumps a popped message's score to now+unackTimeout in place), peeking
+     * without a floor can select a message another worker is currently executing, and resetting it
+     * causes an immediate duplicate delivery.
+     *
+     * <p>The default delegates to {@link #peekFirstIds} for implementations whose peek already
+     * excludes in-flight messages (the SQL queues filter on {@code popped = false}).
+     */
+    default List<String> peekPostponedIds(String queueName, long minDelayMillis, int count) {
+        return peekFirstIds(queueName, count);
+    }
 }

--- a/core/src/test/java/com/netflix/conductor/core/dal/ExecutionDAOFacadeTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/dal/ExecutionDAOFacadeTest.java
@@ -76,6 +76,8 @@ public class ExecutionDAOFacadeTest {
         when(properties.isEventExecutionIndexingEnabled()).thenReturn(true);
         when(properties.isAsyncIndexingEnabled()).thenReturn(true);
         when(properties.isTaskIndexingEnabled()).thenReturn(true);
+        when(properties.getConcurrencySlotReleaseMinDelay())
+                .thenReturn(java.time.Duration.ofSeconds(35));
         executionDAOFacade =
                 new ExecutionDAOFacade(
                         executionDAO,
@@ -452,12 +454,15 @@ public class ExecutionDAOFacadeTest {
 
     @Test
     public void testTerminalTaskReleasesPostponedSuccessorWhenConcurrencyLimited() {
-        when(queueDAO.peekFirstIds(anyString(), eq(1)))
+        when(queueDAO.peekPostponedIds(anyString(), anyLong(), eq(1)))
                 .thenReturn(Collections.singletonList("postponed-id"));
 
         executionDAOFacade.updateTask(concurrencyLimitedTask(TaskModel.Status.COMPLETED, 1));
 
-        verify(queueDAO).peekFirstIds(anyString(), eq(1));
+        // The floor keeps the release away from due or popped-but-unacked (in-flight) messages:
+        // resetting one of those would cause an immediate duplicate delivery.
+        verify(queueDAO)
+                .peekPostponedIds(anyString(), eq(Duration.ofSeconds(35).toMillis()), eq(1));
         verify(queueDAO).resetOffsetTime(anyString(), eq("postponed-id"));
     }
 
@@ -465,7 +470,7 @@ public class ExecutionDAOFacadeTest {
     public void testNonTerminalTaskDoesNotReleaseSuccessor() {
         executionDAOFacade.updateTask(concurrencyLimitedTask(TaskModel.Status.SCHEDULED, 1));
 
-        verify(queueDAO, never()).peekFirstIds(anyString(), anyInt());
+        verify(queueDAO, never()).peekPostponedIds(anyString(), anyLong(), anyInt());
         verify(queueDAO, never()).resetOffsetTime(anyString(), anyString());
     }
 
@@ -473,7 +478,19 @@ public class ExecutionDAOFacadeTest {
     public void testTerminalTaskWithoutConcurrencyLimitDoesNotTouchTheQueue() {
         executionDAOFacade.updateTask(concurrencyLimitedTask(TaskModel.Status.COMPLETED, 0));
 
-        verify(queueDAO, never()).peekFirstIds(anyString(), anyInt());
+        verify(queueDAO, never()).peekPostponedIds(anyString(), anyLong(), anyInt());
+        verify(queueDAO, never()).resetOffsetTime(anyString(), anyString());
+    }
+
+    @Test
+    public void testNoResetWhenOnlyInFlightMessagesAreInTheQueue() {
+        // peekPostponedIds returns nothing when every queue member is due or in-flight;
+        // the release must then leave the queue alone rather than fall back to a raw peek.
+        when(queueDAO.peekPostponedIds(anyString(), anyLong(), eq(1)))
+                .thenReturn(Collections.emptyList());
+
+        executionDAOFacade.updateTask(concurrencyLimitedTask(TaskModel.Status.COMPLETED, 1));
+
         verify(queueDAO, never()).resetOffsetTime(anyString(), anyString());
     }
 
@@ -481,7 +498,7 @@ public class ExecutionDAOFacadeTest {
     public void testReleaseFailureDoesNotFailTheTaskUpdate() {
         // The task write already succeeded; a failed wakeup only costs the successor its
         // postpone window and must not propagate.
-        when(queueDAO.peekFirstIds(anyString(), eq(1)))
+        when(queueDAO.peekPostponedIds(anyString(), anyLong(), eq(1)))
                 .thenThrow(new RuntimeException("queue unavailable"));
 
         executionDAOFacade.updateTask(concurrencyLimitedTask(TaskModel.Status.COMPLETED, 1));

--- a/redis-persistence/src/main/java/io/orkes/conductor/mq/dao/BaseRedisQueueDAO.java
+++ b/redis-persistence/src/main/java/io/orkes/conductor/mq/dao/BaseRedisQueueDAO.java
@@ -110,6 +110,22 @@ public abstract class BaseRedisQueueDAO implements QueueDAO {
         return jedisCommands.zrangeByScore(queueKey, 0, Double.POSITIVE_INFINITY, 0, count);
     }
 
+    /**
+     * This queue keeps popped-but-unacked messages in the same zset with score now+unackTimeout, so
+     * a floor-less peek can return a message another worker is executing right now. The score floor
+     * restricts the result to messages postponed further out than any unack window.
+     */
+    @Override
+    public List<String> peekPostponedIds(String queueName, long minDelayMillis, int count) {
+        String queueKey = queueNamespace + ".QUEUE." + queueName + "." + queueShard;
+        return jedisCommands.zrangeByScore(
+                queueKey,
+                System.currentTimeMillis() + minDelayMillis,
+                Double.POSITIVE_INFINITY,
+                0,
+                count);
+    }
+
     @Override
     public final void push(String queueName, String id, long offsetTimeInSecond) {
         QueueMessage message = new QueueMessage(id, "", offsetTimeInSecond * 1000);

--- a/redis-persistence/src/test/java/io/orkes/conductor/mq/dao/RedisQueueDAOPeekPostponedTest.java
+++ b/redis-persistence/src/test/java/io/orkes/conductor/mq/dao/RedisQueueDAOPeekPostponedTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.orkes.conductor.mq.dao;
+
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.redis.config.RedisProperties;
+import com.netflix.conductor.redis.jedis.JedisStandalone;
+
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * This queue is a single zset: popping a message does not remove it, it bumps the score to
+ * now+unackTimeout in place (pop.lua). {@link QueueDAO#peekPostponedIds} exists so the
+ * concurrency-slot release can wake a genuinely postponed message without ever selecting a
+ * popped-but-unacked one — resetting an in-flight message's score would redeliver it while a worker
+ * is still executing it.
+ */
+public class RedisQueueDAOPeekPostponedTest {
+
+    private static final GenericContainer<?> redis =
+            new GenericContainer<>(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379);
+
+    private static RedisQueueDAO queueDAO;
+
+    @BeforeClass
+    public static void startRedis() {
+        redis.start();
+        JedisPoolConfig config = new JedisPoolConfig();
+        config.setMinIdle(2);
+        config.setMaxTotal(10);
+        JedisPool jedisPool = new JedisPool(config, redis.getHost(), redis.getFirstMappedPort());
+        ConductorProperties conductorProperties = new ConductorProperties();
+        RedisProperties redisProperties = new RedisProperties(conductorProperties);
+        queueDAO =
+                new RedisQueueDAO(
+                        new JedisStandalone(jedisPool), redisProperties, conductorProperties);
+    }
+
+    @AfterClass
+    public static void stopRedis() {
+        redis.stop();
+    }
+
+    @Test
+    public void peekPostponedIdsSkipsInFlightMessagesAndFindsThePostponedOne() {
+        String queueName = "peek_postponed_test";
+
+        // An in-flight message: pushed due-now, then popped - the pop bumps its score to
+        // now+unackTimeout (~30s) but leaves it in the zset.
+        queueDAO.push(queueName, "inflight-msg", 0);
+        List<String> popped = queueDAO.pop(queueName, 1, 500);
+        assertEquals(List.of("inflight-msg"), popped);
+
+        // A genuinely postponed sibling, as taskExecutionPostponeDuration produces (60s).
+        queueDAO.push(queueName, "postponed-msg", 60);
+
+        // A floor-less peek returns the in-flight message first (lower score) - selecting it for
+        // resetOffsetTime is exactly the duplicate-delivery hazard.
+        List<String> unfloored = queueDAO.peekFirstIds(queueName, 2);
+        assertEquals("inflight-msg", unfloored.get(0));
+
+        // The floored peek must see only the postponed message.
+        List<String> floored = queueDAO.peekPostponedIds(queueName, 35_000, 2);
+        assertEquals(List.of("postponed-msg"), floored);
+        assertFalse(floored.contains("inflight-msg"));
+    }
+
+    @Test
+    public void peekPostponedIdsReturnsEmptyWhenOnlyInFlightMessagesExist() {
+        String queueName = "peek_postponed_inflight_only";
+
+        queueDAO.push(queueName, "inflight-only", 0);
+        assertEquals(List.of("inflight-only"), queueDAO.pop(queueName, 1, 500));
+
+        assertTrue(queueDAO.peekPostponedIds(queueName, 35_000, 1).isEmpty());
+        // ...while the floor-less peek would have offered it up for a reset.
+        assertEquals(List.of("inflight-only"), queueDAO.peekFirstIds(queueName, 1));
+    }
+}


### PR DESCRIPTION
Targets #1419's branch — proposed increment before it merges.

## Hazard found while verifying #1419

The Redis queue is a single zset: `pop.lua` bumps a popped message's score to `now+unackTimeout` **in place**, so `peekFirstIds` (`ZRANGEBYSCORE 0 +inf`) can return a message another worker is executing *right now* — and an in-flight score (`now+30s`) sorts **ahead** of a postponed sibling (`now+60s`). `resetOffsetTime` on that member causes an immediate duplicate delivery, while the intended sibling stays stranded.

Reproduced live (MySQL store + Redis queue, real `RedisQueueDAO`):

| member | before release | after release |
|---|---|---|
| `inflight-msg` (popped, unacked) | `+30000 ms` | **`−1 ms` — redeliverable mid-execution** |
| `postponed-sibling` (the actual target) | `+599999 ms` | `+599698 ms` — untouched |

This is not introduced by #1419 — the same peek+reset has run on redis-store deployments since #1105 — but #1419 activates it on the SQL-store deployments where it was previously inert, so it's worth closing in the same change. Exposure: concurrency-limited task types whose messages sit unacked during execution (async system tasks for their whole run; worker tasks in the pop→ack window).

## Change

- `QueueDAO.peekPostponedIds(queueName, minDelayMillis, count)` — only messages postponed at least `minDelayMillis` into the future are eligible for release. Default delegates to `peekFirstIds` (the SQL queues already exclude in-flight rows via `popped = false`).
- `BaseRedisQueueDAO` overrides it with a score floor (`ZRANGEBYSCORE now+minDelay +inf`).
- The facade release uses it, floor from new `conductor.app.concurrencySlotReleaseMinDelay` (default 35s — above the 30s unack windows).

Trade-off, stated plainly: a sibling whose remaining postpone is already below the floor is left to natural expiry (bounded, benign) — a missed wakeup costs seconds; a duplicate delivery of an in-flight task cannot be taken back.

## Verification

- `RedisQueueDAOPeekPostponedTest` (real Redis via testcontainers): floor-less peek returns the in-flight message first (the hazard); floored peek returns only the postponed sibling; in-flight-only queue → empty.
- `ExecutionDAOFacadeTest` 22/22, including new no-reset-when-only-in-flight case.