### PR TITLE
fix: write and compare sqlite index timestamps in UTC (#1497)

### DIFF
--- a/sqlite-persistence/build.gradle
+++ b/sqlite-persistence/build.gradle
@@ -35,4 +35,8 @@ dependencies {
 test {
     //the MySQL unit tests must run within the same JVM to share the same embedded DB
     maxParallelForks = 1
+    // Issue #1497 regression tests need a non-UTC zone to be meaningful; CI runs UTC, where a
+    // local-time/UTC mismatch is invisible. TZ reaches both the forked JVM's default zone and
+    // the native SQLite library's localtime, so they agree.
+    environment 'TZ', 'America/Asuncion'
 }

--- a/sqlite-persistence/build.gradle
+++ b/sqlite-persistence/build.gradle
@@ -38,5 +38,5 @@ test {
     // Issue #1497 regression tests need a non-UTC zone to be meaningful; CI runs UTC, where a
     // local-time/UTC mismatch is invisible. TZ reaches both the forked JVM's default zone and
     // the native SQLite library's localtime, so they agree.
-    environment 'TZ', 'America/Asuncion'
+    environment 'TZ', 'America/Los_Angeles'
 }

--- a/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAO.java
+++ b/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAO.java
@@ -14,8 +14,8 @@ package com.netflix.conductor.sqlite.dao;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.*;
@@ -44,6 +44,12 @@ public class SqliteIndexDAO extends SqliteBaseDAO implements IndexDAO {
 
     private static final int CORE_POOL_SIZE = 6;
     private static final long KEEP_ALIVE_TIME = 1L;
+
+    // Canonical UTC text format for start_time/update_time in the index tables. Matches SQLite's
+    // strftime('%Y-%m-%d %H:%M:%f', ...) byte for byte so migrated and newly written rows compare
+    // correctly (issue #1497).
+    private static final DateTimeFormatter SQLITE_UTC_TIMESTAMP =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneOffset.UTC);
 
     private boolean onlyIndexOnStatusChange;
 
@@ -76,6 +82,17 @@ public class SqliteIndexDAO extends SqliteBaseDAO implements IndexDAO {
                         });
     }
 
+    /**
+     * Renders an ISO-8601 instant as the canonical UTC text stored in the index tables. Matches
+     * SQLite's strftime('%Y-%m-%d %H:%M:%f', ...) byte for byte so migrated and newly written rows
+     * compare correctly. java.sql.Timestamp is deliberately avoided here: its toString() renders in
+     * the JVM default zone, which is what issue #1497 was.
+     */
+    private static String toSqliteUtcTimestamp(String isoInstant) {
+        return SQLITE_UTC_TIMESTAMP.format(
+                Instant.from(DateTimeFormatter.ISO_INSTANT.parse(isoInstant)));
+    }
+
     @Override
     public void indexWorkflow(WorkflowSummary workflow) {
         String INSERT_WORKFLOW_INDEX_SQL =
@@ -91,11 +108,8 @@ public class SqliteIndexDAO extends SqliteBaseDAO implements IndexDAO {
             INSERT_WORKFLOW_INDEX_SQL += " AND workflow_index.status != excluded.status";
         }
 
-        TemporalAccessor updateTa = DateTimeFormatter.ISO_INSTANT.parse(workflow.getUpdateTime());
-        Timestamp updateTime = Timestamp.from(Instant.from(updateTa));
-
-        TemporalAccessor ta = DateTimeFormatter.ISO_INSTANT.parse(workflow.getStartTime());
-        Timestamp startTime = Timestamp.from(Instant.from(ta));
+        String updateTime = toSqliteUtcTimestamp(workflow.getUpdateTime());
+        String startTime = toSqliteUtcTimestamp(workflow.getStartTime());
 
         int rowsUpdated =
                 queryWithTransaction(
@@ -104,8 +118,8 @@ public class SqliteIndexDAO extends SqliteBaseDAO implements IndexDAO {
                                 q.addParameter(workflow.getWorkflowId())
                                         .addParameter(workflow.getCorrelationId())
                                         .addParameter(workflow.getWorkflowType())
-                                        .addParameter(startTime.toString())
-                                        .addParameter(updateTime.toString())
+                                        .addParameter(startTime)
+                                        .addParameter(updateTime)
                                         .addParameter(workflow.getStatus().toString())
                                         .addParameter(
                                                 workflow.getParentWorkflowId() != null
@@ -158,11 +172,8 @@ public class SqliteIndexDAO extends SqliteBaseDAO implements IndexDAO {
             INSERT_TASK_INDEX_SQL += " AND task_index.status != excluded.status";
         }
 
-        TemporalAccessor updateTa = DateTimeFormatter.ISO_INSTANT.parse(task.getUpdateTime());
-        Timestamp updateTime = Timestamp.from(Instant.from(updateTa));
-
-        TemporalAccessor startTa = DateTimeFormatter.ISO_INSTANT.parse(task.getStartTime());
-        Timestamp startTime = Timestamp.from(Instant.from(startTa));
+        String updateTime = toSqliteUtcTimestamp(task.getUpdateTime());
+        String startTime = toSqliteUtcTimestamp(task.getStartTime());
 
         int rowsUpdated =
                 queryWithTransaction(
@@ -172,8 +183,8 @@ public class SqliteIndexDAO extends SqliteBaseDAO implements IndexDAO {
                                         .addParameter(task.getTaskType())
                                         .addParameter(task.getTaskDefName())
                                         .addParameter(task.getStatus().toString())
-                                        .addParameter(startTime.toString())
-                                        .addParameter(updateTime.toString())
+                                        .addParameter(startTime)
+                                        .addParameter(updateTime)
                                         .addParameter(task.getWorkflowType())
                                         .addJsonParameter(task)
                                         .executeUpdate());

--- a/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAO.java
+++ b/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAO.java
@@ -45,9 +45,6 @@ public class SqliteIndexDAO extends SqliteBaseDAO implements IndexDAO {
     private static final int CORE_POOL_SIZE = 6;
     private static final long KEEP_ALIVE_TIME = 1L;
 
-    // Canonical UTC text format for start_time/update_time in the index tables. Matches SQLite's
-    // strftime('%Y-%m-%d %H:%M:%f', ...) byte for byte so migrated and newly written rows compare
-    // correctly (issue #1497).
     private static final DateTimeFormatter SQLITE_UTC_TIMESTAMP =
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneOffset.UTC);
 

--- a/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilder.java
+++ b/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilder.java
@@ -15,7 +15,6 @@ package com.netflix.conductor.sqlite.util;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.regex.Matcher;
@@ -62,6 +61,12 @@ public class SqliteIndexQueryBuilder {
         private List<String> values;
         private final String CONDITION_REGEX = "([a-zA-Z]+)\\s?(=|>|<|IN)\\s?(.*)";
 
+        // Canonical UTC text format the *_time columns are stored in (issue #1497). Must match
+        // SqliteIndexDAO's write-path formatter byte for byte so a bound value compares correctly
+        // against stored text.
+        private static final DateTimeFormatter SQLITE_UTC_TIMESTAMP =
+                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneOffset.UTC);
+
         public Condition() {}
 
         public Condition(String query) {
@@ -103,7 +108,12 @@ public class SqliteIndexQueryBuilder {
                 return "lower(" + attribute + ") LIKE ?";
             } else {
                 if (attribute.endsWith("_time")) {
-                    return attribute + " " + operator + " datetime(?)";
+                    // No datetime() wrapper: it truncates to whole seconds, so
+                    // 'start_time < ?' wrongly excluded a row stored at exactly '...03.000'
+                    // ('...03.000' < '...03' is false -- longer string, same prefix). With
+                    // identical canonical-UTC text on both sides the comparison is exact
+                    // (issue #1497).
+                    return attribute + " " + operator + " ?";
                 } else if (operator.equals("=")
                         && values.size() == 1
                         && values.get(0).contains("*")) {
@@ -151,10 +161,7 @@ public class SqliteIndexQueryBuilder {
         }
 
         private String millisToUtc(String millis) {
-            Long startTimeMilli = Long.parseLong(millis);
-            ZonedDateTime startDate =
-                    ZonedDateTime.ofInstant(Instant.ofEpochMilli(startTimeMilli), ZoneOffset.UTC);
-            return DateTimeFormatter.ISO_DATE_TIME.format(startDate);
+            return SQLITE_UTC_TIMESTAMP.format(Instant.ofEpochMilli(Long.parseLong(millis)));
         }
 
         private boolean isValid() {

--- a/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilder.java
+++ b/sqlite-persistence/src/main/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilder.java
@@ -61,9 +61,7 @@ public class SqliteIndexQueryBuilder {
         private List<String> values;
         private final String CONDITION_REGEX = "([a-zA-Z]+)\\s?(=|>|<|IN)\\s?(.*)";
 
-        // Canonical UTC text format the *_time columns are stored in (issue #1497). Must match
-        // SqliteIndexDAO's write-path formatter byte for byte so a bound value compares correctly
-        // against stored text.
+        /** Must match {@code SqliteIndexDAO}'s write-path format exactly. */
         private static final DateTimeFormatter SQLITE_UTC_TIMESTAMP =
                 DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneOffset.UTC);
 

--- a/sqlite-persistence/src/main/resources/db/migration_sqlite/V6__index_timestamps_to_utc.sql
+++ b/sqlite-persistence/src/main/resources/db/migration_sqlite/V6__index_timestamps_to_utc.sql
@@ -1,27 +1,11 @@
--- Issue #1497: start_time/update_time were written with java.sql.Timestamp.toString(), which
--- renders in the JVM default zone, while searches rendered their bound in UTC. Rewrite existing
--- rows as UTC so both sides agree.
+-- Issue #1497: start_time/update_time were stored in the JVM's local zone while searches used
+-- UTC, so time-range filters missed recent rows. Rewrite both columns in UTC.
 --
--- These columns are derived data: json_data already holds the authoritative instant as an
--- ISO-8601 string with a 'Z' suffix, which SQLite parses natively. So rebuild them from json_data
--- rather than converting the local-time text. No timezone is guessed at any point, which matters
--- more than it looks:
+-- json_data already holds the instant as an ISO-8601 string, so read it from there rather than
+-- converting the stored local text. No timezone is involved.
 --
---   An earlier version of this migration used SQLite's 'utc' modifier to reinterpret the stored
---   local time. That reads the host tz database, while the bad values were written against the
---   *JVM's bundled* tz database -- and the two disagree whenever the JVM's tzdata is older than
---   the OS's. Observed on JDK 21 (tzdata 2023c) on macOS (tzdata 2026c): Paraguay dropped DST in
---   tzdata 2024b, so the JVM wrote America/Asuncion at -04:00 while SQLite read it back at
---   -03:00, leaving every row an hour off. Reconstructing from json_data has no such coupling.
---
--- This is also idempotent and self-correcting: it computes the same answer no matter what the
--- column currently holds, so a row left wrong by an earlier attempt is repaired.
---
--- Two guards, both load-bearing:
---   json_valid()  -- json_extract() raises "malformed JSON" and aborts the whole statement on a
---                    bad row, which would fail the migration and stop the server from booting.
---   COALESCE()    -- a row whose JSON lacks the field yields NULL, and both columns are NOT NULL.
--- Either way the affected row keeps its existing value instead of taking down startup.
+-- json_valid() skips rows with unreadable JSON, which would otherwise abort the statement.
+-- COALESCE keeps the current value when the field is missing, since the columns are NOT NULL.
 UPDATE workflow_index SET
   start_time  = COALESCE(strftime('%Y-%m-%d %H:%M:%f', json_extract(json_data, '$.startTime')),  start_time),
   update_time = COALESCE(strftime('%Y-%m-%d %H:%M:%f', json_extract(json_data, '$.updateTime')), update_time)

--- a/sqlite-persistence/src/main/resources/db/migration_sqlite/V6__index_timestamps_to_utc.sql
+++ b/sqlite-persistence/src/main/resources/db/migration_sqlite/V6__index_timestamps_to_utc.sql
@@ -1,0 +1,19 @@
+-- Issue #1497: start_time/update_time were written with java.sql.Timestamp.toString(), which
+-- renders in the JVM default zone, while searches rendered their bound in UTC. Rewrite existing
+-- rows as UTC so both sides agree. SQLite's 'utc' modifier reads the value as local time and
+-- shifts it using the host tz database, so each row gets the DST offset in force at its own
+-- timestamp. No-op on UTC hosts and on empty tables.
+--
+-- COALESCE is load-bearing: strftime returns NULL for an unparseable value and both columns are
+-- NOT NULL, so without it one malformed row would abort the migration and the server would not
+-- boot. Such rows are left untouched instead.
+--
+-- Known limitation: a DB written under zone A and migrated under zone B is off by (B - A). Not
+-- fixable in SQL.
+UPDATE workflow_index SET
+  start_time  = COALESCE(strftime('%Y-%m-%d %H:%M:%f', start_time,  'utc'), start_time),
+  update_time = COALESCE(strftime('%Y-%m-%d %H:%M:%f', update_time, 'utc'), update_time);
+
+UPDATE task_index SET
+  start_time  = COALESCE(strftime('%Y-%m-%d %H:%M:%f', start_time,  'utc'), start_time),
+  update_time = COALESCE(strftime('%Y-%m-%d %H:%M:%f', update_time, 'utc'), update_time);

--- a/sqlite-persistence/src/main/resources/db/migration_sqlite/V6__index_timestamps_to_utc.sql
+++ b/sqlite-persistence/src/main/resources/db/migration_sqlite/V6__index_timestamps_to_utc.sql
@@ -1,19 +1,33 @@
 -- Issue #1497: start_time/update_time were written with java.sql.Timestamp.toString(), which
 -- renders in the JVM default zone, while searches rendered their bound in UTC. Rewrite existing
--- rows as UTC so both sides agree. SQLite's 'utc' modifier reads the value as local time and
--- shifts it using the host tz database, so each row gets the DST offset in force at its own
--- timestamp. No-op on UTC hosts and on empty tables.
+-- rows as UTC so both sides agree.
 --
--- COALESCE is load-bearing: strftime returns NULL for an unparseable value and both columns are
--- NOT NULL, so without it one malformed row would abort the migration and the server would not
--- boot. Such rows are left untouched instead.
+-- These columns are derived data: json_data already holds the authoritative instant as an
+-- ISO-8601 string with a 'Z' suffix, which SQLite parses natively. So rebuild them from json_data
+-- rather than converting the local-time text. No timezone is guessed at any point, which matters
+-- more than it looks:
 --
--- Known limitation: a DB written under zone A and migrated under zone B is off by (B - A). Not
--- fixable in SQL.
+--   An earlier version of this migration used SQLite's 'utc' modifier to reinterpret the stored
+--   local time. That reads the host tz database, while the bad values were written against the
+--   *JVM's bundled* tz database -- and the two disagree whenever the JVM's tzdata is older than
+--   the OS's. Observed on JDK 21 (tzdata 2023c) on macOS (tzdata 2026c): Paraguay dropped DST in
+--   tzdata 2024b, so the JVM wrote America/Asuncion at -04:00 while SQLite read it back at
+--   -03:00, leaving every row an hour off. Reconstructing from json_data has no such coupling.
+--
+-- This is also idempotent and self-correcting: it computes the same answer no matter what the
+-- column currently holds, so a row left wrong by an earlier attempt is repaired.
+--
+-- Two guards, both load-bearing:
+--   json_valid()  -- json_extract() raises "malformed JSON" and aborts the whole statement on a
+--                    bad row, which would fail the migration and stop the server from booting.
+--   COALESCE()    -- a row whose JSON lacks the field yields NULL, and both columns are NOT NULL.
+-- Either way the affected row keeps its existing value instead of taking down startup.
 UPDATE workflow_index SET
-  start_time  = COALESCE(strftime('%Y-%m-%d %H:%M:%f', start_time,  'utc'), start_time),
-  update_time = COALESCE(strftime('%Y-%m-%d %H:%M:%f', update_time, 'utc'), update_time);
+  start_time  = COALESCE(strftime('%Y-%m-%d %H:%M:%f', json_extract(json_data, '$.startTime')),  start_time),
+  update_time = COALESCE(strftime('%Y-%m-%d %H:%M:%f', json_extract(json_data, '$.updateTime')), update_time)
+WHERE json_valid(json_data);
 
 UPDATE task_index SET
-  start_time  = COALESCE(strftime('%Y-%m-%d %H:%M:%f', start_time,  'utc'), start_time),
-  update_time = COALESCE(strftime('%Y-%m-%d %H:%M:%f', update_time, 'utc'), update_time);
+  start_time  = COALESCE(strftime('%Y-%m-%d %H:%M:%f', json_extract(json_data, '$.startTime')),  start_time),
+  update_time = COALESCE(strftime('%Y-%m-%d %H:%M:%f', json_extract(json_data, '$.updateTime')), update_time)
+WHERE json_valid(json_data);

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAOTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAOTest.java
@@ -373,7 +373,7 @@ public class SqliteIndexDAOTest {
     // Issue #1497 regression: on a negative-UTC-offset host, start_time was written in the JVM's
     // default zone but the search bound was rendered in UTC. A workflow started "now" was
     // therefore invisible to a search bound anchored an hour in the past. This test only proves
-    // anything when the JVM zone differs from UTC, hence the TZ='America/Asuncion' env set on the
+    // anything when the JVM zone differs from UTC, hence the TZ='America/Los_Angeles' env set on the
     // `test` task in sqlite-persistence/build.gradle.
     @Test
     public void searchesFindWorkflowsIndexedInANonUtcZone() {

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAOTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAOTest.java
@@ -373,8 +373,8 @@ public class SqliteIndexDAOTest {
     // Issue #1497 regression: on a negative-UTC-offset host, start_time was written in the JVM's
     // default zone but the search bound was rendered in UTC. A workflow started "now" was
     // therefore invisible to a search bound anchored an hour in the past. This test only proves
-    // anything when the JVM zone differs from UTC, hence the TZ='America/Los_Angeles' env set on the
-    // `test` task in sqlite-persistence/build.gradle.
+    // anything when the JVM zone differs from UTC, hence the TZ env set on the `test` task in
+    // sqlite-persistence/build.gradle.
     @Test
     public void searchesFindWorkflowsIndexedInANonUtcZone() {
         WorkflowSummary wfs = getMockWorkflowSummary("workflow-id-non-utc-zone");

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAOTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexDAOTest.java
@@ -15,10 +15,9 @@ package com.netflix.conductor.sqlite.dao;
 import java.io.File;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.TemporalAccessor;
 import java.util.*;
 import java.util.stream.IntStream;
 
@@ -70,6 +69,11 @@ import static org.junit.Assert.assertEquals;
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class SqliteIndexDAOTest {
+
+    // Canonical UTC text format the index columns are stored in (issue #1497). Byte-identical to
+    // SQLite's strftime('%Y-%m-%d %H:%M:%f', ...), independent of the JVM/host default zone.
+    private static final DateTimeFormatter SQLITE_UTC_TIMESTAMP =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneOffset.UTC);
 
     @Autowired private SqliteIndexDAO indexDAO;
 
@@ -158,10 +162,11 @@ public class SqliteIndexDAOTest {
                 "Workflow type does not match",
                 wfs.getWorkflowType(),
                 result.get(0).get("workflow_type"));
-        TemporalAccessor ta = DateTimeFormatter.ISO_INSTANT.parse(wfs.getStartTime());
-        Timestamp startTime = Timestamp.from(Instant.from(ta));
+        Instant startInstant =
+                Instant.from(DateTimeFormatter.ISO_INSTANT.parse(wfs.getStartTime()));
+        String expectedStartTime = SQLITE_UTC_TIMESTAMP.format(startInstant);
         assertEquals(
-                "Start time does not match", startTime.toString(), result.get(0).get("start_time"));
+                "Start time does not match", expectedStartTime, result.get(0).get("start_time"));
         assertEquals(
                 "Status does not match", wfs.getStatus().toString(), result.get(0).get("status"));
     }
@@ -186,16 +191,15 @@ public class SqliteIndexDAOTest {
                 "Task def name does not match",
                 ts.getTaskDefName(),
                 result.get(0).get("task_def_name"));
-        TemporalAccessor startTa = DateTimeFormatter.ISO_INSTANT.parse(ts.getStartTime());
-        Timestamp startTime = Timestamp.from(Instant.from(startTa));
+        Instant startInstant = Instant.from(DateTimeFormatter.ISO_INSTANT.parse(ts.getStartTime()));
+        String expectedStartTime = SQLITE_UTC_TIMESTAMP.format(startInstant);
         assertEquals(
-                "Start time does not match", startTime.toString(), result.get(0).get("start_time"));
-        TemporalAccessor updateTa = DateTimeFormatter.ISO_INSTANT.parse(ts.getUpdateTime());
-        Timestamp updateTime = Timestamp.from(Instant.from(updateTa));
+                "Start time does not match", expectedStartTime, result.get(0).get("start_time"));
+        Instant updateInstant =
+                Instant.from(DateTimeFormatter.ISO_INSTANT.parse(ts.getUpdateTime()));
+        String expectedUpdateTime = SQLITE_UTC_TIMESTAMP.format(updateInstant);
         assertEquals(
-                "Update time does not match",
-                updateTime.toString(),
-                result.get(0).get("update_time"));
+                "Update time does not match", expectedUpdateTime, result.get(0).get("update_time"));
         assertEquals(
                 "Status does not match", ts.getStatus().toString(), result.get(0).get("status"));
         assertEquals(
@@ -364,6 +368,50 @@ public class SqliteIndexDAOTest {
                 "Wrong workflow returned",
                 wfs.getWorkflowId(),
                 results.getResults().get(0).getWorkflowId());
+    }
+
+    // Issue #1497 regression: on a negative-UTC-offset host, start_time was written in the JVM's
+    // default zone but the search bound was rendered in UTC. A workflow started "now" was
+    // therefore invisible to a search bound anchored an hour in the past. This test only proves
+    // anything when the JVM zone differs from UTC, hence the TZ='America/Asuncion' env set on the
+    // `test` task in sqlite-persistence/build.gradle.
+    @Test
+    public void searchesFindWorkflowsIndexedInANonUtcZone() {
+        WorkflowSummary wfs = getMockWorkflowSummary("workflow-id-non-utc-zone");
+        Instant now = Instant.now();
+        wfs.setStartTime(DateTimeFormatter.ISO_INSTANT.format(now));
+        wfs.setUpdateTime(DateTimeFormatter.ISO_INSTANT.format(now));
+
+        indexDAO.indexWorkflow(wfs);
+
+        long oneHourAgoMillis = now.minusSeconds(3600).toEpochMilli();
+        String query = String.format("startTime>%d", oneHourAgoMillis);
+        SearchResult<WorkflowSummary> results =
+                indexDAO.searchWorkflowSummary(query, "*", 0, 15, new ArrayList<>());
+        assertEquals(
+                "Workflow indexed 'now' should be found by a search bound one hour in the past",
+                1,
+                results.getResults().size());
+    }
+
+    // Issue #1497 regression, task-side. See searchesFindWorkflowsIndexedInANonUtcZone above.
+    @Test
+    public void searchesFindTasksIndexedInANonUtcZone() {
+        TaskSummary ts = getMockTaskSummary("task-id-non-utc-zone");
+        Instant now = Instant.now();
+        ts.setStartTime(DateTimeFormatter.ISO_INSTANT.format(now));
+        ts.setUpdateTime(DateTimeFormatter.ISO_INSTANT.format(now));
+
+        indexDAO.indexTask(ts);
+
+        long oneHourAgoMillis = now.minusSeconds(3600).toEpochMilli();
+        String query = String.format("startTime>%d", oneHourAgoMillis);
+        SearchResult<TaskSummary> results =
+                indexDAO.searchTaskSummary(query, "*", 0, 15, new ArrayList<>());
+        assertEquals(
+                "Task indexed 'now' should be found by a search bound one hour in the past",
+                1,
+                results.getResults().size());
     }
 
     @Test

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexTimestampMigrationTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexTimestampMigrationTest.java
@@ -46,7 +46,7 @@ import static org.junit.Assert.assertTrue;
  *
  * <p>Like {@link SqliteIndexDAOTest}, this is only a meaningful regression test when the JVM's
  * default zone is not UTC, which is why {@code sqlite-persistence/build.gradle} pins the {@code
- * test} task to {@code TZ=America/Asuncion}.
+ * test} task to {@code TZ=America/Los_Angeles}.
  */
 public class SqliteIndexTimestampMigrationTest {
 

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexTimestampMigrationTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexTimestampMigrationTest.java
@@ -21,10 +21,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.Statement;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 
 import org.junit.After;
 import org.junit.Before;
@@ -38,25 +34,25 @@ import static org.junit.Assert.assertTrue;
  * local-time text (JVM default zone), while searches bound their range in UTC. The shipped V6
  * migration rewrites existing rows to the canonical UTC text so old and new rows compare correctly.
  *
- * <p>This test reads the real migration file off the classpath -- rather than pasting the SQL -- so
- * it exercises the artifact that actually ships. It requires {@code
- * db/migration_sqlite/V6__index_timestamps_to_utc.sql} to exist on the test classpath; if the
- * migration hasn't been added yet, {@link #readMigrationSql()} fails every test in this class with
- * an explicit "migration file not found" message.
+ * <p>The migration rebuilds those columns from {@code json_data}, which already holds the
+ * authoritative instant as an ISO-8601 string. It therefore never interprets the local-time text
+ * and never consults a tz database, so every expectation here is an absolute constant and these
+ * tests are deterministic in any host zone -- unlike {@link SqliteIndexDAOTest}, which exercises
+ * the write and search paths and does need a non-UTC zone to be meaningful.
  *
- * <p>Like {@link SqliteIndexDAOTest}, this is only a meaningful regression test when the JVM's
- * default zone is not UTC, which is why {@code sqlite-persistence/build.gradle} pins the {@code
- * test} task to {@code TZ=America/Los_Angeles}.
+ * <p>This test reads the real migration file off the classpath -- rather than pasting the SQL -- so
+ * it exercises the artifact that actually ships.
  */
 public class SqliteIndexTimestampMigrationTest {
 
     private static final String MIGRATION_RESOURCE =
             "db/migration_sqlite/V6__index_timestamps_to_utc.sql";
 
-    private static final DateTimeFormatter SQLITE_UTC_TIMESTAMP =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneOffset.UTC);
-    private static final DateTimeFormatter LOCAL_NAIVE =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+    /** The authoritative instant, as SqliteIndexDAO writes it into json_data. */
+    private static final String TRUTH_ISO = "2026-08-07T03:17:36.285Z";
+
+    /** The canonical UTC text the migration must produce for {@link #TRUTH_ISO}. */
+    private static final String TRUTH_CANONICAL = "2026-08-07 03:17:36.285";
 
     private Path dbFile;
     private Connection connection;
@@ -134,105 +130,161 @@ public class SqliteIndexTimestampMigrationTest {
         }
     }
 
-    /** What the pre-fix SqliteIndexDAO wrote: Timestamp.toString() text in the JVM default zone. */
-    private static String localNaive(LocalDateTime localDateTime) {
-        return LOCAL_NAIVE.format(localDateTime);
+    private void insertWorkflow(String id, String storedTime, String json) throws Exception {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(
+                    "INSERT INTO workflow_index (workflow_id, workflow_type, start_time, update_time, status, json_data) VALUES ('"
+                            + id
+                            + "', 'wf-type', '"
+                            + storedTime
+                            + "', '"
+                            + storedTime
+                            + "', 'COMPLETED', '"
+                            + json
+                            + "')");
+        }
     }
 
-    /** The canonical UTC text the migration is expected to produce for a given local instant. */
-    private static String expectedUtc(LocalDateTime localDateTime) {
-        return SQLITE_UTC_TIMESTAMP.format(
-                localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+    private String[] readTimes(String table, String idColumn, String id) throws Exception {
+        try (Statement statement = connection.createStatement();
+                ResultSet rs =
+                        statement.executeQuery(
+                                "SELECT start_time, update_time FROM "
+                                        + table
+                                        + " WHERE "
+                                        + idColumn
+                                        + " = '"
+                                        + id
+                                        + "'")) {
+            assertTrue("Expected exactly one row", rs.next());
+            return new String[] {rs.getString("start_time"), rs.getString("update_time")};
+        }
+    }
+
+    private static String json(String startTime, String updateTime) {
+        return "{\"startTime\":\"" + startTime + "\",\"updateTime\":\"" + updateTime + "\"}";
     }
 
     @Test
     public void rewritesWorkflowIndexLocalTimeToUtc() throws Exception {
-        LocalDateTime local = LocalDateTime.of(2023, 2, 7, 8, 42, 45, 0);
-        try (Statement statement = connection.createStatement()) {
-            statement.execute(
-                    "INSERT INTO workflow_index (workflow_id, workflow_type, start_time, update_time, status, json_data) VALUES "
-                            + "('wf-1', 'wf-type', '"
-                            + localNaive(local)
-                            + "', '"
-                            + localNaive(local)
-                            + "', 'COMPLETED', '{}')");
-        }
+        // '2026-08-06 23:17:36.285' is the same instant rendered at -04:00, i.e. what the pre-fix
+        // write path stored on a JVM whose default zone is four hours behind UTC.
+        insertWorkflow("wf-1", "2026-08-06 23:17:36.285", json(TRUTH_ISO, TRUTH_ISO));
 
         runMigration();
 
-        try (Statement statement = connection.createStatement();
-                ResultSet rs =
-                        statement.executeQuery(
-                                "SELECT start_time, update_time FROM workflow_index WHERE workflow_id = 'wf-1'")) {
-            assertTrue("Expected exactly one row", rs.next());
-            assertEquals(
-                    "start_time should be rewritten to canonical UTC text",
-                    expectedUtc(local),
-                    rs.getString("start_time"));
-            assertEquals(
-                    "update_time should be rewritten to canonical UTC text",
-                    expectedUtc(local),
-                    rs.getString("update_time"));
-        }
+        String[] times = readTimes("workflow_index", "workflow_id", "wf-1");
+        assertEquals("start_time should be rebuilt from json_data", TRUTH_CANONICAL, times[0]);
+        assertEquals("update_time should be rebuilt from json_data", TRUTH_CANONICAL, times[1]);
     }
 
     @Test
     public void rewritesTaskIndexLocalTimeToUtc() throws Exception {
-        LocalDateTime local = LocalDateTime.of(2023, 2, 7, 9, 41, 45, 0);
         try (Statement statement = connection.createStatement()) {
             statement.execute(
                     "INSERT INTO task_index (task_id, task_type, task_def_name, status, start_time, update_time, workflow_type, json_data) VALUES "
-                            + "('task-1', 'task-type', 'task-def', 'COMPLETED', '"
-                            + localNaive(local)
-                            + "', '"
-                            + localNaive(local)
-                            + "', 'wf-type', '{}')");
+                            + "('task-1', 'task-type', 'task-def', 'COMPLETED', '2026-08-06 23:17:36.285', '2026-08-06 23:17:36.285', 'wf-type', '"
+                            + json(TRUTH_ISO, TRUTH_ISO)
+                            + "')");
         }
 
         runMigration();
 
-        try (Statement statement = connection.createStatement();
-                ResultSet rs =
-                        statement.executeQuery(
-                                "SELECT start_time, update_time FROM task_index WHERE task_id = 'task-1'")) {
-            assertTrue("Expected exactly one row", rs.next());
-            assertEquals(
-                    "start_time should be rewritten to canonical UTC text",
-                    expectedUtc(local),
-                    rs.getString("start_time"));
-            assertEquals(
-                    "update_time should be rewritten to canonical UTC text",
-                    expectedUtc(local),
-                    rs.getString("update_time"));
-        }
+        String[] times = readTimes("task_index", "task_id", "task-1");
+        assertEquals("start_time should be rebuilt from json_data", TRUTH_CANONICAL, times[0]);
+        assertEquals("update_time should be rebuilt from json_data", TRUTH_CANONICAL, times[1]);
     }
 
+    /**
+     * The reason this migration reads json_data instead of reinterpreting the stored local text.
+     *
+     * <p>The bad values were rendered against the JVM's bundled tz database; any SQL that converts
+     * them back has to use the host's. Those disagree whenever the JVM's tzdata is older --
+     * observed on JDK 21 (tzdata 2023c) on macOS (tzdata 2026c), where Paraguay's 2024b switch to
+     * permanent UTC-3 left the JVM writing America/Asuncion at -04:00 and SQLite reading it at
+     * -03:00, so every row came out an hour short. Rebuilding from json_data is exact under any
+     * such skew.
+     */
     @Test
-    public void malformedValueSurvivesUntouched() throws Exception {
-        try (Statement statement = connection.createStatement()) {
-            statement.execute(
-                    "INSERT INTO workflow_index (workflow_id, workflow_type, start_time, update_time, status, json_data) VALUES "
-                            + "('wf-malformed', 'wf-type', 'not-a-timestamp', 'not-a-timestamp', 'COMPLETED', '{}')");
-        }
+    public void repairsRowsWrittenUnderTzdataSkew() throws Exception {
+        insertWorkflow("wf-skew", "2026-08-06 23:17:36.285", json(TRUTH_ISO, TRUTH_ISO));
+        // A row an earlier 'utc'-modifier migration already shifted by the wrong amount: the
+        // rebuild is absolute, so it lands on the truth regardless of what the column held.
+        insertWorkflow("wf-half-fixed", "2026-08-07 02:17:36.285", json(TRUTH_ISO, TRUTH_ISO));
 
         runMigration();
 
-        try (Statement statement = connection.createStatement();
-                ResultSet rs =
-                        statement.executeQuery(
-                                "SELECT start_time, update_time FROM workflow_index WHERE workflow_id = 'wf-malformed'")) {
-            assertTrue("Expected exactly one row", rs.next());
-            assertEquals(
-                    "COALESCE guard should leave an unparseable value untouched rather than"
-                            + " nulling the NOT NULL column",
-                    "not-a-timestamp",
-                    rs.getString("start_time"));
-            assertEquals(
-                    "COALESCE guard should leave an unparseable value untouched rather than"
-                            + " nulling the NOT NULL column",
-                    "not-a-timestamp",
-                    rs.getString("update_time"));
-        }
+        assertEquals(TRUTH_CANONICAL, readTimes("workflow_index", "workflow_id", "wf-skew")[0]);
+        assertEquals(
+                "a row left wrong by an earlier migration attempt should be repaired, not shifted"
+                        + " again",
+                TRUTH_CANONICAL,
+                readTimes("workflow_index", "workflow_id", "wf-half-fixed")[0]);
+    }
+
+    /** Running the migration twice must not move a row that is already correct. */
+    @Test
+    public void isIdempotent() throws Exception {
+        insertWorkflow("wf-twice", "2026-08-06 23:17:36.285", json(TRUTH_ISO, TRUTH_ISO));
+
+        runMigration();
+        runMigration();
+
+        assertEquals(TRUTH_CANONICAL, readTimes("workflow_index", "workflow_id", "wf-twice")[0]);
+    }
+
+    /** ISO_INSTANT omits the fraction when the instant lands on a whole second. */
+    @Test
+    public void handlesInstantsWithoutAFractionalPart() throws Exception {
+        insertWorkflow(
+                "wf-no-millis",
+                "2026-08-06 23:17:36.0",
+                json("2026-08-07T03:17:36Z", "2026-08-07T03:17:36Z"));
+
+        runMigration();
+
+        assertEquals(
+                "a whole-second instant should still be padded to three fractional digits",
+                "2026-08-07 03:17:36.000",
+                readTimes("workflow_index", "workflow_id", "wf-no-millis")[0]);
+    }
+
+    /**
+     * json_extract() raises "malformed JSON" and aborts the whole statement, so without the
+     * json_valid() guard one bad row would fail the migration and stop the server booting.
+     */
+    @Test
+    public void malformedJsonDoesNotAbortTheMigration() throws Exception {
+        insertWorkflow("wf-bad-json", "2026-08-06 23:17:36.285", "not json at all");
+        insertWorkflow("wf-good", "2026-08-06 23:17:36.285", json(TRUTH_ISO, TRUTH_ISO));
+
+        runMigration();
+
+        assertEquals(
+                "the row with unreadable json_data should keep its existing value",
+                "2026-08-06 23:17:36.285",
+                readTimes("workflow_index", "workflow_id", "wf-bad-json")[0]);
+        assertEquals(
+                "a valid row alongside it should still be migrated",
+                TRUTH_CANONICAL,
+                readTimes("workflow_index", "workflow_id", "wf-good")[0]);
+    }
+
+    /** Valid JSON that simply lacks the field yields NULL, which COALESCE must absorb. */
+    @Test
+    public void missingJsonFieldLeavesTheColumnUntouched() throws Exception {
+        insertWorkflow(
+                "wf-no-field", "2026-08-06 23:17:36.285", "{\"workflowId\":\"wf-no-field\"}");
+
+        runMigration();
+
+        String[] times = readTimes("workflow_index", "workflow_id", "wf-no-field");
+        assertEquals(
+                "COALESCE guard should leave the value untouched rather than nulling a NOT NULL"
+                        + " column",
+                "2026-08-06 23:17:36.285",
+                times[0]);
+        assertEquals("2026-08-06 23:17:36.285", times[1]);
     }
 
     @Test

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexTimestampMigrationTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexTimestampMigrationTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2025 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.sqlite.dao;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Issue #1497: the pre-fix {@code SqliteIndexDAO} wrote {@code start_time}/{@code update_time} as
+ * local-time text (JVM default zone), while searches bound their range in UTC. The shipped V6
+ * migration rewrites existing rows to the canonical UTC text so old and new rows compare correctly.
+ *
+ * <p>This test reads the real migration file off the classpath -- rather than pasting the SQL -- so
+ * it exercises the artifact that actually ships. It requires {@code
+ * db/migration_sqlite/V6__index_timestamps_to_utc.sql} to exist on the test classpath; if the
+ * migration hasn't been added yet, {@link #readMigrationSql()} fails every test in this class with
+ * an explicit "migration file not found" message.
+ *
+ * <p>Like {@link SqliteIndexDAOTest}, this is only a meaningful regression test when the JVM's
+ * default zone is not UTC, which is why {@code sqlite-persistence/build.gradle} pins the {@code
+ * test} task to {@code TZ=America/Asuncion}.
+ */
+public class SqliteIndexTimestampMigrationTest {
+
+    private static final String MIGRATION_RESOURCE =
+            "db/migration_sqlite/V6__index_timestamps_to_utc.sql";
+
+    private static final DateTimeFormatter SQLITE_UTC_TIMESTAMP =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneOffset.UTC);
+    private static final DateTimeFormatter LOCAL_NAIVE =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+
+    private Path dbFile;
+    private Connection connection;
+
+    @Before
+    public void setUp() throws Exception {
+        dbFile = Files.createTempFile("sqlite-index-utc-migration-test", ".db");
+        Files.deleteIfExists(dbFile);
+        connection = DriverManager.getConnection("jdbc:sqlite:" + dbFile);
+        try (Statement statement = connection.createStatement()) {
+            // Minimal shape of the tables from V1__initial_schema.sql -- only the columns the
+            // V6 migration touches (plus the NOT NULL columns needed to satisfy the schema).
+            statement.execute(
+                    "CREATE TABLE workflow_index ("
+                            + "workflow_id TEXT NOT NULL PRIMARY KEY,"
+                            + "workflow_type TEXT NOT NULL,"
+                            + "start_time DATETIME NOT NULL,"
+                            + "update_time DATETIME NOT NULL,"
+                            + "status TEXT NOT NULL,"
+                            + "json_data TEXT NOT NULL)");
+            statement.execute(
+                    "CREATE TABLE task_index ("
+                            + "task_id TEXT NOT NULL PRIMARY KEY,"
+                            + "task_type TEXT NOT NULL,"
+                            + "task_def_name TEXT NOT NULL,"
+                            + "status TEXT NOT NULL,"
+                            + "start_time DATETIME NOT NULL,"
+                            + "update_time DATETIME NOT NULL,"
+                            + "workflow_type TEXT NOT NULL,"
+                            + "json_data TEXT NOT NULL)");
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (connection != null) {
+            connection.close();
+        }
+        Files.deleteIfExists(dbFile);
+    }
+
+    /**
+     * Reads the shipped migration off the classpath. Fails loudly (not an NPE downstream) if V6
+     * hasn't been created yet.
+     */
+    private String readMigrationSql() throws IOException {
+        try (InputStream in =
+                Thread.currentThread()
+                        .getContextClassLoader()
+                        .getResourceAsStream(MIGRATION_RESOURCE)) {
+            if (in == null) {
+                throw new AssertionError(
+                        "Migration file not found on classpath: '"
+                                + MIGRATION_RESOURCE
+                                + "'. Expected to find it at "
+                                + "sqlite-persistence/src/main/resources/"
+                                + MIGRATION_RESOURCE
+                                + " -- has the V6 migration been added yet? (issue #1497)");
+            }
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private void runMigration() throws Exception {
+        String sql = readMigrationSql();
+        // sqlite-jdbc's Statement.execute(String) only accepts a single statement, so split on
+        // ';' the way Flyway would apply each statement of the migration in turn.
+        try (Statement statement = connection.createStatement()) {
+            for (String stmt : sql.split(";")) {
+                String trimmed = stmt.trim();
+                if (!trimmed.isEmpty()) {
+                    statement.execute(trimmed);
+                }
+            }
+        }
+    }
+
+    /** What the pre-fix SqliteIndexDAO wrote: Timestamp.toString() text in the JVM default zone. */
+    private static String localNaive(LocalDateTime localDateTime) {
+        return LOCAL_NAIVE.format(localDateTime);
+    }
+
+    /** The canonical UTC text the migration is expected to produce for a given local instant. */
+    private static String expectedUtc(LocalDateTime localDateTime) {
+        return SQLITE_UTC_TIMESTAMP.format(
+                localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+    }
+
+    @Test
+    public void rewritesWorkflowIndexLocalTimeToUtc() throws Exception {
+        LocalDateTime local = LocalDateTime.of(2023, 2, 7, 8, 42, 45, 0);
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(
+                    "INSERT INTO workflow_index (workflow_id, workflow_type, start_time, update_time, status, json_data) VALUES "
+                            + "('wf-1', 'wf-type', '"
+                            + localNaive(local)
+                            + "', '"
+                            + localNaive(local)
+                            + "', 'COMPLETED', '{}')");
+        }
+
+        runMigration();
+
+        try (Statement statement = connection.createStatement();
+                ResultSet rs =
+                        statement.executeQuery(
+                                "SELECT start_time, update_time FROM workflow_index WHERE workflow_id = 'wf-1'")) {
+            assertTrue("Expected exactly one row", rs.next());
+            assertEquals(
+                    "start_time should be rewritten to canonical UTC text",
+                    expectedUtc(local),
+                    rs.getString("start_time"));
+            assertEquals(
+                    "update_time should be rewritten to canonical UTC text",
+                    expectedUtc(local),
+                    rs.getString("update_time"));
+        }
+    }
+
+    @Test
+    public void rewritesTaskIndexLocalTimeToUtc() throws Exception {
+        LocalDateTime local = LocalDateTime.of(2023, 2, 7, 9, 41, 45, 0);
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(
+                    "INSERT INTO task_index (task_id, task_type, task_def_name, status, start_time, update_time, workflow_type, json_data) VALUES "
+                            + "('task-1', 'task-type', 'task-def', 'COMPLETED', '"
+                            + localNaive(local)
+                            + "', '"
+                            + localNaive(local)
+                            + "', 'wf-type', '{}')");
+        }
+
+        runMigration();
+
+        try (Statement statement = connection.createStatement();
+                ResultSet rs =
+                        statement.executeQuery(
+                                "SELECT start_time, update_time FROM task_index WHERE task_id = 'task-1'")) {
+            assertTrue("Expected exactly one row", rs.next());
+            assertEquals(
+                    "start_time should be rewritten to canonical UTC text",
+                    expectedUtc(local),
+                    rs.getString("start_time"));
+            assertEquals(
+                    "update_time should be rewritten to canonical UTC text",
+                    expectedUtc(local),
+                    rs.getString("update_time"));
+        }
+    }
+
+    @Test
+    public void malformedValueSurvivesUntouched() throws Exception {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(
+                    "INSERT INTO workflow_index (workflow_id, workflow_type, start_time, update_time, status, json_data) VALUES "
+                            + "('wf-malformed', 'wf-type', 'not-a-timestamp', 'not-a-timestamp', 'COMPLETED', '{}')");
+        }
+
+        runMigration();
+
+        try (Statement statement = connection.createStatement();
+                ResultSet rs =
+                        statement.executeQuery(
+                                "SELECT start_time, update_time FROM workflow_index WHERE workflow_id = 'wf-malformed'")) {
+            assertTrue("Expected exactly one row", rs.next());
+            assertEquals(
+                    "COALESCE guard should leave an unparseable value untouched rather than"
+                            + " nulling the NOT NULL column",
+                    "not-a-timestamp",
+                    rs.getString("start_time"));
+            assertEquals(
+                    "COALESCE guard should leave an unparseable value untouched rather than"
+                            + " nulling the NOT NULL column",
+                    "not-a-timestamp",
+                    rs.getString("update_time"));
+        }
+    }
+
+    @Test
+    public void emptyTablesAreANoOp() throws Exception {
+        runMigration();
+
+        try (Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery("SELECT COUNT(*) AS c FROM workflow_index")) {
+            assertTrue(rs.next());
+            assertEquals(0, rs.getInt("c"));
+        }
+        try (Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery("SELECT COUNT(*) AS c FROM task_index")) {
+            assertTrue(rs.next());
+            assertEquals(0, rs.getInt("c"));
+        }
+    }
+}

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexTimestampMigrationTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/dao/SqliteIndexTimestampMigrationTest.java
@@ -30,18 +30,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Issue #1497: the pre-fix {@code SqliteIndexDAO} wrote {@code start_time}/{@code update_time} as
- * local-time text (JVM default zone), while searches bound their range in UTC. The shipped V6
- * migration rewrites existing rows to the canonical UTC text so old and new rows compare correctly.
+ * Issue #1497: the V6 migration rewrites the index {@code start_time}/{@code update_time} columns
+ * in UTC, reading the instant from {@code json_data}.
  *
- * <p>The migration rebuilds those columns from {@code json_data}, which already holds the
- * authoritative instant as an ISO-8601 string. It therefore never interprets the local-time text
- * and never consults a tz database, so every expectation here is an absolute constant and these
- * tests are deterministic in any host zone -- unlike {@link SqliteIndexDAOTest}, which exercises
- * the write and search paths and does need a non-UTC zone to be meaningful.
- *
- * <p>This test reads the real migration file off the classpath -- rather than pasting the SQL -- so
- * it exercises the artifact that actually ships.
+ * <p>Because no timezone is involved, every expectation here is a constant and these tests pass in
+ * any host zone. The SQL is read off the classpath so the test covers the file that ships.
  */
 public class SqliteIndexTimestampMigrationTest {
 
@@ -196,20 +189,12 @@ public class SqliteIndexTimestampMigrationTest {
     }
 
     /**
-     * The reason this migration reads json_data instead of reinterpreting the stored local text.
-     *
-     * <p>The bad values were rendered against the JVM's bundled tz database; any SQL that converts
-     * them back has to use the host's. Those disagree whenever the JVM's tzdata is older --
-     * observed on JDK 21 (tzdata 2023c) on macOS (tzdata 2026c), where Paraguay's 2024b switch to
-     * permanent UTC-3 left the JVM writing America/Asuncion at -04:00 and SQLite reading it at
-     * -03:00, so every row came out an hour short. Rebuilding from json_data is exact under any
-     * such skew.
+     * The stored text is ignored, so a row lands on the right instant whatever offset it was
+     * written with and whatever a previous migration left behind.
      */
     @Test
-    public void repairsRowsWrittenUnderTzdataSkew() throws Exception {
+    public void repairsRowsWhateverTheStoredTextSays() throws Exception {
         insertWorkflow("wf-skew", "2026-08-06 23:17:36.285", json(TRUTH_ISO, TRUTH_ISO));
-        // A row an earlier 'utc'-modifier migration already shifted by the wrong amount: the
-        // rebuild is absolute, so it lands on the truth regardless of what the column held.
         insertWorkflow("wf-half-fixed", "2026-08-07 02:17:36.285", json(TRUTH_ISO, TRUTH_ISO));
 
         runMigration();

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilderTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilderTest.java
@@ -213,6 +213,31 @@ public class SqliteIndexQueryBuilderTest {
         verifyNoMoreInteractions(mockQuery);
     }
 
+    // Issue #1497: the bound for a *_time comparison must be rendered in the same canonical UTC
+    // text format the write path now uses (yyyy-MM-dd HH:mm:ss.SSS), and the column must NOT be
+    // wrapped in datetime() -- datetime() truncates to whole seconds, so 'start_time < ?' wrongly
+    // excluded a row stored at exactly '...03.000' ('...03.000' < '...03' is false: longer
+    // string, same prefix).
+    @Test
+    void shouldGenerateQueryForStartTimeGreaterThanInCanonicalUtc() throws SQLException {
+        String inputQuery = "startTime>1675702498000";
+        SqliteIndexQueryBuilder builder =
+                new SqliteIndexQueryBuilder(
+                        "table_name", inputQuery, "", 0, 15, new ArrayList<>(), properties);
+        String generatedQuery = builder.getQuery();
+        assertEquals(
+                "SELECT json_data FROM table_name WHERE start_time > ? LIMIT ? OFFSET ?",
+                generatedQuery);
+        Query mockQuery = mock(Query.class);
+        builder.addParameters(mockQuery);
+        builder.addPagingParameters(mockQuery);
+        InOrder inOrder = Mockito.inOrder(mockQuery);
+        inOrder.verify(mockQuery).addParameter("2023-02-06 16:54:58.000");
+        inOrder.verify(mockQuery).addParameter(15);
+        inOrder.verify(mockQuery).addParameter(0);
+        verifyNoMoreInteractions(mockQuery);
+    }
+
     @Test
     void shouldGenerateQueryForParentWorkflowId() throws SQLException {
         String inputQuery = "parentWorkflowId=\"\"";


### PR DESCRIPTION
Fixes #1497 - take a look at the screen recording for a repro of the issue.

## What changed

`SqliteIndexDAO` wrote `start_time`/`update_time` via `java.sql.Timestamp.toString()`, which renders in the **JVM default zone**, while `SqliteIndexQueryBuilder` rendered the search bound in **UTC**. These columns are TEXT-compared, so every time-range search was wrong by the host's UTC offset.

Both sides now use one canonical format, `yyyy-MM-dd HH:mm:ss.SSS` in UTC, applied to all four index timestamp columns (`workflow_index` and `task_index` × `start_time`/`update_time`).

`V6__index_timestamps_to_utc.sql` converts existing rows.

## How to test

```
./gradlew :conductor-sqlite-persistence:test
```

The suite runs under `TZ=America/Los_Angeles` (set in `sqlite-persistence/build.gradle`). This is deliberate and load-bearing — CI runs UTC, where a local-time/UTC mismatch is invisible and every one of these tests passes vacuously.

To see it red, check out the first commit alone (tests without the fix): 15 failures, including the reported symptom as `expected:<1> but was:<0>`..

🤖 Generated with [Claude Code](https://claude.com/claude-code)

