### PR TITLE
Docs: AI Cookbook top-level tab, Platform tab last, next-steps rendering fix

### DIFF
--- a/docs/devguide/cookbook/index.md
+++ b/docs/devguide/cookbook/index.md
@@ -6,7 +6,7 @@ description: "Complete, runnable Conductor workflow definitions for common orche
 
 <section class="concept-hero concept-hero--cookbook">
   <div class="concept-hero__content">
-    <p>Design patterns are complete, runnable workflow definitions for common orchestration problems. Each page takes one problem, such as parallel fan-out, sagas, timers, or human approval, and gives you a working definition to register, run, and adapt to your own tasks. The section is grouped into workflow patterns, agentic patterns, and agent recipes.</p>
+    <p>Design patterns are complete, runnable workflow definitions for common orchestration problems. Each page takes one problem, such as parallel fan-out, sagas, timers, or human approval, and gives you a working definition to register, run, and adapt to your own tasks. This section covers workflow patterns. Agentic patterns and agent recipes live in <a href="../ai/cookbook/index.html">AI Cookbook</a>.</p>
   </div>
   <svg class="concept-hero__graphic cookbook-hero__graphic" viewBox="0 0 440 205" role="img" aria-label="Cookbook recipes for services, parallel work, timers, events, AI, and code flow into a durable Conductor workflow">
     <defs><marker id="cookbook-arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0,0 L8,4 L0,8 Z" fill="currentColor" /></marker></defs>

--- a/docs/devguide/how-tos/event-bus.md
+++ b/docs/devguide/how-tos/event-bus.md
@@ -61,9 +61,8 @@ Monitor broker queue depth (`event_queue_depth`), message processing (`event_que
 
 ## Next steps
 
-<div class="event-next-steps">
-  <a href="publish-events.html">Publish events →</a>
-  <a href="consume-route-events.html">Consume and route events →</a>
-  <a href="incoming-webhooks.html">Receive webhooks →</a>
-  <a href="../cookbook/sending-signals.html">Send workflow signals →</a>
-</div>
+- **[Publish events](publish-events.md)** — send workflow data to a broker.
+- **[Consume and route events](consume-route-events.md)** — start or advance workflows from incoming messages.
+- **[Incoming webhooks](incoming-webhooks.md)** — accept verified HTTP callbacks.
+- **[Send signals](../cookbook/sending-signals.md)** — advance an execution that is waiting.
+- **[Workflow status events](workflow-status-events.md)** — notify external systems as executions change state.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,32 +31,6 @@ nav:
     - Bring Your Framework Agent: quickstart/framework-agents.md
     - Run a Workflow from JSON: quickstart/first-workflow.md
     - Conductor for AI Assistants: devguide/ai/conductor-for-ai-assistants.md
-  - Platform:
-    - Core Concepts: devguide/concepts/index.md
-    - Why Conductor: devguide/concepts/conductor.md
-    - Architecture: devguide/architecture/index.md
-    - Durable Execution: architecture/durable-execution.md
-    - JSON + Code Native: architecture/json-native.md
-    - Task Lifecycle: devguide/architecture/tasklifecycle.md
-    - Deploy:
-      - Production Deployment: devguide/running/deploy.md
-      - From Source: devguide/running/source.md
-      - Hosted: devguide/running/hosted.md
-      - CI/CD Integration: devguide/how-tos/cicd-integration.md
-      - Best Practices: devguide/bestpractices.md
-    - Configuration: documentation/configuration/appconf.md
-    - Observability:
-      - Server Metrics: documentation/metrics/server.md
-      - Client Metrics: documentation/metrics/client.md
-    - Advanced:
-      - documentation/advanced/extend.md
-      - documentation/advanced/isolationgroups.md
-      - documentation/advanced/archival-of-workflows.md
-      - documentation/advanced/externalpayloadstorage.md
-      - documentation/advanced/file-storage.md
-      - documentation/advanced/redis.md
-      - documentation/advanced/postgresql.md
-      - documentation/advanced/opensearch.md
   - Workflows:
     - Overview: devguide/workflows/index.md
     - Workflows: devguide/concepts/workflows.md
@@ -104,20 +78,9 @@ nav:
       - Human-in-the-Loop: devguide/ai/human-in-the-loop.md
       - Failure Semantics: devguide/ai/failure-semantics.md
     - Production Agent Architecture: devguide/ai/production-agent-architecture.md
-  - Design Patterns:
-    - Overview: devguide/cookbook/index.md
-    - Workflow Patterns:
-      - Microservice Orchestration: devguide/cookbook/microservice-orchestration.md
-      - Dynamic Parallelism: devguide/cookbook/dynamic-parallelism.md
-      - Wait & Timer Patterns: devguide/cookbook/wait-and-timers.md
-      - Task Timeouts & Retries: devguide/cookbook/task-timeouts-and-retries.md
-      - Saga & Compensation: devguide/cookbook/saga-compensation.md
-      - Polling a Long-Running Job: devguide/cookbook/http-poll-long-running-job.md
-      - Scheduled Workflows: devguide/cookbook/workflow-scheduling.md
-      - Dynamic Workflows in Code: devguide/cookbook/dynamic-workflows.md
-      - Event-Driven Patterns: devguide/cookbook/event-driven.md
+  - AI Cookbook:
+    - Overview: devguide/ai/cookbook/index.md
     - Agentic Patterns:
-      - Overview: devguide/ai/cookbook/index.md
       - RAG Agent: devguide/ai/cookbook/rag-agent.md
       - MCP Tool Calling: devguide/ai/cookbook/mcp-tool-calling.md
       - A2A Agent Orchestration: devguide/ai/cookbook/a2a-orchestration.md
@@ -140,6 +103,18 @@ nav:
       - Specialist Review: devguide/ai/cookbook/parallel-specialist-review.md
       - Agent Approval: devguide/ai/cookbook/human-approved-action.md
       - Agent Cancellation: devguide/ai/cookbook/conductor-agent-cancellation.md
+  - Design Patterns:
+    - Overview: devguide/cookbook/index.md
+    - Workflow Patterns:
+      - Microservice Orchestration: devguide/cookbook/microservice-orchestration.md
+      - Dynamic Parallelism: devguide/cookbook/dynamic-parallelism.md
+      - Wait & Timer Patterns: devguide/cookbook/wait-and-timers.md
+      - Task Timeouts & Retries: devguide/cookbook/task-timeouts-and-retries.md
+      - Saga & Compensation: devguide/cookbook/saga-compensation.md
+      - Polling a Long-Running Job: devguide/cookbook/http-poll-long-running-job.md
+      - Scheduled Workflows: devguide/cookbook/workflow-scheduling.md
+      - Dynamic Workflows in Code: devguide/cookbook/dynamic-workflows.md
+      - Event-Driven Patterns: devguide/cookbook/event-driven.md
   - SDK:
     - documentation/clientsdks/index.md
     - Java: documentation/clientsdks/java-sdk.md
@@ -215,6 +190,32 @@ nav:
       - documentation/configuration/workflowdef/systemtasks/ai-tasks.md
     - Event Handlers: documentation/configuration/eventhandlers.md
 
+  - Platform:
+    - Core Concepts: devguide/concepts/index.md
+    - Why Conductor: devguide/concepts/conductor.md
+    - Architecture: devguide/architecture/index.md
+    - Durable Execution: architecture/durable-execution.md
+    - JSON + Code Native: architecture/json-native.md
+    - Task Lifecycle: devguide/architecture/tasklifecycle.md
+    - Deploy:
+      - Production Deployment: devguide/running/deploy.md
+      - From Source: devguide/running/source.md
+      - Hosted: devguide/running/hosted.md
+      - CI/CD Integration: devguide/how-tos/cicd-integration.md
+      - Best Practices: devguide/bestpractices.md
+    - Configuration: documentation/configuration/appconf.md
+    - Observability:
+      - Server Metrics: documentation/metrics/server.md
+      - Client Metrics: documentation/metrics/client.md
+    - Advanced:
+      - documentation/advanced/extend.md
+      - documentation/advanced/isolationgroups.md
+      - documentation/advanced/archival-of-workflows.md
+      - documentation/advanced/externalpayloadstorage.md
+      - documentation/advanced/file-storage.md
+      - documentation/advanced/redis.md
+      - documentation/advanced/postgresql.md
+      - documentation/advanced/opensearch.md
 theme:
   name: material
   logo: img/logo.svg


### PR DESCRIPTION
Implements feedback on the docs refresh:
- Promotes Agentic Patterns and Agent Recipes into a top-level AI Cookbook tab 
- Moves the Platform tab to the end of the tab bar since it is mostly about running OSS
- Replaces the event-driven overview's custom next-steps cards with the standard link list to fix their rendering