### PR TITLE
fix(ui): open API Docs in new tab and navigate back (#1316)

### DIFF
--- a/ui-next/src/pages/apiDocs/ApiReferencePage.tsx
+++ b/ui-next/src/pages/apiDocs/ApiReferencePage.tsx
@@ -1,20 +1,23 @@
-/**
- * API Reference Page
- *
- * Redirects to the Swagger UI for API documentation.
- * This is a simple redirect component that opens the Swagger UI in the current window.
- */
-
 import { useEffect } from "react";
+import { useNavigate, useLocation } from "react-router";
 import { Box, CircularProgress, Typography } from "@mui/material";
 
 const getSwaggerUrl = () =>
   `//${window.location.host}/swagger-ui/index.html?configUrl=/api-docs/swagger-config#/`;
 
 export default function ApiReferencePage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
   useEffect(() => {
-    // Redirect to Swagger UI
-    window.location.href = getSwaggerUrl();
+    window.open(getSwaggerUrl(), "_blank", "noopener,noreferrer");
+    // Go back to wherever the user was; fall back to home on a fresh load.
+    if (location.key === "default") {
+      navigate("/");
+    } else {
+      navigate(-1);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (


### PR DESCRIPTION
Fixes #1316

API Docs was redirecting the current tab to Swagger, so pressing browser back reloaded the same page and immediately redirected again — stuck spinner forever.

Now opens Swagger in a new tab and navigates back in the SPA so the spinner page is never visited.