### PR TITLE
test(persistence): pin the sort-field contract behind #1514

### DIFF
--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilderTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/util/PostgresIndexQueryBuilderTest.java
@@ -725,4 +725,26 @@ public class PostgresIndexQueryBuilderTest {
         inOrder.verify(mockQuery).addParameter(0);
         verifyNoMoreInteractions(mockQuery);
     }
+
+    @Test
+    void shouldSortOnWorkflowTypeWhichBacksTheAgentNameColumn() throws SQLException {
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "workflow_index", "", "", 0, 15, List.of("workflowType:ASC"), properties);
+        assertEquals(
+                "SELECT json_data::TEXT FROM workflow_index ORDER BY workflow_type ASC LIMIT ? OFFSET ?",
+                builder.getQuery());
+    }
+
+    @Test
+    void shouldDropSortFieldsThatAreNotIndexedColumns() throws SQLException {
+        // A sort field outside VALID_FIELDS produces no ORDER BY at all rather than an
+        // error, so LIMIT/OFFSET pages an unordered result set. Callers must send the
+        // indexed column name -- `workflowType`, not `workflowName`. See issue #1514.
+        PostgresIndexQueryBuilder builder =
+                new PostgresIndexQueryBuilder(
+                        "workflow_index", "", "", 0, 15, List.of("workflowName:ASC"), properties);
+        assertEquals(
+                "SELECT json_data::TEXT FROM workflow_index LIMIT ? OFFSET ?", builder.getQuery());
+    }
 }

--- a/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilderTest.java
+++ b/sqlite-persistence/src/test/java/com/netflix/conductor/sqlite/util/SqliteIndexQueryBuilderTest.java
@@ -257,4 +257,25 @@ public class SqliteIndexQueryBuilderTest {
         inOrder.verify(mockQuery).addParameter(0);
         verifyNoMoreInteractions(mockQuery);
     }
+
+    @Test
+    void shouldSortOnWorkflowTypeWhichBacksTheAgentNameColumn() throws SQLException {
+        SqliteIndexQueryBuilder builder =
+                new SqliteIndexQueryBuilder(
+                        "workflow_index", "", "", 0, 15, List.of("workflowType:ASC"), properties);
+        assertEquals(
+                "SELECT json_data FROM workflow_index ORDER BY workflow_type ASC LIMIT ? OFFSET ?",
+                builder.getQuery());
+    }
+
+    @Test
+    void shouldDropSortFieldsThatAreNotIndexedColumns() throws SQLException {
+        // A sort field outside VALID_FIELDS produces no ORDER BY at all rather than an
+        // error, so LIMIT/OFFSET pages an unordered result set. Callers must send the
+        // indexed column name -- `workflowType`, not `workflowName`. See issue #1514.
+        SqliteIndexQueryBuilder builder =
+                new SqliteIndexQueryBuilder(
+                        "workflow_index", "", "", 0, 15, List.of("workflowName:ASC"), properties);
+        assertEquals("SELECT json_data FROM workflow_index LIMIT ? OFFSET ?", builder.getQuery());
+    }
 }


### PR DESCRIPTION
Complements #1515, which fixes the Agent Name sort by removing a UI-side rename of `workflowType` to `workflowName`. Tests only — no production code.

The reason that bug was invisible is that nothing on the backend rejects a wrong sort field: `getSort()` skips anything outside `VALID_FIELDS` and returns `""`, so the query runs with no `ORDER BY` at all. These two tests per builder pin that behaviour — `workflowType:ASC` produces `ORDER BY workflow_type ASC`, `workflowName:ASC` produces no `ORDER BY` — so the next caller that sends an unindexed field is caught by a test rather than by unordered pages.

Passes on `main` as-is and stays valid after #1515 merges.