### PR TITLE
fix(agentspan): MCP/API agents lose every tool result — set _agent_tool_name in enrichToolsScriptDynamic

### DIFF
--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/util/JavaScriptBuilder.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/util/JavaScriptBuilder.java
@@ -1606,6 +1606,7 @@ public class JavaScriptBuilder {
                         + "    if (t.type === 'SIMPLE') {"
                         + "      t.inputParameters._agent_state = agentState;"
                         + "    }"
+                        + "    t.inputParameters._agent_tool_name = n;"
                         + "    result.push(t);"
                         + "  }"
                         + "  return {dynamicTasks: result};");


### PR DESCRIPTION
Fixes #1532.

Any agent whose toolset includes an MCP or API tool never receives its own tool results. Every LLM turn is dispatched with the identical bare `[system, user]` message list, so the model reissues the same call until the ReAct loop hits its iteration cap.

## The fix

One line in `enrichToolsScriptDynamic`, which `enrichToolsScript` already had:

```js
t.inputParameters._agent_tool_name = n;
```

## Why it fixes it

`Join.compactAgentOutput` decides whether a fork branch is an agent tool call by reading that marker from the branch's **input**:

```java
Object agentToolName = forkedTask.getInputData().get("_agent_tool_name");
if (agentToolName != null) {
    compact.put("_agent_tool_name", agentToolName);
    compact.put("_agent_tool_output", output);   // the full payload rides along here
    return compact;
}
// otherwise: only AGENT_PROPAGATED_KEYS = {"_state_updates", "state"}
```

and the caller only records non-empty results:

```java
if (!compact.isEmpty()) task.addOutput(joinOnRef, compact);
```

Setting the marker makes `compact` non-empty **and** attaches `_agent_tool_output`, so the whole chain refills.

## Verification

Reproduced and fixed with the python-sdk examples `04_mcp_weather.py` and `04_http_and_mcp_tools.py`
