### PR TITLE
fix(a2a): add authentication check to A2AAgentServerResource endpoints

### DIFF
--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/a2a/A2AAgentServerResource.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/a2a/A2AAgentServerResource.java
@@ -23,6 +23,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -57,6 +58,7 @@ public class A2AAgentServerResource {
     @GetMapping(
             value = "${conductor.a2a.server.agentBasePath:/api/a2a/agent}",
             produces = "application/json")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> listAgents(HttpServletRequest httpRequest) {
         String base = requestBaseUrl(httpRequest);
         List<?> agents =
@@ -78,6 +80,7 @@ public class A2AAgentServerResource {
                 "${conductor.a2a.server.agentBasePath:/api/a2a/agent}/{agent}/.well-known/agent.json"
             },
             produces = "application/json")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<?> agentCard(
             @PathVariable("agent") String agentName, HttpServletRequest httpRequest) {
         try {
@@ -94,6 +97,7 @@ public class A2AAgentServerResource {
                 "${conductor.a2a.server.agentBasePath:/api/a2a/agent}/{agent}/rpc"
             },
             produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.TEXT_EVENT_STREAM_VALUE})
+    @PreAuthorize("isAuthenticated()")
     public Object jsonRpc(
             @PathVariable("agent") String agentName,
             @RequestBody(required = false) JsonNode request) {

--- a/ai/src/main/java/org/conductoross/conductor/ai/a2a/server/A2AServerProperties.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/a2a/server/A2AServerProperties.java
@@ -58,6 +58,13 @@ public class A2AServerProperties {
     private boolean exposeAll = false;
 
     /**
+     * When true, agent-level RBAC is enforced on A2A endpoints (agentCard and jsonRpc require READ
+     * and EXECUTE permissions respectively). Defaults to {@code false} so existing deployments that
+     * enable A2A are not broken; set to {@code true} once RBAC is configured.
+     */
+    private boolean rbacEnabled = false;
+
+    /**
      * Externally-reachable base URL (scheme://host[:port]) advertised in the Agent Card's {@code
      * url}. If blank, it is derived from the incoming request.
      */

--- a/ai/src/main/java/org/conductoross/conductor/ai/a2a/server/A2AServerProperties.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/a2a/server/A2AServerProperties.java
@@ -58,13 +58,6 @@ public class A2AServerProperties {
     private boolean exposeAll = false;
 
     /**
-     * When true, agent-level RBAC is enforced on A2A endpoints (agentCard and jsonRpc require READ
-     * and EXECUTE permissions respectively). Defaults to {@code false} so existing deployments that
-     * enable A2A are not broken; set to {@code true} once RBAC is configured.
-     */
-    private boolean rbacEnabled = false;
-
-    /**
      * Externally-reachable base URL (scheme://host[:port]) advertised in the Agent Card's {@code
      * url}. If blank, it is derived from the incoming request.
      */


### PR DESCRIPTION
The 3 A2A server endpoints had no auth check at all — anyone could list, discover, or invoke agents without being authenticated.

Added `@PreAuthorize("isAuthenticated()")` to `listAgents`, `agentCard`, and `jsonRpc` in `A2AAgentServerResource`.