### PR TITLE
Default the name-validation.enabled placeholder in NameValidator

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/constraints/ValidNameConstraint.java
+++ b/common/src/main/java/com/netflix/conductor/common/constraints/ValidNameConstraint.java
@@ -51,7 +51,10 @@ public @interface ValidNameConstraint {
         public static final String INVALID_NAME_MESSAGE =
                 "Allowed characters are alphanumeric, underscores, spaces, hyphens, and special characters like <, >, {, }, #";
 
-        @Value("${conductor.app.workflow.name-validation.enabled}")
+        // Defaulted so consumers that don't define the property can still construct this
+        // validator; conductor-common is on their classpath too. See
+        // NameValidatorPlaceholderTest.
+        @Value("${conductor.app.workflow.name-validation.enabled:false}")
         private boolean nameValidationEnabled;
 
         @Override

--- a/common/src/test/java/com/netflix/conductor/common/constraints/NameValidatorPlaceholderTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/constraints/NameValidatorPlaceholderTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.common.constraints;
+
+import org.junit.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.test.context.support.TestPropertySourceUtils;
+
+import jakarta.validation.ConstraintValidatorContext;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies {@link ValidNameConstraint.NameValidator}'s {@code @Value} placeholder resolves in a
+ * context that does not define {@code conductor.app.workflow.name-validation.enabled}.
+ *
+ * <p>{@code NameValidator} ships in conductor-common, so Hibernate Validator instantiates it inside
+ * every consuming application's context, not only conductor-server's. Without a default on the
+ * placeholder, a consumer that does not define the property fails bean creation with a {@code
+ * PlaceholderResolutionException}. That failure is lazy — it happens on the first request that
+ * triggers bean validation, so it surfaces as a 500 on workflow/task registration in an application
+ * that started up cleanly.
+ *
+ * <p>{@link NameValidatorTest} cannot catch this because it injects the field with {@link
+ * org.springframework.test.util.ReflectionTestUtils}, bypassing placeholder resolution entirely.
+ */
+public class NameValidatorPlaceholderTest {
+
+    @Test
+    public void validatorIsConstructableWhenPropertyIsUndefined() {
+        try (AnnotationConfigApplicationContext context =
+                new AnnotationConfigApplicationContext()) {
+            context.registerBean(PropertySourcesPlaceholderConfigurer.class);
+            context.register(ValidNameConstraint.NameValidator.class);
+            context.refresh();
+
+            ValidNameConstraint.NameValidator validator =
+                    context.getBean(ValidNameConstraint.NameValidator.class);
+
+            // Validation defaults to off, matching conductor-server's application.properties, so a
+            // name that would otherwise be rejected passes.
+            assertTrue(validator.isValid("workflowDef@", null));
+        }
+    }
+
+    @Test
+    public void explicitPropertyStillTakesEffect() {
+        try (AnnotationConfigApplicationContext context =
+                new AnnotationConfigApplicationContext()) {
+            TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
+                    context, "conductor.app.workflow.name-validation.enabled=true");
+            context.registerBean(PropertySourcesPlaceholderConfigurer.class);
+            context.register(ValidNameConstraint.NameValidator.class);
+            context.refresh();
+
+            ValidNameConstraint.NameValidator validator =
+                    context.getBean(ValidNameConstraint.NameValidator.class);
+
+            ConstraintValidatorContext validatorContext = mock(ConstraintValidatorContext.class);
+            when(validatorContext.buildConstraintViolationWithTemplate(anyString()))
+                    .thenReturn(mock(ConstraintValidatorContext.ConstraintViolationBuilder.class));
+
+            // The default must not shadow an explicitly configured value.
+            assertTrue(validator.isValid("workflowDef", null));
+            assertFalse(validator.isValid("workflowDef@", validatorContext));
+        }
+    }
+}


### PR DESCRIPTION
# Default the `name-validation.enabled` placeholder in `NameValidator`

## Problem

`ValidNameConstraint.NameValidator` reads its configuration through a bare `@Value` with no default:

```java
@Value("${conductor.app.workflow.name-validation.enabled}")
private boolean nameValidationEnabled;
```

`NameValidator` lives in **conductor-common**, so Hibernate Validator instantiates it inside *every* consuming application's context — not only `conductor-server`'s. `conductor-server` defines the property in its own `application.properties`, but an application that embeds conductor-common (or conductor-core / conductor-rest) and supplies its own configuration has no reason to know the key exists. When it doesn't, bean creation fails:

```
org.springframework.beans.factory.BeanCreationException: Error creating bean with name
'com.netflix.conductor.common.constraints.ValidNameConstraint$NameValidator':
Injection of autowired dependencies failed
Caused by: org.springframework.util.PlaceholderResolutionException: Could not resolve
placeholder 'conductor.app.workflow.name-validation.enabled'
```

The failure is **lazy**, which is what makes it unpleasant to diagnose. Hibernate Validator creates the validator on first use, so nothing fails at startup — the application boots cleanly and reports healthy. The error appears only on the first request carrying a `@ValidNameConstraint` field, i.e. as a **500 on `POST /api/metadata/workflow`** (or the task-definition equivalent). Because the response is a generic 500 on a registration call, it reads as a malformed payload rather than a configuration problem.

This is the only bare `@Value` without a default in Conductor's main source.

## Fix

```java
@Value("${conductor.app.workflow.name-validation.enabled:false}")
```

`false` is the value `conductor-server` already ships in its `application.properties`, so **behaviour is unchanged for anyone who sets the property**, and consumers that don't set it now inherit conductor-server's own default instead of a crash.

## Tests

Adds `NameValidatorPlaceholderTest` with two cases:

- `validatorIsConstructableWhenPropertyIsUndefined` — builds a context that omits the property and asserts the bean is created, with validation defaulting to off.
- `explicitPropertyStillTakesEffect` — sets the property to `true` and asserts an invalid name is still rejected, so the default cannot mask a configured value.

The existing `NameValidatorTest` cannot catch this: it assigns the field via `ReflectionTestUtils.setField`, which bypasses placeholder resolution entirely.

I verified the new test is load-bearing by reverting the default — `NameValidatorPlaceholderTest.validatorIsConstructableWhenPropertyIsUndefined` then fails with the original `BeanCreationException`, while all three pre-existing `NameValidatorTest` cases stay green.

Verified on `main` @ `1bad2c88d`: `conductor-common` 109 tests / 0 failures, `./gradlew :conductor-common:build` successful, `spotlessCheck` clean.

## Notes

Found while running a Spring Boot application at ReliaQuest that embeds conductor-common with its own configuration; a 500 on workflow registration was the only symptom. No API change, and no behavioural change for existing deployments.
