### PR TITLE
fix: stamp/preserve createTime

### DIFF
--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentService.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentService.java
@@ -886,19 +886,14 @@ public class AgentService {
 
     /**
      * Persist an agent-generated workflow with the metadata lifecycle used by normal workflow
-     * definitions. Direct DAO updates bypass {@link MetadataService} and leave a newly deployed
-     * agent's create time at zero, which prevents the definitions table from rendering it.
+     * definitions, routing to {@link MetadataService#registerWorkflowDef}/{@link
+     * MetadataService#updateWorkflowDef} so the create/update {@link
+     * org.conductoross.conductor.core.listener.MetadataChangeListener} events fire correctly.
+     * {@code createTime} itself no longer needs juggling here — {@link
+     * MetadataService#updateWorkflowDef} preserves it on update.
      */
     private void upsertWorkflowDef(WorkflowDef def) {
-        Optional<WorkflowDef> existing =
-                metadataDAO.getWorkflowDef(def.getName(), def.getVersion());
-        if (existing.isPresent()) {
-            // Older direct-DAO deployments have no create time; repair it on their next deploy.
-            if (existing.get().getCreateTime() == 0) {
-                def.setCreateTime(System.currentTimeMillis());
-            } else {
-                def.setCreateTime(existing.get().getCreateTime());
-            }
+        if (metadataDAO.getWorkflowDef(def.getName(), def.getVersion()).isPresent()) {
             metadataService.updateWorkflowDef(def);
         } else {
             metadataService.registerWorkflowDef(def);

--- a/core/src/main/java/com/netflix/conductor/service/MetadataServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/MetadataServiceImpl.java
@@ -124,6 +124,12 @@ public class MetadataServiceImpl implements MetadataService {
      * @param workflowDef Workflow definition to be updated
      */
     public void updateWorkflowDef(WorkflowDef workflowDef) {
+        long createTime =
+                metadataDAO
+                        .getWorkflowDef(workflowDef.getName(), workflowDef.getVersion())
+                        .map(WorkflowDef::getCreateTime)
+                        .orElse(0L);
+        workflowDef.setCreateTime(createTime == 0 ? System.currentTimeMillis() : createTime);
         workflowDef.setUpdateTime(System.currentTimeMillis());
         metadataDAO.updateWorkflowDef(workflowDef);
         metadataChangeListener.onWorkflowDefUpdated(workflowDef);

--- a/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
@@ -332,6 +332,36 @@ public class MetadataServiceTest {
         verify(metadataDAO, times(1)).updateWorkflowDef(workflowDef);
     }
 
+    @Test
+    public void testUpdateWorkflowDefPreservesCreateTime() {
+        String workflowName = "another-workflow";
+        WorkflowDef workflowDef = new WorkflowDef();
+        workflowDef.setName(workflowName);
+        workflowDef.setOwnerEmail("sample@test.com");
+        List<WorkflowTask> tasks = new ArrayList<>();
+        WorkflowTask workflowTask = new WorkflowTask();
+        workflowTask.setTaskReferenceName("hello");
+        workflowTask.setName("hello");
+        tasks.add(workflowTask);
+        workflowDef.setTasks(tasks);
+
+        metadataService.registerWorkflowDef(workflowDef);
+        long originalCreateTime = workflowDef.getCreateTime();
+        assertTrue(originalCreateTime > 0);
+        when(metadataDAO.getWorkflowDef(workflowName, workflowDef.getVersion()))
+                .thenReturn(Optional.of(workflowDef));
+
+        WorkflowDef updated = new WorkflowDef();
+        updated.setName(workflowName);
+        updated.setVersion(workflowDef.getVersion());
+        updated.setOwnerEmail("sample@test.com");
+        updated.setTasks(tasks);
+        updated.setCreateTime(999L); // caller attempts to overwrite createTime
+        metadataService.updateWorkflowDef(Collections.singletonList(updated));
+
+        assertEquals(originalCreateTime, updated.getCreateTime().longValue());
+    }
+
     @Test(expected = ConstraintViolationException.class)
     public void testUpdateWorkflowDefWithCaseExpression() {
         WorkflowDef workflowDef = new WorkflowDef();

--- a/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/AgentSpanDeploymentContractEndToEndTest.java
+++ b/test-harness/src/test/java/com/netflix/conductor/test/integration/agent/AgentSpanDeploymentContractEndToEndTest.java
@@ -42,6 +42,7 @@ import org.conductoross.conductor.ai.agentspan.runtime.service.AgentService;
 import org.conductoross.conductor.common.metadata.agent.AgentConfig;
 import org.conductoross.conductor.common.metadata.agent.AgentStartRequest;
 import org.conductoross.conductor.common.metadata.agent.AgentStartResponse;
+import org.conductoross.conductor.common.metadata.agent.AgentSummary;
 import org.conductoross.conductor.common.metadata.agent.CallbackConfig;
 import org.conductoross.conductor.common.metadata.agent.CompileResponse;
 import org.conductoross.conductor.common.metadata.agent.CreateTrackingWorkflowRequest;
@@ -525,6 +526,52 @@ class AgentSpanDeploymentContractEndToEndTest {
         assertFalse(workflow.getInput().containsKey("credentials"));
         assertFalse(workflow.getInput().containsKey("SHOULD_NOT_BE_WORKFLOW_INPUT"));
         assertTrue(first.getRequiredWorkers().contains(statefulTool));
+    }
+
+    @Test
+    void deployStampsCreateTimeAndRedeployPreservesIt() {
+        String agent = "createtime_agent_" + UUID.randomUUID().toString().replace('-', '_');
+
+        agentService.deploy(
+                AgentStartRequest.builder()
+                        .agentConfig(
+                                AgentConfig.builder()
+                                        .name(agent)
+                                        .model("openai/gpt-4o-mini")
+                                        .build())
+                        .build());
+
+        long firstCreateTime = createTimeOf(agent);
+        assertTrue(firstCreateTime > 0);
+
+        // Redeploy the same agent (same name -> same version, per AgentCompiler) with a real
+        // change, and confirm createTime is carried forward rather than reset.
+        agentService.deploy(
+                AgentStartRequest.builder()
+                        .agentConfig(
+                                AgentConfig.builder()
+                                        .name(agent)
+                                        .model("openai/gpt-4o-mini")
+                                        .tools(
+                                                List.of(
+                                                        ToolConfig.builder()
+                                                                .name("createtime_tool_" + agent)
+                                                                .description("Added on redeploy")
+                                                                .toolType("worker")
+                                                                .build()))
+                                        .build())
+                        .build());
+
+        assertEquals(firstCreateTime, createTimeOf(agent));
+    }
+
+    private long createTimeOf(String agentName) {
+        return agentService.listAgents().stream()
+                .filter(summary -> agentName.equals(summary.getName()))
+                .findFirst()
+                .map(AgentSummary::getCreateTime)
+                .orElseThrow(
+                        () -> new AssertionError("Agent not found in listAgents(): " + agentName));
     }
 
     @Test


### PR DESCRIPTION
Pull Request Title: fix: preserve createTime on WorkflowDef update in MetadataServiceImpl

Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

### Root cause:

- `MetadataServiceImpl.updateTaskDef()` preserves `createTime` on update
- `MetadataServiceImpl.updateWorkflowDef()` does not: it stamps `updateTime` only and passes the caller-supplied `createTime` directly to the DAO
- Agent definitions are persisted as `WorkflowDef`s — this asymmetry is the direct cause of #4311

### Fix:

- `MetadataServiceImpl.updateWorkflowDef()` fetches the existing `WorkflowDef` via `metadataDAO.getWorkflowDef(name, version)`
- Preserves the stored `createTime` when present, stamps a new value only when unset
- Mirrors the existing `updateTaskDef()` pattern
- Preserves the existing upsert semantics of `updateWorkflowDef` — does not throw when the row is missing, unlike `updateTaskDef`
- `createdBy` is intentionally left unchanged; a related gap was ruled working-as-intended by the maintainer in the closed conductor-oss/conductor#1450
- `AgentService.upsertWorkflowDef()`: removed the now-redundant manual `createTime` merge, superseded by the fix above

Tests added
----

- `MetadataServiceTest.testUpdateWorkflowDefPreservesCreateTime`
    - Registering a `WorkflowDef` stamps `createTime`
    - Updating it with a different caller-supplied value preserves the original
- `AgentSpanDeploymentContractEndToEndTest.deployStampsCreateTimeAndRedeployPreservesIt`
    - Deploying an agent stamps a non-zero `createTime`
    - Redeploying it preserves that value

Alternatives considered
----

- Push the guarantee into all five `MetadataDAO` backends (Redis, Postgres, MySQL, Sqlite, Cassandra)
    - Rejected: `MetadataServiceImpl` is the sole production caller of these DAO methods, so a single fix point is sufficient
    - Would have duplicated the same merge logic five times
- Fix only in `AgentService.upsertWorkflowDef()`
    - Rejected: does not cover other or future callers that bypass `AgentService`
- Merge the Postgres/MySQL `created_on` column into the hydrated object on read
    - Rejected: asymmetric, as Redis/Cassandra/Sqlite have no equivalent column
- Add a dedicated `MetadataDAO` method (e.g. `touchCreateTime`)
    - Rejected: no new capability is needed
