### PR TITLE
feat(ui): add agent execution input output tab

### DIFF
--- a/ui-next/src/pages/execution/LeftPanelTabs.test.tsx
+++ b/ui-next/src/pages/execution/LeftPanelTabs.test.tsx
@@ -38,6 +38,7 @@ describe("LeftPanelTabs", () => {
       "Workflow View",
       "Task List",
       "Timeline",
+      "Input/Output",
       "Agent Definition",
       "JSON",
     ]);
@@ -75,6 +76,22 @@ describe("LeftPanelTabs", () => {
     screen.getByRole("tab", { name: "Agent Definition" }).click();
     expect(onChangeExecutionTab).toHaveBeenCalledWith(
       ExecutionTabs.SUMMARY_TAB,
+    );
+  });
+
+  it("opens the existing Input/Output view for an agent execution", () => {
+    const onChangeExecutionTab = vi.fn();
+    render(
+      <LeftPanelTabs
+        execution={agentExecution}
+        openedTab={ExecutionTabs.AGENT_EXECUTION_TAB}
+        onChangeExecutionTab={onChangeExecutionTab}
+      />,
+    );
+
+    screen.getByRole("tab", { name: "Input/Output" }).click();
+    expect(onChangeExecutionTab).toHaveBeenCalledWith(
+      ExecutionTabs.WORKFLOW_INPUT_OUTPUT_TAB,
     );
   });
 });

--- a/ui-next/src/pages/execution/LeftPanelTabs.tsx
+++ b/ui-next/src/pages/execution/LeftPanelTabs.tsx
@@ -33,11 +33,9 @@ export default function LeftPanelTabs({
 
   const isAgentWorkflow = isAgentWorkflowExecution(execution);
 
-  // Agent-classified executions get a curated tab set that matches
-  // Conductor-Agents' UI 1:1: Agent Execution, Workflow View (Diagram, relabeled),
-  // Task List, Timeline, Agent Definition (Summary, relabeled), JSON — no
-  // Workflow Input/Output, Variables, or Tasks to Domain. Regular workflows
-  // keep the full Conductor tab set unchanged.
+  // Agent-classified executions use a focused tab set. Input/Output remains
+  // available because it exposes the submitted prompt and final agent result.
+  // Variables and Tasks to Domain remain workflow-only controls.
   const leftPanelTabItems = isAgentWorkflow
     ? [
         {
@@ -60,6 +58,12 @@ export default function LeftPanelTabs({
           label: "Timeline",
           onClick: () => onChangeExecutionTab(ExecutionTabs.TIMELINE_TAB),
           value: ExecutionTabs.TIMELINE_TAB,
+        },
+        {
+          label: "Input/Output",
+          onClick: () =>
+            onChangeExecutionTab(ExecutionTabs.WORKFLOW_INPUT_OUTPUT_TAB),
+          value: ExecutionTabs.WORKFLOW_INPUT_OUTPUT_TAB,
         },
         {
           label: "Agent Definition",


### PR DESCRIPTION
Pull Request type
----

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

Agent-classified workflow executions now include an **Input/Output** tab directly
after **Timeline**. The tab reuses the existing execution-level Input/Output view,
so users can inspect the submitted prompt/input and final agent result without
searching task details or raw execution JSON.

The change is UI-only: it does not introduce an API, schema, or backend change.
Variables and Tasks to Domain remain excluded from the focused agent tab set.

<img width="1696" height="573" alt="image" src="https://github.com/user-attachments/assets/cd3ac716-f036-4f48-acaf-1ab26125c94d" />

Tests
----

- `pnpm exec vitest run src/pages/execution/LeftPanelTabs.test.tsx`
- `pnpm run typecheck`

Alternatives considered
----

- None

Enterprise UI Playwright Tests
----

No `conductor-ui-branch` override is needed; this change is in the Conductor
`ui-next` source.
