### PR TITLE
docs: require issue discussion before PR for external contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,21 @@ I want to contribute!
 We welcome Pull Requests and already have many outstanding community contributions!
 Creating and reviewing Pull Requests takes time, so this section helps you to set up a smooth Pull Request experience.
 
+### Issue-first policy
+
+**Before writing any code, please file a GitHub issue and discuss your proposed change with the maintainers.**
+
+This applies to all external contributors for bug fixes, features, and improvements of any size. Here's why this matters:
+
+- We may already be working on the same thing, or have decided not to pursue it.
+- The best solution often looks different from the first idea — a short discussion saves everyone from throw-away work.
+- We need to agree on the approach before implementation begins, not after.
+
+**Pull Requests submitted without a prior issue discussion will be closed at the maintainers' discretion.** Commenting "I'll take this" on an issue is not sufficient — please wait for a maintainer to confirm the approach before opening a PR.
+
 The stable branch is [main](https://github.com/conductor-oss/conductor/tree/main).
 
 Please create pull requests for your contributions against [main](https://github.com/conductor-oss/conductor/tree/main) only.
-
-It's a great idea to discuss the new feature you're considering in the [Slack channel](https://join.slack.com/t/orkes-conductor/shared_invite/zt-3dpcskdyd-W895bJDm8psAV7viYG3jFA#/shared-invite/email) before writing any code. There are often different ways you can implement a feature. Getting some discussion about different options helps shape the best solution. When starting directly with a Pull Request, there is the risk of having to make considerable changes. Sometimes that is the best approach, though! Showing an idea with code can be very helpful; be aware that it might be throw-away work. Some of our best Pull Requests came out of multiple competing implementations, which helped shape it to perfection.
 
 Also, consider that not every feature is a good fit for Conductor. A few things to consider are:
 
@@ -34,9 +44,9 @@ Also, consider that not every feature is a good fit for Conductor. A few things 
 * Should the feature be implemented in the main Conductor repository, or would it be better to set up a separate repository? Especially for integration with other systems, a separate repository is often the right choice because the life-cycle of it will be different.
 * Is it part of the Conductor project roadmap?
 
-Of course, for more minor bug fixes and improvements, the process can be more light-weight.
+You can also discuss ideas in the [Slack channel](https://join.slack.com/t/orkes-conductor/shared_invite/zt-3dpcskdyd-W895bJDm8psAV7viYG3jFA#/shared-invite/email) before filing an issue — that's a great place to get informal feedback early.
 
-We'll try to be responsive to Pull Requests. Do keep in mind that because of the inherently distributed nature of open source projects, responses to a PR might take some time because of time zones, weekends, and other things we may be working on.
+We'll try to be responsive to issues and Pull Requests. Do keep in mind that because of the inherently distributed nature of open source projects, responses might take some time because of time zones, weekends, and other things we may be working on.
 
 I want to report an issue
 -----


### PR DESCRIPTION
## Summary

- Adds an explicit **Issue-first policy** subsection to `CONTRIBUTING.md`
- Makes clear that external contributors must file and discuss an issue with maintainers before writing any code
- States that PRs submitted without prior issue discussion will be closed at the maintainers' discretion
- Clarifies that simply commenting "I'll take this" on an issue is not sufficient — contributors must wait for maintainer confirmation of the approach

## Why now

We've been receiving PRs from outside contributors that land without any prior discussion, requiring significant back-and-forth or outright closure. This change sets the expectation up front so contributors invest time in the right direction.

## User impact

Outside contributors will see clearly what's expected before opening a PR, reducing wasted effort on both sides.