### PR TITLE
fix: resolve persistence concurrency-limit wiring and add /api/health endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ on:
     paths-ignore:
       - "conductor-clients/**"
   workflow_dispatch:
+    inputs:
+      e2e_profiles:
+        description: 'E2E profiles to run in addition to redis-es7 (which always runs): "all", "none", or a comma separated subset of redis-es8, postgres, mysql, redis-os3, cassandra-es7'
+        required: false
+        default: all
+        type: string
   # GitHub Actions cron expressions are UTC.
   schedule:
     - cron: "0 2 * * *"
@@ -350,12 +356,50 @@ jobs:
     steps:
       - id: set-matrix
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          E2E_PROFILES: ${{ inputs.e2e_profiles }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "schedule" ]; then
-            echo 'matrix={"include":[{"name":"redis-es8","script":"./e2e/run_tests-es8.sh"},{"name":"postgres","script":"./e2e/run_tests-postgres.sh"},{"name":"mysql","script":"./e2e/run_tests-mysql.sh"},{"name":"redis-os3","script":"./e2e/run_tests-redis-os3.sh"},{"name":"redis-es7","script":"./e2e/run_tests-redis-es7.sh"},{"name":"cassandra-es7","script":"./e2e/run_tests-cassandra-es7.sh"}]}' >> "$GITHUB_OUTPUT"
-          else
-            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
-          fi
+          set -euo pipefail
+
+          # redis-es7 runs on every trigger, so every push and pull request gets one full
+          # end-to-end run. It is listed first because the matrix runs sequentially
+          # (max-parallel: 1), so it is also the first to report.
+          always='[{"name":"redis-es7","script":"./e2e/run_tests-redis-es7.sh"}]'
+          optional='[{"name":"redis-es8","script":"./e2e/run_tests-es8.sh"},
+                     {"name":"postgres","script":"./e2e/run_tests-postgres.sh"},
+                     {"name":"mysql","script":"./e2e/run_tests-mysql.sh"},
+                     {"name":"redis-os3","script":"./e2e/run_tests-redis-os3.sh"},
+                     {"name":"cassandra-es7","script":"./e2e/run_tests-cassandra-es7.sh"}]'
+
+          case "$EVENT_NAME" in
+            workflow_dispatch) selection="${E2E_PROFILES:-all}" ;;
+            schedule)          selection="all" ;;
+            *)                 selection="none" ;;
+          esac
+
+          case "$selection" in
+            all)  extra="$optional" ;;
+            none) extra='[]' ;;
+            *)
+              # Comma separated subset, e.g. "mysql,postgres". redis-es7 is always added.
+              unknown=$(jq -rn --argjson optional "$optional" --arg sel "$selection" '
+                ($sel | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length > 0))) as $want
+                | (($optional | map(.name)) + ["redis-es7"]) as $known
+                | [$want[] | select(. as $n | ($known | any(. == $n)) | not)] | join(", ")')
+              if [ -n "$unknown" ]; then
+                echo "::error::Unknown e2e profile(s): $unknown. Valid values: all, none, redis-es7, $(jq -r --argjson o "$optional" -n '$o | map(.name) | join(", ")')"
+                exit 1
+              fi
+              extra=$(jq -c --arg sel "$selection" '
+                ($sel | split(",") | map(gsub("^\\s+|\\s+$";""))) as $want
+                | map(select(.name as $n | $want | any(. == $n)))' <<< "$optional")
+              ;;
+          esac
+
+          include=$(jq -cn --argjson always "$always" --argjson extra "$extra" '$always + $extra')
+          echo "Selected e2e profiles: $(jq -r 'map(.name) | join(", ")' <<< "$include")"
+          echo "matrix={\"include\":$include}" >> "$GITHUB_OUTPUT"
 
   e2e:
     needs: generate-e2e-matrix
@@ -366,6 +410,8 @@ jobs:
       checks: write
     strategy:
       fail-fast: false
+      # One backend at a time, in the order generate-e2e-matrix lists them (redis-es7 first).
+      max-parallel: 1
       matrix: ${{ fromJson(needs.generate-e2e-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v7

--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/config/CassandraConfiguration.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/config/CassandraConfiguration.java
@@ -30,7 +30,6 @@ import com.netflix.conductor.cassandra.dao.CassandraPollDataDAO;
 import com.netflix.conductor.cassandra.dao.CassandraRateLimitingDAO;
 import com.netflix.conductor.cassandra.util.Statements;
 import com.netflix.conductor.dao.EventHandlerDAO;
-import com.netflix.conductor.dao.ExecutionDAO;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.dao.RateLimitingDAO;
@@ -88,7 +87,7 @@ public class CassandraConfiguration {
     }
 
     @Bean
-    public ExecutionDAO cassandraExecutionDAO(
+    public CassandraExecutionDAO cassandraExecutionDAO(
             Session session,
             ObjectMapper objectMapper,
             CassandraProperties properties,

--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/config/CassandraConfiguration.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/config/CassandraConfiguration.java
@@ -27,11 +27,13 @@ import com.netflix.conductor.cassandra.dao.CassandraExecutionDAO;
 import com.netflix.conductor.cassandra.dao.CassandraFileMetadataDAO;
 import com.netflix.conductor.cassandra.dao.CassandraMetadataDAO;
 import com.netflix.conductor.cassandra.dao.CassandraPollDataDAO;
+import com.netflix.conductor.cassandra.dao.CassandraRateLimitingDAO;
 import com.netflix.conductor.cassandra.util.Statements;
 import com.netflix.conductor.dao.EventHandlerDAO;
 import com.netflix.conductor.dao.ExecutionDAO;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.dao.QueueDAO;
+import com.netflix.conductor.dao.RateLimitingDAO;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Metadata;
@@ -117,6 +119,15 @@ public class CassandraConfiguration {
     public CassandraFileMetadataDAO cassandraFileMetadataDAO(
             Session session, ObjectMapper objectMapper, CassandraProperties properties) {
         return new CassandraFileMetadataDAO(session, objectMapper, properties);
+    }
+
+    @Bean
+    public RateLimitingDAO cassandraRateLimitingDAO(
+            Session session,
+            ObjectMapper objectMapper,
+            CassandraProperties properties,
+            Statements statements) {
+        return new CassandraRateLimitingDAO(session, objectMapper, properties, statements);
     }
 
     @Bean

--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/config/cache/CacheableEventHandlerDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/config/cache/CacheableEventHandlerDAO.java
@@ -67,14 +67,17 @@ public class CacheableEventHandlerDAO implements EventHandlerDAO {
                         this::refreshEventHandlersCache, 0, cacheRefreshTime, TimeUnit.SECONDS);
     }
 
+    // The key expressions reference the argument positionally rather than by name: this module is
+    // not compiled with -parameters, so an "#eventHandler" reference resolves to null and every
+    // call fails with SpelEvaluationException EL1007E instead of being cached.
     @Override
-    @CachePut(value = EVENT_HANDLER_CACHE, key = "#eventHandler.name")
+    @CachePut(value = EVENT_HANDLER_CACHE, key = "#p0.name")
     public void addEventHandler(EventHandler eventHandler) {
         cassandraEventHandlerDAO.addEventHandler(eventHandler);
     }
 
     @Override
-    @CachePut(value = EVENT_HANDLER_CACHE, key = "#eventHandler.name")
+    @CachePut(value = EVENT_HANDLER_CACHE, key = "#p0.name")
     public void updateEventHandler(EventHandler eventHandler) {
         cassandraEventHandlerDAO.updateEventHandler(eventHandler);
     }

--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/config/cache/CacheableMetadataDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/config/cache/CacheableMetadataDAO.java
@@ -71,15 +71,18 @@ public class CacheableMetadataDAO implements MetadataDAO {
                 "Scheduled cache refresh for Task Definitions, every {} seconds", cacheRefreshTime);
     }
 
+    // The key expressions reference the argument positionally rather than by name: this module is
+    // not compiled with -parameters, so a "#taskDef" reference resolves to null and every call
+    // fails with SpelEvaluationException EL1007E instead of being cached.
     @Override
-    @CachePut(value = TASK_DEF_CACHE, key = "#taskDef.name")
+    @CachePut(value = TASK_DEF_CACHE, key = "#p0.name")
     public TaskDef createTaskDef(TaskDef taskDef) {
         cassandraMetadataDAO.createTaskDef(taskDef);
         return taskDef;
     }
 
     @Override
-    @CachePut(value = TASK_DEF_CACHE, key = "#taskDef.name")
+    @CachePut(value = TASK_DEF_CACHE, key = "#p0.name")
     public TaskDef updateTaskDef(TaskDef taskDef) {
         return cassandraMetadataDAO.updateTaskDef(taskDef);
     }

--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraBaseDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraBaseDAO.java
@@ -39,6 +39,7 @@ import static com.netflix.conductor.cassandra.util.Constants.HANDLERS_KEY;
 import static com.netflix.conductor.cassandra.util.Constants.JSON_DATA_KEY;
 import static com.netflix.conductor.cassandra.util.Constants.MESSAGE_ID_KEY;
 import static com.netflix.conductor.cassandra.util.Constants.PAYLOAD_KEY;
+import static com.netflix.conductor.cassandra.util.Constants.RATE_LIMIT_BUCKET_ID_KEY;
 import static com.netflix.conductor.cassandra.util.Constants.SHARD_ID_KEY;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_EVENT_EXECUTIONS;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_EVENT_HANDLERS;
@@ -48,6 +49,7 @@ import static com.netflix.conductor.cassandra.util.Constants.TABLE_FILE_METADATA
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_TASK_DEFS;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_TASK_DEF_LIMIT;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_TASK_LOOKUP;
+import static com.netflix.conductor.cassandra.util.Constants.TABLE_TASK_RATE_LIMIT;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_WORKFLOWS;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_WORKFLOW_DEFS;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_WORKFLOW_DEFS_INDEX;
@@ -80,6 +82,9 @@ import static com.netflix.conductor.cassandra.util.Constants.WORKFLOW_VERSION_KE
  *
  * <p>CREATE TABLE IF NOT EXISTS conductor.task_def_limit( task_def_name text, task_id uuid,
  * workflow_id uuid, PRIMARY KEY ((task_def_name), task_id_key) );
+ *
+ * <p>CREATE TABLE IF NOT EXISTS conductor.task_rate_limit( task_def_name text, rate_limit_bucket_id
+ * timeuuid, PRIMARY KEY ((task_def_name), rate_limit_bucket_id) );
  *
  * <p>CREATE TABLE IF NOT EXISTS conductor.workflow_definitions( workflow_def_name text, version
  * int, workflow_definition text, PRIMARY KEY ((workflow_def_name), version) );
@@ -132,6 +137,7 @@ public abstract class CassandraBaseDAO {
                 session.execute(getCreateWorkflowsTableStatement());
                 session.execute(getCreateTaskLookupTableStatement());
                 session.execute(getCreateTaskDefLimitTableStatement());
+                session.execute(getCreateTaskRateLimitTableStatement());
                 session.execute(getCreateWorkflowDefsTableStatement());
                 session.execute(getCreateWorkflowDefsIndexTableStatement());
                 session.execute(getCreateTaskDefsTableStatement());
@@ -224,6 +230,14 @@ public abstract class CassandraBaseDAO {
                 .addPartitionKey(TASK_DEF_NAME_KEY, DataType.text())
                 .addClusteringColumn(TASK_ID_KEY, DataType.uuid())
                 .addColumn(WORKFLOW_ID_KEY, DataType.uuid())
+                .getQueryString();
+    }
+
+    private String getCreateTaskRateLimitTableStatement() {
+        return SchemaBuilder.createTable(properties.getKeyspace(), TABLE_TASK_RATE_LIMIT)
+                .ifNotExists()
+                .addPartitionKey(TASK_DEF_NAME_KEY, DataType.text())
+                .addClusteringColumn(RATE_LIMIT_BUCKET_ID_KEY, DataType.timeuuid())
                 .getQueryString();
     }
 

--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraBaseDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraBaseDAO.java
@@ -25,6 +25,7 @@ import com.netflix.conductor.metrics.Monitors;
 import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.schemabuilder.SchemaBuilder;
+import com.datastax.driver.core.schemabuilder.TableOptions.CompactionOptions.TimeWindowCompactionStrategyOptions.CompactionWindowUnit;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
@@ -233,11 +234,24 @@ public abstract class CassandraBaseDAO {
                 .getQueryString();
     }
 
+    /**
+     * Rows in this table are written once and only ever removed by TTL expiry, and the rate limit
+     * check counts live rows in a clustering range. With the default gc_grace_seconds of 10 days
+     * the count would read through expired rows as tombstones long after their (usually seconds
+     * long) rate limit window closed, so a short gc_grace and time window compaction are used to
+     * let expired buckets drop out quickly.
+     */
     private String getCreateTaskRateLimitTableStatement() {
         return SchemaBuilder.createTable(properties.getKeyspace(), TABLE_TASK_RATE_LIMIT)
                 .ifNotExists()
                 .addPartitionKey(TASK_DEF_NAME_KEY, DataType.text())
                 .addClusteringColumn(RATE_LIMIT_BUCKET_ID_KEY, DataType.timeuuid())
+                .withOptions()
+                .gcGraceSeconds(3600)
+                .compactionOptions(
+                        SchemaBuilder.timeWindowCompactionStrategy()
+                                .compactionWindowUnit(CompactionWindowUnit.MINUTES)
+                                .compactionWindowSize(10))
                 .getQueryString();
     }
 

--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraRateLimitingDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraRateLimitingDAO.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.cassandra.dao;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.conductor.annotations.Trace;
+import com.netflix.conductor.cassandra.config.CassandraProperties;
+import com.netflix.conductor.cassandra.util.Statements;
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.core.exception.TransientException;
+import com.netflix.conductor.dao.RateLimitingDAO;
+import com.netflix.conductor.metrics.Monitors;
+import com.netflix.conductor.model.TaskModel;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.DriverException;
+import com.datastax.driver.core.utils.UUIDs;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Rate limits tasks using a "task_rate_limit" bucket table: one row per task execution within the
+ * rate limit frequency window, keyed by a timeuuid and expiring via TTL once the window elapses.
+ */
+@Trace
+public class CassandraRateLimitingDAO extends CassandraBaseDAO implements RateLimitingDAO {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CassandraRateLimitingDAO.class);
+    private static final String CLASS_NAME = CassandraRateLimitingDAO.class.getSimpleName();
+
+    private final PreparedStatement selectRateLimitCountStatement;
+    private final PreparedStatement insertRateLimitBucketStatement;
+
+    public CassandraRateLimitingDAO(
+            Session session,
+            ObjectMapper objectMapper,
+            CassandraProperties properties,
+            Statements statements) {
+        super(session, objectMapper, properties);
+        this.selectRateLimitCountStatement =
+                session.prepare(statements.getSelectRateLimitCountStatement());
+        this.insertRateLimitBucketStatement =
+                session.prepare(statements.getInsertRateLimitBucketStatement());
+    }
+
+    @Override
+    public boolean exceedsRateLimitPerFrequency(TaskModel task, TaskDef taskDef) {
+        ImmutablePair<Integer, Integer> rateLimitPair =
+                Optional.ofNullable(taskDef)
+                        .map(
+                                definition ->
+                                        new ImmutablePair<>(
+                                                definition.getRateLimitPerFrequency(),
+                                                definition.getRateLimitFrequencyInSeconds()))
+                        .orElse(
+                                new ImmutablePair<>(
+                                        task.getRateLimitPerFrequency(),
+                                        task.getRateLimitFrequencyInSeconds()));
+
+        int rateLimitPerFrequency = rateLimitPair.getLeft();
+        int rateLimitFrequencyInSeconds = rateLimitPair.getRight();
+        if (rateLimitPerFrequency <= 0 || rateLimitFrequencyInSeconds <= 0) {
+            LOGGER.debug(
+                    "Rate limit not applied to the Task: {} either rateLimitPerFrequency: {} or rateLimitFrequencyInSeconds: {} is 0 or less",
+                    task,
+                    rateLimitPerFrequency,
+                    rateLimitFrequencyInSeconds);
+            return false;
+        }
+
+        try {
+            recordCassandraDaoRequests("exceedsRateLimitPerFrequency");
+            long nowMillis = System.currentTimeMillis();
+            UUID windowStart = UUIDs.startOf(nowMillis - (rateLimitFrequencyInSeconds * 1000L));
+            ResultSet resultSet =
+                    session.execute(
+                            selectRateLimitCountStatement.bind(task.getTaskDefName(), windowStart));
+            long currentBucketCount = resultSet.one().getLong(0);
+
+            if (currentBucketCount < rateLimitPerFrequency) {
+                session.execute(
+                        insertRateLimitBucketStatement.bind(
+                                task.getTaskDefName(),
+                                UUIDs.timeBased(),
+                                rateLimitFrequencyInSeconds));
+                LOGGER.info(
+                        "TaskId: {} with TaskDefinition of: {} has rateLimitPerFrequency: {} and rateLimitFrequencyInSeconds: {} within the rate limit with current count {}",
+                        task.getTaskId(),
+                        task.getTaskDefName(),
+                        rateLimitPerFrequency,
+                        rateLimitFrequencyInSeconds,
+                        currentBucketCount + 1);
+                Monitors.recordTaskRateLimited(task.getTaskDefName(), rateLimitPerFrequency);
+                return false;
+            } else {
+                LOGGER.info(
+                        "TaskId: {} with TaskDefinition of: {} has rateLimitPerFrequency: {} and rateLimitFrequencyInSeconds: {} is out of bounds of rate limit with current count {}",
+                        task.getTaskId(),
+                        task.getTaskDefName(),
+                        rateLimitPerFrequency,
+                        rateLimitFrequencyInSeconds,
+                        currentBucketCount);
+                return true;
+            }
+        } catch (DriverException e) {
+            Monitors.error(CLASS_NAME, "exceedsRateLimitPerFrequency");
+            String errorMsg =
+                    String.format(
+                            "Failed to check rate limit for task: %s in taskDef: %s",
+                            task.getTaskId(), task.getTaskDefName());
+            LOGGER.error(errorMsg, e);
+            throw new TransientException(errorMsg, e);
+        }
+    }
+}

--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraRateLimitingDAO.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/dao/CassandraRateLimitingDAO.java
@@ -38,6 +38,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /**
  * Rate limits tasks using a "task_rate_limit" bucket table: one row per task execution within the
  * rate limit frequency window, keyed by a timeuuid and expiring via TTL once the window elapses.
+ *
+ * <p>The limit is approximate. Counting the window and recording the execution are two statements
+ * rather than one atomic operation, so concurrent pollers can admit more executions than the limit
+ * allows - the same is true of the redis implementation this mirrors. On a multi node cluster a
+ * {@code conductor.cassandra.readConsistencyLevel} below quorum can also count a stale window.
  */
 @Trace
 public class CassandraRateLimitingDAO extends CassandraBaseDAO implements RateLimitingDAO {

--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/util/Constants.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/util/Constants.java
@@ -19,6 +19,7 @@ public interface Constants {
     String TABLE_WORKFLOWS = "workflows";
     String TABLE_TASK_LOOKUP = "task_lookup";
     String TABLE_TASK_DEF_LIMIT = "task_def_limit";
+    String TABLE_TASK_RATE_LIMIT = "task_rate_limit";
     String TABLE_WORKFLOW_DEFS = "workflow_definitions";
     String TABLE_WORKFLOW_DEFS_INDEX = "workflow_defs_index";
     String TABLE_TASK_DEFS = "task_definitions";
@@ -51,6 +52,7 @@ public interface Constants {
     String EVENT_HANDLER_KEY = "event_handler";
     String MESSAGE_ID_KEY = "message_id";
     String EVENT_EXECUTION_ID_KEY = "event_execution_id";
+    String RATE_LIMIT_BUCKET_ID_KEY = "rate_limit_bucket_id";
 
     String ENTITY_TYPE_WORKFLOW = "workflow";
     String ENTITY_TYPE_TASK = "task";

--- a/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/util/Statements.java
+++ b/cassandra-persistence/src/main/java/com/netflix/conductor/cassandra/util/Statements.java
@@ -23,12 +23,14 @@ import static com.netflix.conductor.cassandra.util.Constants.EVENT_HANDLER_NAME_
 import static com.netflix.conductor.cassandra.util.Constants.HANDLERS_KEY;
 import static com.netflix.conductor.cassandra.util.Constants.MESSAGE_ID_KEY;
 import static com.netflix.conductor.cassandra.util.Constants.PAYLOAD_KEY;
+import static com.netflix.conductor.cassandra.util.Constants.RATE_LIMIT_BUCKET_ID_KEY;
 import static com.netflix.conductor.cassandra.util.Constants.SHARD_ID_KEY;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_EVENT_EXECUTIONS;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_EVENT_HANDLERS;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_TASK_DEFS;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_TASK_DEF_LIMIT;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_TASK_LOOKUP;
+import static com.netflix.conductor.cassandra.util.Constants.TABLE_TASK_RATE_LIMIT;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_WORKFLOWS;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_WORKFLOW_DEFS;
 import static com.netflix.conductor.cassandra.util.Constants.TABLE_WORKFLOW_DEFS_INDEX;
@@ -48,6 +50,7 @@ import static com.netflix.conductor.cassandra.util.Constants.WORKFLOW_VERSION_KE
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.gte;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
 
 /**
@@ -123,6 +126,15 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
  *       ('handlers',?,?);
  *   <li>SELECT * FROM conductor.event_handlers WHERE handlers=?;
  *   <li>DELETE FROM conductor.event_handlers WHERE handlers='handlers' AND event_handler_name=?;
+ * </ul>
+ *
+ * <em>RateLimitingDAO</em>
+ *
+ * <ul>
+ *   <li>SELECT count(*) FROM conductor.task_rate_limit WHERE task_def_name=? AND
+ *       rate_limit_bucket_id>=?;
+ *   <li>INSERT INTO conductor.task_rate_limit (task_def_name,rate_limit_bucket_id) VALUES (?,?)
+ *       USING TTL ?;
  * </ul>
  */
 public class Statements {
@@ -599,6 +611,36 @@ public class Statements {
                 .from(keyspace, TABLE_EVENT_HANDLERS)
                 .where(eq(HANDLERS_KEY, HANDLERS_KEY))
                 .and(eq(EVENT_HANDLER_NAME_KEY, bindMarker()))
+                .getQueryString();
+    }
+
+    // RateLimitingDAO
+    // Select Statements
+
+    /**
+     * @return cql query statement to count rate limit bucket entries for a task def within the rate
+     *     limit frequency window from the "task_rate_limit" table
+     */
+    public String getSelectRateLimitCountStatement() {
+        return QueryBuilder.select()
+                .countAll()
+                .from(keyspace, TABLE_TASK_RATE_LIMIT)
+                .where(eq(TASK_DEF_NAME_KEY, bindMarker()))
+                .and(gte(RATE_LIMIT_BUCKET_ID_KEY, bindMarker()))
+                .getQueryString();
+    }
+
+    // Insert Statements
+
+    /**
+     * @return cql query statement to add a rate limit bucket entry, expiring after the rate limit
+     *     frequency window, into the "task_rate_limit" table
+     */
+    public String getInsertRateLimitBucketStatement() {
+        return QueryBuilder.insertInto(keyspace, TABLE_TASK_RATE_LIMIT)
+                .value(TASK_DEF_NAME_KEY, bindMarker())
+                .value(RATE_LIMIT_BUCKET_ID_KEY, bindMarker())
+                .using(QueryBuilder.ttl(bindMarker()))
                 .getQueryString();
     }
 }

--- a/cassandra-persistence/src/test/groovy/com/netflix/conductor/cassandra/dao/CacheableDAOSpec.groovy
+++ b/cassandra-persistence/src/test/groovy/com/netflix/conductor/cassandra/dao/CacheableDAOSpec.groovy
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.cassandra.dao
+
+import org.springframework.cache.CacheManager
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+
+import com.netflix.conductor.cassandra.config.cache.CacheableEventHandlerDAO
+import com.netflix.conductor.cassandra.config.cache.CacheableMetadataDAO
+import com.netflix.conductor.cassandra.config.cache.CachingConfig
+import com.netflix.conductor.common.metadata.events.EventHandler
+import com.netflix.conductor.common.metadata.tasks.TaskDef
+import com.netflix.conductor.dao.EventHandlerDAO
+import com.netflix.conductor.dao.MetadataDAO
+
+import static com.netflix.conductor.cassandra.config.cache.CachingConfig.EVENT_HANDLER_CACHE
+import static com.netflix.conductor.cassandra.config.cache.CachingConfig.TASK_DEF_CACHE
+
+/**
+ * Exercises the caching wrappers through a real Spring context, using the production
+ * {@link CachingConfig}. The @CachePut key expressions are evaluated by the cache interceptor, so a
+ * broken expression cannot be caught by calling these DAOs directly - it only surfaces at runtime,
+ * as a SpelEvaluationException on every write.
+ */
+class CacheableDAOSpec extends CassandraSpec {
+
+    AnnotationConfigApplicationContext context
+    CacheManager cacheManager
+    MetadataDAO metadataDAO
+    EventHandlerDAO eventHandlerDAO
+
+    def setup() {
+        context = new AnnotationConfigApplicationContext(CachingConfig)
+        cacheManager = context.getBean(CacheManager)
+
+        // initializeBean applies the caching BeanPostProcessor, so what comes back is the proxy the
+        // server actually calls.
+        metadataDAO = context.beanFactory.initializeBean(
+                new CacheableMetadataDAO(
+                        new CassandraMetadataDAO(session, objectMapper, cassandraProperties, statements),
+                        cassandraProperties,
+                        cacheManager),
+                'cacheableMetadataDAO') as MetadataDAO
+
+        eventHandlerDAO = context.beanFactory.initializeBean(
+                new CacheableEventHandlerDAO(
+                        new CassandraEventHandlerDAO(session, objectMapper, cassandraProperties, statements),
+                        cassandraProperties,
+                        cacheManager),
+                'cacheableEventHandlerDAO') as EventHandlerDAO
+    }
+
+    def cleanup() {
+        context?.close()
+    }
+
+    def "createTaskDef caches the task def under its name"() {
+        given:
+        def taskDef = new TaskDef(name: 'cached_task_def', description: 'cached', retryCount: 0)
+
+        when:
+        metadataDAO.createTaskDef(taskDef)
+
+        then: 'the key resolves from the argument, with no SpelEvaluationException'
+        noExceptionThrown()
+        cacheManager.getCache(TASK_DEF_CACHE).get('cached_task_def').get().name == 'cached_task_def'
+    }
+
+    def "updateTaskDef refreshes the cached task def"() {
+        given:
+        metadataDAO.createTaskDef(new TaskDef(name: 'updated_task_def', description: 'first', retryCount: 0))
+
+        when:
+        metadataDAO.updateTaskDef(new TaskDef(name: 'updated_task_def', description: 'second', retryCount: 0))
+
+        then:
+        noExceptionThrown()
+        cacheManager.getCache(TASK_DEF_CACHE).get('updated_task_def').get().description == 'second'
+    }
+
+    def "addEventHandler resolves its cache key from the event handler"() {
+        given:
+        def eventHandler = new EventHandler(name: 'cached_event_handler', event: 'conductor:test', active: false)
+
+        when:
+        eventHandlerDAO.addEventHandler(eventHandler)
+
+        then: 'an entry exists under the resolved key, so no SpelEvaluationException was thrown'
+        noExceptionThrown()
+        cacheManager.getCache(EVENT_HANDLER_CACHE).get('cached_event_handler') != null
+
+        and: 'the value is null because @CachePut is on a void method - the periodic refresh is what populates it'
+        cacheManager.getCache(EVENT_HANDLER_CACHE).get('cached_event_handler').get() == null
+    }
+}

--- a/cassandra-persistence/src/test/groovy/com/netflix/conductor/cassandra/dao/CassandraRateLimitingDAOSpec.groovy
+++ b/cassandra-persistence/src/test/groovy/com/netflix/conductor/cassandra/dao/CassandraRateLimitingDAOSpec.groovy
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.cassandra.dao
+
+import com.netflix.conductor.common.metadata.tasks.TaskDef
+import com.netflix.conductor.model.TaskModel
+
+import spock.lang.Subject
+
+class CassandraRateLimitingDAOSpec extends CassandraSpec {
+
+    @Subject
+    CassandraRateLimitingDAO rateLimitingDAO
+
+    def setup() {
+        rateLimitingDAO = new CassandraRateLimitingDAO(session, objectMapper, cassandraProperties, statements)
+    }
+
+    // Each feature uses its own task def name: rate limit buckets live in the shared keyspace for
+    // the lifetime of the spec, so reusing a name would leak counts between features.
+    private static TaskModel task(String taskDefName) {
+        new TaskModel(taskId: UUID.randomUUID().toString(), taskDefName: taskDefName)
+    }
+
+    def "tasks are rate limited once the limit within the frequency window is reached"() {
+        given:
+        def taskDef = new TaskDef(name: 'limited_task', rateLimitPerFrequency: 2, rateLimitFrequencyInSeconds: 300)
+
+        expect: 'the first two executions to be within the limit'
+        !rateLimitingDAO.exceedsRateLimitPerFrequency(task(taskDef.name), taskDef)
+        !rateLimitingDAO.exceedsRateLimitPerFrequency(task(taskDef.name), taskDef)
+
+        and: 'every execution after that to be rate limited'
+        rateLimitingDAO.exceedsRateLimitPerFrequency(task(taskDef.name), taskDef)
+        rateLimitingDAO.exceedsRateLimitPerFrequency(task(taskDef.name), taskDef)
+    }
+
+    def "rate limit is not applied when it is not configured"() {
+        given:
+        def taskDef = new TaskDef(name: 'unlimited_task', rateLimitPerFrequency: 0, rateLimitFrequencyInSeconds: 0)
+
+        expect:
+        (1..5).every { !rateLimitingDAO.exceedsRateLimitPerFrequency(task(taskDef.name), taskDef) }
+    }
+
+    def "buckets outside the frequency window no longer count towards the limit"() {
+        given:
+        def taskDef = new TaskDef(name: 'sliding_window_task', rateLimitPerFrequency: 1, rateLimitFrequencyInSeconds: 1)
+
+        expect: 'the first execution to be within the limit and the second to be rate limited'
+        !rateLimitingDAO.exceedsRateLimitPerFrequency(task(taskDef.name), taskDef)
+        rateLimitingDAO.exceedsRateLimitPerFrequency(task(taskDef.name), taskDef)
+
+        when: 'the one second window elapses'
+        Thread.sleep(1500)
+
+        then: 'the earlier execution has dropped out of the window'
+        !rateLimitingDAO.exceedsRateLimitPerFrequency(task(taskDef.name), taskDef)
+    }
+
+    def "rate limits are tracked per task def"() {
+        given:
+        def taskDef = new TaskDef(name: 'task_def_a', rateLimitPerFrequency: 1, rateLimitFrequencyInSeconds: 300)
+        def otherTaskDef = new TaskDef(name: 'task_def_b', rateLimitPerFrequency: 1, rateLimitFrequencyInSeconds: 300)
+
+        when: 'one task def exhausts its limit'
+        rateLimitingDAO.exceedsRateLimitPerFrequency(task(taskDef.name), taskDef)
+
+        then:
+        rateLimitingDAO.exceedsRateLimitPerFrequency(task(taskDef.name), taskDef)
+
+        and: 'another task def is unaffected'
+        !rateLimitingDAO.exceedsRateLimitPerFrequency(task(otherTaskDef.name), otherTaskDef)
+    }
+
+    def "rate limit falls back to the values on the task when there is no task def"() {
+        given:
+        def task = task('task_without_def')
+        task.rateLimitPerFrequency = 1
+        task.rateLimitFrequencyInSeconds = 300
+
+        expect:
+        !rateLimitingDAO.exceedsRateLimitPerFrequency(task, null)
+
+        and:
+        rateLimitingDAO.exceedsRateLimitPerFrequency(task, null)
+    }
+}

--- a/docker/server/config/config-cassandra-es7.properties
+++ b/docker/server/config/config-cassandra-es7.properties
@@ -6,6 +6,11 @@ conductor.cassandra.replicationFactorValue=1
 conductor.cassandra.readConsistencyLevel=ONE
 conductor.cassandra.writeConsistencyLevel=ONE
 
+# AI integrations: off (Cassandra has no SkillPackageDAO/SkillMetadataDAO implementation, and
+# ConductorAgentSpanConfiguration requires both when conductor.integrations.ai.enabled is true,
+# which is the default in application.properties)
+conductor.integrations.ai.enabled=false
+
 # Task queue: Redis (Cassandra has no native queue implementation)
 conductor.queue.type=redis_standalone
 conductor.redis.hosts=rs:6379:us-east-1c

--- a/e2e/src/test/java/io/conductor/e2e/control/DynamicForkTests.java
+++ b/e2e/src/test/java/io/conductor/e2e/control/DynamicForkTests.java
@@ -571,17 +571,6 @@ public class DynamicForkTests {
                         () -> {
                             var wf = workflowAdminClient.getWorkflow(workflowId, true);
                             assertEquals(Workflow.WorkflowStatus.FAILED, wf.getStatus());
-                            // All 3 attempts (original + 2 retries) must be present. The final
-                            // retry's task record can lag the workflow FAILED status under load,
-                            // so assert the count inside the await rather than in a follow-up read.
-                            var attempts =
-                                    wf.getTasks().stream()
-                                            .filter(
-                                                    it ->
-                                                            "fail_on_purpose"
-                                                                    .equals(it.getTaskDefName()))
-                                            .toList();
-                            assertEquals(3, attempts.size());
                         });
 
         var workflow = workflowAdminClient.getWorkflow(workflowId, true);
@@ -590,9 +579,80 @@ public class DynamicForkTests {
                         .filter(it -> "fail_on_purpose".equals(it.getTaskDefName()))
                         .toList();
 
+        // How many attempts a failing branch gets inside a FORK_JOIN_DYNAMIC is not deterministic:
+        // JOIN is evaluated from its own queue and fails the workflow as soon as it observes the
+        // failed branch, which can happen before the decider schedules a pending retry. So this
+        // test asserts what it is about - that ${CPEWF_TASK_ID} resolves to the id of the task it
+        // is evaluated for, on every attempt that did run. testCorrectTaskIdOnRetriesWithoutFork
+        // covers the retry sequence deterministically, outside a fork.
+        assertFalse(tasks.isEmpty(), "the forked task must have run at least once");
         for (Task t : tasks) {
             assertEquals(t.getTaskId(), t.getInputData().get("task_id"));
         }
+    }
+
+    @Test
+    @SneakyThrows
+    @DisplayName("${CPEWF_TASK_ID} gives the correct task id on every retry of a plain task")
+    public void testCorrectTaskIdOnRetriesWithoutFork() {
+        startFailureWorkers();
+        var workflowAdminClient = ApiUtil.WORKFLOW_CLIENT;
+        var metadataAdminClient = ApiUtil.METADATA_CLIENT;
+
+        var mapper = new ObjectMapperProvider().getObjectMapper();
+        var taskDef =
+                mapper.readValue(
+                        TestUtil.getResourceAsString(
+                                "metadata/cpewf_task_id_dyn_fork_task_def.json"),
+                        TaskDef.class);
+        metadataAdminClient.registerTaskDefs(List.of(taskDef));
+
+        // No fork and no JOIN, so the retry sequence is driven only by the failing task itself:
+        // retryCount 2 on the task definition means exactly 3 attempts before the workflow fails.
+        var task = new WorkflowTask();
+        task.setName("fail_on_purpose");
+        task.setTaskReferenceName("fail_on_purpose_ref");
+        task.setType(TaskType.TASK_TYPE_SIMPLE);
+        task.setInputParameters(Map.of("task_id", "${CPEWF_TASK_ID}"));
+
+        var workflowDef = new WorkflowDef();
+        workflowDef.setName("cpewf_task_id_retries_no_fork");
+        workflowDef.setVersion(1);
+        workflowDef.setOwnerEmail("test@conductor.io");
+        workflowDef.setSchemaVersion(2);
+        workflowDef.setTimeoutSeconds(0);
+        workflowDef.setTasks(List.of(task));
+        metadataAdminClient.updateWorkflowDefs(List.of(workflowDef));
+
+        var startWorkflowRequest = new StartWorkflowRequest();
+        startWorkflowRequest.setName(workflowDef.getName());
+        startWorkflowRequest.setVersion(workflowDef.getVersion());
+        var workflowId = workflowAdminClient.startWorkflow(startWorkflowRequest);
+
+        await().atMost(1, TimeUnit.MINUTES)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            var wf = workflowAdminClient.getWorkflow(workflowId, true);
+                            assertEquals(Workflow.WorkflowStatus.FAILED, wf.getStatus());
+                            assertEquals(
+                                    3,
+                                    attemptsOf(wf).size(),
+                                    "original attempt plus the 2 retries from the task definition");
+                        });
+
+        for (Task t : attemptsOf(workflowAdminClient.getWorkflow(workflowId, true))) {
+            assertEquals(
+                    t.getTaskId(),
+                    t.getInputData().get("task_id"),
+                    "${CPEWF_TASK_ID} must resolve to the id of the attempt it is evaluated for");
+        }
+    }
+
+    private static List<Task> attemptsOf(Workflow workflow) {
+        return workflow.getTasks().stream()
+                .filter(it -> "fail_on_purpose".equals(it.getTaskDefName()))
+                .collect(Collectors.toList());
     }
 
     @Test

--- a/e2e/src/test/java/io/conductor/e2e/control/DynamicForkTests.java
+++ b/e2e/src/test/java/io/conductor/e2e/control/DynamicForkTests.java
@@ -571,6 +571,17 @@ public class DynamicForkTests {
                         () -> {
                             var wf = workflowAdminClient.getWorkflow(workflowId, true);
                             assertEquals(Workflow.WorkflowStatus.FAILED, wf.getStatus());
+                            // All 3 attempts (original + 2 retries) must be present. The final
+                            // retry's task record can lag the workflow FAILED status under load,
+                            // so assert the count inside the await rather than in a follow-up read.
+                            var attempts =
+                                    wf.getTasks().stream()
+                                            .filter(
+                                                    it ->
+                                                            "fail_on_purpose"
+                                                                    .equals(it.getTaskDefName()))
+                                            .toList();
+                            assertEquals(3, attempts.size());
                         });
 
         var workflow = workflowAdminClient.getWorkflow(workflowId, true);
@@ -579,80 +590,9 @@ public class DynamicForkTests {
                         .filter(it -> "fail_on_purpose".equals(it.getTaskDefName()))
                         .toList();
 
-        // How many attempts a failing branch gets inside a FORK_JOIN_DYNAMIC is not deterministic:
-        // JOIN is evaluated from its own queue and fails the workflow as soon as it observes the
-        // failed branch, which can happen before the decider schedules a pending retry. So this
-        // test asserts what it is about - that ${CPEWF_TASK_ID} resolves to the id of the task it
-        // is evaluated for, on every attempt that did run. testCorrectTaskIdOnRetriesWithoutFork
-        // covers the retry sequence deterministically, outside a fork.
-        assertFalse(tasks.isEmpty(), "the forked task must have run at least once");
         for (Task t : tasks) {
             assertEquals(t.getTaskId(), t.getInputData().get("task_id"));
         }
-    }
-
-    @Test
-    @SneakyThrows
-    @DisplayName("${CPEWF_TASK_ID} gives the correct task id on every retry of a plain task")
-    public void testCorrectTaskIdOnRetriesWithoutFork() {
-        startFailureWorkers();
-        var workflowAdminClient = ApiUtil.WORKFLOW_CLIENT;
-        var metadataAdminClient = ApiUtil.METADATA_CLIENT;
-
-        var mapper = new ObjectMapperProvider().getObjectMapper();
-        var taskDef =
-                mapper.readValue(
-                        TestUtil.getResourceAsString(
-                                "metadata/cpewf_task_id_dyn_fork_task_def.json"),
-                        TaskDef.class);
-        metadataAdminClient.registerTaskDefs(List.of(taskDef));
-
-        // No fork and no JOIN, so the retry sequence is driven only by the failing task itself:
-        // retryCount 2 on the task definition means exactly 3 attempts before the workflow fails.
-        var task = new WorkflowTask();
-        task.setName("fail_on_purpose");
-        task.setTaskReferenceName("fail_on_purpose_ref");
-        task.setType(TaskType.TASK_TYPE_SIMPLE);
-        task.setInputParameters(Map.of("task_id", "${CPEWF_TASK_ID}"));
-
-        var workflowDef = new WorkflowDef();
-        workflowDef.setName("cpewf_task_id_retries_no_fork");
-        workflowDef.setVersion(1);
-        workflowDef.setOwnerEmail("test@conductor.io");
-        workflowDef.setSchemaVersion(2);
-        workflowDef.setTimeoutSeconds(0);
-        workflowDef.setTasks(List.of(task));
-        metadataAdminClient.updateWorkflowDefs(List.of(workflowDef));
-
-        var startWorkflowRequest = new StartWorkflowRequest();
-        startWorkflowRequest.setName(workflowDef.getName());
-        startWorkflowRequest.setVersion(workflowDef.getVersion());
-        var workflowId = workflowAdminClient.startWorkflow(startWorkflowRequest);
-
-        await().atMost(1, TimeUnit.MINUTES)
-                .pollInterval(1, TimeUnit.SECONDS)
-                .untilAsserted(
-                        () -> {
-                            var wf = workflowAdminClient.getWorkflow(workflowId, true);
-                            assertEquals(Workflow.WorkflowStatus.FAILED, wf.getStatus());
-                            assertEquals(
-                                    3,
-                                    attemptsOf(wf).size(),
-                                    "original attempt plus the 2 retries from the task definition");
-                        });
-
-        for (Task t : attemptsOf(workflowAdminClient.getWorkflow(workflowId, true))) {
-            assertEquals(
-                    t.getTaskId(),
-                    t.getInputData().get("task_id"),
-                    "${CPEWF_TASK_ID} must resolve to the id of the attempt it is evaluated for");
-        }
-    }
-
-    private static List<Task> attemptsOf(Workflow workflow) {
-        return workflow.getTasks().stream()
-                .filter(it -> "fail_on_purpose".equals(it.getTaskDefName()))
-                .collect(Collectors.toList());
     }
 
     @Test

--- a/mysql-persistence/src/main/java/com/netflix/conductor/mysql/config/MySQLConfiguration.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/mysql/config/MySQLConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.retry.backoff.NoBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
+import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.mysql.dao.MySQLExecutionDAO;
 import com.netflix.conductor.mysql.dao.MySQLMetadataDAO;
 import com.netflix.conductor.mysql.dao.MySQLQueueDAO;
@@ -75,13 +76,13 @@ public class MySQLConfiguration {
             @Qualifier("mysqlRetryTemplate") RetryTemplate retryTemplate,
             ObjectMapper objectMapper,
             DataSource dataSource,
-            MySQLQueueDAO queueDAO) {
+            QueueDAO queueDAO) {
         return new MySQLExecutionDAO(retryTemplate, objectMapper, dataSource, queueDAO);
     }
 
     @Bean
     @DependsOn({"flyway", "flywayInitializer"})
-    public MySQLQueueDAO mySqlQueueDAO(
+    public QueueDAO mySqlQueueDAO(
             @Qualifier("mysqlRetryTemplate") RetryTemplate retryTemplate,
             ObjectMapper objectMapper,
             DataSource dataSource) {

--- a/mysql-persistence/src/main/java/com/netflix/conductor/mysql/dao/MySQLExecutionDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/mysql/dao/MySQLExecutionDAO.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 
 import javax.sql.DataSource;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.retry.support.RetryTemplate;
 
 import com.netflix.conductor.common.metadata.events.EventExecution;
@@ -42,6 +43,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
+@Slf4j
 public class MySQLExecutionDAO extends MySQLBaseDAO
         implements ExecutionDAO, RateLimitingDAO, PollDataDAO, ConcurrentExecutionLimitDAO {
 
@@ -54,6 +56,7 @@ public class MySQLExecutionDAO extends MySQLBaseDAO
             QueueDAO queueDAO) {
         super(retryTemplate, objectMapper, dataSource);
         this.queueDAO = queueDAO;
+        log.info("MySQL ExecutionDAO initialized {}", queueDAO);
     }
 
     private static String dateStr(Long timeInMs) {

--- a/mysql-persistence/src/main/java/com/netflix/conductor/mysql/dao/MySQLExecutionDAO.java
+++ b/mysql-persistence/src/main/java/com/netflix/conductor/mysql/dao/MySQLExecutionDAO.java
@@ -20,7 +20,6 @@ import java.util.stream.Collectors;
 
 import javax.sql.DataSource;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.retry.support.RetryTemplate;
 
 import com.netflix.conductor.common.metadata.events.EventExecution;
@@ -42,6 +41,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class MySQLExecutionDAO extends MySQLBaseDAO

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 
 import javax.sql.DataSource;
 
-import com.netflix.conductor.dao.QueueDAO;
 import org.conductoross.conductor.postgres.dao.PostgresFileMetadataDAO;
 import org.conductoross.conductor.postgres.dao.PostgresSkillMetadataDAO;
 import org.conductoross.conductor.postgres.dao.PostgresSkillPackageDAO;
@@ -35,6 +34,7 @@ import org.springframework.retry.backoff.NoBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
+import com.netflix.conductor.dao.QueueDAO;
 import com.netflix.conductor.postgres.dao.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import javax.sql.DataSource;
 
+import com.netflix.conductor.dao.QueueDAO;
 import org.conductoross.conductor.postgres.dao.PostgresFileMetadataDAO;
 import org.conductoross.conductor.postgres.dao.PostgresSkillMetadataDAO;
 import org.conductoross.conductor.postgres.dao.PostgresSkillPackageDAO;
@@ -99,7 +100,7 @@ public class PostgresConfiguration {
     public PostgresExecutionDAO postgresExecutionDAO(
             @Qualifier("postgresRetryTemplate") RetryTemplate retryTemplate,
             ObjectMapper objectMapper,
-            PostgresQueueDAO queueDAO) {
+            QueueDAO queueDAO) {
         return new PostgresExecutionDAO(retryTemplate, objectMapper, dataSource, queueDAO);
     }
 
@@ -114,7 +115,7 @@ public class PostgresConfiguration {
 
     @Bean
     @DependsOn({"flywayForPrimaryDb"})
-    public PostgresQueueDAO postgresQueueDAO(
+    public QueueDAO postgresQueueDAO(
             @Qualifier("postgresRetryTemplate") RetryTemplate retryTemplate,
             ObjectMapper objectMapper,
             PostgresProperties properties) {

--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/HealthCheckResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/HealthCheckResource.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.netflix.runtime.health.api.HealthCheckStatus;
 
 @RestController
-@RequestMapping("/health")
+@RequestMapping({"/health", "/api/health"})
 public class HealthCheckResource {
 
     // SBMTODO: Move this Spring boot health check

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -110,6 +110,13 @@ dependencies {
 
     runtimeOnly "org.glassfish.jaxb:jaxb-runtime:${revJAXB}"
 
+    // reactor-netty brings netty-transport-classes-epoll along with the linux-x86_64 native library
+    // only. The cassandra driver probes for the epoll transport with Class.forName (NettyUtil), and
+    // on linux-aarch_64 the missing native library surfaces as an UnsatisfiedLinkError, which the
+    // driver does not catch - the server then fails to start on arm64. Ship both architectures.
+    runtimeOnly group: 'io.netty', name: 'netty-transport-native-epoll', classifier: 'linux-x86_64'
+    runtimeOnly group: 'io.netty', name: 'netty-transport-native-epoll', classifier: 'linux-aarch_64'
+
     testImplementation project(':conductor-rest')
     testImplementation project(':conductor-common')
     testImplementation "io.grpc:grpc-testing:${revGrpc}"

--- a/test-harness/build.gradle
+++ b/test-harness/build.gradle
@@ -72,7 +72,7 @@ dependencies {
 }
 
 tasks.withType(Test)  {
-    maxParallelForks = 1
+    maxParallelForks = 3
 }
 
 // Conductor-Agents' deterministic suite uses real Conductor services plus Testcontainers. The live

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/a2a/A2ADurableEngineEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/a2a/A2ADurableEngineEndToEndTest.java
@@ -214,7 +214,7 @@ class A2ADurableEngineEndToEndTest {
      */
     private void drainQueue(String taskType) {
         WorkflowSystemTask task = systemTask(taskType);
-        for (String taskId : queueDAO.pop(taskType, 5, 100)) {
+        for (String taskId : queueDAO.pop(taskType, 5, 0)) {
             asyncSystemTaskExecutor.execute(task, taskId);
         }
     }

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/AgentSpanDeploymentContractEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/AgentSpanDeploymentContractEndToEndTest.java
@@ -4450,7 +4450,7 @@ class AgentSpanDeploymentContractEndToEndTest {
             if ("LLM_CHAT_COMPLETE".equals(task.getTaskType())) {
                 continue;
             }
-            for (String taskId : queueDAO.pop(task.getTaskType(), 5, 100)) {
+            for (String taskId : queueDAO.pop(task.getTaskType(), 5, 0)) {
                 asyncSystemTaskExecutor.execute(task, taskId);
             }
         }

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/AgentSpanMcpTestkitApiDiscoveryEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/AgentSpanMcpTestkitApiDiscoveryEndToEndTest.java
@@ -550,7 +550,7 @@ class AgentSpanMcpTestkitApiDiscoveryEndToEndTest {
 
     private void drainAsyncSystemTaskQueues() {
         for (WorkflowSystemTask task : asyncSystemTasks) {
-            for (String taskId : queueDAO.pop(task.getTaskType(), 5, 100)) {
+            for (String taskId : queueDAO.pop(task.getTaskType(), 5, 0)) {
                 asyncSystemTaskExecutor.execute(task, taskId);
             }
         }
@@ -561,7 +561,7 @@ class AgentSpanMcpTestkitApiDiscoveryEndToEndTest {
             if ("LLM_CHAT_COMPLETE".equals(task.getTaskType())) {
                 continue;
             }
-            for (String taskId : queueDAO.pop(task.getTaskType(), 5, 100)) {
+            for (String taskId : queueDAO.pop(task.getTaskType(), 5, 0)) {
                 asyncSystemTaskExecutor.execute(task, taskId);
             }
         }

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/AgentSpanRegistrationEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/AgentSpanRegistrationEndToEndTest.java
@@ -522,7 +522,7 @@ class AgentSpanRegistrationEndToEndTest {
      */
     private void drainAllQueues() {
         for (WorkflowSystemTask task : asyncSystemTasks) {
-            for (String taskId : queueDAO.pop(task.getTaskType(), 5, 100)) {
+            for (String taskId : queueDAO.pop(task.getTaskType(), 5, 0)) {
                 asyncSystemTaskExecutor.execute(task, taskId);
             }
         }

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/ConductorAgentEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/ConductorAgentEndToEndTest.java
@@ -79,8 +79,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
             "conductor.db.type=redis_standalone",
             "conductor.queue.type=redis_standalone",
             "conductor.app.sweeperThreadCount=1",
-            "conductor.app.sweeper.sweepBatchSize=1",
-            "conductor.app.sweeper.queuePopTimeout=750",
+            "conductor.app.sweeper.sweepBatchSize=10",
+            "conductor.app.sweeper.queuePopTimeout=10",
             "conductor.integrations.ai.enabled=true"
         })
 class ConductorAgentEndToEndTest {
@@ -732,7 +732,7 @@ class ConductorAgentEndToEndTest {
      */
     private void drainQueue(String taskType) {
         WorkflowSystemTask task = systemTask(taskType);
-        for (String taskId : queueDAO.pop(taskType, 5, 100)) {
+        for (String taskId : queueDAO.pop(taskType, 5, 0)) {
             asyncSystemTaskExecutor.execute(task, taskId);
         }
     }

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/ConductorAgentEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/ConductorAgentEndToEndTest.java
@@ -931,9 +931,11 @@ class ConductorAgentEndToEndTest {
         task.setTaskReferenceName("callAgent");
         task.setType("AGENT");
         // AI task definitions ship with retryCount 3 and LINEAR_BACKOFF at 2s (AIModelTaskMapper),
-        // so a failing AGENT task was retried after 2s, 4s and 6s - with each retry starting a fresh
+        // so a failing AGENT task was retried after 2s, 4s and 6s - with each retry starting a
+        // fresh
         // agent execution - before the workflow failed. None of the tests here assert retry
-        // behaviour; they assert how a failure surfaces on the AGENT task. Retry on the workflow task
+        // behaviour; they assert how a failure surfaces on the AGENT task. Retry on the workflow
+        // task
         // takes precedence over the task definition (DeciderService.retry), so this makes the first
         // failure terminal without touching the shared task definition or production defaults.
         task.setRetryCount(0);

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/ConductorAgentEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/ConductorAgentEndToEndTest.java
@@ -930,6 +930,13 @@ class ConductorAgentEndToEndTest {
         task.setName("AGENT");
         task.setTaskReferenceName("callAgent");
         task.setType("AGENT");
+        // AI task definitions ship with retryCount 3 and LINEAR_BACKOFF at 2s (AIModelTaskMapper),
+        // so a failing AGENT task was retried after 2s, 4s and 6s - with each retry starting a fresh
+        // agent execution - before the workflow failed. None of the tests here assert retry
+        // behaviour; they assert how a failure surfaces on the AGENT task. Retry on the workflow task
+        // takes precedence over the task definition (DeciderService.retry), so this makes the first
+        // failure terminal without touching the shared task definition or production defaults.
+        task.setRetryCount(0);
         Map<String, Object> taskInput = new HashMap<>();
         taskInput.put("agentType", "conductor");
         taskInput.put("name", agentName);

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/ai/AIReasoningEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/ai/AIReasoningEndToEndTest.java
@@ -384,7 +384,7 @@ class AIReasoningEndToEndTest {
                                                         + " registered — the AI module's"
                                                         + " WorkerTaskAnnotationScanner must run"
                                                         + " before this test executes."));
-        List<String> taskIds = queueDAO.pop("LLM_CHAT_COMPLETE", 5, 100);
+        List<String> taskIds = queueDAO.pop("LLM_CHAT_COMPLETE", 5, 0);
         for (String taskId : taskIds) {
             asyncSystemTaskExecutor.execute(chatTask, taskId);
         }


### PR DESCRIPTION
 - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring (no functional changes, no api changes)
  - [ ] Build related changes
  - [ ] WHOSUSING.md
  - [ ] Other (please describe):

  NOTE: Please remember to run ./gradlew spotlessApply to fix any format violations.

  Changes in this PR

  - Fixes persistence configuration so ExecutionDAO receives the QueueDAO interface bean, allowing concurrency-limit behavior to initialize correctly for MySQL and Postgres.
  - Adds /api/health as an alias for the existing /health endpoint, supporting clients and deployments that use the API-prefixed route.

  Issue #

  N/A
