### PR TITLE
Bump jackson to 2.18.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ allprojects {
             resolutionStrategy.eachDependency { details ->
                 // Compat: align all com.fasterxml.jackson.* to the same version — mixed versions cause ClassNotFoundException
                 if (details.requested.group.startsWith('com.fasterxml.jackson.')) {
-                    details.useVersion "2.17.0"
+                    details.useVersion "2.18.9"
                 }
                 // Compat: commons-lang3 3.18.0+ required by Testcontainers/commons-compress
                 if (details.requested.group == 'org.apache.commons' && details.requested.name == 'commons-lang3') {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -73,7 +73,7 @@ ext {
     revSpock = '2.4-M4-groovy-4.0'
     revSpotifyCompletableFutures = '0.3.3'
     revTestContainer = '1.21.4'
-    revFasterXml = '2.15.3'
+    revFasterXml = '2.18.9'
     revAmqpClient = '5.13.0'
     revKafka = '2.6.0'
     revMicrometer = '1.14.6'

--- a/os-persistence-v2/build.gradle
+++ b/os-persistence-v2/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation "org.apache.commons:commons-lang3"
     implementation "com.google.guava:guava:${revGuava}"
 
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.18.0'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.18.9'
 
     implementation 'org.opensearch.client:opensearch-java:2.18.0'
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'

--- a/os-persistence-v3/build.gradle
+++ b/os-persistence-v3/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation "org.apache.commons:commons-lang3"
     implementation "com.google.guava:guava:${revGuava}"
 
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.18.0'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.18.9'
 
     implementation 'org.opensearch.client:opensearch-java:3.5.0'
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.3.1'


### PR DESCRIPTION
- global jackson version force moved from 2.17.0 to 2.18.9
- aligned the two other jackson version literals in the repo that had drifted out of sync

Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_

Enterprise UI Playwright Tests
----
Every PR automatically triggers the enterprise UI Playwright E2E test suite.
Tests run against conductor-ui `main` by default. To test against a different
conductor-ui branch, add this line anywhere in the PR description:

```
conductor-ui-branch: my-feature-branch
```
