### PR TITLE
Prebuild OSS UI

### DIFF
--- a/ui-next/.gitignore
+++ b/ui-next/.gitignore
@@ -10,6 +10,9 @@ dist
 build
 storybook-static
 
+# Marker written by build:lib:watch (detected by enterprise conductor-ui)
+.lib-watch
+
 # Test / Playwright
 /test-results/
 /playwright-report/

--- a/ui-next/package.json
+++ b/ui-next/package.json
@@ -3,13 +3,17 @@
   "version": "0.0.0",
   "description": "Open Source Conductor UI - Core components, pages, and plugin infrastructure",
   "type": "module",
-  "main": "./dist/conductor-ui.js",
-  "module": "./dist/conductor-ui.js",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/conductor-ui.js",
+      "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./*": {
+      "import": "./dist/*.js",
+      "types": "./dist/*.d.ts"
     },
     "./styles.css": "./dist/style.css",
     "./global.css": "./dist/global.css"
@@ -20,7 +24,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "build:lib": "vite build --mode lib && cp src/index.css dist/global.css",
+    "build:lib": "node scripts/clear-lib-watch.mjs && vite build --mode lib && tsc --emitDeclarationOnly --outDir dist --declaration --rootDir src --noEmit false && cp src/index.css dist/global.css",
+    "build:lib:watch": "node scripts/build-lib-watch.mjs",
     "build:all": "vite build && vite build --mode lib",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",

--- a/ui-next/scripts/build-lib-watch.mjs
+++ b/ui-next/scripts/build-lib-watch.mjs
@@ -1,0 +1,57 @@
+/**
+ * Wraps `vite build --mode lib --watch` and writes a `.lib-watch` marker so
+ * enterprise conductor-ui can detect that OSS dist/ is being live-rebuilt.
+ */
+import { spawn } from "child_process";
+import { existsSync, unlinkSync, writeFileSync } from "fs";
+import { createRequire } from "module";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageDir = resolve(__dirname, "..");
+const markerPath = resolve(packageDir, ".lib-watch");
+
+const require = createRequire(import.meta.url);
+const viteBin = resolve(
+  dirname(require.resolve("vite/package.json")),
+  "bin/vite.js",
+);
+
+writeFileSync(markerPath, `${process.pid}\n`, "utf8");
+
+const cleanup = () => {
+  try {
+    if (existsSync(markerPath)) unlinkSync(markerPath);
+  } catch {
+    // ignore
+  }
+};
+
+const exitWithCleanup = (code = 0) => {
+  cleanup();
+  process.exit(code);
+};
+
+process.on("SIGINT", () => exitWithCleanup(130));
+process.on("SIGTERM", () => exitWithCleanup(143));
+process.on("exit", cleanup);
+
+const child = spawn(
+  process.execPath,
+  [viteBin, "build", "--mode", "lib", "--watch"],
+  {
+    cwd: packageDir,
+    stdio: "inherit",
+    env: process.env,
+  },
+);
+
+child.on("exit", (code, signal) => {
+  cleanup();
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});

--- a/ui-next/scripts/clear-lib-watch.mjs
+++ b/ui-next/scripts/clear-lib-watch.mjs
@@ -1,0 +1,16 @@
+/**
+ * Removes a stale `.lib-watch` marker left by build:lib:watch.
+ * Run at the start of one-shot `build:lib` so enterprise doesn't think watch is active.
+ */
+import { existsSync, unlinkSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const markerPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../.lib-watch",
+);
+
+if (existsSync(markerPath)) {
+  unlinkSync(markerPath);
+}

--- a/ui-next/src/pages/execution/AgentExecution/AgentDefinitionView.test.tsx
+++ b/ui-next/src/pages/execution/AgentExecution/AgentDefinitionView.test.tsx
@@ -20,7 +20,9 @@ vi.mock("reaflow", () => ({
         <div key={node.id}>
           {node.data.sublabel && <span>{node.data.sublabel}</span>}
           {node.data.strategy && (
-            <span data-testid={`strategy-${node.id}`}>{node.data.strategy}</span>
+            <span data-testid={`strategy-${node.id}`}>
+              {node.data.strategy}
+            </span>
           )}
           {node.data.maxTurns !== undefined && (
             <span data-testid={`turns-${node.id}`}>
@@ -116,7 +118,9 @@ describe("AgentDefinitionDiagram — strategy / maxTurns visibility", () => {
       />,
     );
 
-    expect(screen.getByTestId("strategy-agent")).toHaveTextContent("sequential");
+    expect(screen.getByTestId("strategy-agent")).toHaveTextContent(
+      "sequential",
+    );
     expect(screen.getByTestId("turns-agent")).toHaveTextContent("10 turns");
   });
 
@@ -142,7 +146,9 @@ describe("AgentDefinitionDiagram — strategy / maxTurns visibility", () => {
     );
 
     // Coordinator root: strategy and turns shown
-    expect(screen.getByTestId("strategy-agent")).toHaveTextContent("sequential");
+    expect(screen.getByTestId("strategy-agent")).toHaveTextContent(
+      "sequential",
+    );
     expect(screen.getByTestId("turns-agent")).toHaveTextContent("5 turns");
 
     // Leaf sub-agent: strategy and turns suppressed

--- a/ui-next/vite.config.ts
+++ b/ui-next/vite.config.ts
@@ -91,6 +91,10 @@ export default defineConfig(({ mode }) => {
         // Without this, Vite emits asset references like "/assets/logo-xxxx.svg"
         // which only resolve within the OSS app's own build output.
         assetsInlineLimit: Infinity,
+        // Vite strips CSS imports out of the emitted JS, so per-chunk CSS would
+        // be orphaned — nothing in dist/ imports it. Collect it into one
+        // dist/style.css that consumers import via "conductor-ui/styles.css".
+        cssCodeSplit: false,
         rollupOptions: {
           input,
           external: isExternal,
@@ -101,6 +105,12 @@ export default defineConfig(({ mode }) => {
             preserveModules: true,
             preserveModulesRoot: "src",
             entryFileNames: "[name].js",
+            assetFileNames: (asset) => {
+              const name = asset.names?.[0] ?? "";
+              return name.endsWith(".css")
+                ? "style.css"
+                : "assets/[name]-[hash][extname]";
+            },
           },
         },
         sourcemap: true,

--- a/ui-next/vite.config.ts
+++ b/ui-next/vite.config.ts
@@ -1,7 +1,7 @@
 import react from "@vitejs/plugin-react";
 import { createHash } from "crypto";
-import { globSync } from "fs";
-import { dirname, resolve } from "path";
+import { readdirSync } from "fs";
+import { dirname, resolve, sep } from "path";
 import { fileURLToPath } from "url";
 import { defineConfig, loadEnv, Plugin } from "vite";
 import svgr from "vite-plugin-svgr";
@@ -40,18 +40,21 @@ export default defineConfig(({ mode }) => {
   // directory structure so enterprise can consume pre-built dist/ files via
   // deep imports (e.g. "conductor-ui/pages/definition/...").
   if (mode === "lib") {
-    const srcFiles = globSync("src/**/*.{ts,tsx}", {
-      cwd: __dirname,
-      exclude: (f) =>
-        f.includes(".test.") ||
-        f.includes(".spec.") ||
-        f.endsWith("setupTests.ts"),
-    });
+    const srcDir = resolve(__dirname, "src");
+    const srcFiles = readdirSync(srcDir, { recursive: true })
+      .map((entry) => entry.toString().split(sep).join("/"))
+      .filter(
+        (file) =>
+          /\.tsx?$/.test(file) &&
+          !file.includes(".test.") &&
+          !file.includes(".spec.") &&
+          !file.endsWith("setupTests.ts"),
+      );
 
     const input = Object.fromEntries(
       srcFiles.map((file) => [
-        file.replace(/^src\//, "").replace(/\.[^.]+$/, ""),
-        resolve(__dirname, file),
+        file.replace(/\.[^.]+$/, ""),
+        resolve(srcDir, file),
       ]),
     );
 

--- a/ui-next/vite.config.ts
+++ b/ui-next/vite.config.ts
@@ -1,5 +1,6 @@
 import react from "@vitejs/plugin-react";
 import { createHash } from "crypto";
+import { globSync } from "fs";
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 import { defineConfig, loadEnv, Plugin } from "vite";
@@ -35,27 +36,68 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, packageDir);
   const BASE_URL = env.VITE_PUBLIC_URL || "/";
 
-  // Library build mode - creates npm package
-  // Note: Type declarations (dts) disabled due to compatibility issues
-  // Run `tsc --emitDeclarationOnly` separately if needed
+  // Library build mode — emits individual ES modules preserving the src/
+  // directory structure so enterprise can consume pre-built dist/ files via
+  // deep imports (e.g. "conductor-ui/pages/definition/...").
   if (mode === "lib") {
+    const srcFiles = globSync("src/**/*.{ts,tsx}", {
+      cwd: __dirname,
+      exclude: (f) =>
+        f.includes(".test.") ||
+        f.includes(".spec.") ||
+        f.endsWith("setupTests.ts"),
+    });
+
+    const input = Object.fromEntries(
+      srcFiles.map((file) => [
+        file.replace(/^src\//, "").replace(/\.[^.]+$/, ""),
+        resolve(__dirname, file),
+      ]),
+    );
+
+    // Bare-import roots from tsconfig paths — these resolve into src/ and
+    // must NOT be externalized.  Everything else (node_modules) is external.
+    const tsconfigPathRoots = [
+      "commonServices",
+      "components",
+      "growthbook",
+      "images",
+      "pages",
+      "plugins",
+      "queryClient",
+      "shared",
+      "templates",
+      "testData",
+      "theme",
+      "types",
+      "useArrowNavigation",
+      "utils",
+    ];
+
+    const isExternal = (id: string) => {
+      if (id.startsWith(".") || id.startsWith("/")) return false;
+      if (tsconfigPathRoots.some((r) => id === r || id.startsWith(`${r}/`)))
+        return false;
+      return true;
+    };
+
     return {
       plugins: [react(), tsconfigPaths(), svgr()],
       build: {
-        lib: {
-          entry: resolve(__dirname, "src/index.ts"),
-          name: "ConductorUI",
-          fileName: "conductor-ui",
-          formats: ["es"] as const,
-        },
+        // Inline all assets as data URIs so the lib output is self-contained.
+        // Without this, Vite emits asset references like "/assets/logo-xxxx.svg"
+        // which only resolve within the OSS app's own build output.
+        assetsInlineLimit: Infinity,
         rollupOptions: {
-          external: isLibPeerExternal,
+          input,
+          external: isExternal,
+          preserveEntrySignatures: "allow-extension",
           output: {
-            globals: {
-              react: "React",
-              "react-dom": "ReactDOM",
-              "react-router-dom": "ReactRouterDOM",
-            },
+            dir: "dist",
+            format: "es" as const,
+            preserveModules: true,
+            preserveModulesRoot: "src",
+            entryFileNames: "[name].js",
           },
         },
         sourcemap: true,


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

conductor-ui-branch: feature/prebuild-oss-ui

Changes in this PR
----
- Change ui-next build:lib from a single bundled conductor-ui.js to a preserveModules ES build that mirrors src/, so enterprise conductor-ui can resolve deep imports from pre-built dist/ instead of transforming ~1,200 OSS TSX files on every start/build (high memory).
- Emit .d.ts as part of build:lib, and add package exports for deep paths (./*).
- Add build:lib:watch with a .lib-watch marker so enterprise can detect a live OSS rebuild and pick up dist/ changes while developing.