### PR TITLE
fix(build): bump springdoc to 2.8.6 for Spring Framework 6.2 compatibility

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -62,7 +62,7 @@ ext {
     revJq = '0.0.13'
     revJsr311Api = '1.1.1'
     revMockServerClient = '5.12.0'
-    revSpringDoc = '2.1.0'
+    revSpringDoc = '2.8.6'
     revOrkesQueues = '2.0.0.rc3'
     revPowerMock = '2.0.9'
     revProtogenAnnotations = '1.0.0'

--- a/kafka/build.gradle
+++ b/kafka/build.gradle
@@ -17,8 +17,6 @@ dependencies {
     implementation "org.apache.kafka:kafka-clients:${revKafka}"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-web'
-    testImplementation "org.testcontainers:mockserver:${revTestContainer}"
-    testImplementation "org.mock-server:mockserver-client-java:${revMockServerClient}"
 
     testImplementation "org.apache.groovy:groovy-all:${revGroovy}"
     testImplementation "org.spockframework:spock-core:${revSpock}"

--- a/rest/src/test/java/com/netflix/conductor/rest/OpenApiDocsTest.java
+++ b/rest/src/test/java/com/netflix/conductor/rest/OpenApiDocsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.rest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Guards the springdoc-openapi / Spring Framework pairing.
+ *
+ * <p>springdoc reflects over the {@code @RestControllerAdvice} beans in the context while building
+ * the OpenAPI document. Versions of springdoc built against Spring Framework 6.0 call {@code new
+ * ControllerAdviceBean(Object)}, a constructor removed in Spring Framework 6.2 — so an incompatible
+ * pairing compiles, links, and starts cleanly, and only fails when {@code /api-docs} is first
+ * requested. Nothing short of a real request for the document detects it, which is why this test
+ * loads a context and asks for the document rather than asserting on versions.
+ *
+ * <p>The context is assembled explicitly rather than by component scan: scanning {@code
+ * com.netflix.conductor.rest.controllers} would drag in every resource and its service
+ * dependencies, none of which this test needs. The advice below is a local stand-in for the
+ * production ones for the same reason — springdoc walks whatever advice beans are present, so any
+ * one reproduces the failure.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+        classes = OpenApiDocsTest.TestConfig.class,
+        // mirrors server/src/main/resources/application.properties
+        properties = "springdoc.api-docs.path=/api-docs")
+@AutoConfigureMockMvc
+public class OpenApiDocsTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @Test
+    public void servesTheOpenApiDocument() throws Exception {
+        mockMvc.perform(get("/api-docs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.openapi").exists())
+                .andExpect(jsonPath("$.paths['/probe']").exists());
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    @Import({ProbeExceptionHandler.class, ProbeController.class})
+    static class TestConfig {}
+
+    @RestController
+    static class ProbeController {
+
+        @GetMapping("/probe")
+        public String probe() {
+            return "ok";
+        }
+    }
+
+    /** Stands in for the production advices; springdoc only needs one to be present. */
+    @RestControllerAdvice
+    static class ProbeExceptionHandler {
+
+        @ExceptionHandler(IllegalStateException.class)
+        public ResponseEntity<String> handle(IllegalStateException e) {
+            return ResponseEntity.internalServerError().body(e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
`GET /api-docs` returns 500, so Swagger UI is unusable:

```
NoSuchMethodError: 'void ControllerAdviceBean.<init>(java.lang.Object)'
```

springdoc 2.1.0 calls `ControllerAdviceBean(Object)`, removed in Spring Framework 6.2. `8f78c0a78` bumped Spring Boot 3.3.5 → 3.5.14 (Framework 6.1 → 6.2) and left `revSpringDoc` at 2.1.0. It links lazily on first call, so the server starts clean and only `/api-docs` breaks.

## Notes

- Nothing caught this because no test had ever requested the document.
- The test uses a local `@RestControllerAdvice` instead of `ApplicationExceptionMapper` — springdoc only needs some advice bean present, and importing the production one into a context breaks `ApplicationExceptionMapperTest`, which installs a JVM-wide static `LoggerFactory` mock into the shared Gradle test JVM.
- `kafka/build.gradle` drops two unused test deps. mockserver pulls the pre-jakarta `io.swagger.core.v3:swagger-core`, which duplicates springdoc's `swagger-core-jakarta` packages and is missing `ObjectMapperFactory.createJson31()` — enough to break the module's Spring context under 2.8.6. Nothing in `kafka/src` references mockserver or testcontainers, so removing them leaves only the jakarta artifacts on the classpath.