### PR TITLE
changed pop messages to preserve priority first

### DIFF
--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresQueueDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresQueueDAO.java
@@ -141,7 +141,7 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
         final String SQL =
                 "SELECT message_id FROM queue_message "
                         + "WHERE queue_name = ? AND popped = false "
-                        + "ORDER BY deliver_on, priority DESC, created_on LIMIT ?";
+                        + "ORDER BY priority DESC, deliver_on, created_on LIMIT ?";
         return queryWithTransaction(
                 SQL,
                 q -> q.addParameter(queueName).addParameter(count).executeScalarList(String.class));
@@ -489,7 +489,7 @@ public class PostgresQueueDAO extends PostgresBaseDAO implements QueueDAO {
                         + "    WHERE queue_name = ? "
                         + "      AND popped = false "
                         + "      AND deliver_on <= (current_timestamp + (1000 || ' microseconds')::interval) "
-                        + "    ORDER BY deliver_on, priority DESC, created_on "
+                        + "    ORDER BY priority DESC, deliver_on, created_on "
                         + "    LIMIT ? "
                         + "    FOR UPDATE SKIP LOCKED "
                         + ") "


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Additionl information
---
Persistance: postgres
Lock: Redis

Changes in this PR
----

The bugfix https://github.com/conductor-oss/conductor/pull/515 was wrong. It affects sub-workflows a lot. The priority is used exactly to run quickly sub-workflows.
Changing ordering back, like it is in other extensions (e.g. mysql-persistence).