### PR TITLE
Fix/agent execution diagram fixes

### DIFF
--- a/ui-next/src/pages/execution/AgentExecution/AgentExecutionDiagram.tsx
+++ b/ui-next/src/pages/execution/AgentExecution/AgentExecutionDiagram.tsx
@@ -1513,6 +1513,8 @@ interface AgentExecutionDiagramProps {
   selectedId: string | null;
   onNodeSelect: (id: string | null, node: DetailNodeData | null) => void;
   onDrillIn?: (sub: AgentRunData) => void;
+  /** Fetch a collapsed sub-agent's own execution and expand it in place (issue #1452). */
+  onExpand?: (sub: AgentRunData) => void;
   onBack?: () => void;
 }
 

--- a/ui-next/src/pages/execution/AgentExecution/AgentExecutionDiagram.tsx
+++ b/ui-next/src/pages/execution/AgentExecution/AgentExecutionDiagram.tsx
@@ -131,6 +131,11 @@ interface DiagramNodeData {
   event?: AgentEvent;
   subAgentRun?: AgentRunData;
   nextTurn?: string;
+  /** For "subagent" kind: own sub-agent count/expansion state (issue #1452) */
+  subAgentCount?: number;
+  expanded?: boolean;
+  expanding?: boolean;
+  expandError?: boolean;
   /** For group nodes */
   groupType?: "agents" | "tools";
   groupAgents?: AgentRunData[];
@@ -232,6 +237,7 @@ function NodeCard({
   selected,
   onSelect,
   onDrillIn,
+  onExpand,
   onBack,
   onToggleGroup,
 }: {
@@ -241,6 +247,7 @@ function NodeCard({
   selected: boolean;
   onSelect: () => void;
   onDrillIn?: (r: AgentRunData) => void;
+  onExpand?: (r: AgentRunData) => void;
   onBack?: () => void;
   onToggleGroup?: () => void;
 }) {
@@ -736,25 +743,58 @@ function NodeCard({
 
         {/* "View execution" drill-in for sub-agents */}
         {data.kind === "subagent" && data.subAgentRun && (
-          <div
-            onClick={(e) => {
-              e.stopPropagation();
-              onDrillIn?.(data.subAgentRun!);
-            }}
-            style={{
-              marginTop: 6,
-              display: "inline-flex",
-              alignItems: "center",
-              gap: 4,
-              padding: "3px 10px",
-              borderRadius: "5px",
-              backgroundColor: "#4969e4",
-              cursor: "pointer",
-              fontSize: "0.78em",
-              color: "white",
-            }}
-          >
-            View execution <ArrowRight size={10} />
+          <div style={{ display: "flex", gap: 6, marginTop: 6 }}>
+            <div
+              onClick={(e) => {
+                e.stopPropagation();
+                onDrillIn?.(data.subAgentRun!);
+              }}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 4,
+                padding: "3px 10px",
+                borderRadius: "5px",
+                backgroundColor: "#4969e4",
+                cursor: "pointer",
+                fontSize: "0.78em",
+                color: "white",
+              }}
+            >
+              View execution <ArrowRight size={10} />
+            </div>
+
+            {/* Expand in place — reveals this agent's own sub-agents inline
+                instead of navigating away (issue #1452). Only shown when the
+                definition says this agent actually has children. */}
+            {!data.expanded &&
+              !!data.subAgentCount &&
+              data.subAgentCount > 0 && (
+                <div
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (!data.expanding) onExpand?.(data.subAgentRun!);
+                  }}
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 4,
+                    padding: "3px 10px",
+                    borderRadius: "5px",
+                    backgroundColor: data.expandError ? "#fef2f2" : "#f3f4f6",
+                    border: data.expandError ? "1px solid #fca5a5" : "none",
+                    cursor: data.expanding ? "default" : "pointer",
+                    fontSize: "0.78em",
+                    color: data.expandError ? "#b91c1c" : "#374151",
+                  }}
+                >
+                  {data.expanding
+                    ? "Loading…"
+                    : data.expandError
+                      ? "Retry expand"
+                      : `Expand (${data.subAgentCount})`}
+                </div>
+              )}
           </div>
         )}
 
@@ -792,8 +832,15 @@ function NodeCard({
 
 // ─── Reaflow node wrapper ─────────────────────────────────────────────────────
 const DiagramNode = (nodeProps: any) => {
-  const { selectedId, onSelect, onDrillIn, onBack, onToggleGroup, properties } =
-    nodeProps;
+  const {
+    selectedId,
+    onSelect,
+    onDrillIn,
+    onExpand,
+    onBack,
+    onToggleGroup,
+    properties,
+  } = nodeProps;
   const data: DiagramNodeData = properties?.data;
   return (
     <Node
@@ -816,6 +863,7 @@ const DiagramNode = (nodeProps: any) => {
               selected={selectedId === properties?.id}
               onSelect={() => onSelect(properties?.id)}
               onDrillIn={onDrillIn}
+              onExpand={onExpand}
               onBack={onBack}
               onToggleGroup={
                 onToggleGroup ? () => onToggleGroup(properties?.id) : undefined
@@ -848,6 +896,7 @@ function buildTurnNodes(
   done: Set<string>,
   prevRef: { id: string },
   expandedGroups: Set<string>,
+  idPrefix = "",
 ) {
   const push = (id: string, data: DiagramNodeData, h = H) => {
     nodes.push({ id, width: W, height: h, data });
@@ -988,7 +1037,22 @@ function buildTurnNodes(
       strategy: sub.strategy,
       ts: toTS(sub.status),
       subAgentRun: sub,
+      subAgentCount: sub.subAgentCount,
+      expanded: sub.expanded,
+      expanding: sub.expanding,
+      expandError: sub.expandError,
     });
+    if (sub.expanded && sub.turns.length > 0) {
+      appendAgentRunTurns(
+        sub,
+        nodes,
+        edges,
+        done,
+        prevRef,
+        expandedGroups,
+        `${idPrefix}${sub.id}-`,
+      );
+    }
     for (const ev of turn.events) {
       if (
         ev.type === EventType.GUARDRAIL_PASS ||
@@ -1274,10 +1338,16 @@ function buildTurnNodes(
 
   // Sub-agents: single node if one; inline if < threshold; collapsed group if >= threshold
   if (turn.subAgents.length > 0) {
-    const subGroupId = `subgroup-${timelineItemId(turn)}`;
+    const subGroupId = `${idPrefix}subgroup-${timelineItemId(turn)}`;
     const isSubExpanded = expandedGroups.has(subGroupId);
 
     if (turn.subAgents.length < COLLAPSE_THRESHOLD || isSubExpanded) {
+      // NOTE: parallel siblings intentionally don't get subAgentCount/expand
+      // here — expanding a branch inline would need pushParallel's fork/join
+      // layout to support a multi-node chain per branch, which is out of
+      // scope for this pass. Only single-sub-agent turns (below) expand
+      // in place; a parallel sibling with its own children still needs
+      // "View execution" (drill-in) to inspect them.
       const makeSubBranch = (sub: AgentRunData) => ({
         id: `sub-${sub.id}`,
         data: {
@@ -1328,7 +1398,22 @@ function buildTurnNodes(
           strategy: sub.strategy,
           ts: toTS(sub.status),
           subAgentRun: sub,
+          subAgentCount: sub.subAgentCount,
+          expanded: sub.expanded,
+          expanding: sub.expanding,
+          expandError: sub.expandError,
         });
+        if (sub.expanded && sub.turns.length > 0) {
+          appendAgentRunTurns(
+            sub,
+            nodes,
+            edges,
+            done,
+            prevRef,
+            expandedGroups,
+            `${idPrefix}${sub.id}-`,
+          );
+        }
       } else {
         pushParallel(
           `${subGroupId}-fork`,
@@ -1362,6 +1447,59 @@ function buildTurnNodes(
         ts,
       });
     }
+  }
+}
+
+/**
+ * Lay out an agent run's own turn sequence, continuing the chain from
+ * `prevRef`. Shared by the top-level diagram build and by expanding a
+ * collapsed sub-agent node in place (issue #1452) — `idPrefix` keeps node
+ * ids from a nested agent's own turns/groups from colliding with a sibling
+ * or ancestor's turns of the same number (e.g. two different agents both
+ * having a "Turn 1").
+ */
+function appendAgentRunTurns(
+  agentRun: AgentRunData,
+  nodes: NodeData<DiagramNodeData>[],
+  edges: EdgeData[],
+  done: Set<string>,
+  prevRef: { id: string },
+  expandedGroups: Set<string>,
+  idPrefix: string,
+) {
+  const allTurns = agentRun.turns;
+  for (let i = 0; i < allTurns.length; i++) {
+    const turn = allTurns[i];
+
+    // Insert orange "Turn N" separator before every turn after the first
+    if (i > 0) {
+      const turnId = timelineItemId(turn);
+      const ntId = `${idPrefix}turn-sep-${turnId}`;
+      nodes.push({
+        id: ntId,
+        width: 72,
+        height: 72,
+        data: {
+          kind: "next",
+          label: timelineItemLabel(turn),
+          nextTurn: `${idPrefix}${turnId}`,
+          ts: toTS(turn.status),
+        },
+      });
+      const fromPort = prevRef.id.endsWith("-join")
+        ? `${prevRef.id}-south-port`
+        : undefined;
+      edges.push({
+        id: `${prevRef.id}→${ntId}`,
+        from: prevRef.id,
+        to: ntId,
+        ...(fromPort ? { fromPort } : {}),
+      });
+      if (turn.status === AgentStatus.COMPLETED) done.add(ntId);
+      prevRef.id = ntId;
+    }
+
+    buildTurnNodes(turn, nodes, edges, done, prevRef, expandedGroups, idPrefix);
   }
 }
 
@@ -1403,40 +1541,15 @@ function buildDiagram(
   });
   if (agentRun.status === AgentStatus.COMPLETED) done.add("start");
 
-  const allTurns = agentRun.turns;
-  for (let i = 0; i < allTurns.length; i++) {
-    const turn = allTurns[i];
-
-    // Insert orange "Turn N" separator before every turn after the first
-    if (i > 0) {
-      const turnId = timelineItemId(turn);
-      const ntId = `turn-sep-${turnId}`;
-      nodes.push({
-        id: ntId,
-        width: 72,
-        height: 72,
-        data: {
-          kind: "next",
-          label: timelineItemLabel(turn),
-          nextTurn: turnId,
-          ts: toTS(turn.status),
-        },
-      });
-      const fromPort = prevRef.id.endsWith("-join")
-        ? `${prevRef.id}-south-port`
-        : undefined;
-      edges.push({
-        id: `${prevRef.id}→${ntId}`,
-        from: prevRef.id,
-        to: ntId,
-        ...(fromPort ? { fromPort } : {}),
-      });
-      if (turn.status === AgentStatus.COMPLETED) done.add(ntId);
-      prevRef.id = ntId;
-    }
-
-    buildTurnNodes(turn, nodes, edges, done, prevRef, expandedGroups);
-  }
+  appendAgentRunTurns(
+    agentRun,
+    nodes,
+    edges,
+    done,
+    prevRef,
+    expandedGroups,
+    "",
+  );
 
   return { nodes, edges, done };
 }
@@ -1525,6 +1638,7 @@ export function AgentExecutionDiagram({
   selectedId,
   onNodeSelect,
   onDrillIn,
+  onExpand,
   onBack,
 }: AgentExecutionDiagramProps) {
   const hasBack = !!onBack;
@@ -1892,6 +2006,7 @@ export function AgentExecutionDiagram({
               selectedId={selectedId}
               onSelect={handle}
               onDrillIn={onDrillIn}
+              onExpand={onExpand}
               onBack={onBack}
               onToggleGroup={toggleGroup}
             />

--- a/ui-next/src/pages/execution/AgentExecution/AgentExecutionTab.tsx
+++ b/ui-next/src/pages/execution/AgentExecution/AgentExecutionTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import { usePushHistory } from "utils/hooks/usePushHistory";
 import { AGENT_EXECUTIONS_URL } from "utils/constants/route";
 import { Box, MenuItem, Select, SelectChangeEvent, Alert } from "@mui/material";
@@ -6,6 +6,7 @@ import { AgentExecutionHeader } from "./AgentExecutionHeader";
 import { AgentRunView } from "./AgentRunView";
 import {
   computeMetrics,
+  replaceAgentRunNode,
   transformWorkflowExecutionToAgentRun,
 } from "./agentExecutionUtils";
 import {
@@ -49,7 +50,7 @@ export function AgentExecutionTab({ execution }: AgentExecutionTabProps) {
     DEFAULT_MOCK_SCENARIO,
   );
 
-  const { rootRun, transformError } = useMemo(() => {
+  const { rootRun: baseRun, transformError } = useMemo(() => {
     if (execution?.workflowId) {
       try {
         return {
@@ -82,6 +83,57 @@ export function AgentExecutionTab({ execution }: AgentExecutionTabProps) {
     }
     return { rootRun: MOCK_SCENARIOS[scenario], transformError: null };
   }, [execution?.workflowId, execution?.tasks, scenario]);
+
+  // Sub-agent nodes start as shallow stubs (their own execution hasn't been
+  // fetched yet). `rootRun` holds the tree as progressively expanded in
+  // place — see handleExpandSubAgent — and resets whenever a genuinely new
+  // execution/scenario loads.
+  const [rootRun, setRootRun] = useState<AgentRunData>(baseRun);
+  useEffect(() => {
+    setRootRun(baseRun);
+  }, [baseRun]);
+
+  // Fetch a collapsed sub-agent's own execution and splice its real
+  // turns/subAgents into the tree in place, instead of navigating away like
+  // "drill in" does. Fixes #1452: nested sub-agents beyond one level were
+  // never drawn because that data was never fetched at all.
+  const handleExpandSubAgent = useCallback(async (sub: AgentRunData) => {
+    if (!sub.subWorkflowId || sub.expanded || sub.expanding) return;
+    setRootRun((prev) =>
+      replaceAgentRunNode(prev, sub.id, (node) => ({
+        ...node,
+        expanding: true,
+        expandError: false,
+      })),
+    );
+    try {
+      const res = await fetch(
+        `/api/agent/executions/${sub.subWorkflowId}/full`,
+      );
+      if (!res.ok) throw new Error(`request failed with ${res.status}`);
+      const subExecution: WorkflowExecution = await res.json();
+      const expanded = transformWorkflowExecutionToAgentRun(subExecution);
+      setRootRun((prev) =>
+        replaceAgentRunNode(prev, sub.id, (node) => ({
+          ...node,
+          turns: expanded.turns,
+          agentDef: node.agentDef ?? expanded.agentDef,
+          model: node.model ?? expanded.model,
+          expanded: true,
+          expanding: false,
+        })),
+      );
+    } catch (err) {
+      console.error("[AgentExecution] Failed to expand sub-agent:", err);
+      setRootRun((prev) =>
+        replaceAgentRunNode(prev, sub.id, (node) => ({
+          ...node,
+          expanding: false,
+          expandError: true,
+        })),
+      );
+    }
+  }, []);
 
   const navigate = usePushHistory();
 
@@ -209,6 +261,7 @@ export function AgentExecutionTab({ execution }: AgentExecutionTabProps) {
         <AgentRunView
           agentRun={rootRun}
           onDrillIn={onDrillIn}
+          onExpand={handleExpandSubAgent}
           onBack={onBack}
           isRoot
         />

--- a/ui-next/src/pages/execution/AgentExecution/AgentRunView.tsx
+++ b/ui-next/src/pages/execution/AgentExecution/AgentRunView.tsx
@@ -29,6 +29,8 @@ import { TurnDetail } from "./TurnDetail";
 interface AgentRunViewProps {
   agentRun: AgentRunData;
   onDrillIn: (subAgentRun: AgentRunData) => void;
+  /** Fetch a collapsed sub-agent's own execution and expand it in place (issue #1452). */
+  onExpand?: (subAgentRun: AgentRunData) => void;
   onBack?: () => void;
   isRoot?: boolean;
 }
@@ -305,6 +307,7 @@ function AgentRunHeader({
 export function AgentRunView({
   agentRun,
   onDrillIn,
+  onExpand,
   onBack,
   isRoot,
 }: AgentRunViewProps) {
@@ -580,6 +583,7 @@ export function AgentRunView({
               selectedId={selectedId}
               onNodeSelect={handleNodeSelect}
               onDrillIn={onDrillIn}
+              onExpand={onExpand}
               onBack={onBack}
             />
           ) : (
@@ -594,7 +598,11 @@ export function AgentRunView({
               }}
             >
               {activeTurnData && (
-                <TurnDetail turn={activeTurnData} onDrillIn={onDrillIn} />
+                <TurnDetail
+                  turn={activeTurnData}
+                  onDrillIn={onDrillIn}
+                  onExpand={onExpand}
+                />
               )}
             </Box>
           )}

--- a/ui-next/src/pages/execution/AgentExecution/SubAgentTree.tsx
+++ b/ui-next/src/pages/execution/AgentExecution/SubAgentTree.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Box, Chip, Collapse, IconButton, Typography } from "@mui/material";
 import {
   ArrowRight,
@@ -19,6 +19,8 @@ interface SubAgentTreeProps {
   subAgents: AgentRunData[];
   strategy?: AgentStrategy;
   onDrillIn: (agentRun: AgentRunData) => void;
+  /** Fetch a collapsed sub-agent's own execution and expand it in place (issue #1452). */
+  onExpand?: (agentRun: AgentRunData) => void;
   depth?: number;
 }
 
@@ -44,10 +46,16 @@ const OUTPUT_PREVIEW_LINES = 4;
 interface SubAgentNodeProps {
   agent: AgentRunData;
   onDrillIn: (run: AgentRunData) => void;
+  onExpand?: (run: AgentRunData) => void;
   depth: number;
 }
 
-function SubAgentNode({ agent, onDrillIn, depth }: SubAgentNodeProps) {
+function SubAgentNode({
+  agent,
+  onDrillIn,
+  onExpand,
+  depth,
+}: SubAgentNodeProps) {
   const [outputExpanded, setOutputExpanded] = useState(false);
   const [childrenExpanded, setChildrenExpanded] = useState(false);
 
@@ -56,6 +64,16 @@ function SubAgentNode({ agent, onDrillIn, depth }: SubAgentNodeProps) {
   const hasOutput = !!agent.output;
   const hasFailure =
     !!agent.failureReason && agent.status === AgentStatus.FAILED;
+  // Definition says this agent has its own children, but that execution
+  // hasn't been fetched yet — show an "Expand" control instead of the caret
+  // toggle (issue #1452: nested sub-agents beyond one level were invisible).
+  const canExpand = !hasChildren && !agent.expanded && !!agent.subAgentCount;
+
+  // Auto-reveal once the fetch completes, so the user doesn't have to click
+  // the caret toggle separately right after clicking "Expand".
+  useEffect(() => {
+    if (agent.expanded) setChildrenExpanded(true);
+  }, [agent.expanded]);
 
   const indent = depth * 16;
 
@@ -147,6 +165,35 @@ function SubAgentNode({ agent, onDrillIn, depth }: SubAgentNodeProps) {
           </IconButton>
         )}
 
+        {/* Expand in place — fetches this sub-agent's own execution instead
+            of navigating away, revealing its children (issue #1452). */}
+        {canExpand && (
+          <Box
+            onClick={() => {
+              if (!agent.expanding) onExpand?.(agent);
+            }}
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 0.5,
+              px: 1,
+              py: 0.25,
+              borderRadius: 1,
+              fontSize: "0.7rem",
+              color: agent.expandError ? "#d32f2f" : "text.secondary",
+              backgroundColor: agent.expandError ? "#ffebee" : "grey.100",
+              cursor: agent.expanding ? "default" : "pointer",
+              flexShrink: 0,
+            }}
+          >
+            {agent.expanding
+              ? "Loading…"
+              : agent.expandError
+                ? "Retry expand"
+                : `Expand (${agent.subAgentCount})`}
+          </Box>
+        )}
+
         {/* Drill-in */}
         <IconButton
           size="small"
@@ -229,6 +276,7 @@ function SubAgentNode({ agent, onDrillIn, depth }: SubAgentNodeProps) {
             <SubAgentTree
               subAgents={allSubAgents}
               onDrillIn={onDrillIn}
+              onExpand={onExpand}
               depth={depth + 1}
             />
           </Box>
@@ -242,6 +290,7 @@ export function SubAgentTree({
   subAgents,
   strategy,
   onDrillIn,
+  onExpand,
   depth = 0,
 }: SubAgentTreeProps) {
   if (subAgents.length === 0) return null;
@@ -385,6 +434,7 @@ export function SubAgentTree({
           key={agent.id}
           agent={agent}
           onDrillIn={onDrillIn}
+          onExpand={onExpand}
           depth={depth}
         />
       ))}

--- a/ui-next/src/pages/execution/AgentExecution/TurnDetail.tsx
+++ b/ui-next/src/pages/execution/AgentExecution/TurnDetail.tsx
@@ -11,6 +11,8 @@ import { SubAgentTree } from "./SubAgentTree";
 interface TurnDetailProps {
   turn: AgentTurn;
   onDrillIn: (agentRun: AgentRunData) => void;
+  /** Fetch a collapsed sub-agent's own execution and expand it in place (issue #1452). */
+  onExpand?: (agentRun: AgentRunData) => void;
 }
 
 export function TurnDetail({ turn, onDrillIn }: TurnDetailProps) {

--- a/ui-next/src/pages/execution/AgentExecution/TurnDetail.tsx
+++ b/ui-next/src/pages/execution/AgentExecution/TurnDetail.tsx
@@ -15,7 +15,7 @@ interface TurnDetailProps {
   onExpand?: (agentRun: AgentRunData) => void;
 }
 
-export function TurnDetail({ turn, onDrillIn }: TurnDetailProps) {
+export function TurnDetail({ turn, onDrillIn, onExpand }: TurnDetailProps) {
   return (
     <Box>
       {/* Header bar */}
@@ -64,6 +64,7 @@ export function TurnDetail({ turn, onDrillIn }: TurnDetailProps) {
             subAgents={turn.subAgents}
             strategy={turn.strategy}
             onDrillIn={onDrillIn}
+            onExpand={onExpand}
           />
         </Box>
       )}

--- a/ui-next/src/pages/execution/AgentExecution/agentExecutionUtils.test.ts
+++ b/ui-next/src/pages/execution/AgentExecution/agentExecutionUtils.test.ts
@@ -4,11 +4,17 @@ import {
   computeMetrics,
   isFailedTaskStatus,
   mapTaskStatus,
+  replaceAgentRunNode,
   taskSuccess,
   timelineItemKind,
   transformWorkflowExecutionToAgentRun,
 } from "./agentExecutionUtils";
-import { AgentStatus, AgentStrategy, AgentTimelineKind } from "./types";
+import {
+  AgentRunData,
+  AgentStatus,
+  AgentStrategy,
+  AgentTimelineKind,
+} from "./types";
 
 function task(overrides: Record<string, unknown>) {
   return {
@@ -408,6 +414,10 @@ describe("transformWorkflowExecutionToAgentRun timeline", () => {
       .find((sub) => sub.agentName === "researcher");
 
     expect(researcher?.strategy).toBe(AgentStrategy.ROUTER);
+    // Regression coverage for issue #1452: the Execution diagram needs this
+    // count to know a collapsed sub-agent has its own children worth
+    // expanding, even before that sub-agent's own execution has been fetched.
+    expect(researcher?.subAgentCount).toBe(2);
   });
 
   it("shows no strategy for a leaf sub-agent (no nested agents of its own)", () => {
@@ -443,6 +453,7 @@ describe("transformWorkflowExecutionToAgentRun timeline", () => {
       .find((sub) => sub.agentName === "writer");
 
     expect(writer?.strategy).toBeUndefined();
+    expect(writer?.subAgentCount).toBeUndefined();
   });
 
   it("derives the root agent's own strategy from its definition, not the runtime shape", () => {
@@ -471,5 +482,121 @@ describe("transformWorkflowExecutionToAgentRun timeline", () => {
     );
 
     expect(run.strategy).toBe(AgentStrategy.ROUTER);
+  });
+});
+
+// Regression coverage for issue #1452: the Execution diagram only ever
+// rendered one level of a sub-agent tree because the underlying AgentRunData
+// for a sub-agent was a shallow stub — its own execution was never fetched
+// unless the user fully navigated away via "drill in". replaceAgentRunNode
+// is the pure tree-update primitive that splices a freshly-fetched
+// sub-agent's real turns/subAgents into the existing tree in place, which is
+// what makes lazy expand-in-place possible.
+describe("replaceAgentRunNode", () => {
+  function leaf(id: string): AgentRunData {
+    return {
+      id,
+      agentName: id,
+      turns: [],
+      status: AgentStatus.COMPLETED,
+      totalTokens: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+      totalDurationMs: 0,
+    };
+  }
+
+  function withChild(root: AgentRunData, child: AgentRunData): AgentRunData {
+    return {
+      ...root,
+      turns: [
+        {
+          turnNumber: 1,
+          status: AgentStatus.COMPLETED,
+          durationMs: 0,
+          tokens: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+          subAgents: [child],
+          events: [],
+        },
+      ],
+    };
+  }
+
+  it("replaces a top-level sub-agent with the updater's result", () => {
+    const root = withChild(leaf("root"), leaf("child"));
+
+    const updated = replaceAgentRunNode(root, "child", (node) => ({
+      ...node,
+      expanded: true,
+      turns: [
+        {
+          turnNumber: 1,
+          status: AgentStatus.COMPLETED,
+          durationMs: 0,
+          tokens: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+          subAgents: [leaf("grandchild")],
+          events: [],
+        },
+      ],
+    }));
+
+    const updatedChild = updated.turns[0].subAgents[0];
+    expect(updatedChild.expanded).toBe(true);
+    expect(updatedChild.turns[0].subAgents[0].id).toBe("grandchild");
+  });
+
+  it("finds and replaces a deeply nested sub-agent, several levels down", () => {
+    const grandchild = leaf("grandchild");
+    const child = withChild(leaf("child"), grandchild);
+    const root = withChild(leaf("root"), child);
+
+    const updated = replaceAgentRunNode(root, "grandchild", (node) => ({
+      ...node,
+      expanded: true,
+    }));
+
+    const updatedGrandchild =
+      updated.turns[0].subAgents[0].turns[0].subAgents[0];
+    expect(updatedGrandchild.expanded).toBe(true);
+  });
+
+  it("replaces the root itself when targetId matches the root's own id", () => {
+    const root = leaf("root");
+    const updated = replaceAgentRunNode(root, "root", (node) => ({
+      ...node,
+      expanded: true,
+    }));
+    expect(updated.expanded).toBe(true);
+  });
+
+  it("returns the same reference untouched when targetId isn't found", () => {
+    const root = withChild(leaf("root"), leaf("child"));
+    const updated = replaceAgentRunNode(root, "nonexistent", (node) => ({
+      ...node,
+      expanded: true,
+    }));
+    expect(updated).toBe(root);
+  });
+
+  it("leaves sibling branches referentially unchanged (no unnecessary re-renders)", () => {
+    const untouchedSibling = leaf("sibling");
+    const root: AgentRunData = {
+      ...leaf("root"),
+      turns: [
+        {
+          turnNumber: 1,
+          status: AgentStatus.COMPLETED,
+          durationMs: 0,
+          tokens: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+          subAgents: [leaf("target"), untouchedSibling],
+          events: [],
+        },
+      ],
+    };
+
+    const updated = replaceAgentRunNode(root, "target", (node) => ({
+      ...node,
+      expanded: true,
+    }));
+
+    expect(updated.turns[0].subAgents[1]).toBe(untouchedSibling);
   });
 });

--- a/ui-next/src/pages/execution/AgentExecution/agentExecutionUtils.ts
+++ b/ui-next/src/pages/execution/AgentExecution/agentExecutionUtils.ts
@@ -436,6 +436,23 @@ function parseAgentStrategy(raw: unknown): AgentStrategy | undefined {
     : undefined;
 }
 
+/** Recursively visits every agent definition node (root + agentDef.agents[], depth-first). */
+function walkAgentDefTree(
+  agentDef: Record<string, unknown> | undefined,
+  visit: (
+    def: Record<string, unknown>,
+    children: Array<Record<string, unknown>>,
+  ) => void,
+): void {
+  if (!agentDef) return;
+  const children =
+    (agentDef.agents as Array<Record<string, unknown>> | undefined) ?? [];
+  visit(agentDef, children);
+  for (const child of children) {
+    walkAgentDefTree(child, visit);
+  }
+}
+
 /**
  * Recursively index each agent definition's OWN strategy by name, mirroring how
  * the Definition tab walks agentDef.agents[]. Only agents that actually have
@@ -444,19 +461,14 @@ function parseAgentStrategy(raw: unknown): AgentStrategy | undefined {
  */
 function indexAgentDefStrategies(
   agentDef: Record<string, unknown> | undefined,
-  index: Map<string, AgentStrategy> = new Map(),
 ): Map<string, AgentStrategy> {
-  if (!agentDef) return index;
-  const children =
-    (agentDef.agents as Array<Record<string, unknown>> | undefined) ?? [];
-  if (children.length > 0) {
-    const name = agentDef.name as string | undefined;
-    const strategy = parseAgentStrategy(agentDef.strategy);
+  const index = new Map<string, AgentStrategy>();
+  walkAgentDefTree(agentDef, (def, children) => {
+    if (children.length === 0) return;
+    const name = def.name as string | undefined;
+    const strategy = parseAgentStrategy(def.strategy);
     if (name && strategy) index.set(name.toLowerCase(), strategy);
-  }
-  for (const child of children) {
-    indexAgentDefStrategies(child, index);
-  }
+  });
   return index;
 }
 
@@ -465,6 +477,66 @@ function lookupOwnStrategy(
   name: string | undefined,
 ): AgentStrategy | undefined {
   return name ? index.get(name.toLowerCase()) : undefined;
+}
+
+/**
+ * Recursively index each agent definition's own direct sub-agent COUNT by name.
+ * Unlike the strategy index, this only needs one level of children to know
+ * whether an agent orchestrates anything — used to show an "Expand" control
+ * on a collapsed sub-agent node before its own execution has been fetched
+ * (issue #1452: nested sub-agents beyond one level were never drawn).
+ */
+function indexAgentDefChildCounts(
+  agentDef: Record<string, unknown> | undefined,
+): Map<string, number> {
+  const index = new Map<string, number>();
+  walkAgentDefTree(agentDef, (def, children) => {
+    const name = def.name as string | undefined;
+    if (name && children.length > 0)
+      index.set(name.toLowerCase(), children.length);
+  });
+  return index;
+}
+
+function lookupChildCount(
+  index: Map<string, number>,
+  name: string | undefined,
+): number | undefined {
+  return name ? index.get(name.toLowerCase()) : undefined;
+}
+
+/**
+ * Recursively locate the sub-agent run with the given id anywhere in the tree
+ * and return a new tree with that node replaced by `updater(node)`. Used to
+ * splice a freshly-fetched sub-agent's real turns/subAgents into the existing
+ * tree in place when the user expands a collapsed node (issue #1452), without
+ * navigating away like "drill in" does.
+ *
+ * Returns the original reference untouched when `targetId` isn't found so
+ * callers can no-op cheaply (e.g. React state updates that don't need to
+ * re-render when nothing changed).
+ */
+export function replaceAgentRunNode(
+  root: AgentRunData,
+  targetId: string,
+  updater: (node: AgentRunData) => AgentRunData,
+): AgentRunData {
+  if (root.id === targetId) return updater(root);
+
+  let rootChanged = false;
+  const turns = root.turns.map((turn) => {
+    let turnChanged = false;
+    const subAgents = turn.subAgents.map((sub) => {
+      const updated = replaceAgentRunNode(sub, targetId, updater);
+      if (updated !== sub) turnChanged = true;
+      return updated;
+    });
+    if (!turnChanged) return turn;
+    rootChanged = true;
+    return { ...turn, subAgents };
+  });
+
+  return rootChanged ? { ...root, turns } : root;
 }
 
 /**
@@ -508,11 +580,11 @@ function transformChainWorkflowToAgentRun(
   // Grab the per-step agent configs from the definition metadata for gate label info
   const agentsDef = ((execution.workflowDefinition?.metadata?.agentDef as any)
     ?.agents ?? []) as Array<Record<string, unknown>>;
-  const strategyIndex = indexAgentDefStrategies(
-    execution.workflowDefinition?.metadata?.agentDef as
-      | Record<string, unknown>
-      | undefined,
-  );
+  const chainAgentDef = execution.workflowDefinition?.metadata?.agentDef as
+    | Record<string, unknown>
+    | undefined;
+  const strategyIndex = indexAgentDefStrategies(chainAgentDef);
+  const childCountIndex = indexAgentDefChildCounts(chainAgentDef);
 
   const turns: AgentTurn[] = sortedSteps.map(
     ([stepN, task], idx): AgentTurn => {
@@ -558,6 +630,7 @@ function transformChainWorkflowToAgentRun(
         totalTokens: ZERO_TOKENS,
         totalDurationMs: durationMs,
         strategy: lookupOwnStrategy(strategyIndex, agentName),
+        subAgentCount: lookupChildCount(childCountIndex, agentName),
         agentType: task.inputData?.agentType as string | undefined,
         invocationStrategy: AgentStrategy.SEQUENTIAL,
         input: task.inputData?.workflowInput ?? task.inputData,
@@ -717,6 +790,7 @@ export function transformWorkflowExecutionToAgentRun(
     | Record<string, unknown>
     | undefined;
   const strategyIndex = indexAgentDefStrategies(agentDefMeta);
+  const childCountIndex = indexAgentDefChildCounts(agentDefMeta);
   const guardrailFnNames = new Set<string>();
   for (const gList of [
     (agentDefMeta?.input_guardrails as
@@ -917,6 +991,7 @@ export function transformWorkflowExecutionToAgentRun(
             totalTokens: ZERO_TOKENS,
             totalDurationMs: durationMs,
             strategy: lookupOwnStrategy(strategyIndex, agentName),
+            subAgentCount: lookupChildCount(childCountIndex, agentName),
             agentType: task.inputData?.agentType as string | undefined,
             invocationStrategy: AgentStrategy.HANDOFF,
             input: agentInput,
@@ -1354,6 +1429,7 @@ export function transformWorkflowExecutionToAgentRun(
       totalDurationMs: dur,
       agentType: task.inputData?.agentType as string | undefined,
       strategy: lookupOwnStrategy(strategyIndex, agentName),
+      subAgentCount: lookupChildCount(childCountIndex, agentName),
       invocationStrategy:
         rootSubWorkflows.length > 1
           ? AgentStrategy.PARALLEL

--- a/ui-next/src/pages/execution/AgentExecution/types.ts
+++ b/ui-next/src/pages/execution/AgentExecution/types.ts
@@ -160,6 +160,18 @@ export interface AgentRunData {
   failureReason?: string;
   /** Agent definition from workflow.definition.metadata.agentDef */
   agentDef?: Record<string, unknown>;
+  /**
+   * Number of this agent's own direct sub-agents, known from its definition
+   * even before its execution has been fetched. Drives the "Expand" control
+   * on collapsed sub-agent nodes in the Execution tab (issue #1452).
+   */
+  subAgentCount?: number;
+  /** True once this sub-agent's own execution has been fetched and its real turns/subAgents are populated in place. */
+  expanded?: boolean;
+  /** True while a fetch for this sub-agent's own execution is in flight. */
+  expanding?: boolean;
+  /** True if the last attempt to fetch this sub-agent's own execution failed. */
+  expandError?: boolean;
 }
 
 export interface ExecutionMetrics {


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

The Agent Execution diagram only ever rendered one level of a sub-agent
tree — a sub-agent's own execution was never fetched, only referenced.
`ztest_15rou` (router → parallel) showed "2 sub-agents" but drew nothing,
because that data simply hadn't been fetched yet.

Fix: sub-agent nodes that have children (per their own agent definition)
now show an **Expand** control. Clicking it fetches that sub-agent's own
execution (the same endpoint "drill in" already uses) and splices its
real turns/sub-agents into the diagram in place — no navigation away.
Works recursively, so a 3-level tree expands level by level.

Issue #1452

## Screenshots

### Before — collapsed, 4 of 9 nodes visible, no way to see the rest
<img width="1400" height="900" alt="1-before-collapsed" src="https://github.com/user-attachments/assets/6613af50-7800-4d43-89ea-f29b73d8e5bf" />

### After — first Expand click reveals level 2
<img width="1400" height="1800" alt="2-after-first-expand" src="https://github.com/user-attachments/assets/a1ecbfe4-818e-4de7-a3d4-38db4ff86709" />

### After — second Expand click, full 9-node tree, AGENTS count 4→9
<img width="1400" height="2400" alt="3-after-full-tree" src="https://github.com/user-attachments/assets/3e52fc95-4d3b-4a4e-a159-3db7b4573a62" />

## Test plan
- `tsc --noEmit`, `eslint`, `prettier --check` — all clean
- Full suite: 738 passing
- New regression tests for the tree-splice helper and child-count indexing
- Manually verified against a reconstructed 3-level tree matching the
  reported repro (sequential → router → parallel)

Alternatives considered
----

Considered eagerly fetching and rendering the entire tree on load instead
of lazy expand-on-click. Rejected: a wide/deep agent swarm could mean
dozens of parallel network calls up front for a tree the user may never
fully open. Lazy expand-on-click (the option this issue itself proposed)
fetches only what's actually opened.
