### PR TITLE
fix(ui): Open Agent Definitions from Agent Executions

### DIFF
--- a/ui-next/src/pages/execution/Execution.tsx
+++ b/ui-next/src/pages/execution/Execution.tsx
@@ -34,6 +34,7 @@ import {
 } from "types/Execution";
 import { TaskStatus } from "types/TaskStatus";
 import {
+  AGENT_DEFINITION_URL,
   AGENT_EXECUTIONS_URL,
   WORKFLOW_EXECUTION_URL,
 } from "utils/constants/route";
@@ -87,6 +88,8 @@ const SecondaryActions = ({
   const isDynamic = (
     execution?.input?._systemMetadata as Record<string, unknown>
   )?.dynamic;
+  const isAgentExecution = isAgentWorkflowExecution(execution);
+  const definitionName = execution.workflowType || execution.workflowName || "";
   return (
     execution && (
       <Box
@@ -126,9 +129,13 @@ const SecondaryActions = ({
                 startIcon={<OpenIcon />}
                 sx={{ minWidth: "fit-content" }}
                 component={NavLink as React.ElementType}
-                path={`/workflowDef/${encodeURIComponent(
-                  execution.workflowType || execution.workflowName || "",
-                )}/${execution.workflowVersion}`}
+                path={
+                  isAgentExecution
+                    ? `${AGENT_DEFINITION_URL.BASE}/${encodeURIComponent(
+                        definitionName,
+                      )}/${execution.workflowVersion}`
+                    : `/workflowDef/${encodeURIComponent(definitionName)}/${execution.workflowVersion}`
+                }
               >
                 View definition
               </Button>


### PR DESCRIPTION
Pull Request type
----

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

- Keep the existing View definition label for every execution.
- Agent executions open the matching Agent Definition using the existing Agents list name and version route.
- Standard workflow executions keep the existing workflow definition link.

Tests
----

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

Alternatives considered
----

- Resolve the route from agent metadata. Rejected because the Agents list and execution list already use the executed workflow name and version.
