### PR TITLE
Resolve #1501: how Agent executions and the id for the agent execution in the agent execution page

### DIFF
--- a/ui-next/src/pages/execution/Execution.test.tsx
+++ b/ui-next/src/pages/execution/Execution.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import { getExecutionBreadcrumbItems } from "./Execution";
 import { ReasonForIncompletion } from "./ReasonForIncompletion";
 
 describe("ReasonForIncompletion", () => {
@@ -16,5 +17,47 @@ describe("ReasonForIncompletion", () => {
           element?.tagName === "PRE" && element.textContent === reason,
       ),
     ).toBeInTheDocument();
+  });
+});
+
+describe("getExecutionBreadcrumbItems", () => {
+  it("builds agent execution breadcrumbs with the route execution ID", () => {
+    const breadcrumbItems = getExecutionBreadcrumbItems(
+      "/agentExecutions/agent-execution-id",
+      "workflow-execution-id",
+      "agent-execution-id",
+    );
+
+    expect(breadcrumbItems[0]).toMatchObject({
+      label: "Agent Executions",
+      to: "/agentExecutions",
+    });
+    expect(breadcrumbItems[1]).toMatchObject({
+      label: "agent-execution-id",
+      to: "",
+      icon: {
+        props: { text: "agent-execution-id" },
+      },
+    });
+  });
+
+  it("builds workflow execution breadcrumbs with the workflow ID", () => {
+    const breadcrumbItems = getExecutionBreadcrumbItems(
+      "/execution/workflow-execution-id",
+      "workflow-execution-id",
+      "agent-execution-id",
+    );
+
+    expect(breadcrumbItems[0]).toMatchObject({
+      label: "Workflow Executions",
+      to: "/executions",
+    });
+    expect(breadcrumbItems[1]).toMatchObject({
+      label: "workflow-execution-id",
+      to: "",
+      icon: {
+        props: { text: "workflow-execution-id" },
+      },
+    });
   });
 });

--- a/ui-next/src/pages/execution/Execution.tsx
+++ b/ui-next/src/pages/execution/Execution.tsx
@@ -12,7 +12,10 @@ import {
 import { Flow } from "components/features/flow/Flow";
 import OpenIcon from "components/icons/OpenIcon";
 import ButtonLinks from "components/layout/header/ButtonLinks";
-import { ConductorSectionHeader } from "components/layout/section/ConductorSectionHeader";
+import {
+  ConductorSectionHeader,
+  ConductorSectionHeaderProps,
+} from "components/layout/section/ConductorSectionHeader";
 import { SidebarContext } from "components/providers/sidebar/context/SidebarContext";
 import Error from "components/ui/Error";
 import MuiAlert from "components/ui/MuiAlert";
@@ -271,6 +274,35 @@ const ExecutionAlert = ({
     );
   }
   return null;
+};
+
+type ExecutionBreadcrumbItem = NonNullable<
+  ConductorSectionHeaderProps["breadcrumbItems"]
+>[number];
+
+export const getExecutionBreadcrumbItems = (
+  pathname: string,
+  workflowId: string | undefined,
+  executionId: string,
+): ExecutionBreadcrumbItem[] => {
+  const isAgentExecutionRoute = pathname.startsWith(
+    `${AGENT_EXECUTIONS_URL.BASE}/`,
+  );
+  const displayedExecutionId = isAgentExecutionRoute
+    ? executionId
+    : workflowId || "";
+
+  return [
+    {
+      label: isAgentExecutionRoute ? "Agent Executions" : "Workflow Executions",
+      to: isAgentExecutionRoute ? AGENT_EXECUTIONS_URL.BASE : "/executions",
+    },
+    {
+      label: displayedExecutionId,
+      to: "",
+      icon: <CopyClipboardButton text={displayedExecutionId} />,
+    },
+  ];
 };
 
 export default function Execution() {
@@ -707,14 +739,11 @@ export default function Execution() {
                   />
                 </Stack>
               }
-              breadcrumbItems={[
-                { label: "Workflow Executions", to: "/executions" },
-                {
-                  label: execution.workflowId || "",
-                  to: "",
-                  icon: <CopyClipboardButton text={execution.workflowId} />,
-                },
-              ]}
+              breadcrumbItems={getExecutionBreadcrumbItems(
+                location.pathname,
+                execution.workflowId,
+                executionId,
+              )}
               buttonsComponent={
                 <Stack
                   flexDirection="row"


### PR DESCRIPTION
## Summary

Update the execution-page breadcrumb so agent routes show “Agent Executions” and the agent execution route ID, while preserving the existing workflow breadcrumb behavior.