### PR TITLE
fix(ui): refresh selected agent execution details

### DIFF
--- a/ui-next/src/pages/execution/AgentExecution/AgentDetailPanel.tsx
+++ b/ui-next/src/pages/execution/AgentExecution/AgentDetailPanel.tsx
@@ -261,6 +261,10 @@ interface FetchedAgentExecution {
 
 const fetchedAgentExecutions = new Map<string, FetchedAgentExecution | null>();
 
+function isTerminalExecution(execution: WorkflowExecution): boolean {
+  return execution.status !== "RUNNING" && execution.status !== "PAUSED";
+}
+
 function useAgentExecutionDetail(run: AgentRunData): {
   data: FetchedAgentExecution | null;
   loading: boolean;
@@ -277,8 +281,9 @@ function useAgentExecutionDetail(run: AgentRunData): {
       setLoading(false);
       return;
     }
-    if (fetchedAgentExecutions.has(executionId)) {
-      setData(fetchedAgentExecutions.get(executionId) ?? null);
+    const cached = fetchedAgentExecutions.get(executionId);
+    if (cached && isTerminalExecution(cached.rawExecution)) {
+      setData(cached);
       setLoading(false);
       return;
     }
@@ -296,7 +301,11 @@ function useAgentExecutionDetail(run: AgentRunData): {
               rawExecution,
             }
           : null;
-        fetchedAgentExecutions.set(executionId, detail);
+        if (rawExecution && isTerminalExecution(rawExecution)) {
+          fetchedAgentExecutions.set(executionId, detail);
+        } else {
+          fetchedAgentExecutions.delete(executionId);
+        }
         setData(detail);
       })
       .catch(() => {
@@ -311,7 +320,7 @@ function useAgentExecutionDetail(run: AgentRunData): {
     return () => {
       cancelled = true;
     };
-  }, [executionId]);
+  }, [executionId, run.status]);
 
   return { data, loading };
 }

--- a/ui-next/src/pages/execution/AgentExecution/AgentRunView.test.tsx
+++ b/ui-next/src/pages/execution/AgentExecution/AgentRunView.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeAll, vi } from "vitest";
+import { AgentRunView } from "./AgentRunView";
+import { AgentRunData, AgentStatus, AgentStrategy } from "./types";
+
+vi.mock("./AgentExecutionDiagram", () => ({
+  AgentExecutionDiagram: ({ agentRun, onNodeSelect }: any) => {
+    const subAgent = agentRun.turns[0].subAgents[0];
+    return (
+      <button
+        onClick={() =>
+          onNodeSelect(`sub-${subAgent.id}`, {
+            kind: "subagent",
+            label: subAgent.agentName,
+            status: subAgent.status,
+            strategy: AgentStrategy.HANDOFF,
+            subAgentRun: subAgent,
+          })
+        }
+      >
+        Select claim verifier
+      </button>
+    );
+  },
+}));
+
+vi.mock("./agentExecutionUtils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./agentExecutionUtils")>()),
+  transformWorkflowExecutionToAgentRun: (execution: any) => execution.__run,
+}));
+
+const ZERO_TOKENS = {
+  promptTokens: 0,
+  completionTokens: 0,
+  totalTokens: 0,
+};
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+function subAgent(
+  status: AgentStatus,
+  output?: string,
+  executionId = "claim-verifier-execution",
+): AgentRunData {
+  return {
+    id: "claim-verifier-run",
+    subWorkflowId: executionId,
+    agentName: "claim_verifier",
+    turns: [],
+    status,
+    totalTokens: ZERO_TOKENS,
+    totalDurationMs: 0,
+    strategy: AgentStrategy.SINGLE,
+    output,
+  };
+}
+
+function rootRun(child: AgentRunData): AgentRunData {
+  return {
+    id: "root-run",
+    agentName: "root_agent",
+    status: child.status,
+    totalTokens: ZERO_TOKENS,
+    totalDurationMs: 0,
+    turns: [
+      {
+        turnNumber: 1,
+        events: [],
+        status: child.status,
+        durationMs: 0,
+        tokens: ZERO_TOKENS,
+        subAgents: [child],
+      },
+    ],
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("AgentRunView", () => {
+  it.each(["RUNNING", "PAUSED"])(
+    "refreshes a selected sub-agent after %s execution detail completes",
+    async (initialExecutionStatus) => {
+      const executionId = `claim-verifier-${initialExecutionStatus}`;
+      const runningChild = subAgent(
+        AgentStatus.RUNNING,
+        undefined,
+        executionId,
+      );
+      const completedChild = subAgent(
+        AgentStatus.COMPLETED,
+        "verified claim output",
+        executionId,
+      );
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            status: initialExecutionStatus,
+            __run: runningChild,
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ status: "COMPLETED", __run: completedChild }),
+        });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const { rerender } = render(
+        <AgentRunView
+          agentRun={rootRun(runningChild)}
+          onDrillIn={vi.fn()}
+          isRoot
+        />,
+      );
+
+      fireEvent.click(screen.getByText("Select claim verifier"));
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+      fireEvent.click(screen.getByRole("tab", { name: "Output" }));
+      expect(
+        screen.getByText(/No output captured for this execution/),
+      ).toBeInTheDocument();
+
+      rerender(
+        <AgentRunView
+          agentRun={rootRun(completedChild)}
+          onDrillIn={vi.fn()}
+          isRoot
+        />,
+      );
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+      expect(
+        await screen.findByText("verified claim output"),
+      ).toBeInTheDocument();
+    },
+  );
+});

--- a/ui-next/src/pages/execution/AgentExecution/AgentRunView.tsx
+++ b/ui-next/src/pages/execution/AgentExecution/AgentRunView.tsx
@@ -35,6 +35,17 @@ interface AgentRunViewProps {
 
 type ViewMode = "diagram" | "timeline";
 
+function findSubAgent(run: AgentRunData, id: string): AgentRunData | undefined {
+  for (const turn of run.turns) {
+    for (const subAgent of turn.subAgents) {
+      if (subAgent.id === id) return subAgent;
+      const nested = findSubAgent(subAgent, id);
+      if (nested) return nested;
+    }
+  }
+  return undefined;
+}
+
 // ─── Status chip ──────────────────────────────────────────────────────────────
 
 function StatusChip({ status }: { status: AgentStatus }) {
@@ -318,6 +329,25 @@ export function AgentRunView({
       agentRun.turns[0] ? timelineItemId(agentRun.turns[0]) : "turn-1",
     );
   }, [agentRun.id]);
+
+  // A selected node may outlive the execution snapshot from which it was
+  // created. Keep its sub-agent data synchronized as polling adds the final
+  // status and output to the parent execution.
+  useEffect(() => {
+    if (!selectedId) return;
+    setSelectedNode((current) => {
+      const selectedRunId = current?.subAgentRun?.id;
+      if (!current || !selectedRunId) return current;
+
+      const latestRun = findSubAgent(agentRun, selectedRunId);
+      if (!latestRun || latestRun === current.subAgentRun) return current;
+      return {
+        ...current,
+        status: latestRun.status,
+        subAgentRun: latestRun,
+      };
+    });
+  }, [agentRun, selectedId]);
 
   const handleDragStart = useCallback((e: ReactMouseEvent) => {
     isDragging.current = true;


### PR DESCRIPTION
## Summary

- Refresh the currently selected sub-agent from each new parent execution snapshot, preserving the selection while status, output, and detail data update.
- Cache child execution detail only after terminal states; running and paused detail is refetched when the run reaches a terminal state.
- Add regression coverage for running and paused detail transitions.

## Screenshot evidence: selected sub-agent refresh

<table>
  <tr>
    <th>Before — main</th>
    <th>After — freshness fix</th>
  </tr>
  <tr>
    <td>
<img width="1440" height="1000" alt="main-before-after-poll" src="https://github.com/user-attachments/assets/75d7d920-4b99-44ce-8f95-65ae2339eb98" />

    </td>
    <td>
<img width="1440" height="1000" alt="fixed-after-after-poll" src="https://github.com/user-attachments/assets/090fbbee-bd6f-4a25-9654-0d2fe7d0c8a0" />
    </td>
  </tr>
</table>

## Verification

- `./gradlew spotlessApply`
- `cd ui-next && npm run typecheck`
- `cd ui-next && npm test -- AgentRunView.test.tsx`

## Scope

UI-only freshness fix. No OCG, memory, feedback, rating, reason, modal, API, backend, workflow, persistence, or model changes.