### PR TITLE
fix(wait-task): accept ISO-8601 duration and fix misleading error message

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/utils/DateTimeUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/DateTimeUtils.java
@@ -36,13 +36,18 @@ public class DateTimeUtils {
 
     public static Duration parseDuration(String text) {
         Matcher m = DURATION_PATTERN.matcher(text);
-        if (!m.matches()) throw new IllegalArgumentException("Not valid duration: " + text);
-
-        int days = (m.start(1) == -1 ? 0 : Integer.parseInt(m.group(1)));
-        int hours = (m.start(2) == -1 ? 0 : Integer.parseInt(m.group(2)));
-        int mins = (m.start(3) == -1 ? 0 : Integer.parseInt(m.group(3)));
-        int secs = (m.start(4) == -1 ? 0 : Integer.parseInt(m.group(4)));
-        return Duration.ofSeconds((days * 86400) + (hours * 60L + mins) * 60L + secs);
+        if (m.matches()) {
+            int days = (m.start(1) == -1 ? 0 : Integer.parseInt(m.group(1)));
+            int hours = (m.start(2) == -1 ? 0 : Integer.parseInt(m.group(2)));
+            int mins = (m.start(3) == -1 ? 0 : Integer.parseInt(m.group(3)));
+            int secs = (m.start(4) == -1 ? 0 : Integer.parseInt(m.group(4)));
+            return Duration.ofSeconds((days * 86400) + (hours * 60L + mins) * 60L + secs);
+        }
+        try {
+            return Duration.parse(text);
+        } catch (java.time.format.DateTimeParseException e) {
+            throw new IllegalArgumentException("Not valid duration: " + text);
+        }
     }
 
     public static Date parseDate(String date) throws ParseException {

--- a/core/src/main/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraint.java
+++ b/core/src/main/java/com/netflix/conductor/validations/WorkflowTaskTypeConstraint.java
@@ -330,8 +330,8 @@ public @interface WorkflowTaskTypeConstraint {
                 context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
                 valid = false;
             } catch (IllegalArgumentException e) {
-                String message = "Either date or duration is passed as null ";
-                context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+                context.buildConstraintViolationWithTemplate(e.getMessage())
+                        .addConstraintViolation();
                 valid = false;
             } catch (ParseException e) {
                 String message = "Unable to parse date ";

--- a/core/src/test/java/com/netflix/conductor/core/utils/DateTimeUtilsTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/utils/DateTimeUtilsTest.java
@@ -61,7 +61,13 @@ public class DateTimeUtilsTest {
                 Arguments.of("5H 5M 5S", Duration.ofSeconds(5 * 60 * 60 + 5 * 60 + 5)),
                 Arguments.of(
                         "5D 5H 5M 5S",
-                        Duration.ofSeconds(5 * 24 * 60 * 60 + 5 * 60 * 60 + 5 * 60 + 5)));
+                        Duration.ofSeconds(5 * 24 * 60 * 60 + 5 * 60 * 60 + 5 * 60 + 5)),
+                Arguments.of("PT5S", Duration.ofSeconds(5)),
+                Arguments.of("PT5M", Duration.ofMinutes(5)),
+                Arguments.of("PT5H", Duration.ofHours(5)),
+                Arguments.of("P5D", Duration.ofDays(5)),
+                Arguments.of("PT1H30M", Duration.ofSeconds(5400)),
+                Arguments.of("P1DT2H", Duration.ofSeconds(86400 + 7200)));
     }
 
     @ParameterizedTest(name = "[{0}] is valid duration")


### PR DESCRIPTION
## What

A WAIT task with `"duration": "PT1S"` (ISO-8601) failed with "Either date or duration is passed as null" — a message that implies the field was absent, when it was actually present but in an unsupported format.

Two changes:

1. **`DateTimeUtils.parseDuration()`** — after the custom format (`"1s"`, `"2m"`) fails to match, fall back to `java.time.Duration.parse()` so ISO-8601 durations like `"PT1S"`, `"P5D"`, `"PT1H30M"` work natively.

2. **`WorkflowTaskTypeConstraint`** — when `parseDuration()` still throws (genuinely invalid input), surface the actual error message instead of the misleading "passed as null" message.

Fixes #1310

## How to verify

1. Define a workflow with a WAIT task using ISO-8601 duration:
   ```json
   { "type": "WAIT", "name": "wait1", "taskReferenceName": "wait_ref",
     "inputParameters": { "duration": "PT1S" } }
   ```
2. Before fix: task fails immediately with "Either date or duration is passed as null".
3. After fix: task waits 1 second and completes normally.
4. To test the error message fix: use an invalid value like `"duration": "PT"` — the error now reads "Not valid duration: PT" instead of blaming null.