### PR TITLE
fix(ui-next): sort Agent Name on the column that is actually indexed

### DIFF
--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilderTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilderTest.java
@@ -725,4 +725,26 @@ public class PostgresIndexQueryBuilderTest {
         inOrder.verify(mockQuery).addParameter(0);
         verifyNoMoreInteractions(mockQuery);
     }
+
+    @Test
+    void shouldSortOnWorkflowTypeWhichBacksTheAgentNameColumn() throws SQLException {
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "workflow_index", "", "", 0, 15, List.of("workflowType:ASC"), properties);
+        assertEquals(
+                "SELECT json_data::TEXT FROM workflow_index ORDER BY workflow_type ASC LIMIT ? OFFSET ?",
+                builder.getQuery());
+    }
+
+    @Test
+    void shouldDropSortFieldsThatAreNotIndexedColumns() throws SQLException {
+        // A sort field outside VALID_FIELDS produces no ORDER BY at all rather than an
+        // error, so LIMIT/OFFSET pages an unordered result set. Callers must send the
+        // indexed column name -- `workflowType`, not `workflowName`. See issue #1514.
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "workflow_index", "", "", 0, 15, List.of("workflowName:ASC"), properties);
+        assertEquals(
+                "SELECT json_data::TEXT FROM workflow_index LIMIT ? OFFSET ?", builder.getQuery());
+    }
 }

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilderTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilderTest.java
@@ -257,4 +257,25 @@ public class SqliteIndexQueryBuilderTest {
         inOrder.verify(mockQuery).addParameter(0);
         verifyNoMoreInteractions(mockQuery);
     }
+
+    @Test
+    void shouldSortOnWorkflowTypeWhichBacksTheAgentNameColumn() throws SQLException {
+        SqliteIndexQueryBuilder builder =
+                new SqliteIndexQueryBuilder(
+                        "workflow_index", "", "", 0, 15, List.of("workflowType:ASC"), properties);
+        assertEquals(
+                "SELECT json_data FROM workflow_index ORDER BY workflow_type ASC LIMIT ? OFFSET ?",
+                builder.getQuery());
+    }
+
+    @Test
+    void shouldDropSortFieldsThatAreNotIndexedColumns() throws SQLException {
+        // A sort field outside VALID_FIELDS produces no ORDER BY at all rather than an
+        // error, so LIMIT/OFFSET pages an unordered result set. Callers must send the
+        // indexed column name -- `workflowType`, not `workflowName`. See issue #1514.
+        SqliteIndexQueryBuilder builder =
+                new SqliteIndexQueryBuilder(
+                        "workflow_index", "", "", 0, 15, List.of("workflowName:ASC"), properties);
+        assertEquals("SELECT json_data FROM workflow_index LIMIT ? OFFSET ?", builder.getQuery());
+    }
 }

--- a/ui-next/src/pages/agent/executions/workflowSearchComponents/AdvancedSearch.tsx
+++ b/ui-next/src/pages/agent/executions/workflowSearchComponents/AdvancedSearch.tsx
@@ -29,7 +29,7 @@ import { IObject } from "types/common";
 import { WorkflowExecutionStatus } from "types/Execution";
 import { TaskExecutionResult } from "types/TaskExecution";
 import { DoSearchProps } from "types/WorkflowExecution";
-import { dateToEpoch, useLocalStorage } from "utils";
+import { buildSortParam, dateToEpoch, useLocalStorage } from "utils";
 import { WORKFLOW_SEARCH_QUERY_SUGGESTIONS } from "utils/constants/common";
 import { ERROR_URL } from "utils/constants/route";
 import { useAgentNames, useWorkflowSearch } from "utils/query";
@@ -265,9 +265,7 @@ export default function AdvancedSearch({
   };
 
   const handleSort = (changedColumn: string, direction: string) => {
-    const sortColumn =
-      changedColumn === "workflowType" ? "workflowName" : changedColumn;
-    const newSort = `${sortColumn}:${direction.toUpperCase()}`;
+    const newSort = buildSortParam(changedColumn, direction);
 
     // Only refetch if sort actually changed
     if (sort !== newSort) {

--- a/ui-next/src/pages/agent/executions/workflowSearchComponents/BasicSearch.tsx
+++ b/ui-next/src/pages/agent/executions/workflowSearchComponents/BasicSearch.tsx
@@ -25,7 +25,7 @@ import { WorkflowExecutionStatus } from "types/Execution";
 import { TaskExecutionResult } from "types/TaskExecution";
 import { DoSearchProps } from "types/WorkflowExecution";
 import { IObject } from "types/common";
-import { dateToEpoch, useLocalStorage } from "utils";
+import { buildSortParam, dateToEpoch, useLocalStorage } from "utils";
 import { ERROR_URL } from "utils/constants/route";
 import { useAutoCompleteInputValidation } from "utils/hooks/useAutoCompleteInputValidation";
 import { useAgentNames, useWorkflowSearch } from "utils/query";
@@ -321,9 +321,7 @@ export default function BasicSearch({
   );
 
   const handleSort = (changedColumn: string, direction: string) => {
-    const sortColumn =
-      changedColumn === "workflowType" ? "workflowName" : changedColumn;
-    const newSort = `${sortColumn}:${direction.toUpperCase()}`;
+    const newSort = buildSortParam(changedColumn, direction);
 
     // Only refetch if sort actually changed
     if (sort !== newSort) {

--- a/ui-next/src/pages/executions/TaskSearch.tsx
+++ b/ui-next/src/pages/executions/TaskSearch.tsx
@@ -18,7 +18,7 @@ import { colors } from "theme/tokens/variables";
 import { Key } from "ts-key-enum";
 import { TaskExecutionResult } from "types/TaskExecution";
 import { IObject } from "types/common";
-import { dateToEpoch } from "utils";
+import { buildSortParam, dateToEpoch } from "utils";
 import { pluralizeResults } from "utils/helpers";
 import { ERROR_URL, NEW_TASK_DEF_URL } from "utils/constants/route";
 import { commonlyUsedDateTime, getSearchDateTime } from "utils/date";
@@ -241,9 +241,7 @@ export function TaskSearch() {
   };
 
   const handleSort = (changedColumn: string, direction: string) => {
-    const sortColumn =
-      changedColumn === "workflowType" ? "workflowName" : changedColumn;
-    const sort = `${sortColumn}:${direction.toUpperCase()}`;
+    const sort = buildSortParam(changedColumn, direction);
     setPage(1);
     setSort(sort);
   };

--- a/ui-next/src/pages/executions/workflowSearchComponents/AdvancedSearch.tsx
+++ b/ui-next/src/pages/executions/workflowSearchComponents/AdvancedSearch.tsx
@@ -29,7 +29,7 @@ import { IObject } from "types/common";
 import { WorkflowExecutionStatus } from "types/Execution";
 import { TaskExecutionResult } from "types/TaskExecution";
 import { DoSearchProps } from "types/WorkflowExecution";
-import { dateToEpoch, useLocalStorage } from "utils";
+import { buildSortParam, dateToEpoch, useLocalStorage } from "utils";
 import { WORKFLOW_SEARCH_QUERY_SUGGESTIONS } from "utils/constants/common";
 import { ERROR_URL } from "utils/constants/route";
 import { useWorkflowNames, useWorkflowSearch } from "utils/query";
@@ -266,9 +266,7 @@ export default function AdvancedSearch({
   };
 
   const handleSort = (changedColumn: string, direction: string) => {
-    const sortColumn =
-      changedColumn === "workflowType" ? "workflowName" : changedColumn;
-    const newSort = `${sortColumn}:${direction.toUpperCase()}`;
+    const newSort = buildSortParam(changedColumn, direction);
 
     // Only refetch if sort actually changed
     if (sort !== newSort) {

--- a/ui-next/src/pages/executions/workflowSearchComponents/BasicSearch.tsx
+++ b/ui-next/src/pages/executions/workflowSearchComponents/BasicSearch.tsx
@@ -25,7 +25,7 @@ import { WorkflowExecutionStatus } from "types/Execution";
 import { TaskExecutionResult } from "types/TaskExecution";
 import { DoSearchProps } from "types/WorkflowExecution";
 import { IObject } from "types/common";
-import { dateToEpoch, useLocalStorage } from "utils";
+import { buildSortParam, dateToEpoch, useLocalStorage } from "utils";
 import { ERROR_URL } from "utils/constants/route";
 import { useAutoCompleteInputValidation } from "utils/hooks/useAutoCompleteInputValidation";
 import { useWorkflowNames, useWorkflowSearch } from "utils/query";
@@ -343,9 +343,7 @@ export default function BasicSearch({
   );
 
   const handleSort = (changedColumn: string, direction: string) => {
-    const sortColumn =
-      changedColumn === "workflowType" ? "workflowName" : changedColumn;
-    const newSort = `${sortColumn}:${direction.toUpperCase()}`;
+    const newSort = buildSortParam(changedColumn, direction);
 
     // Only refetch if sort actually changed
     if (sort !== newSort) {

--- a/ui-next/src/utils/__tests__/executionSort.test.ts
+++ b/ui-next/src/utils/__tests__/executionSort.test.ts
@@ -1,0 +1,22 @@
+import { buildSortParam } from "../executionSort";
+
+describe("buildSortParam", () => {
+  // The Agent Name column renders `workflowType`, and `workflow_type` is the
+  // indexed column behind it. Sending anything else makes the backend drop the
+  // ORDER BY, which is issue #1514.
+  it("sorts the Agent Name column on workflowType", () => {
+    expect(buildSortParam("workflowType", "asc")).toBe("workflowType:ASC");
+    expect(buildSortParam("workflowType", "desc")).toBe("workflowType:DESC");
+  });
+
+  it("passes other sortable columns through unchanged", () => {
+    expect(buildSortParam("startTime", "desc")).toBe("startTime:DESC");
+    expect(buildSortParam("workflowId", "asc")).toBe("workflowId:ASC");
+    expect(buildSortParam("updateTime", "asc")).toBe("updateTime:ASC");
+    expect(buildSortParam("status", "desc")).toBe("status:DESC");
+  });
+
+  it("uppercases the direction", () => {
+    expect(buildSortParam("startTime", "ASC")).toBe("startTime:ASC");
+  });
+});

--- a/ui-next/src/utils/executionSort.ts
+++ b/ui-next/src/utils/executionSort.ts
@@ -1,0 +1,11 @@
+/**
+ * Builds the `sort` query parameter sent to the execution/task search APIs.
+ *
+ * The value must name a field the index query builder recognises. It lowercases
+ * and snake_cases the field before matching it against its allow-list, and
+ * silently emits no ORDER BY when there is no match — so a wrong field name
+ * here shows up as unordered results rather than an error.
+ */
+export function buildSortParam(columnId: string, direction: string): string {
+  return `${columnId}:${direction.toUpperCase()}`;
+}

--- a/ui-next/src/utils/index.ts
+++ b/ui-next/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from "./array";
 export * from "./date";
+export * from "./executionSort";
 export * from "./flags";
 export * from "./gtag";
 export * from "./handleValidChars";


### PR DESCRIPTION
Fixes #1514

`handleSort` was renaming the column id `workflowType` to `workflowName` before sending it. `workflowName` isn't a real field on any backend — not in the sqlite/postgres `VALID_FIELDS`, not in the ES mappings — so the sort was dropped and rows came back in whatever order the query plan yielded. On Elasticsearch it's worse: the unmapped field is rejected outright and the search returns **HTTP 500**, so the page fails to load rather than mis-ordering. **This PR deletes that rename;** the column id now goes through unchanged. The same bad remap existed on the workflow executions and task search pages, so all five call sites now share one helper.

### Before — clicking the name column sends `workflowName:DESC` → 500, table empty
![before](https://raw.githubusercontent.com/conductor-oss/conductor/assets/pr-1516-screenshots/sort-before.png)

### After — sends `workflowType:DESC` → 200, rows sorted
![after](https://raw.githubusercontent.com/conductor-oss/conductor/assets/pr-1516-screenshots/sort-after.png)

Same URL, same filters, same server; only the `handleSort` line differs. (Captured on the Workflow Executions page, which shares the identical remap — the environment had no agent executions to show.)

Frontend-only, no backend behaviour change. Tests added at both layers (`buildSortParam`, sqlite + postgres query builders), each confirmed failing before the fix.

Not addressed here: `workflow_type` is non-unique and no tiebreaker is appended, so rows sharing an agent name can still shuffle across page boundaries under offset paging.