### PR TITLE
docs(redis): document Valkey compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ powershell -c "irm https://conductor-oss.github.io/conductor-skills/install.ps1 
 | Postgres + ES7 | [config-postgres-es7.properties](docker/server/config/config-postgres-es7.properties) |
 | MySQL + ES7 | [config-mysql.properties](docker/server/config/config-mysql.properties) |
 
+**Using Valkey?** Conductor's Redis backend uses standard RESP commands only, so [Valkey](https://valkey.io) — the open-source, BSD-3-licensed fork of Redis — works as a drop-in replacement. Point any `config-redis*.properties` file's `conductor.redis.hosts` at your Valkey endpoint; `conductor.db.type` stays `redis_standalone`/`redis_cluster`/`redis_sentinel` since it selects the wire protocol, not the product. See [Redis configuration](docs/documentation/advanced/redis.md#valkey-compatibility) for details.
+
 </details>
 
 ---

--- a/docs/documentation/advanced/redis.md
+++ b/docs/documentation/advanced/redis.md
@@ -50,3 +50,11 @@ conductor.redis.hosts=host0:6379:us-east-1c:my_str0ng_pazz;host1:6379:us-east-1c
 
 - In a cluster, all nodes use the same username and password.
 - In a sentinel configuration, sentinels and redis nodes use the same database index, username, and password.
+
+## Valkey compatibility
+
+Conductor's Redis backend (Jedis 6.0.0, Redisson 3.22.0) communicates using standard RESP commands only — no Redis modules (RedisSearch, RedisJSON, etc.) are used. This means [Valkey](https://valkey.io), the open-source, BSD-3-licensed fork of Redis, works as a drop-in replacement, including managed offerings such as AWS ElastiCache for Valkey and GCP Memorystore for Valkey.
+
+No new configuration is required. Point `conductor.redis.hosts` at your Valkey endpoint(s); `conductor.db.type` stays `redis_standalone`, `redis_cluster`, or `redis_sentinel` — these values select the wire protocol Conductor speaks, not the specific product serving it.
+
+Redisson, which backs Conductor's distributed locking, [officially supports Valkey 7.2 and above](https://redisson.pro/docs/data-and-services/data-partitioning/).

--- a/docs/documentation/advanced/redis.md
+++ b/docs/documentation/advanced/redis.md
@@ -57,4 +57,4 @@ Conductor's Redis backend (Jedis 6.0.0, Redisson 3.22.0) communicates using stan
 
 No new configuration is required. Point `conductor.redis.hosts` at your Valkey endpoint(s); `conductor.db.type` stays `redis_standalone`, `redis_cluster`, or `redis_sentinel` — these values select the wire protocol Conductor speaks, not the specific product serving it.
 
-Redisson, which backs Conductor's distributed locking, [officially supports Valkey 7.2 and above](https://redisson.pro/docs/data-and-services/data-partitioning/).
+Redisson, which backs Conductor's distributed locking, [officially supports Valkey 7.2.5 and above](https://github.com/redisson/redisson).


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [x] Other (please describe): Documentation

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

Documents Valkey as a compatible persistence backend for Conductor. Conductor's Redis
backend (Jedis 6.0.0, Redisson 3.22.0) communicates using standard RESP commands only —
no Redis modules (RedisSearch, RedisJSON, etc.) are used — so Valkey works as a drop-in
replacement, including managed offerings like AWS ElastiCache for Valkey and GCP
Memorystore for Valkey. Today this compatibility is undocumented, so users have to
discover and verify it themselves.

This PR is docs-only, scoped down from the original proposal in conductor-oss/conductor#1403 per maintainer
feedback ("Readme updates and documentation can be added for Valkey... we need not go
in detail in adding Docker Compose or integration instructions with specific cloud
providers"). No Docker Compose samples, config templates, or CI changes are included.

- Adds a "Valkey compatibility" section to `docs/documentation/advanced/redis.md`,
  stating the RESP-only compatibility, that no new configuration is required beyond
  pointing `conductor.redis.hosts` at the Valkey endpoint, and that Redisson officially
  supports Valkey 7.2.5 and above.
- Adds a one-line pointer to this section in `README.md`'s Backend Configuration table.

No code, configuration, or test changes. No existing Redis documentation, samples, or
behavior is modified.

Alternatives considered
----

The original issue proposed a Docker Compose sample, standalone/cluster/sentinel config
templates, an AWS ElastiCache walkthrough, a Redis→Valkey migration guide, and a CI job
validating the existing test suite against Valkey. The maintainer asked to keep this to
README/documentation only, so those pieces are deliberately left out of this PR rather
than deferred to a follow-up — see conductor-oss/conductor#1403 for that scoping discussion.

Testing
----

This is a documentation-only change; no code or runtime tests are required. The fork PR
was reviewed and approved, including verification of the Redisson compatibility link and
version claim.

Reviewer comments addressed
----

- Replaced the unrelated Redisson Pro data-partitioning link with the Redisson repository README.
- Updated the compatibility wording to match Redisson's documented "from 7.2.5" support range.

Fixes conductor-oss/conductor#1403