### PR TITLE
fix: self-hosted models — base_url NPE + OPENAI_BASE_URL silently ignored

### DIFF
--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/ai/AgentspanAIModelProvider.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/ai/AgentspanAIModelProvider.java
@@ -199,15 +199,18 @@ public class AgentspanAIModelProvider extends AIModelProvider {
     }
 
     /**
-     * Resolve the credential-store base URL for a provider (e.g. {@code OLLAMA_BASE_URL} for
-     * ollama), or null when none is stored. Used by the provider-status endpoint — the server-side
-     * source of truth that doctor and the UI query.
+     * Resolve the configured base URL for a provider. Checks the credential store first, then
+     * falls back to {@link System#getenv} so that {@code OPENAI_BASE_URL} (and equivalents) work
+     * in standalone OSS mode. Used by the provider-status endpoint — the server-side source of
+     * truth that doctor and the UI query.
      */
     public String resolveConfiguredBaseUrl(String provider) {
         String envVarName = PROVIDER_TO_BASE_URL_ENV.get(provider.toLowerCase());
         if (envVarName == null) return null;
         String value = resolveUserCredential(envVarName);
-        return (value != null && !value.isBlank()) ? value : null;
+        if (value != null && !value.isBlank()) return value;
+        String sysVal = getSystemEnv(envVarName);
+        return (sysVal != null && !sysVal.isBlank()) ? sysVal : null;
     }
 
     /** Resolve any named credential from the (global) credential store. */
@@ -221,11 +224,11 @@ public class AgentspanAIModelProvider extends AIModelProvider {
     }
 
     /**
-     * Resolve base URL: per-agent (from task input) &gt; credential store &gt; null.
+     * Resolve base URL: per-agent (from task input) &gt; credential store &gt; System.getenv()
+     * &gt; null.
      *
-     * <p>The credential store is the single source of truth. Env-var-set base URLs are seeded into
-     * the store at startup by the host's credential env-seeder, so {@code System.getenv()} is never
-     * read directly here.
+     * <p>The System.getenv() fallback covers standalone OSS mode where no credential store
+     * env-seeder is active, ensuring OPENAI_BASE_URL and similar variables take effect.
      */
     @SuppressWarnings("unchecked")
     private String resolveBaseUrl(String provider) {
@@ -248,16 +251,29 @@ public class AgentspanAIModelProvider extends AIModelProvider {
 
         // 2. Credential store — covers both env-var-seeded credentials (populated at startup
         //    by the host's env-seeder) and credentials added manually via the UI.
-        //    Direct System.getenv() is intentionally not used here: env vars are always
-        //    seeded into the credential store at startup, so the store is the single
-        //    source of truth and avoids bypassing external credential stores.
         String credVal = resolveUserCredential(envVarName);
         if (credVal != null && !credVal.isBlank()) {
             log.debug("Using credential {} for provider '{}': {}", envVarName, provider, credVal);
             return credVal;
         }
 
+        // 3. Direct System.getenv() fallback for standalone OSS mode where no credential
+        //    store / env-seeder is wired up.  Without this, OPENAI_BASE_URL (and similar)
+        //    are silently ignored: the agent appears to work but routes to the real provider
+        //    instead of the configured self-hosted host.
+        String sysEnvVal = getSystemEnv(envVarName);
+        if (sysEnvVal != null && !sysEnvVal.isBlank()) {
+            log.debug(
+                    "Using system env {} for provider '{}': {}", envVarName, provider, sysEnvVal);
+            return sysEnvVal;
+        }
+
         return null;
+    }
+
+    /** Reads an env variable. Protected so tests can override without PowerMock. */
+    protected String getSystemEnv(String name) {
+        return System.getenv(name);
     }
 
     /** Create a fresh AIModel instance with a per-user API key and optional base URL. */

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/ai/AgentspanAIModelProvider.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/ai/AgentspanAIModelProvider.java
@@ -199,10 +199,10 @@ public class AgentspanAIModelProvider extends AIModelProvider {
     }
 
     /**
-     * Resolve the configured base URL for a provider. Checks the credential store first, then
-     * falls back to {@link System#getenv} so that {@code OPENAI_BASE_URL} (and equivalents) work
-     * in standalone OSS mode. Used by the provider-status endpoint — the server-side source of
-     * truth that doctor and the UI query.
+     * Resolve the configured base URL for a provider. Checks the credential store first, then falls
+     * back to {@link System#getenv} so that {@code OPENAI_BASE_URL} (and equivalents) work in
+     * standalone OSS mode. Used by the provider-status endpoint — the server-side source of truth
+     * that doctor and the UI query.
      */
     public String resolveConfiguredBaseUrl(String provider) {
         String envVarName = PROVIDER_TO_BASE_URL_ENV.get(provider.toLowerCase());
@@ -224,8 +224,8 @@ public class AgentspanAIModelProvider extends AIModelProvider {
     }
 
     /**
-     * Resolve base URL: per-agent (from task input) &gt; credential store &gt; System.getenv()
-     * &gt; null.
+     * Resolve base URL: per-agent (from task input) &gt; credential store &gt; System.getenv() &gt;
+     * null.
      *
      * <p>The System.getenv() fallback covers standalone OSS mode where no credential store
      * env-seeder is active, ensuring OPENAI_BASE_URL and similar variables take effect.
@@ -263,8 +263,7 @@ public class AgentspanAIModelProvider extends AIModelProvider {
         //    instead of the configured self-hosted host.
         String sysEnvVal = getSystemEnv(envVarName);
         if (sysEnvVal != null && !sysEnvVal.isBlank()) {
-            log.debug(
-                    "Using system env {} for provider '{}': {}", envVarName, provider, sysEnvVal);
+            log.debug("Using system env {} for provider '{}': {}", envVarName, provider, sysEnvVal);
             return sysEnvVal;
         }
 

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/controller/ProviderController.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/controller/ProviderController.java
@@ -86,15 +86,24 @@ public class ProviderController {
             Map<String, Object> entry = new LinkedHashMap<>();
             entry.put("name", name);
             entry.put("configured", modelProvider.isProviderConfigured(name));
-            if ("ollama".equals(name)) {
-                String baseUrl = modelProvider.resolveConfiguredBaseUrl("ollama");
-                if (baseUrl == null) {
-                    baseUrl =
-                            environment.getProperty(
-                                    "conductor.ai.ollama.base-url", "http://localhost:11434");
-                }
+            String baseUrl = modelProvider.resolveConfiguredBaseUrl(name);
+            if ("ollama".equals(name) && baseUrl == null) {
+                baseUrl =
+                        environment.getProperty(
+                                "conductor.ai.ollama.base-url", "http://localhost:11434");
+            }
+            if (baseUrl != null) {
                 entry.put("baseUrl", baseUrl);
-                entry.put("reachable", probe(baseUrl));
+            }
+            if ("ollama".equals(name)) {
+                entry.put(
+                        "reachable",
+                        probe(
+                                baseUrl != null
+                                        ? baseUrl
+                                        : environment.getProperty(
+                                                "conductor.ai.ollama.base-url",
+                                                "http://localhost:11434")));
             }
             providers.add(entry);
         }

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/ai/AgentspanAIModelProviderTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/ai/AgentspanAIModelProviderTest.java
@@ -49,4 +49,36 @@ class AgentspanAIModelProviderTest {
     void unknownProviderNeverAppearsConfigured() {
         assertThat(provider.isProviderConfigured("unknown-provider")).isFalse();
     }
+
+    // =================================================================
+    // OPENAI_BASE_URL env-var fallback (issue-1416 — Bug 2)
+    // =================================================================
+
+    /**
+     * resolveConfiguredBaseUrl returns the value from the env-var fallback path when the
+     * credential store has nothing — verified via a subclass that injects a fake env value.
+     */
+    @Test
+    void resolveConfiguredBaseUrl_returnsEnvVarFallbackWhenCredentialStoreEmpty() {
+        String fakeUrl = "http://localhost:9001/v1";
+
+        AgentspanAIModelProvider providerWithEnv =
+                new AgentspanAIModelProvider(
+                        List.of(),
+                        new StandardEnvironment(),
+                        new OkHttpClient(),
+                        new CredentialResolutionService(new NoopSecretsDAO())) {
+                    @Override
+                    protected String getSystemEnv(String name) {
+                        return "OPENAI_BASE_URL".equals(name) ? fakeUrl : null;
+                    }
+                };
+
+        assertThat(providerWithEnv.resolveConfiguredBaseUrl("openai")).isEqualTo(fakeUrl);
+    }
+
+    @Test
+    void resolveConfiguredBaseUrl_returnsNullWhenNeitherStoreNorEnvHasValue() {
+        assertThat(provider.resolveConfiguredBaseUrl("openai")).isNull();
+    }
 }

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/ai/AgentspanAIModelProviderTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/ai/AgentspanAIModelProviderTest.java
@@ -55,8 +55,8 @@ class AgentspanAIModelProviderTest {
     // =================================================================
 
     /**
-     * resolveConfiguredBaseUrl returns the value from the env-var fallback path when the
-     * credential store has nothing — verified via a subclass that injects a fake env value.
+     * resolveConfiguredBaseUrl returns the value from the env-var fallback path when the credential
+     * store has nothing — verified via a subclass that injects a fake env value.
      */
     @Test
     void resolveConfiguredBaseUrl_returnsEnvVarFallbackWhenCredentialStoreEmpty() {

--- a/ai/src/main/java/org/conductoross/conductor/ai/LLMHelper.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/LLMHelper.java
@@ -424,15 +424,17 @@ public class LLMHelper {
                 finishReason = result.getMetadata().getFinishReason();
             } else {
                 responses.add(result.getOutput().getText());
-                result.getOutput()
-                        .getMedia()
-                        .forEach(
-                                m ->
-                                        media.add(
-                                                org.conductoross.conductor.ai.model.Media.builder()
-                                                        .data(m.getDataAsByteArray())
-                                                        .mimeType(m.getMimeType().toString())
-                                                        .build()));
+                List<org.springframework.ai.content.Media> outputMedia =
+                        result.getOutput().getMedia();
+                if (outputMedia != null) {
+                    outputMedia.forEach(
+                            m ->
+                                    media.add(
+                                            org.conductoross.conductor.ai.model.Media.builder()
+                                                    .data(m.getDataAsByteArray())
+                                                    .mimeType(m.getMimeType().toString())
+                                                    .build()));
+                }
                 // storeMedia(outputLocation, result.getOutput().getMedia());
                 if (finishReason == null) {
                     finishReason = result.getMetadata().getFinishReason();
@@ -707,6 +709,10 @@ public class LLMHelper {
 
     private void storeMedia(
             String location, List<org.conductoross.conductor.ai.model.Media> media) {
+
+        if (media == null || media.isEmpty()) {
+            return;
+        }
 
         DocumentLoader documentLoader =
                 documentLoaders.stream()

--- a/ai/src/test/java/org/conductoross/conductor/ai/LLMHelperChatCompleteTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/LLMHelperChatCompleteTest.java
@@ -595,8 +595,8 @@ public class LLMHelperChatCompleteTest {
     // =================================================================
 
     /**
-     * Spring AI 1.1.x AssistantMessage.getMedia() can return null when no media was set.
-     * The helper must not NPE on the media-collection loop.
+     * Spring AI 1.1.x AssistantMessage.getMedia() can return null when no media was set. The helper
+     * must not NPE on the media-collection loop.
      */
     @Test
     void chatComplete_nullMediaFromSpringAI_doesNotNPE() {

--- a/ai/src/test/java/org/conductoross/conductor/ai/LLMHelperChatCompleteTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/LLMHelperChatCompleteTest.java
@@ -591,6 +591,33 @@ public class LLMHelperChatCompleteTest {
     }
 
     // =================================================================
+    // chatComplete — null media from Spring AI (issue-1416)
+    // =================================================================
+
+    /**
+     * Spring AI 1.1.x AssistantMessage.getMedia() can return null when no media was set.
+     * The helper must not NPE on the media-collection loop.
+     */
+    @Test
+    void chatComplete_nullMediaFromSpringAI_doesNotNPE() {
+        // Build an AssistantMessage whose getMedia() returns null (no-arg constructor default).
+        AssistantMessage assistant = new AssistantMessage("hello from self-hosted model");
+
+        StagedChatModel model = new StagedChatModel();
+        model.stage(responseOf(assistant, "stop", metaWithUsage(5, 10, 15)));
+
+        ChatCompletion in = new ChatCompletion();
+        in.setLlmProvider("fake");
+        in.setModel("self-hosted/llama3");
+        in.getMessages().add(new ChatMessage(ChatMessage.Role.user, "Which host are you?"));
+
+        LLMResponse out =
+                helper.chatComplete(task("t17"), new FakeAIModel(model), in, null, x -> {});
+        assertEquals("hello from self-hosted model", out.getResult());
+        assertEquals("STOP", out.getFinishReason());
+    }
+
+    // =================================================================
     // generateEmbeddings — passthrough to the underlying AIModel
     // =================================================================
 


### PR DESCRIPTION
Fixes #1416

## What was broken

**1. NPE when self-hosted model returns no media**
Spring AI 1.1.x returns `null` from `AssistantMessage.getMedia()` when a model response contains no media (common with Ollama, vLLM, and other self-hosted endpoints). This caused a hard crash in `LLMHelper` — the task would fail with `Cannot invoke "List.stream()" because "media" is null`.

**2. OPENAI_BASE_URL env var silently ignored**
Setting `OPENAI_BASE_URL=http://my-host/v1` had no effect in standalone OSS mode. The server only checked the credential store for base URLs, which is never populated in OSS mode. Requests silently went to `api.openai.com` instead of the configured self-hosted endpoint. Same issue affected `OLLAMA_BASE_URL`, `ANTHROPIC_BASE_URL`, etc.

## What was fixed

- Added null guard in `LLMHelper` before iterating over media from model responses
- Added `System.getenv()` fallback in `AgentspanAIModelProvider.resolveBaseUrl()` so base URL env vars are respected in standalone mode
- Updated `GET /api/providers/status` to show `baseUrl` for any provider that has one configured (not just Ollama), so you can confirm the server picked up your env var

## How to verify

Start the server with a custom OpenAI base URL:
```bash
OPENAI_BASE_URL=http://localhost:9999/v1 \
  ./gradlew :conductor-server:bootRun --args='--server.port=8090' -x test
```

Check the provider status:
```bash
curl -s http://localhost:8090/api/providers/status | jq '.providers[] | select(.name == "openai")'
```

**Before fix:** `{ "name": "openai", "configured": true }` — no baseUrl, env var ignored  
**After fix:** `{ "name": "openai", "configured": true, "baseUrl": "http://localhost:9999/v1" }` — env var picked up

For the null media fix, run the unit tests:
```bash
./gradlew :conductor-agentspan:test :conductor-ai:test
```