### PR TITLE
fix: 404 on SSE stream open for nonexistent execution IDs

### DIFF
--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentService.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentService.java
@@ -1218,6 +1218,7 @@ public class AgentService {
     /** Open an SSE stream for an agent execution. Replays missed events on reconnect. */
     public SseEmitter openStream(String executionId, Long lastEventId) {
         log.info("Opening SSE stream for execution {} (lastEventId={})", executionId, lastEventId);
+        workflowService.getExecutionStatus(executionId, false);
         return streamRegistry.register(executionId, lastEventId);
     }
 

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentServiceOpenStreamTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentServiceOpenStreamTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.agentspan.runtime.service;
+
+import org.conductoross.conductor.ai.agentspan.runtime.compiler.AgentCompiler;
+import org.conductoross.conductor.ai.agentspan.runtime.normalizer.NormalizerRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.netflix.conductor.core.exception.NotFoundException;
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.dao.ExecutionDAO;
+import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.service.MetadataService;
+import com.netflix.conductor.service.TaskService;
+import com.netflix.conductor.service.WorkflowService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link AgentService#openStream} — verifies that SSE streams are rejected for
+ * unknown execution IDs (issue #1334).
+ */
+class AgentServiceOpenStreamTest {
+
+    private WorkflowService workflowService;
+    private AgentStreamRegistry streamRegistry;
+    private AgentService agentService;
+
+    @BeforeEach
+    void setUp() {
+        workflowService = mock(WorkflowService.class);
+        streamRegistry = mock(AgentStreamRegistry.class);
+        agentService =
+                new AgentService(
+                        mock(AgentCompiler.class),
+                        mock(NormalizerRegistry.class),
+                        mock(ExecutionDAO.class),
+                        mock(MetadataDAO.class),
+                        workflowService,
+                        mock(TaskService.class),
+                        mock(WorkflowExecutor.class),
+                        streamRegistry,
+                        mock(SkillRegistryService.class),
+                        mock(MetadataService.class));
+    }
+
+    @Test
+    void openStream_throwsNotFoundForUnknownExecutionId() {
+        when(workflowService.getExecutionStatus(eq("bad-id"), anyBoolean()))
+                .thenThrow(new NotFoundException("bad-id"));
+
+        assertThatThrownBy(() -> agentService.openStream("bad-id", null))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    void openStream_doesNotRegisterEmitterWhenExecutionNotFound() {
+        when(workflowService.getExecutionStatus(eq("bad-id"), anyBoolean()))
+                .thenThrow(new NotFoundException("bad-id"));
+
+        try {
+            agentService.openStream("bad-id", null);
+        } catch (NotFoundException ignored) {
+        }
+
+        verify(streamRegistry, never()).register(any(), any());
+    }
+
+    @Test
+    void openStream_registersEmitterWhenExecutionExists() {
+        SseEmitter emitter = new SseEmitter();
+        when(workflowService.getExecutionStatus(eq("good-id"), anyBoolean())).thenReturn(null);
+        when(streamRegistry.register(eq("good-id"), eq(null))).thenReturn(emitter);
+
+        SseEmitter result = agentService.openStream("good-id", null);
+
+        assertThat(result).isSameAs(emitter);
+        verify(streamRegistry).register("good-id", null);
+    }
+}


### PR DESCRIPTION
Fixes #1334

## What was broken

Calling `GET /api/agent/stream/{executionId}` with a nonexistent or garbage ID returned 200 and streamed heartbeats forever — the server never checked if the execution actually existed before opening the SSE connection.

## Fix

One line — added an existence check in `AgentService.openStream()` via `workflowService.getExecutionStatus()` before registering the emitter. If the execution doesn't exist it throws `NotFoundException`, which maps to 404.

## How to verify

```bash
# Before: hangs forever with heartbeats
# After: returns 404 immediately
curl -v http://localhost:8090/api/agent/stream/deadbeef-0000-0000
```

For the happy path, start an agent and stream its execution:

```bash
curl -s -X POST http://localhost:8090/api/agent/start \
  -H "Content-Type: application/json" \
  -d '{"prompt":"hello","agentConfig":{"name":"test","model":"openai/gpt-4o-mini","instructions":"You are helpful."}}' | jq .executionId

curl -v http://localhost:8090/api/agent/stream/<executionId>
# → 200 + :connected + events

curl -s http://localhost:8090/api/agent/executions/497a0cf9-f014-4fae-82a8-8a866585b256
{"executionId":"497a0cf9-f014-4fae-82a8-8a866585b256","agentName":"test-agent","version":1,"status":"FAILED","input":{"prompt":"Say hello in one word","media":[],"context":{},"session_id":"","cwd":"."},"output":{"result":null,"finishReason":null,"context":{}}}%              
                                                                                                                                                   
curl -s http://localhost:8090/api/agent/executions/497a0cf9-f014-4fae-82a8-blah-blah
{"status":404,"message":"No such workflow found by id: 497a0cf9-f014-4fae-82a8-8a866585b2562222","instance":"192.168.1.11","retryable":false}%     
```
