### PR TITLE
fix(ai): a retried LLM chat task should keep its conversation history

### DIFF
--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/ai/AgentChatCompleteTaskMapper.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/ai/AgentChatCompleteTaskMapper.java
@@ -147,6 +147,7 @@ public class AgentChatCompleteTaskMapper extends AIModelTaskMapper<ChatCompletio
             validateRunnableConversation(chatCompletion);
             ensureEndsWithUserMessage(chatCompletion, taskModel);
             ensureJsonOutputUserMessage(chatCompletion);
+            preserveAssembledChatInputOnRetry(taskModel, "messages", "tools");
         } catch (Exception e) {
             if (e instanceof TerminateWorkflowException) {
                 throw (TerminateWorkflowException) e;

--- a/ai/src/main/java/org/conductoross/conductor/ai/tasks/mapper/AIModelTaskMapper.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/tasks/mapper/AIModelTaskMapper.java
@@ -12,6 +12,7 @@
  */
 package org.conductoross.conductor.ai.tasks.mapper;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -179,5 +180,44 @@ public abstract class AIModelTaskMapper<T extends LLMWorkerInput> implements Tas
                 return;
             }
         }
+    }
+
+    /**
+     * Preserves the chat input assembled during initial task mapping when the task is retried.
+     *
+     * <p>A retry copies the previous task input and then resolves the workflow task's input
+     * parameters again. That would replace the assembled conversation and tools with their original
+     * definitions. Removing those parameters from the task's private copy of the definition
+     * prevents that overwrite.
+     *
+     * <p>The workflow task is copied first because its original definition may be shared by later
+     * retries or other tasks in the workflow.
+     *
+     * <p>This method is best-effort: if the copy fails, the original definition is left intact and
+     * a retry will lose the assembled input.
+     */
+    protected void preserveAssembledChatInputOnRetry(TaskModel task, String... assembledKeys) {
+        WorkflowTask sharedDefinition = task.getWorkflowTask();
+        if (sharedDefinition == null || sharedDefinition.getInputParameters() == null) {
+            return;
+        }
+        WorkflowTask taskOwnedDefinition;
+        try {
+            taskOwnedDefinition = objectMapper.convertValue(sharedDefinition, WorkflowTask.class);
+        } catch (IllegalArgumentException e) {
+            log.warn(
+                    "Could not copy the task definition for {} — a retry of this task would fall back"
+                            + " to the static template",
+                    task.getTaskId(),
+                    e);
+            return;
+        }
+        Map<String, Object> inputParameters =
+                new HashMap<>(taskOwnedDefinition.getInputParameters());
+        for (String key : assembledKeys) {
+            inputParameters.remove(key);
+        }
+        taskOwnedDefinition.setInputParameters(inputParameters);
+        task.setWorkflowTask(taskOwnedDefinition);
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/tasks/mapper/ChatCompleteTaskMapper.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/tasks/mapper/ChatCompleteTaskMapper.java
@@ -94,6 +94,7 @@ public class ChatCompleteTaskMapper extends AIModelTaskMapper<ChatCompletion> {
             // calls, and sub-workflow context are still preserved in both cases.
             getHistory(workflowModel, taskModel, chatCompletion);
             updateTaskModel(chatCompletion, taskModel);
+            preserveAssembledChatInputOnRetry(taskModel, "messages", "tools");
 
         } catch (Exception e) {
             if (e instanceof TerminateWorkflowException) {

--- a/ai/src/test/java/org/conductoross/conductor/ai/tasks/mapper/PreserveAssembledChatInputOnRetryTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/tasks/mapper/PreserveAssembledChatInputOnRetryTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.tasks.mapper;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
+import com.netflix.conductor.model.TaskModel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link AIModelTaskMapper#preserveAssembledChatInputOnRetry(TaskModel, String...)}.
+ *
+ * <p>The chat-complete mappers assemble {@code messages}/{@code tools} imperatively (conversation
+ * history, f-string substitution) and write them into the task's {@code inputData}. Retry and rerun
+ * do not re-run the mapper: they copy the task and re-resolve the carried definition's {@code
+ * inputParameters} over it ({@code putAll}), which would overwrite the assembled values with the
+ * definition's static template. Detaching those keys from a task-owned copy of the definition means
+ * re-resolution never produces them, so the attempt's own input survives.
+ */
+class PreserveAssembledChatInputOnRetryTest {
+
+    private final ChatCompleteTaskMapper mapper = new ChatCompleteTaskMapper();
+
+    private static WorkflowTask sharedDefinition() {
+        WorkflowTask def = new WorkflowTask();
+        def.setName("chat");
+        def.setTaskReferenceName("chat_ref");
+        Map<String, Object> params = new HashMap<>();
+        params.put(
+                "messages",
+                List.of(
+                        Map.of("role", "system", "message", "You are helpful."),
+                        Map.of("role", "user", "message", "${workflow.input.question}")));
+        params.put("tools", List.of("calculator"));
+        params.put("llmProvider", "openai");
+        params.put("model", "gpt-4o");
+        def.setInputParameters(params);
+        return def;
+    }
+
+    private static TaskModel mappedTask(WorkflowTask sharedDef) {
+        TaskModel task = new TaskModel();
+        task.setTaskId("task-1");
+        task.setReferenceTaskName("chat_ref");
+        task.setWorkflowTask(sharedDef);
+        // What the mapper assembled imperatively: resolved template + history walked from the
+        // workflow — none of it derivable from the definition.
+        task.getInputData()
+                .put(
+                        "messages",
+                        List.of(
+                                Map.of("role", "system", "message", "You are helpful."),
+                                Map.of("role", "user", "message", "What is the capital of France?"),
+                                Map.of("role", "assistant", "message", "Paris."),
+                                Map.of("role", "user", "message", "And its population?")));
+        task.getInputData().put("tools", List.of("calculator"));
+        task.getInputData().put("llmProvider", "openai");
+        task.getInputData().put("model", "gpt-4o");
+        return task;
+    }
+
+    /** Replicates WorkflowExecutorOps#taskToBeRescheduled's input handling exactly. */
+    private static TaskModel simulateRetry(TaskModel task) {
+        TaskModel retried = task.copy();
+        // parametersUtils.getTaskInput resolves the CARRIED definition's inputParameters; for a
+        // template-free map that is the map itself. The point under test is structural: which
+        // keys exist in the resolved map at all.
+        Map<String, Object> resolved =
+                new HashMap<>(retried.getWorkflowTask().getInputParameters());
+        retried.getInputData().putAll(resolved);
+        return retried;
+    }
+
+    @Test
+    void detachReplacesDefinitionWithTaskOwnedCopyLackingAssembledKeys() {
+        WorkflowTask sharedDef = sharedDefinition();
+        TaskModel task = mappedTask(sharedDef);
+
+        mapper.preserveAssembledChatInputOnRetry(task, "messages", "tools");
+
+        assertThat(task.getWorkflowTask()).isNotSameAs(sharedDef);
+        assertThat(task.getWorkflowTask().getInputParameters())
+                .doesNotContainKeys("messages", "tools")
+                .containsKeys("llmProvider", "model");
+        // The assembled input itself is untouched.
+        assertThat((List<?>) task.getInputData().get("messages")).hasSize(4);
+    }
+
+    @Test
+    void sharedCachedDefinitionIsNeverMutated() {
+        WorkflowTask sharedDef = sharedDefinition();
+        TaskModel task = mappedTask(sharedDef);
+
+        mapper.preserveAssembledChatInputOnRetry(task, "messages", "tools");
+
+        // The instance from the cached WorkflowDef — read by every execution and every DO_WHILE
+        // iteration — must keep its template.
+        assertThat(sharedDef.getInputParameters()).containsKeys("messages", "tools");
+    }
+
+    @Test
+    void retryPreservesTheAssembledConversation() {
+        WorkflowTask sharedDef = sharedDefinition();
+        TaskModel task = mappedTask(sharedDef);
+        mapper.preserveAssembledChatInputOnRetry(task, "messages", "tools");
+
+        TaskModel retried = simulateRetry(task);
+
+        // The 4-message assembled conversation survives; the static 2-message template never
+        // enters the resolved input.
+        assertThat((List<?>) retried.getInputData().get("messages")).hasSize(4);
+        assertThat(retried.getInputData().get("tools")).isEqualTo(List.of("calculator"));
+        // Declarative keys are still re-resolved as before.
+        assertThat(retried.getInputData()).containsEntry("llmProvider", "openai");
+    }
+
+    @Test
+    void withoutDetachRetryClobbersHistory_documentsTheBug() {
+        WorkflowTask sharedDef = sharedDefinition();
+        TaskModel task = mappedTask(sharedDef);
+        // No detach: this is the pre-fix behaviour.
+
+        TaskModel retried = simulateRetry(task);
+
+        // The assembled 4-message conversation is overwritten by the 2-message static template.
+        assertThat((List<?>) retried.getInputData().get("messages")).hasSize(2);
+    }
+
+    @Test
+    void templatePatternsInsideConversationContentAreNeverReInterpreted() {
+        WorkflowTask sharedDef = sharedDefinition();
+        TaskModel task = mappedTask(sharedDef);
+        // A conversation turn whose content contains template-like syntax (very common in
+        // code-generation chats). It must survive retry verbatim — which is guaranteed
+        // structurally, because detached keys never pass through the resolver at all.
+        task.getInputData()
+                .put(
+                        "messages",
+                        List.of(
+                                Map.of(
+                                        "role", "assistant",
+                                        "message", "Use `${workflow.input.secret}` as the key.")));
+        mapper.preserveAssembledChatInputOnRetry(task, "messages", "tools");
+
+        TaskModel retried = simulateRetry(task);
+
+        assertThat(retried.getWorkflowTask().getInputParameters()).doesNotContainKey("messages");
+        List<?> messages = (List<?>) retried.getInputData().get("messages");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> only = (Map<String, Object>) messages.get(0);
+        assertThat(only.get("message")).isEqualTo("Use `${workflow.input.secret}` as the key.");
+    }
+
+    @Test
+    void noOpWhenDefinitionDoesNotDeclareAssembledKeys() {
+        WorkflowTask sharedDef = sharedDefinition();
+        sharedDef.getInputParameters().remove("messages");
+        sharedDef.getInputParameters().remove("tools");
+        TaskModel task = mappedTask(sharedDef);
+
+        mapper.preserveAssembledChatInputOnRetry(task, "messages", "tools");
+
+        // Nothing to remove, so the task's definition is unchanged in content and the shared
+        // instance is left alone.
+        assertThat(task.getWorkflowTask().getInputParameters())
+                .doesNotContainKeys("messages", "tools")
+                .containsEntry("llmProvider", "openai")
+                .containsEntry("model", "gpt-4o");
+        assertThat(sharedDef.getInputParameters()).doesNotContainKeys("messages", "tools");
+    }
+
+    @Test
+    void nullDefinitionAndNullParametersAreTolerated() {
+        TaskModel task = new TaskModel();
+        task.setTaskId("task-2");
+        mapper.preserveAssembledChatInputOnRetry(task, "messages");
+
+        WorkflowTask def = new WorkflowTask();
+        def.setInputParameters(null);
+        task.setWorkflowTask(def);
+        mapper.preserveAssembledChatInputOnRetry(task, "messages");
+
+        assertThat(task.getWorkflowTask()).isSameAs(def);
+    }
+}

--- a/test-harness/src/test/groovy/com/netflix/conductor/test/integration/LlmChatRetryContextSpec.groovy
+++ b/test-harness/src/test/groovy/com/netflix/conductor/test/integration/LlmChatRetryContextSpec.groovy
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.test.integration
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.TestPropertySource
+
+import com.netflix.conductor.common.metadata.tasks.TaskDef
+import com.netflix.conductor.common.metadata.tasks.TaskResult
+import com.netflix.conductor.common.metadata.tasks.TaskType
+import com.netflix.conductor.common.metadata.workflow.WorkflowDef
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask
+import com.netflix.conductor.core.dal.ExecutionDAOFacade
+import com.netflix.conductor.model.TaskModel
+import com.netflix.conductor.model.WorkflowModel
+import com.netflix.conductor.test.base.AbstractSpecification
+
+import groovy.json.JsonOutput
+
+/**
+ * <p>Conversation history is not carried by {@code ${...}} references. The LLM_CHAT_COMPLETE task
+ * mapper reconstructs it at scheduling time by walking the workflow's completed tasks. Retry is a
+ * different code path — it copies the task and re-resolves the carried definition's
+ * inputParameters over it (WorkflowExecutorOps#taskToBeRescheduled) — so it can hand the model a
+ * bare template with none of the tool exchanges that already happened. The model, seeing what
+ * looks like a new request, re-issues a tool call it has already made.
+ */
+@TestPropertySource(properties = ["conductor.integrations.ai.enabled=true"])
+class LlmChatRetryContextSpec extends AbstractSpecification {
+
+    private static final String CHAT_WORKFLOW = 'retry_llm_chat_context'
+    private static final String TOOL_WORKFLOW = 'retry_tool_input_control'
+
+    private static final String CUSTOMER_TOOL = 'lookup_customer'
+    private static final String WEATHER_TOOL = 'fetch_weather'
+    private static final String CHAT_REF = 'chat'
+
+    private static final String SYSTEM_MESSAGE = 'Answer using the customer lookup you already ran.'
+    private static final String USER_MESSAGE = "What's the weather where customer 4471 lives?"
+
+    /** Distinctive token from the tool result. Asserting on it proves the ACTUAL prior exchange
+     * was preserved — a merely tool-shaped message would say nothing about which call it describes. */
+    private static final String TOOL_RESULT_MARKER = 'Seattle'
+
+    @Autowired
+    ExecutionDAOFacade executionDAOFacade
+
+    def setup() {
+        registerTaskDef(TaskType.LLM_CHAT_COMPLETE.name())
+        registerTaskDef(CUSTOMER_TOOL)
+        registerTaskDef(WEATHER_TOOL)
+        metadataService.registerWorkflowDef(chatWorkflowDefinition())
+        metadataService.registerWorkflowDef(toolWorkflowDefinition())
+    }
+
+    def cleanup() {
+        unregister(CHAT_WORKFLOW)
+        unregister(TOOL_WORKFLOW)
+    }
+
+    def "a retried LLM chat task keeps its assembled conversation"() {
+        given: "a chat task scheduled after a tool call has already completed"
+        String workflowId = startWorkflow(CHAT_WORKFLOW, 1, 'retry-llm-chat-context', [:], null)
+        workflowTestUtil.pollAndCompleteTask(CUSTOMER_TOOL, 'worker',
+                [customer_id: '4471', name: 'Jane Doe', city: TOOL_RESULT_MARKER])
+
+        TaskModel firstAttempt = awaitChatAttempt(workflowId, 0)
+
+        and: "the fresh dispatch did receive the tool exchange — the behaviour a retry must match"
+        List<Map<String, Object>> assembled = messages(firstAttempt)
+        assert roles(assembled) != ['system', 'user']
+        assert hasToolExchange(assembled)
+
+        and: "the keys are dropped from the task's own copy, not from the shared definition"
+        WorkflowTask runtimeTemplate = workflowModel(workflowId)
+                .workflowDefinition
+                .getTaskByRefName(CHAT_REF)
+        assert runtimeTemplate.inputParameters.messages*.message == [SYSTEM_MESSAGE, USER_MESSAGE]
+        assert runtimeTemplate.inputParameters.tools*.name == [CUSTOMER_TOOL]
+        assert !firstAttempt.workflowTask.inputParameters.containsKey('messages')
+        assert !firstAttempt.workflowTask.inputParameters.containsKey('tools')
+        assert firstAttempt.inputData.tools*.name == [CUSTOMER_TOOL]
+
+        when: "the chat task fails and the workflow is retried"
+        failIfPending(workflowId, firstAttempt)
+        conditions.eventually {
+            assert workflowModel(workflowId).status == WorkflowModel.Status.FAILED
+        }
+        workflowExecutor.retry(workflowId, false)
+
+        then: "the retried attempt still carries the exchange, not the definition's bare template"
+        TaskModel retried = awaitChatAttempt(workflowId, 1)
+        List<Map<String, Object>> retriedMessages = messages(retried)
+
+        // Structural: some tool exchange survived. Only [system, user] means the retry path
+        // discarded the history the mapper assembled at scheduling time.
+        hasToolExchange(retriedMessages)
+
+        and: "it is the ACTUAL prior exchange, not merely something tool-shaped"
+        String blob = JsonOutput.toJson(retriedMessages)
+        blob.contains(CUSTOMER_TOOL)
+        blob.contains(TOOL_RESULT_MARKER)
+
+        and: "byte-for-byte what the first attempt was dispatched with"
+        retriedMessages == assembled
+
+        and: "the retried attempt carries the stripped definition too, so a second retry also holds"
+        !retried.workflowTask.inputParameters.containsKey('messages')
+        !retried.workflowTask.inputParameters.containsKey('tools')
+    }
+
+    // ── fixtures ─────────────────────────────────────────────────────────────
+
+    private void registerTaskDef(String name) {
+        try {
+            metadataService.registerTaskDef([new TaskDef(name: name, retryCount: 0, timeoutSeconds: 120)])
+        } catch (ignored) {
+            // Shared system task names may already be registered by another AI spec.
+        }
+    }
+
+    private void unregister(String name) {
+        try {
+            metadataService.unregisterWorkflowDef(name, 1)
+        } catch (ignored) {
+            // The definition may already have been removed when setup failed.
+        }
+    }
+
+    /**
+     * The tool runs first; the chat task names it in {@code participants} so the mapper folds its
+     * result into the conversation. The definition's own {@code messages} is the two-entry template
+     * that a retry would otherwise resolve back over the assembled value.
+     */
+    private static WorkflowDef chatWorkflowDefinition() {
+        WorkflowTask tool = new WorkflowTask(
+                name: CUSTOMER_TOOL,
+                taskReferenceName: CUSTOMER_TOOL,
+                type: TaskType.SIMPLE.name(),
+                inputParameters: [customer_id: '4471'])
+
+        WorkflowTask chat = new WorkflowTask(
+                name: TaskType.LLM_CHAT_COMPLETE.name(),
+                taskReferenceName: CHAT_REF,
+                type: TaskType.LLM_CHAT_COMPLETE.name(),
+                inputParameters: [
+                    llmProvider : 'test',
+                    model       : 'test',
+                    messages    : [
+                        [role: 'system', message: SYSTEM_MESSAGE],
+                        [role: 'user', message: USER_MESSAGE]
+                    ],
+                    tools       : [
+                        [name: CUSTOMER_TOOL, type: 'SIMPLE', description: 'Look up a customer.']
+                    ],
+                    participants: [(CUSTOMER_TOOL): 'user']
+                ])
+
+        return new WorkflowDef(
+                name: CHAT_WORKFLOW,
+                version: 1,
+                schemaVersion: 2,
+                ownerEmail: 'test@conductor.test',
+                tasks: [tool, chat])
+    }
+
+    private static WorkflowDef toolWorkflowDefinition() {
+        WorkflowTask weather = new WorkflowTask(
+                name: WEATHER_TOOL,
+                taskReferenceName: WEATHER_TOOL,
+                type: TaskType.SIMPLE.name(),
+                inputParameters: [city: '${workflow.input.city}'])
+
+        return new WorkflowDef(
+                name: TOOL_WORKFLOW,
+                version: 1,
+                schemaVersion: 2,
+                ownerEmail: 'test@conductor.test',
+                tasks: [weather])
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private WorkflowModel workflowModel(String workflowId, boolean includeTasks = false) {
+        return executionDAOFacade.getWorkflowModel(workflowId, includeTasks)
+    }
+
+    private TaskModel awaitChatAttempt(String workflowId, int retryCount) {
+        return awaitTaskAttempt(workflowId, CHAT_REF, retryCount)
+    }
+
+    /** Identity comes from retryCount, never from the input: the failed attempt still holds the
+     * assembled conversation, so selecting "the task whose messages have history" would find it
+     * every time and pass against a broken server. */
+    private TaskModel awaitTaskAttempt(String workflowId, String refName, int retryCount) {
+        TaskModel found
+        conditions.eventually {
+            found = workflowModel(workflowId, true).tasks.find {
+                it.referenceTaskName == refName && it.retryCount == retryCount
+            }
+            assert found != null
+            assert found.inputData
+        }
+        return found
+    }
+
+    /** The chat task is a system task and may already have failed on its own (no LLM provider is
+     * configured here). Only fail it explicitly if it is still pending. */
+    private void failIfPending(String workflowId, TaskModel task) {
+        TaskModel current = workflowModel(workflowId, true).tasks.find { it.taskId == task.taskId }
+        if (current == null || current.status.terminal) {
+            return
+        }
+        workflowExecutor.updateTask(new TaskResult(
+                taskId: task.taskId,
+                workflowInstanceId: workflowId,
+                status: TaskResult.Status.FAILED_WITH_TERMINAL_ERROR,
+                reasonForIncompletion: 'intentional retry regression failure'))
+    }
+
+    @SuppressWarnings('unchecked')
+    private static List<Map<String, Object>> messages(TaskModel task) {
+        return (task.inputData.messages ?: []) as List<Map<String, Object>>
+    }
+
+    private static List<String> roles(List<Map<String, Object>> messages) {
+        return messages*.role*.toString()
+    }
+
+    private static boolean hasToolExchange(List<Map<String, Object>> messages) {
+        return messages.any { it.toolCalls || it.role?.toString()?.toLowerCase() in ['tool', 'tool_call'] }
+    }
+}


### PR DESCRIPTION
## The bug

Retrying an `LLM_CHAT_COMPLETE` task in an agent workflow loses the entire conversation. The retried attempt sees only the static `[system, user]` template from the workflow definition, not the history the first attempt had.

## Why it happens

Conversation history is never expressed as a `${...}` reference in the workflow definition. `AgentChatCompleteTaskMapper` assembles it **imperatively in Java** at scheduling time — walking the workflow's completed tasks, extracting tool results, condensing if the context window demands it — and writes the result into the task's `inputData`.

Retry doesn't re-run the mapper. It copies the task and re-resolves the *definition*:

```java
TaskModel taskToBeRetried = task.copy();              // history is here...
taskToBeRetried.getInputData().putAll(taskInput);     // ...and clobbered by re-resolving
                                                      //    the definition's inputParameters
```

Since the definition's `inputParameters` contain only the static template, `putAll` overwrites the assembled conversation with it. The history existed solely in the first attempt's `inputData`, and that's what gets replaced.

## Fix
The mapper strips `messages` and `tools` from the task's own copy of the definition before it's persisted, so at retry time `getWorkflowTask().getInputParameters()` doesn't have them, the re-resolved `taskInput` in `taskToBeRescheduled()` doesn't have them, and `putAll` can't overwrite the assembled values which is the root cause of this bug.

`AIModelTaskMapper#detachAssembledInputFromDefinition(TaskModel, String... keys)`, shared by both chat-complete mappers.

## Testing
- groovy test
- It is covered in https://github.com/conductor-oss/python-sdk/pull/462. Verified in the local environment before the test PR is merged.
