### PR TITLE
Resolve #1499: On conductor-oss 3.32.0-rc.23/24, the JOIN inside an agent's DO_WHILE loop returns empty output even…

### DIFF
--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/util/AgentToolJoinStateMergeScriptTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/util/AgentToolJoinStateMergeScriptTest.java
@@ -12,7 +12,6 @@
  */
 package org.conductoross.conductor.ai.agentspan.runtime.util;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,7 +29,7 @@ class AgentToolJoinStateMergeScriptTest {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     @Test
-    void appendsHttpAndMcpJoinEnvelopesWhilePreservingPriorResultsAndMergingState()
+    void appendsHttpAndMcpJoinEnvelopesWhilePreservingPriorResultsAndShallowMergingState()
             throws Exception {
         Map<String, Object> httpOutput =
                 map(
@@ -41,7 +40,7 @@ class AgentToolJoinStateMergeScriptTest {
                                 "body",
                                 map("temperature", 64, "conditions", "clear")),
                         "_state_updates",
-                        map("weatherLoaded", true, "regions", List.of("us-east")));
+                        map("weatherLoaded", true, "region", "us-east"));
         Map<String, Object> mcpOutput =
                 map(
                         "content",
@@ -49,7 +48,7 @@ class AgentToolJoinStateMergeScriptTest {
                         "isError",
                         false,
                         "_state_updates",
-                        map("nextPage", "forecast-2", "regions", List.of("us-west", "eu-west")));
+                        map("nextPage", "forecast-2", "region", "eu-west"));
 
         Map<String, Object> joinOutput = new LinkedHashMap<>();
         joinOutput.put(
@@ -63,11 +62,7 @@ class AgentToolJoinStateMergeScriptTest {
                 evaluate(
                         map(
                                 "currentState",
-                                map(
-                                        "requestId",
-                                        "request-1",
-                                        "regions",
-                                        new ArrayList<>(List.of("us-west"))),
+                                map("requestId", "request-1", "region", "us-west"),
                                 "previousToolResults",
                                 List.of(map("name", "catalog", "output", map("count", 3))),
                                 "joinOutput",
@@ -87,8 +82,8 @@ class AgentToolJoinStateMergeScriptTest {
                         map(
                                 "requestId",
                                 "request-1",
-                                "regions",
-                                List.of("us-west", "us-east", "eu-west"),
+                                "region",
+                                "eu-west",
                                 "weatherLoaded",
                                 true,
                                 "nextPage",
@@ -98,7 +93,8 @@ class AgentToolJoinStateMergeScriptTest {
     @SuppressWarnings("unchecked")
     private Map<String, Object> evaluate(Map<String, Object> inputs) throws Exception {
         try (Context context = Context.newBuilder("js").allowAllAccess(true).build()) {
-            context.getBindings("js").putMember("$", inputs);
+            context.getBindings("js").putMember("inputsJson", MAPPER.writeValueAsString(inputs));
+            context.eval("js", "var $ = JSON.parse(inputsJson);");
             String result =
                     context.eval(
                                     "js",

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/util/AgentToolJoinStateMergeScriptTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/util/AgentToolJoinStateMergeScriptTest.java
@@ -94,11 +94,12 @@ class AgentToolJoinStateMergeScriptTest {
     private Map<String, Object> evaluate(Map<String, Object> inputs) throws Exception {
         try (Context context = Context.newBuilder("js").allowAllAccess(true).build()) {
             context.getBindings("js").putMember("inputsJson", MAPPER.writeValueAsString(inputs));
-            context.eval("js", "var $ = JSON.parse(inputsJson);");
             String result =
                     context.eval(
                                     "js",
-                                    "JSON.stringify(" + JavaScriptBuilder.stateMergeScript() + ");")
+                                    "(function($) { return JSON.stringify("
+                                            + JavaScriptBuilder.stateMergeScript()
+                                            + "); })(JSON.parse(inputsJson));")
                             .asString();
             return MAPPER.readValue(result, Map.class);
         }

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/util/AgentToolJoinStateMergeScriptTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/util/AgentToolJoinStateMergeScriptTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.agentspan.runtime.util;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.graalvm.polyglot.Context;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Verifies that JOIN tool envelopes remain complete observations for the next LLM turn. */
+class AgentToolJoinStateMergeScriptTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void appendsHttpAndMcpJoinEnvelopesWhilePreservingPriorResultsAndMergingState()
+            throws Exception {
+        Map<String, Object> httpOutput =
+                map(
+                        "response",
+                        map(
+                                "statusCode",
+                                200,
+                                "body",
+                                map("temperature", 64, "conditions", "clear")),
+                        "_state_updates",
+                        map("weatherLoaded", true, "regions", List.of("us-east")));
+        Map<String, Object> mcpOutput =
+                map(
+                        "content",
+                        List.of(map("type", "text", "text", "Forecast available")),
+                        "isError",
+                        false,
+                        "_state_updates",
+                        map("nextPage", "forecast-2", "regions", List.of("us-west", "eu-west")));
+
+        Map<String, Object> joinOutput = new LinkedHashMap<>();
+        joinOutput.put(
+                "weather_0__1",
+                map("_agent_tool_name", "weather", "_agent_tool_output", httpOutput));
+        joinOutput.put(
+                "forecast_1__1",
+                map("_agent_tool_name", "forecast", "_agent_tool_output", mcpOutput));
+
+        Map<String, Object> result =
+                evaluate(
+                        map(
+                                "currentState",
+                                map(
+                                        "requestId",
+                                        "request-1",
+                                        "regions",
+                                        new ArrayList<>(List.of("us-west"))),
+                                "previousToolResults",
+                                List.of(map("name", "catalog", "output", map("count", 3))),
+                                "joinOutput",
+                                joinOutput));
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> toolResults =
+                (List<Map<String, Object>>) result.get("toolResults");
+        assertThat(toolResults)
+                .containsExactly(
+                        map("name", "catalog", "output", map("count", 3)),
+                        map("name", "weather", "output", httpOutput),
+                        map("name", "forecast", "output", mcpOutput));
+
+        assertThat(result.get("mergedState"))
+                .isEqualTo(
+                        map(
+                                "requestId",
+                                "request-1",
+                                "regions",
+                                List.of("us-west", "us-east", "eu-west"),
+                                "weatherLoaded",
+                                true,
+                                "nextPage",
+                                "forecast-2"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> evaluate(Map<String, Object> inputs) throws Exception {
+        try (Context context = Context.newBuilder("js").allowAllAccess(true).build()) {
+            context.getBindings("js").putMember("$", inputs);
+            String result =
+                    context.eval(
+                                    "js",
+                                    "JSON.stringify(" + JavaScriptBuilder.stateMergeScript() + ");")
+                            .asString();
+            return MAPPER.readValue(result, Map.class);
+        }
+    }
+
+    private static Map<String, Object> map(Object... entries) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (int index = 0; index < entries.length; index += 2) {
+            result.put((String) entries[index], entries[index + 1]);
+        }
+        return result;
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
@@ -163,6 +163,14 @@ public class Join extends WorkflowSystemTask {
         Map<String, Object> output = forkedTask.getOutputData();
         Map<String, Object> compact = new LinkedHashMap<>();
         Object agentToolName = forkedTask.getInputData().get("_agent_tool_name");
+        if (agentToolName == null) {
+            WorkflowTask workflowTask = forkedTask.getWorkflowTask();
+            Map<String, Object> inputParameters =
+                    workflowTask == null ? null : workflowTask.getInputParameters();
+            if (inputParameters != null) {
+                agentToolName = inputParameters.get("_agent_tool_name");
+            }
+        }
         if (agentToolName != null) {
             compact.put("_agent_tool_name", agentToolName);
             compact.put("_agent_tool_output", output);

--- a/core/src/test/java/com/netflix/conductor/core/execution/tasks/JoinTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/tasks/JoinTest.java
@@ -183,6 +183,100 @@ public class JoinTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    public void testAgentJoinUsesWorkflowTaskMarkerForIterationQualifiedDynamicTool() {
+        Join join = new Join(mock(ConductorProperties.class));
+
+        Map<String, Object> httpOutput =
+                Map.of(
+                        "response",
+                        Map.of(
+                                "statusCode",
+                                200,
+                                "body",
+                                Map.of("temperature", 64)));
+        TaskModel forkedTask = forkedTaskWithOutput("weather_0__1", httpOutput);
+        WorkflowTask dynamicTool = new WorkflowTask();
+        dynamicTool.setInputParameters(Map.of("_agent_tool_name", "weather"));
+        forkedTask.setWorkflowTask(dynamicTool);
+
+        WorkflowDef agentDef = new WorkflowDef();
+        agentDef.setMetadata(Map.of("agent_sdk", "python"));
+        WorkflowModel workflow = new WorkflowModel();
+        workflow.setWorkflowDefinition(agentDef);
+        workflow.setTasks(List.of(forkedTask));
+
+        TaskModel joinTask = joinTaskOn("weather_0");
+        joinTask.setIteration(1);
+
+        assertTrue(join.execute(workflow, joinTask, null));
+        assertEquals(TaskModel.Status.COMPLETED, joinTask.getStatus());
+        assertEquals(
+                Map.of("_agent_tool_name", "weather", "_agent_tool_output", httpOutput),
+                joinTask.getOutputData().get("weather_0__1"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testAgentJoinPrefersRuntimeToolMarkerOverWorkflowTaskMarker() {
+        Join join = new Join(mock(ConductorProperties.class));
+
+        Map<String, Object> toolOutput = Map.of("content", List.of("forecast"), "isError", false);
+        TaskModel forkedTask = forkedTaskWithOutput("weather", toolOutput);
+        forkedTask.setInputData(Map.of("_agent_tool_name", "runtime-weather"));
+        forkedTask
+                .getWorkflowTask()
+                .setInputParameters(Map.of("_agent_tool_name", "definition-weather"));
+
+        WorkflowDef agentDef = new WorkflowDef();
+        agentDef.setMetadata(Map.of("agent_sdk", "python"));
+        WorkflowModel workflow = new WorkflowModel();
+        workflow.setWorkflowDefinition(agentDef);
+        workflow.setTasks(List.of(forkedTask));
+
+        TaskModel joinTask = joinTaskOn("weather");
+
+        assertTrue(join.execute(workflow, joinTask, null));
+        Map<String, Object> compact =
+                (Map<String, Object>) joinTask.getOutputData().get("weather");
+        assertEquals("runtime-weather", compact.get("_agent_tool_name"));
+        assertEquals(toolOutput, compact.get("_agent_tool_output"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testUnmarkedAgentWorkflowDefCompactsOnlyStateKeys() {
+        Join join = new Join(mock(ConductorProperties.class));
+
+        Map<String, Object> forkOutput =
+                Map.of(
+                        "state",
+                        "running",
+                        "_state_updates",
+                        Map.of("temperatureUnit", "fahrenheit"),
+                        "response",
+                        Map.of("statusCode", 200));
+        TaskModel forkedTask = forkedTaskWithOutput("t1", forkOutput);
+
+        WorkflowDef agentDef = new WorkflowDef();
+        agentDef.setMetadata(Map.of("agent_sdk", "python"));
+        WorkflowModel workflow = new WorkflowModel();
+        workflow.setWorkflowDefinition(agentDef);
+        workflow.setTasks(List.of(forkedTask));
+
+        TaskModel joinTask = joinTaskOn("t1");
+
+        assertTrue(join.execute(workflow, joinTask, null));
+        assertEquals(
+                Map.of(
+                        "state",
+                        "running",
+                        "_state_updates",
+                        Map.of("temperatureUnit", "fahrenheit")),
+                joinTask.getOutputData().get("t1"));
+    }
+
+    @Test
     public void testNonAgentWorkflowDefCopiesFullForkOutput() {
         ConductorProperties properties = mock(ConductorProperties.class);
         Join join = new Join(properties);
@@ -232,5 +326,25 @@ public class JoinTest {
         assertTrue(done);
         assertNull(workflow.getWorkflowDefinition());
         assertEquals(TaskModel.Status.COMPLETED, joinTask.getStatus());
+    }
+
+    @Test
+    public void testNullWorkflowMetadataAndForkWorkflowTaskDoNotCreateAgentEnvelope() {
+        Join join = new Join(mock(ConductorProperties.class));
+
+        Map<String, Object> forkOutput = Map.of("response", Map.of("statusCode", 200));
+        TaskModel forkedTask = forkedTaskWithOutput("tool", forkOutput);
+        forkedTask.setWorkflowTask(null);
+        forkedTask.setInputData(Map.of("_agent_tool_name", "weather"));
+
+        WorkflowModel workflow = new WorkflowModel();
+        workflow.setWorkflowDefinition(new WorkflowDef());
+        workflow.setTasks(List.of(forkedTask));
+
+        TaskModel joinTask = joinTaskOn("tool");
+
+        assertTrue(join.execute(workflow, joinTask, null));
+        assertEquals(TaskModel.Status.COMPLETED, joinTask.getStatus());
+        assertEquals(forkOutput, joinTask.getOutputData().get("tool"));
     }
 }

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -120,6 +120,65 @@ State mapping:
 | `ai/.../agent/ConductorAgentDelegate.java` | Durable Conductor-agent state machine |
 | `agentspan/.../service/ServiceAgentClient.java` | In-process AgentService implementation |
 | `ai/.../a2a/A2AService.java` | Remote Agent2Agent transport |
+| `agentspan/.../runtime/util/JavaScriptBuilder.java` | Builds dynamic tool tasks and stamps each task definition with `_agent_tool_name` |
+| `agentspan/.../runtime/compiler/ToolCompiler.java` | Compiles `FORK_JOIN_DYNAMIC` → `JOIN` → state/tool-result merge chains |
+| `core/.../execution/tasks/Join.java` | Aggregates fork outputs and preserves agent tool observations across loop iterations |
 
 The test strategy is documented in [testing.md](./testing.md), with the coverage matrix in
 [test-plan.md](./test-plan.md).
+
+## 7. Agent loop JOIN contract
+
+Issue-specific rationale, the implementation sequence, and regression coverage are documented in
+[`issue-1499-agent-loop-join/`](./issue-1499-agent-loop-join/architecture.md). This section remains
+the source of truth for the shared runtime contract and exact names.
+
+Tool-enabled agents compile each tool turn into this durable sequence:
+
+```text
+LLM_CHAT_COMPLETE
+  → enrich dynamic tool definitions
+  → FORK_JOIN_DYNAMIC
+  → JOIN
+  → merge state and tool observations
+  → SET_VARIABLE(_agent_state, _last_tool_results)
+  → next DO_WHILE iteration
+```
+
+`JavaScriptBuilder` writes the logical tool name to the generated `WorkflowTask` input parameters
+as `_agent_tool_name`. The marker is orchestration metadata, not a provider argument. A mapped
+`TaskModel` normally also carries it in `inputData`, but JOIN correctness must not depend on that
+resolved copy: task mappers, payload storage, and system-task request models may retain the marker
+only on `TaskModel.workflowTask.inputParameters`.
+
+For an agent workflow, `Join.compactAgentOutput(TaskModel)` resolves the marker in this order:
+
+1. `forkedTask.inputData["_agent_tool_name"]`;
+2. `forkedTask.workflowTask.inputParameters["_agent_tool_name"]` when the runtime input does not
+   contain it.
+
+When a marker is found, JOIN writes one namespaced observation under the forked task's actual
+iteration-qualified reference name:
+
+```json
+{
+  "<forked-task-ref>": {
+    "_agent_tool_name": "<logical-tool-name>",
+    "_agent_tool_output": { "<complete-tool-output>": "..." }
+  }
+}
+```
+
+The complete tool output is preserved inside `_agent_tool_output`; it is not reduced to the
+general agent merge keys. `JavaScriptBuilder.stateMergeScript()` consumes this envelope, appends
+`{name, output}` to `workflow.variables._last_tool_results`, and makes the observation available to
+the next LLM turn.
+
+Agent fork branches without `_agent_tool_name` retain the existing compact behavior and propagate
+only `_state_updates` and `state`. Non-agent workflows retain stock JOIN behavior and copy the full
+fork output directly. JOIN completion, failure, optional-task, permissive-task, and DO_WHILE
+iteration semantics do not change.
+
+The implementation is limited to `Join.compactAgentOutput(TaskModel)` plus focused tests. It does
+not change `FORK_JOIN_DYNAMIC`, `DO_WHILE`, task mapping, payload storage, workflow metadata,
+`JavaScriptBuilder.stateMergeScript()`, or any public API.

--- a/docs/design/data-model.md
+++ b/docs/design/data-model.md
@@ -92,10 +92,45 @@ Terminal executions additionally expose `agentEndTime`. Completed executions ret
 result. Waiting executions complete the current task with `waiting: true`, an A2A
 `input-required` status, and may expose `pendingTool` and `text`.
 
-## 5. Invariants
+## 5. Agent tool JOIN envelope
+
+Dynamic agent tools use two internal keys shared by the compiler, JOIN, and the state-merge script:
+
+| Key | Type | Owner | Purpose |
+|---|---|---|---|
+| `_agent_tool_name` | `String` | Dynamic `WorkflowTask.inputParameters`; copied into JOIN output | Stable logical tool name independent of generated and iteration-qualified task references |
+| `_agent_tool_output` | `Map<String,Object>` | JOIN output | Complete terminal output from the HTTP, MCP, HUMAN, SIMPLE, or other generated tool task |
+
+The JOIN output type is `Map<String,Object>`, keyed by the actual forked task reference name. Each
+marked tool value is another `Map<String,Object>` with exactly the two keys above. For example:
+
+```json
+{
+  "weather_0__1": {
+    "_agent_tool_name": "weather",
+    "_agent_tool_output": {
+      "response": {
+        "statusCode": 200,
+        "body": { "temperature": 64 }
+      }
+    }
+  }
+}
+```
+
+The task reference remains an execution identity and may include a DO_WHILE iteration suffix. The
+logical name is always read from `_agent_tool_name`; consumers must not reconstruct it from the
+task reference.
+
+## 6. Invariants
 
 1. `agentStartTime` is set once and survives retries and process restarts.
 2. `executionId` is persisted before later invocations poll status.
 3. A successful status call resets `agentPollFailures` to zero.
 4. The idempotency key uses retry-stable task identity, never `taskId`.
 5. Every invocation returns a complete `TaskResult`; the annotation runtime applies and persists it.
+6. A completed dynamic agent tool with non-empty output contributes one non-empty JOIN observation.
+7. `_agent_tool_name` is resolved from runtime input first and the persisted `WorkflowTask`
+   definition second.
+8. `_agent_tool_output` preserves the complete tool output so the next LLM turn receives the
+   observation without provider-specific reconstruction.

--- a/docs/design/issue-1499-agent-loop-join/architecture.md
+++ b/docs/design/issue-1499-agent-loop-join/architecture.md
@@ -1,0 +1,149 @@
+# Architecture — Preserve Dynamic Tool Output Through Agent Loop JOIN
+
+> `docs/design/architecture.md` is the repository-wide source of truth for the complete agent
+> runtime layout, exact shared keys, types, and JOIN contract. This issue-specific document records
+> the problem, scope, and implementation boundary for issue #1499 without redefining those shared
+> contracts.
+
+## 1. Problem
+
+Tool-enabled agents compile an LLM turn into a `FORK_JOIN_DYNAMIC` followed by `JOIN`, an INLINE
+state merge, and a `SET_VARIABLE` update inside a `DO_WHILE` loop. The generated tool tasks finish,
+but their JOIN output can be empty. The merge task then receives no new observation, so
+`workflow.variables._last_tool_results` does not change and the next LLM turn requests the same
+tools until the loop reaches `max_turns`.
+
+The failure is caused by a representation mismatch at the JOIN boundary:
+
+1. `JavaScriptBuilder.enrichToolsScriptDynamic(...)` stamps the logical tool name into the generated
+   `WorkflowTask.inputParameters` map under `_agent_tool_name`.
+2. Dynamic task mapping creates the executable `TaskModel` and retains its `WorkflowTask`.
+3. `Join.compactAgentOutput(TaskModel)` currently looks only in `TaskModel.inputData` for
+   `_agent_tool_name`.
+4. In the failing execution shape, the marker is absent from resolved `inputData` but remains in
+   `TaskModel.workflowTask.inputParameters`.
+5. Agent JOIN compaction sees neither `_state_updates` nor `state` in an ordinary HTTP or MCP tool
+   result, returns an empty map, and omits the completed branch from JOIN output.
+
+This is not a JOIN completion bug: the JOIN reaches `COMPLETED`. It is a loss of agent-specific
+observation metadata while producing the JOIN output.
+
+## 2. Scope
+
+### In scope
+
+- Resolve `_agent_tool_name` from the executable task input first and the retained workflow-task
+  definition second.
+- Preserve the completed tool's entire `Map<String,Object>` output under `_agent_tool_output`.
+- Keep the JOIN output keyed by the actual, iteration-qualified fork task reference.
+- Add focused unit coverage for the failing `DO_WHILE` dynamic-tool representation.
+- Add consumer-level coverage proving the JOIN envelope becomes the next turn's tool result.
+
+### Out of scope
+
+- Changing `DO_WHILE` iteration scheduling or task-reference suffixing.
+- Changing `FORK_JOIN_DYNAMIC` mapping or copying every workflow-task input into task input data.
+- Changing JOIN terminal, failure, optional-task, or permissive-task semantics.
+- Expanding agent JOIN output for unmarked branches.
+- Changing non-agent JOIN output.
+- Changing the agent prompt, LLM provider integration, tool dispatch, or maximum-turn behavior.
+- Reproducing the issue against a live LLM, MCP server, or HTTP server in automated tests.
+
+## 3. Existing and target flow
+
+```text
+LLM_CHAT_COMPLETE
+  -> INLINE enrich tools
+  -> FORK_JOIN_DYNAMIC
+  -> dynamic HTTP / MCP / HUMAN / SIMPLE tool tasks
+  -> JOIN
+  -> INLINE merge state and observations
+  -> SET_VARIABLE(_agent_state, _last_tool_results)
+  -> next DO_WHILE iteration
+```
+
+The target change is confined to the JOIN output step. A marked task produces this value under its
+actual joined reference:
+
+```json
+{
+  "weather_0__1": {
+    "_agent_tool_name": "weather",
+    "_agent_tool_output": {
+      "response": {
+        "statusCode": 200,
+        "body": {
+          "temperature": 64
+        }
+      }
+    }
+  }
+}
+```
+
+`JavaScriptBuilder.stateMergeScript()` already consumes this envelope and appends
+`{"name": "weather", "output": {...}}` to `_last_tool_results`. No script contract change is
+required.
+
+## 4. Complete file layout
+
+The implementation changes only the following production and test files:
+
+| File | Responsibility |
+|---|---|
+| `core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java` | Add the workflow-task input fallback when resolving `_agent_tool_name`; retain existing compaction and status behavior. |
+| `core/src/test/java/com/netflix/conductor/core/execution/tasks/JoinTest.java` | Cover fallback, precedence, unmarked-agent compatibility, non-agent compatibility, and null metadata. |
+| `agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/util/AgentToolJoinStateMergeScriptTest.java` | Execute the existing merge script with HTTP- and MCP-shaped JOIN envelopes and assert the next-turn tool-result shape. |
+
+The design-doc set is:
+
+| File | Responsibility |
+|---|---|
+| `docs/design/architecture.md` | Canonical shared runtime contract, names, types, and source layout. |
+| `docs/design/data-model.md` | Canonical `_agent_tool_name` / `_agent_tool_output` envelope and invariants. |
+| `docs/design/issue-1499-agent-loop-join/architecture.md` | Issue scope, root cause, compatibility boundary, and affected files. |
+| `docs/design/issue-1499-agent-loop-join/implementation-plan.md` | Ordered implementation steps and exact algorithm. |
+| `docs/design/issue-1499-agent-loop-join/testing.md` | Focused regression matrix and repository-evidenced commands. |
+
+No public API, persistence schema, task-definition schema, or configuration property is added.
+
+## 5. Exact contracts
+
+The shared envelope and invariants are defined in
+[`../data-model.md`](../data-model.md#5-agent-tool-join-envelope). The implementation uses the
+existing concrete types:
+
+| Symbol | Type | Relevant member |
+|---|---|---|
+| `TaskModel` | engine execution model | `Map<String,Object> getInputData()`, `Map<String,Object> getOutputData()`, `WorkflowTask getWorkflowTask()` |
+| `WorkflowTask` | workflow task definition | `Map<String,Object> getInputParameters()` |
+| `Join.compactAgentOutput(TaskModel)` | private static helper | returns `Map<String,Object>` |
+| `_agent_tool_name` | internal marker | `String` logical tool name |
+| `_agent_tool_output` | JOIN envelope value | complete `Map<String,Object>` task output |
+
+Marker resolution order is deterministic:
+
+1. Read `forkedTask.getInputData().get("_agent_tool_name")`.
+2. If absent, read
+   `forkedTask.getWorkflowTask().getInputParameters().get("_agent_tool_name")` when both objects
+   exist.
+3. If a marker is found, return a two-entry `LinkedHashMap` containing `_agent_tool_name` and
+   `_agent_tool_output`.
+4. If no marker is found, preserve the existing agent compaction of `_state_updates` and `state`.
+
+Runtime `inputData` intentionally wins when both representations contain a marker because it is the
+resolved execution input. The workflow-task value is a recovery path for the dynamic-task shape,
+not an override.
+
+## 6. Compatibility
+
+- **Marked agent tool:** JOIN emits one non-empty observation with the complete output.
+- **Unmarked agent branch:** JOIN continues to copy only `_state_updates` and `state`.
+- **Non-agent workflow:** JOIN continues to copy the complete fork output directly.
+- **Missing `WorkflowDef`, `WorkflowTask`, input map, or marker:** no exception and no accidental
+  agent-tool envelope.
+- **Iteration-qualified references:** unchanged; the envelope remains keyed by the reference already
+  resolved by JOIN for the current loop iteration.
+
+The change therefore repairs the missing observation without broadening general JOIN payloads or
+altering orchestration decisions.

--- a/docs/design/issue-1499-agent-loop-join/implementation-plan.md
+++ b/docs/design/issue-1499-agent-loop-join/implementation-plan.md
@@ -1,0 +1,107 @@
+# Implementation Plan — Issue #1499 Agent Loop JOIN Output
+
+This plan implements the contract in [architecture.md](./architecture.md). Exact shared keys, types,
+and invariants remain canonical in [`../architecture.md`](../architecture.md#7-agent-loop-join-contract)
+and [`../data-model.md`](../data-model.md#5-agent-tool-join-envelope).
+
+## 1. Update JOIN marker resolution
+
+Edit `core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java` only inside
+`compactAgentOutput(TaskModel)` and, if useful for readability, one private marker-resolution
+helper.
+
+The algorithm is:
+
+```text
+output = forkedTask.outputData
+toolName = forkedTask.inputData["_agent_tool_name"]
+
+if toolName is null and forkedTask.workflowTask is not null:
+    definitionInputs = forkedTask.workflowTask.inputParameters
+    if definitionInputs is not null:
+        toolName = definitionInputs["_agent_tool_name"]
+
+if toolName is not null:
+    return linked map {
+        "_agent_tool_name": toolName,
+        "_agent_tool_output": output
+    }
+
+return existing compact map containing only present keys from:
+    "_state_updates", "state"
+```
+
+Implementation constraints:
+
+- Do not change the outer `Join.execute(...)` loop.
+- Do not add output for a fork task whose `outputData` is empty; the existing guard remains the
+  owner of that behavior.
+- Do not parse the iteration-qualified reference to infer a tool name.
+- Do not mutate `TaskModel.inputData`, `WorkflowTask.inputParameters`, or tool output.
+- Do not add `_agent_tool_name` to `AGENT_PROPAGATED_KEYS`; marked tool output requires the
+  namespaced envelope, while unmarked state branches retain compact propagation.
+- Preserve `LinkedHashMap` so the emitted envelope remains deterministic in tests and serialized
+  output.
+
+## 2. Add engine regression tests
+
+Extend `core/src/test/java/com/netflix/conductor/core/execution/tasks/JoinTest.java` with focused
+tests using real `WorkflowDef`, `WorkflowTask`, `WorkflowModel`, and `TaskModel` values. Existing
+test helpers may be extended, but production behavior must not be mocked.
+
+Required cases:
+
+1. **Workflow-task fallback:** agent workflow; completed fork task; non-empty HTTP-shaped output;
+   `_agent_tool_name` only in `WorkflowTask.inputParameters`; JOIN output contains the complete
+   two-key envelope.
+2. **Runtime precedence:** both input locations contain different names; emitted name comes from
+   `TaskModel.inputData`.
+3. **Unmarked agent compatibility:** output containing `state`, `_state_updates`, and an unrelated
+   key emits only the two allowed state keys.
+4. **Non-agent compatibility:** the same fork output is copied unchanged.
+5. **Null safety:** absent workflow definition or absent `WorkflowTask` does not throw and does not
+   enable the agent-tool envelope.
+
+The primary regression should model loop execution identity by using an iteration-qualified task
+reference such as `weather_0__1` in both the fork task and JOIN `joinOn` resolution. The test need
+not execute the complete `DO_WHILE` scheduler because the defect is isolated to JOIN compaction
+after task-reference resolution.
+
+## 3. Add merge-consumer tests
+
+Create
+`agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/util/AgentToolJoinStateMergeScriptTest.java`.
+
+Use the repository's existing GraalJS test pattern for `JavaScriptBuilder` scripts. Execute
+`JavaScriptBuilder.stateMergeScript()` with:
+
+- an HTTP-shaped `_agent_tool_output` containing `response.statusCode` and `response.body`;
+- an MCP-shaped `_agent_tool_output` containing `content` and `isError`; and
+- an existing `previousToolResults` list to prove observations append rather than replace history.
+
+Assert that `toolResults` contains entries shaped as `Map<String,Object>` with exactly the logical
+`name` and complete `output` value expected by the next LLM turn. Also assert that existing
+`_state_updates` behavior remains intact.
+
+No live service, network socket, credential, or full example execution is part of this test.
+
+## 4. Documentation consistency
+
+Keep these documents mutually consistent:
+
+- `docs/design/architecture.md` owns the shared JOIN contract and source layout.
+- `docs/design/data-model.md` owns the two-key envelope and invariants.
+- This issue set owns rationale, implementation sequencing, and regression coverage.
+
+Do not document a new API, configuration property, task type, or persisted field because the fix
+introduces none.
+
+## 5. Completion criteria
+
+- A completed marked dynamic tool contributes a non-empty JOIN entry even when its marker exists
+  only on `WorkflowTask.inputParameters`.
+- The complete HTTP, MCP, HUMAN, SIMPLE, media, RAG, or sub-workflow tool output remains available
+  to `stateMergeScript()` without provider-specific extraction in JOIN.
+- Runtime marker precedence, unmarked agent compaction, non-agent JOIN output, and JOIN lifecycle
+  behavior remain unchanged.
+- Focused core and agentspan tests pass after formatting.

--- a/docs/design/issue-1499-agent-loop-join/testing.md
+++ b/docs/design/issue-1499-agent-loop-join/testing.md
@@ -1,0 +1,53 @@
+# Testing — Issue #1499 Agent Loop JOIN Output
+
+This test plan verifies the implementation described in [architecture.md](./architecture.md) and
+[implementation-plan.md](./implementation-plan.md).
+
+## 1. Regression matrix
+
+| Case | Setup | Expected result |
+|---|---|---|
+| Dynamic marker fallback | Agent `WorkflowDef`; completed iteration-qualified fork task; `_agent_tool_name` only in `WorkflowTask.inputParameters` | JOIN completes and emits `_agent_tool_name` plus complete `_agent_tool_output`. |
+| Runtime marker precedence | Different marker values in `TaskModel.inputData` and `WorkflowTask.inputParameters` | JOIN uses the runtime `inputData` value. |
+| HTTP observation | Envelope wraps `response.statusCode` and `response.body` | Merge script appends `{name, output}` without dropping response fields. |
+| MCP observation | Envelope wraps `content` and `isError` | Merge script appends `{name, output}` without provider-specific conversion. |
+| Prior observations | `previousToolResults` already contains an entry | Merge script retains prior entries and appends the current turn. |
+| State update compatibility | Tool output includes `_state_updates` | Merge script preserves existing shallow state-merge behavior. |
+| Unmarked agent branch | Output contains state keys plus unrelated data | JOIN emits only `_state_updates` and `state`. |
+| Non-agent workflow | Same completed fork task without agent metadata | JOIN copies the full output unchanged. |
+| Missing metadata | Null workflow definition or null workflow task | JOIN does not throw and does not create a marked-tool envelope. |
+
+## 2. Why focused tests are sufficient
+
+The observed workflow already proves that dynamic tools reach terminal status. The defect occurs
+after JOIN resolves the current iteration's task references and before the existing merge script
+receives the task output. A real `Join.execute(...)` unit test covers that engine boundary without
+requiring an LLM, an MCP transport, an HTTP endpoint, or repeated `DO_WHILE` scheduling.
+
+The script test covers the next boundary independently: once JOIN emits the documented envelope,
+`stateMergeScript()` must append the observation to `_last_tool_results`. Together these tests cover
+the complete data path that failed in issue #1499 while remaining deterministic.
+
+## 3. Repository-evidenced commands
+
+Run from the repository root, in this order:
+
+```bash
+./gradlew spotlessApply
+./gradlew :conductor-core:test --tests com.netflix.conductor.core.execution.tasks.JoinTest
+./gradlew :conductor-agentspan:test --tests org.conductoross.conductor.ai.agentspan.runtime.util.AgentToolJoinStateMergeScriptTest
+```
+
+These commands are already used by the repository design guidance for the affected modules. Do not
+replace them with custom Gradle configuration or sandbox workarounds.
+
+## 4. Acceptance criteria
+
+1. `JoinTest` proves the workflow-task marker fallback and compatibility cases.
+2. `AgentToolJoinStateMergeScriptTest` proves HTTP- and MCP-shaped observations reach the next-turn
+   tool-result list with complete outputs.
+3. Spotless completes without changing unrelated files.
+4. The two focused test commands pass.
+5. If a command is blocked by sandbox restrictions on networking, sockets, file locks, or another
+   operating-system facility, report the exact command and blocker and stop without changing
+   Gradle, cache, daemon, wrapper, environment, or project configuration.

--- a/docs/design/testing.md
+++ b/docs/design/testing.md
@@ -45,11 +45,40 @@ Core annotation tests cover:
 
 These tests keep the reusable worker contract independent from engine-internal task models.
 
-## 4. Commands
+## 4. Agent loop JOIN regression
+
+`JoinTest` covers the engine boundary with real `WorkflowDef`, `WorkflowTask`, `WorkflowModel`, and
+`TaskModel` instances. Add a focused regression for the issue #1499 execution shape:
+
+1. Mark the workflow as an agent with `metadata.agentDef`.
+2. Create a completed dynamic tool task whose iteration-qualified reference is joined from a
+   `DO_WHILE` iteration.
+3. Put `_agent_tool_name` only in `TaskModel.workflowTask.inputParameters`; omit it from
+   `TaskModel.inputData` to model the failing runtime representation.
+4. Give the task a non-empty HTTP- or MCP-shaped output.
+5. Execute JOIN and assert that it completes with a non-empty entry containing the logical name and
+   the complete output under `_agent_tool_output`.
+
+The same test class retains explicit compatibility cases:
+
+- a marker already present in `TaskModel.inputData` takes precedence;
+- an unmarked agent branch still propagates only `_state_updates` and `state`;
+- a non-agent JOIN still copies the full fork output; and
+- missing workflow metadata does not throw or enable agent compaction.
+
+`AgentToolJoinStateMergeScriptTest` exercises the consumer boundary by passing the JOIN envelope to
+`stateMergeScript()` and asserting that `toolResults` contains `{name, output}` for the next agent
+turn. This test uses both an HTTP-shaped response and an MCP-shaped response so the contract stays
+provider-neutral.
+
+No live LLM, MCP server, HTTP server, or full example execution is required for the regression.
+
+## 5. Commands
 
 ```bash
 ./gradlew spotlessApply
-./gradlew :conductor-ai:test
+./gradlew :conductor-core:test --tests com.netflix.conductor.core.execution.tasks.JoinTest
+./gradlew :conductor-agentspan:test --tests org.conductoross.conductor.ai.agentspan.runtime.util.AgentToolJoinStateMergeScriptTest
 ```
 
 Credentialed or live-server integration tests remain opt-in and skip when their prerequisites are


### PR DESCRIPTION
## Summary

Implement the approved issue #1499 fix strictly at the agent JOIN boundary: recover `_agent_tool_name` from retained workflow-task inputs when absent from resolved runtime inputs, preserve the complete tool output envelope, and add focused engine and merge-consumer regressions. No scheduler, compiler, script, API, documentation, or non-agent behavior changes are needed.