### PR TITLE
fix: proper 404/400/409 for common agent API client errors

### DIFF
--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentService.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentService.java
@@ -41,6 +41,7 @@ import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.run.SearchResult;
 import com.netflix.conductor.common.run.Workflow;
 import com.netflix.conductor.common.run.WorkflowSummary;
+import com.netflix.conductor.core.exception.ConflictException;
 import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.core.execution.WorkflowExecutor;
 import com.netflix.conductor.dao.ExecutionDAO;
@@ -558,7 +559,11 @@ public class AgentService {
 
     /** Resume a paused agent execution. */
     public void resumeAgent(String executionId) {
-        workflowService.resumeWorkflow(executionId);
+        try {
+            workflowService.resumeWorkflow(executionId);
+        } catch (IllegalStateException e) {
+            throw new ConflictException(e.getMessage());
+        }
     }
 
     /** Cancel a running agent execution. */
@@ -674,6 +679,9 @@ public class AgentService {
         // Set the stop flag — the DoWhile loop condition checks this variable.
         // Get the workflow model, update its variables map, and persist.
         WorkflowModel workflow = executionDAO.getWorkflow(executionId, false);
+        if (workflow == null) {
+            throw new NotFoundException("No agent execution found: " + executionId);
+        }
         workflow.getVariables().put("_stop_requested", true);
         executionDAO.updateWorkflow(workflow);
         // Note: the SDK also sends a WMQ unblock message via the Conductor client
@@ -689,6 +697,9 @@ public class AgentService {
      */
     public void signalAgent(String executionId, String message) {
         WorkflowModel workflow = executionDAO.getWorkflow(executionId, false);
+        if (workflow == null) {
+            throw new NotFoundException("No agent execution found: " + executionId);
+        }
         workflow.getVariables().put("_signal_injection", message != null ? message : "");
         executionDAO.updateWorkflow(workflow);
     }
@@ -1209,6 +1220,10 @@ public class AgentService {
                 request.setRawConfig(skillRegistryService.resolveRawConfig(request.getSkillRef()));
             }
             return normalizerRegistry.normalize(request.getFramework(), request.getRawConfig());
+        }
+        if (request.getAgentConfig() == null) {
+            throw new IllegalArgumentException(
+                    "agentConfig is required when framework is not specified");
         }
         return request.getAgentConfig();
     }

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentServiceErrorHandlingTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentServiceErrorHandlingTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.agentspan.runtime.service;
+
+import org.conductoross.conductor.ai.agentspan.runtime.compiler.AgentCompiler;
+import org.conductoross.conductor.ai.agentspan.runtime.normalizer.NormalizerRegistry;
+import org.conductoross.conductor.common.metadata.agent.AgentStartRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.netflix.conductor.core.exception.ConflictException;
+import com.netflix.conductor.core.exception.NotFoundException;
+import com.netflix.conductor.core.execution.WorkflowExecutor;
+import com.netflix.conductor.dao.ExecutionDAO;
+import com.netflix.conductor.dao.MetadataDAO;
+import com.netflix.conductor.service.MetadataService;
+import com.netflix.conductor.service.TaskService;
+import com.netflix.conductor.service.WorkflowService;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for error handling in {@link AgentService} — verifies that client errors produce
+ * meaningful HTTP-mappable exceptions instead of NPEs (issue #1332).
+ */
+class AgentServiceErrorHandlingTest {
+
+    private ExecutionDAO executionDAO;
+    private WorkflowService workflowService;
+    private AgentService agentService;
+
+    @BeforeEach
+    void setUp() {
+        executionDAO = mock(ExecutionDAO.class);
+        workflowService = mock(WorkflowService.class);
+        agentService =
+                new AgentService(
+                        mock(AgentCompiler.class),
+                        mock(NormalizerRegistry.class),
+                        executionDAO,
+                        mock(MetadataDAO.class),
+                        workflowService,
+                        mock(TaskService.class),
+                        mock(WorkflowExecutor.class),
+                        mock(AgentStreamRegistry.class),
+                        mock(SkillRegistryService.class),
+                        mock(MetadataService.class));
+    }
+
+    // ── stop / signal with unknown execution ID ──────────────────────
+
+    @Test
+    void stopAgent_throwsNotFoundForUnknownExecutionId() {
+        when(executionDAO.getWorkflow(eq("bad-id"), anyBoolean())).thenReturn(null);
+
+        assertThatThrownBy(() -> agentService.stopAgent("bad-id"))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    void signalAgent_throwsNotFoundForUnknownExecutionId() {
+        when(executionDAO.getWorkflow(eq("bad-id"), anyBoolean())).thenReturn(null);
+
+        assertThatThrownBy(() -> agentService.signalAgent("bad-id", "hello"))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ── compile / start with missing agentConfig ─────────────────────
+
+    @Test
+    void compile_throwsIllegalArgumentWhenAgentConfigIsNull() {
+        assertThatThrownBy(() -> agentService.compile(new AgentStartRequest()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("agentConfig is required");
+    }
+
+    @Test
+    void start_throwsIllegalArgumentWhenNoAgentSpecified() {
+        AgentStartRequest request = new AgentStartRequest();
+        request.setPrompt("hello");
+        assertThatThrownBy(() -> agentService.start(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("agentName or inline agent construction details");
+    }
+
+    // ── resume on non-PAUSED execution ───────────────────────────────
+
+    @Test
+    void resumeAgent_throwsConflictWhenWorkflowIsNotPaused() {
+        doThrow(
+                        new IllegalStateException(
+                                "The workflow completed-id is not PAUSED so cannot resume."))
+                .when(workflowService)
+                .resumeWorkflow(eq("completed-id"));
+
+        assertThatThrownBy(() -> agentService.resumeAgent("completed-id"))
+                .isInstanceOf(ConflictException.class);
+    }
+}


### PR DESCRIPTION
Fixes #1332

## What was broken

Several agent endpoints crashed with 500 NPE for routine mistakes:

- `stop` / `signal` with an unknown execution ID → NPE (workflow lookup returns null, code dereferenced it)
- `compile` / `start` with `{}` body → NPE (agentConfig is null, code called methods on it)
- `resume` on a completed/failed execution → 500 (IllegalStateException not mapped, unlike `pause` which correctly returns 409)

## Fix

- `stopAgent` / `signalAgent`: null check → 404
- `resolveConfig`: null agentConfig check → 400
- `resumeAgent`: wrap IllegalStateException → 409 (consistent with pause)

## Verified locally

```bash
curl -s -X POST http://localhost:8090/api/agent/deadbeef-0000/stop | jq .


{
  "status": 404,
  "message": "No agent execution found: deadbeef-0000",
  "instance": "192.168.1.11",
  "retryable": false
}
curl -s -X POST http://localhost:8090/api/agent/deadbeef-0000/signal \
    -H "Content-Type: application/json" -d '{"message":"x"}' | jq .
{
  "status": 404,
  "message": "No agent execution found: deadbeef-0000",
  "instance": "192.168.1.11",
  "retryable": false
}
curl -s -X POST http://localhost:8090/api/agent/compile \
    -H "Content-Type: application/json" -d '{}' | jq .
{
  "status": 400,
  "message": "agentConfig is required when framework is not specified",
  "instance": "192.168.1.11",
  "retryable": false
}
  curl -s -X PUT http://localhost:8090/api/agent/497a0cf9-f014-4fae-82a8-8a866585b256/resume | jq .
{
  "status": 409,
  "message": "The workflow 497a0cf9-f014-4fae-82a8-8a866585b256 is not PAUSED so cannot resume. Current status is FAILED",
  "instance": "192.168.1.11",
  "retryable": false
}
curl -s -X POST http://localhost:8090/api/agent/deadbeef-0000/stop | jq .
{
  "status": 404,
  "message": "No agent execution found: deadbeef-0000",
  "instance": "192.168.1.11",
  "retryable": false
}
```