### PR TITLE
Resolve #1501: how Agent executions and the id for the agent execution in the agent execution page

### DIFF
--- a/ui-next/src/pages/execution/Execution.tsx
+++ b/ui-next/src/pages/execution/Execution.tsx
@@ -708,7 +708,9 @@ export default function Execution() {
                 </Stack>
               }
               breadcrumbItems={[
-                { label: "Workflow Executions", to: "/executions" },
+                isAgentExecution
+                  ? { label: "Agent Executions", to: AGENT_EXECUTIONS_URL.BASE }
+                  : { label: "Workflow Executions", to: "/executions" },
                 {
                   label: execution.workflowId || "",
                   to: "",


### PR DESCRIPTION
## Summary

Issue #1501 asks that the agent execution page header stop labeling agent runs as "Workflow Executions". The fix is a single-file, minimal change in ui-next/src/pages/execution/Execution.tsx: the hardcoded breadcrumb (lines 710-717) that shows "Workflow Executions" → /executions plus the execution id should, for agent-classified executions, instead show "Agent Executions" → /agentExecutions. The helper `isAgentWorkflowExecution` and the `AGENT_EXECUTIONS_URL` constant are already imported and…