### PR TITLE
feat(ai): add Valkey vector store backend

### DIFF
--- a/ai/README.md
+++ b/ai/README.md
@@ -39,6 +39,7 @@ The Conductor AI module provides built-in integration with 13 popular LLM provid
 | **PostgreSQL (pgvector)** | ✅ | ✅ | Postgres with vector extension |
 | **Pinecone** | ✅ | ✅ | Managed vector database |
 | **MongoDB Atlas** | ✅ | ✅ | MongoDB vector search |
+| **Valkey** | ✅ | ✅ | In-memory vector search via the valkey-search module |
 
 > **Note**: Multiple named instances of these providers can be configured. See [Vector Database Configuration](VECTORDB_CONFIGURATION.md) for details.
 

--- a/ai/VECTORDB_CONFIGURATION.md
+++ b/ai/VECTORDB_CONFIGURATION.md
@@ -15,6 +15,7 @@ Conductor supports multiple vector database providers with the ability to config
 - **PostgreSQL** (with pgvector extension)
 - **MongoDB** (with Atlas Vector Search)
 - **Pinecone**
+- **Valkey** (with the valkey-search module)
 
 ## Configuration Format
 
@@ -25,7 +26,7 @@ conductor:
   vectordb:
     instances:
       - name: "instance-name"        # Unique identifier for this instance
-        type: "database-type"        # Type: postgres, mongodb, or pinecone
+        type: "database-type"        # Type: postgres, mongodb, pinecone, or valkey
         <type-specific-config>:      # Configuration block for the database type
           # ... type-specific properties
 ```
@@ -100,6 +101,48 @@ conductor:
         pinecone:
           apiKey: "your-pinecone-api-key"
 ```
+
+### Valkey (valkey-search)
+
+Requires a Valkey server with the [valkey-search](https://github.com/valkey-io/valkey-search)
+module loaded, which provides the `FT.CREATE` and `FT.SEARCH` commands. The
+`valkey/valkey-bundle` image ships the module; the plain `valkey` image does not.
+
+```yaml
+conductor:
+  vectordb:
+    instances:
+      - name: "valkey-embeddings"
+        type: "valkey"
+        valkey:
+          host: "localhost"
+          port: 6379
+          password: "${VALKEY_PASSWORD}"   # Resolve from the environment, never inline
+          database: 0
+          useTls: false
+          dimensions: 1536
+          distanceMetric: "cosine"         # Options: cosine, l2, ip
+          indexingMethod: "hnsw"           # Options: hnsw, flat
+          keyPrefix: "conductor"
+          requestTimeoutMs: 2000
+```
+
+**Limitations of this release:**
+
+- Standalone mode only. Valkey Cluster is not supported yet, because a clustered
+  deployment requires additional key-slot design.
+- Not compatible with managed services that do not ship the search module. Verify
+  module availability with your provider before choosing this backend.
+
+**Score semantics:** `score` on returned documents is the raw cosine distance, so
+**lower is closer** — an exact match scores `0.0` and an orthogonal vector scores `1.0`.
+This matches the PostgreSQL backend. MongoDB and Pinecone instead return a similarity
+where higher is closer, so do not compare score values across backends.
+
+**Keys and indexes:** documents are stored as hashes under
+`<keyPrefix>:<indexName>:<namespace>:<docId>`, and each `(indexName, namespace)` pair
+gets its own search index named `<keyPrefix>:<indexName>:<namespace>`. Two namespaces
+sharing an index name therefore stay isolated.
 
 ### Mixed Configuration (Multiple Types)
 
@@ -176,6 +219,22 @@ When using vector database tasks in your workflows, reference the instance by it
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `apiKey` | String | Required | Pinecone API key |
+
+## Valkey Configuration Options
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `host` | String | "localhost" | Valkey server hostname. Must not be blank |
+| `port` | Integer | 6379 | Valkey server port. Must be 1-65535 |
+| `username` | String | null | Username for ACL authentication |
+| `password` | String | null | Password. Source from the environment, not the config file |
+| `database` | Integer | 0 | Logical database index. Must be >= 0 |
+| `useTls` | Boolean | false | Enable TLS with full certificate and hostname verification |
+| `dimensions` | Integer | 256 | Vector dimensions. Must be positive and match your embedding model |
+| `distanceMetric` | String | "cosine" | Distance metric (cosine, l2, ip). Unknown values are rejected at startup |
+| `indexingMethod` | String | "hnsw" | Index algorithm (hnsw or flat). Unknown values are rejected at startup |
+| `keyPrefix` | String | "conductor" | Root segment for keys and index names. Trailing colons are stripped; must match `[a-zA-Z0-9_.-]+` |
+| `requestTimeoutMs` | Integer | 2000 | Per-request timeout in milliseconds. Must be positive |
 
 ## Migration from Old Configuration
 
@@ -256,4 +315,18 @@ If you see an error like "Vector DB instance not found: xyz", check:
 
 - Verify API key is valid and has necessary permissions
 - Ensure index exists in your Pinecone account before using it
+
+### Valkey
+
+- `unknown command 'FT.CREATE'` means the server is running without the
+  `valkey-search` module. Load the module, or use the `valkey/valkey-bundle` image
+  instead of the plain `valkey` image.
+- Searches returning no results after successful writes usually means `dimensions`
+  does not match the vector length your embedding model produces. Compare the
+  configured value against `FT.INFO <keyPrefix>:<indexName>:<namespace>` and check
+  whether its `hash_indexing_failures` counter is climbing.
+- `dimensions` is fixed when the index is created and there is no ALTER equivalent.
+  Changing it requires `FT.DROPINDEX` on the affected index followed by re-indexing.
+- Remember that `score` is a distance, so ascending order is closest-first. Sorting
+  descending will return the least relevant documents.
 

--- a/ai/VECTORDB_CONFIGURATION.md
+++ b/ai/VECTORDB_CONFIGURATION.md
@@ -124,7 +124,7 @@ conductor:
           distanceMetric: "cosine"         # Options: cosine, l2, ip
           indexingMethod: "hnsw"           # Options: hnsw, flat
           keyPrefix: "conductor"
-          requestTimeoutMs: 2000
+          requestTimeoutMs: 2000       # Also bounds FT.SEARCH/KNN latency
 ```
 
 **Limitations of this release:**
@@ -134,10 +134,15 @@ conductor:
 - Not compatible with managed services that do not ship the search module. Verify
   module availability with your provider before choosing this backend.
 
-**Score semantics:** `score` on returned documents is the raw cosine distance, so
-**lower is closer** — an exact match scores `0.0` and an orthogonal vector scores `1.0`.
+**Score semantics:** `score` on returned documents is a Valkey Search distance, so
+**lower is closer** for `cosine`, `l2`, and `ip`. For cosine, an exact match scores `0.0`
+and an orthogonal vector scores `1.0`. For inner product, Valkey Search uses `1 - dot(X,Y)`.
 This matches the PostgreSQL backend. MongoDB and Pinecone instead return a similarity
 where higher is closer, so do not compare score values across backends.
+
+**Search timeout:** `requestTimeoutMs` is the timeout for every Valkey command, including
+`FT.SEARCH` KNN queries. Increase it for large indexes or higher `EF_RUNTIME` settings if
+searches exceed the configured deadline.
 
 **Keys and indexes:** documents are stored as hashes under
 `<keyPrefix>:<indexName>:<namespace>:<docId>`, and each `(indexName, namespace)` pair
@@ -234,7 +239,7 @@ When using vector database tasks in your workflows, reference the instance by it
 | `distanceMetric` | String | "cosine" | Distance metric (cosine, l2, ip). Unknown values are rejected at startup |
 | `indexingMethod` | String | "hnsw" | Index algorithm (hnsw or flat). Unknown values are rejected at startup |
 | `keyPrefix` | String | "conductor" | Root segment for keys and index names. Trailing colons are stripped; must match `[a-zA-Z0-9_.-]+` |
-| `requestTimeoutMs` | Integer | 2000 | Per-request timeout in milliseconds. Must be positive |
+| `requestTimeoutMs` | Integer | 2000 | Per-command timeout in milliseconds, including FT.SEARCH/KNN. Must be positive |
 
 ## Migration from Old Configuration
 
@@ -327,6 +332,7 @@ If you see an error like "Vector DB instance not found: xyz", check:
   whether its `hash_indexing_failures` counter is climbing.
 - `dimensions` is fixed when the index is created and there is no ALTER equivalent.
   Changing it requires `FT.DROPINDEX` on the affected index followed by re-indexing.
-- Remember that `score` is a distance, so ascending order is closest-first. Sorting
-  descending will return the least relevant documents.
-
+- When reusing an existing index, its vector dimensions are validated with `FT.INFO` and
+  must match the configured `dimensions` value.
+- Remember that `score` is a distance for all supported metrics, so ascending order is
+  closest-first. Sorting descending will return the least relevant documents.

--- a/ai/build.gradle
+++ b/ai/build.gradle
@@ -61,6 +61,9 @@ dependencies {
     testImplementation "com.squareup.okhttp3:mockwebserver:4.12.0"
     testImplementation "org.testcontainers:mongodb:${revTestContainer}"
     testImplementation "org.testcontainers:postgresql:${revTestContainer}"
+    // Core Testcontainers is used directly by ValkeyVectorDBRoundTripTest via GenericContainer.
+    // Declared explicitly rather than relied upon transitively through the modules above.
+    testImplementation "org.testcontainers:testcontainers:${revTestContainer}"
     testImplementation "org.postgresql:postgresql:${revPostgres}"
     testImplementation "org.apache.commons:commons-compress:${revCommonsCompress}"
     testImplementation "com.h2database:h2:2.4.240"

--- a/ai/build.gradle
+++ b/ai/build.gradle
@@ -43,6 +43,11 @@ dependencies {
 
     //Vector Databases
 
+    // Valkey GLIDE client for the Valkey vector store provider.
+    // The uber jar bundles Rust natives for 7 platforms (~40 MB). Upgrades require re-auditing
+    // native code because Java-layer patches cannot reach the bundled binaries.
+    api "io.valkey:valkey-glide:${revValkeyGlide}"
+
     api "org.mongodb:mongodb-driver-sync:${mongodb}"
     api "org.mongodb:mongodb-driver-core:${mongodb}"
     api "org.mongodb:bson:${mongodb}"

--- a/ai/src/main/java/org/conductoross/conductor/ai/vectordb/VectorDBInstanceConfig.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/vectordb/VectorDBInstanceConfig.java
@@ -12,6 +12,7 @@
  */
 package org.conductoross.conductor.ai.vectordb;
 
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -92,13 +93,28 @@ public class VectorDBInstanceConfig implements VectorDBConfig<VectorDB> {
                             instance.getName(),
                             instance.getType());
                 }
-            } catch (Exception e) {
+            } catch (IllegalArgumentException | IllegalStateException e) {
+                // The configuration itself is invalid (bad enum value, blank name, etc.) and needs
+                // an operator fix, not a retry, so fail startup loudly.
                 failedNames.add(instance.getName() + " (type: " + instance.getType() + ")");
                 failures.add(e);
+            } catch (RuntimeException e) {
+                // A runtime/connectivity failure (e.g. Valkey unreachable at boot). Unlike the
+                // other
+                // vector DB backends, ValkeyVectorDB connects eagerly at construction, so without
+                // this distinction a transient network blip would abort the entire server instead
+                // of just this instance. Log and skip, matching how the other backends already
+                // tolerate this.
+                log.error(
+                        "Failed to initialize vector DB instance: {} (type: {}), reason: {}",
+                        instance.getName(),
+                        instance.getType(),
+                        e.getMessage());
             }
         }
 
         if (!failures.isEmpty()) {
+            closeAlreadyCreated(vectorDBMap);
             IllegalStateException aggregate =
                     new IllegalStateException(
                             "Failed to initialize vector DB instance(s): "
@@ -108,6 +124,27 @@ public class VectorDBInstanceConfig implements VectorDBConfig<VectorDB> {
         }
 
         return vectorDBMap;
+    }
+
+    /**
+     * Closes any instances that were successfully created before a later instance failed. Without
+     * this, a successfully-connected instance (e.g. an open GLIDE client) would be discarded along
+     * with the map when the aggregate exception below is thrown, since {@link VectorDBProvider} is
+     * never constructed to close it later.
+     */
+    private void closeAlreadyCreated(Map<String, VectorDB> vectorDBMap) {
+        for (Map.Entry<String, VectorDB> entry : vectorDBMap.entrySet()) {
+            if (entry.getValue() instanceof Closeable) {
+                try {
+                    ((Closeable) entry.getValue()).close();
+                } catch (Exception e) {
+                    log.warn(
+                            "Failed to close vector DB instance '{}' during startup failure cleanup",
+                            entry.getKey(),
+                            e);
+                }
+            }
+        }
     }
 
     /** Creates a VectorDB instance based on the configuration type. */

--- a/ai/src/main/java/org/conductoross/conductor/ai/vectordb/VectorDBInstanceConfig.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/vectordb/VectorDBInstanceConfig.java
@@ -14,11 +14,13 @@ package org.conductoross.conductor.ai.vectordb;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.conductoross.conductor.ai.vectordb.mongodb.MongoDBConfig;
 import org.conductoross.conductor.ai.vectordb.pinecone.PineconeConfig;
 import org.conductoross.conductor.ai.vectordb.postgres.PostgresConfig;
+import org.conductoross.conductor.ai.vectordb.valkey.ValkeyConfig;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -107,7 +109,7 @@ public class VectorDBInstanceConfig implements VectorDBConfig<VectorDB> {
             return null;
         }
 
-        switch (type.toLowerCase()) {
+        switch (type.toLowerCase(Locale.ROOT)) {
             case "postgres":
             case "pgvectordb":
                 return createPostgresVectorDB(instance);
@@ -117,6 +119,9 @@ public class VectorDBInstanceConfig implements VectorDBConfig<VectorDB> {
             case "pinecone":
             case "pineconedb":
                 return createPineconeVectorDB(instance);
+            case "valkey":
+            case "valkeyvectordb":
+                return createValkeyVectorDB(instance);
             default:
                 log.error("Unknown vector DB type: {} for instance: {}", type, instance.getName());
                 return null;
@@ -150,6 +155,15 @@ public class VectorDBInstanceConfig implements VectorDBConfig<VectorDB> {
         return config.get(instance.getName());
     }
 
+    private VectorDB createValkeyVectorDB(VectorDBInstance instance) {
+        ValkeyConfig config = instance.getValkey();
+        if (config == null) {
+            log.error("Valkey configuration missing for instance: {}", instance.getName());
+            return null;
+        }
+        return config.get(instance.getName());
+    }
+
     /** Represents a single vector DB instance configuration. */
     public static class VectorDBInstance {
         private String name;
@@ -157,6 +171,7 @@ public class VectorDBInstanceConfig implements VectorDBConfig<VectorDB> {
         private PostgresConfig postgres;
         private MongoDBConfig mongodb;
         private PineconeConfig pinecone;
+        private ValkeyConfig valkey;
 
         public String getName() {
             return name;
@@ -196,6 +211,14 @@ public class VectorDBInstanceConfig implements VectorDBConfig<VectorDB> {
 
         public void setPinecone(PineconeConfig pinecone) {
             this.pinecone = pinecone;
+        }
+
+        public ValkeyConfig getValkey() {
+            return valkey;
+        }
+
+        public void setValkey(ValkeyConfig valkey) {
+            this.valkey = valkey;
         }
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/vectordb/VectorDBInstanceConfig.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/vectordb/VectorDBInstanceConfig.java
@@ -12,6 +12,7 @@
  */
 package org.conductoross.conductor.ai.vectordb;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -79,6 +80,8 @@ public class VectorDBInstanceConfig implements VectorDBConfig<VectorDB> {
             return vectorDBMap;
         }
 
+        List<String> failedNames = new ArrayList<>();
+        List<Exception> failures = new ArrayList<>();
         for (VectorDBInstance instance : instances) {
             try {
                 VectorDB vectorDB = createVectorDB(instance);
@@ -90,12 +93,18 @@ public class VectorDBInstanceConfig implements VectorDBConfig<VectorDB> {
                             instance.getType());
                 }
             } catch (Exception e) {
-                log.error(
-                        "Failed to initialize vector DB instance: {} (type: {}), reason: {}",
-                        instance.getName(),
-                        instance.getType(),
-                        e.getMessage());
+                failedNames.add(instance.getName() + " (type: " + instance.getType() + ")");
+                failures.add(e);
             }
+        }
+
+        if (!failures.isEmpty()) {
+            IllegalStateException aggregate =
+                    new IllegalStateException(
+                            "Failed to initialize vector DB instance(s): "
+                                    + String.join(", ", failedNames));
+            failures.forEach(aggregate::addSuppressed);
+            throw aggregate;
         }
 
         return vectorDBMap;

--- a/ai/src/main/java/org/conductoross/conductor/ai/vectordb/VectorDBInstanceConfig.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/vectordb/VectorDBInstanceConfig.java
@@ -23,6 +23,7 @@ import org.conductoross.conductor.ai.vectordb.mongodb.MongoDBConfig;
 import org.conductoross.conductor.ai.vectordb.pinecone.PineconeConfig;
 import org.conductoross.conductor.ai.vectordb.postgres.PostgresConfig;
 import org.conductoross.conductor.ai.vectordb.valkey.ValkeyConfig;
+import org.conductoross.conductor.ai.vectordb.valkey.ValkeyConnectionException;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -98,13 +99,14 @@ public class VectorDBInstanceConfig implements VectorDBConfig<VectorDB> {
                 // an operator fix, not a retry, so fail startup loudly.
                 failedNames.add(instance.getName() + " (type: " + instance.getType() + ")");
                 failures.add(e);
-            } catch (RuntimeException e) {
-                // A runtime/connectivity failure (e.g. Valkey unreachable at boot). Unlike the
-                // other
-                // vector DB backends, ValkeyVectorDB connects eagerly at construction, so without
-                // this distinction a transient network blip would abort the entire server instead
-                // of just this instance. Log and skip, matching how the other backends already
-                // tolerate this.
+            } catch (ValkeyConnectionException e) {
+                // A connectivity failure (e.g. Valkey unreachable at boot), not a configuration
+                // error. Unlike the other vector DB backends, ValkeyVectorDB connects eagerly at
+                // construction, so without this distinction a transient network blip would abort
+                // the entire server instead of just this instance. Log and skip, matching how the
+                // other backends already tolerate this. Deliberately narrower than catching
+                // RuntimeException: a genuine bug (NPE, ClassCastException, etc.) from any backend
+                // must still propagate and fail loudly rather than being silently dropped here.
                 log.error(
                         "Failed to initialize vector DB instance: {} (type: {}), reason: {}",
                         instance.getName(),

--- a/ai/src/main/java/org/conductoross/conductor/ai/vectordb/VectorDBProvider.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/vectordb/VectorDBProvider.java
@@ -46,35 +46,27 @@ public class VectorDBProvider {
      */
     public VectorDBProvider(
             VectorDBInstanceConfig instanceConfig, ObjectProvider<VectorDB> defaultInstances) {
-        try {
-            Map<String, VectorDB> instances = instanceConfig.getVectorDBInstances();
-            vectorDBs.putAll(instances);
-            defaultInstances.forEach(
-                    db -> {
-                        if (vectorDBs.putIfAbsent(db.getName(), db) == null) {
-                            log.info(
-                                    "Registered default vector DB instance: {} (type: {})",
-                                    db.getName(),
-                                    db.getType());
-                        } else {
-                            log.warn(
-                                    "Vector DB instance '{}' already registered explicitly; "
-                                            + "auto-registered default not applied",
-                                    db.getName());
-                        }
-                    });
-            log.info("Initialized VectorDBProvider with {} instances", vectorDBs.size());
-            vectorDBs
-                    .keySet()
-                    .forEach(
-                            name ->
-                                    log.info(
-                                            "  - {} (type: {})",
-                                            name,
-                                            vectorDBs.get(name).getType()));
-        } catch (Exception e) {
-            log.error("Failed to initialize VectorDBProvider: {}", e.getMessage(), e);
-        }
+        Map<String, VectorDB> instances = instanceConfig.getVectorDBInstances();
+        vectorDBs.putAll(instances);
+        defaultInstances.forEach(
+                db -> {
+                    if (vectorDBs.putIfAbsent(db.getName(), db) == null) {
+                        log.info(
+                                "Registered default vector DB instance: {} (type: {})",
+                                db.getName(),
+                                db.getType());
+                    } else {
+                        log.warn(
+                                "Vector DB instance '{}' already registered explicitly; "
+                                        + "auto-registered default not applied",
+                                db.getName());
+                    }
+                });
+        log.info("Initialized VectorDBProvider with {} instances", vectorDBs.size());
+        vectorDBs
+                .keySet()
+                .forEach(
+                        name -> log.info("  - {} (type: {})", name, vectorDBs.get(name).getType()));
     }
 
     /**

--- a/ai/src/main/java/org/conductoross/conductor/ai/vectordb/VectorDBProvider.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/vectordb/VectorDBProvider.java
@@ -12,6 +12,7 @@
  */
 package org.conductoross.conductor.ai.vectordb;
 
+import java.io.Closeable;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Component;
 
 import com.netflix.conductor.sdk.workflow.executor.task.TaskContext;
 
+import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -91,5 +93,28 @@ public class VectorDBProvider {
                     vectorDBs.keySet());
         }
         return db;
+    }
+
+    /**
+     * Closes all registered VectorDB instances that implement {@link Closeable}. Each instance is
+     * closed independently so that one failure does not prevent others from releasing resources.
+     */
+    @PreDestroy
+    void dispose() {
+        for (Map.Entry<String, VectorDB> entry : vectorDBs.entrySet()) {
+            VectorDB db = entry.getValue();
+            if (db instanceof Closeable) {
+                try {
+                    ((Closeable) db).close();
+                    log.info(
+                            "Closed vector DB instance: {} (type: {})", db.getName(), db.getType());
+                } catch (Exception e) {
+                    log.warn(
+                            "Failed to close vector DB instance '{}': {}",
+                            entry.getKey(),
+                            e.getMessage());
+                }
+            }
+        }
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/vectordb/VectorDBProvider.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/vectordb/VectorDBProvider.java
@@ -88,8 +88,10 @@ public class VectorDBProvider {
     }
 
     /**
-     * Closes all registered VectorDB instances that implement {@link Closeable}. Each instance is
-     * closed independently so that one failure does not prevent others from releasing resources.
+     * Closes all registered VectorDB instances that implement {@link Closeable}, then clears the
+     * map so a lookup after shutdown reports "not found" instead of handing back an already-closed
+     * instance. Each instance is closed independently so that one failure does not prevent others
+     * from releasing resources.
      */
     @PreDestroy
     void dispose() {
@@ -101,12 +103,10 @@ public class VectorDBProvider {
                     log.info(
                             "Closed vector DB instance: {} (type: {})", db.getName(), db.getType());
                 } catch (Exception e) {
-                    log.warn(
-                            "Failed to close vector DB instance '{}': {}",
-                            entry.getKey(),
-                            e.getMessage());
+                    log.warn("Failed to close vector DB instance '{}'", entry.getKey(), e);
                 }
             }
         }
+        vectorDBs.clear();
     }
 }

--- a/ai/src/main/java/org/conductoross/conductor/ai/vectordb/VectorDBProvider.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/vectordb/VectorDBProvider.java
@@ -15,6 +15,7 @@ package org.conductoross.conductor.ai.vectordb;
 import java.io.Closeable;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Component;
@@ -36,6 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 public class VectorDBProvider {
 
     private final Map<String, VectorDB> vectorDBs = new ConcurrentHashMap<>();
+    private final AtomicBoolean disposed = new AtomicBoolean(false);
 
     /**
      * Initializes the provider with configured vector database instances, then merges in any
@@ -77,6 +79,10 @@ public class VectorDBProvider {
      * @return The VectorDB instance, or null if not found
      */
     public VectorDB get(String name, TaskContext taskContext) {
+        if (disposed.get()) {
+            log.warn("VectorDBProvider is shut down; returning null for '{}'", name);
+            return null;
+        }
         VectorDB db = vectorDBs.get(name);
         if (db == null) {
             log.warn(
@@ -88,13 +94,14 @@ public class VectorDBProvider {
     }
 
     /**
-     * Closes all registered VectorDB instances that implement {@link Closeable}, then clears the
-     * map so a lookup after shutdown reports "not found" instead of handing back an already-closed
-     * instance. Each instance is closed independently so that one failure does not prevent others
-     * from releasing resources.
+     * Marks the provider disposed (so concurrent {@link #get} calls immediately start returning
+     * null instead of racing the close loop below), then closes all registered VectorDB instances
+     * that implement {@link Closeable} and clears the map. Each instance is closed independently so
+     * that one failure does not prevent others from releasing resources.
      */
     @PreDestroy
     void dispose() {
+        disposed.set(true);
         for (Map.Entry<String, VectorDB> entry : vectorDBs.entrySet()) {
             VectorDB db = entry.getValue();
             if (db instanceof Closeable) {

--- a/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyConfig.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyConfig.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.vectordb.valkey;
+
+import java.util.Locale;
+
+import org.conductoross.conductor.ai.vectordb.VectorDBConfig;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * Configuration for a Valkey-backed vector database instance. Requires a Valkey server with the
+ * {@code valkey-search} module loaded.
+ *
+ * <p>Configuration example:
+ *
+ * <pre>
+ * conductor.vectordb.instances:
+ *   - name: "valkey-local"
+ *     type: "valkey"
+ *     valkey:
+ *       host: "localhost"
+ *       port: 6379
+ *       useTls: true
+ *       password: "${VALKEY_PASSWORD}"
+ *       dimensions: 1536
+ *       distanceMetric: "cosine"
+ * </pre>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ValkeyConfig implements VectorDBConfig<ValkeyVectorDB> {
+
+    private String host = "localhost";
+
+    private Integer port = 6379;
+
+    private String username;
+
+    @ToString.Exclude private String password;
+
+    private Integer database = 0;
+
+    private Boolean useTls = false;
+
+    private Integer dimensions = 256;
+
+    /** Distance metric: "cosine", "l2", or "ip". Unknown values are rejected at construction. */
+    private String distanceMetric = "cosine";
+
+    /** Indexing algorithm: "hnsw" or "flat". Unknown values are rejected at construction. */
+    private String indexingMethod = "hnsw";
+
+    /**
+     * Key prefix for hash keys and FT.CREATE PREFIX filter. Keys follow the schema: {@code
+     * <keyPrefix>:<indexName>:<namespace>:<docId>}.
+     */
+    private String keyPrefix = "conductor";
+
+    /** Timeout in milliseconds for each GLIDE future resolution. */
+    private Integer requestTimeoutMs = 2000;
+
+    @Override
+    public ValkeyVectorDB get() {
+        throw new UnsupportedOperationException("Use get(String name) instead");
+    }
+
+    public ValkeyVectorDB get(String name) {
+        // Validate metric and algorithm eagerly so mis-configuration fails at startup
+        resolveDistanceMetric(distanceMetric);
+        resolveIndexingMethod(indexingMethod);
+        return new ValkeyVectorDB(name, this);
+    }
+
+    /**
+     * Maps a user-facing distance metric string to the corresponding GLIDE DistanceMetric enum.
+     * Rejects unknown values with an informative error. Uses Locale.ROOT for case folding.
+     */
+    static glide.api.models.commands.FT.FTCreateOptions.DistanceMetric resolveDistanceMetric(
+            String metric) {
+        if (metric == null) {
+            return glide.api.models.commands.FT.FTCreateOptions.DistanceMetric.COSINE;
+        }
+        switch (metric.toLowerCase(Locale.ROOT)) {
+            case "cosine":
+                return glide.api.models.commands.FT.FTCreateOptions.DistanceMetric.COSINE;
+            case "l2":
+                return glide.api.models.commands.FT.FTCreateOptions.DistanceMetric.L2;
+            case "ip":
+                return glide.api.models.commands.FT.FTCreateOptions.DistanceMetric.IP;
+            default:
+                throw new IllegalArgumentException(
+                        "Unknown distance metric: '"
+                                + metric
+                                + "'. Supported values: cosine, l2, ip");
+        }
+    }
+
+    /**
+     * Validates the indexing method string. Returns the normalized value or throws on unknown
+     * input. Uses Locale.ROOT for case folding.
+     */
+    static String resolveIndexingMethod(String method) {
+        if (method == null) {
+            return "hnsw";
+        }
+        switch (method.toLowerCase(Locale.ROOT)) {
+            case "hnsw":
+                return "hnsw";
+            case "flat":
+                return "flat";
+            default:
+                throw new IllegalArgumentException(
+                        "Unknown indexing method: '" + method + "'. Supported values: hnsw, flat");
+        }
+    }
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyConfig.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyConfig.java
@@ -80,7 +80,11 @@ public class ValkeyConfig implements VectorDBConfig<ValkeyVectorDB> {
     }
 
     public ValkeyVectorDB get(String name) {
-        // Validate metric and algorithm eagerly so mis-configuration fails at startup
+        // Validate name, metric, and algorithm eagerly so mis-configuration fails at startup with a
+        // clear message instead of surfacing later as an opaque NullPointerException.
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Valkey vector DB instance name must not be blank");
+        }
         resolveDistanceMetric(distanceMetric);
         resolveIndexingMethod(indexingMethod);
         return new ValkeyVectorDB(name, this);

--- a/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyConnectionException.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyConnectionException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.vectordb.valkey;
+
+/**
+ * Thrown when establishing the GLIDE client connection fails (unreachable host, auth failure,
+ * timeout). Deliberately a distinct type from other {@link RuntimeException}s so callers can
+ * distinguish "this instance is temporarily unreachable" from a genuine programming error or
+ * configuration bug, which should not be silently tolerated.
+ */
+public class ValkeyConnectionException extends RuntimeException {
+    public ValkeyConnectionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDB.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDB.java
@@ -184,7 +184,9 @@ public class ValkeyVectorDB extends VectorDB implements Closeable {
                     timeoutMs,
                     "GLIDE client creation");
         } catch (RuntimeException e) {
-            throw new RuntimeException(
+            // A distinct type (not a bare RuntimeException) so callers can tell "the server was
+            // unreachable" apart from a genuine bug and choose to tolerate only the former.
+            throw new ValkeyConnectionException(
                     "Failed to create Valkey GLIDE client for "
                             + cfg.getHost()
                             + ":"

--- a/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDB.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDB.java
@@ -43,8 +43,8 @@ import static glide.api.models.GlideString.gs;
  * Valkey vector database backend using the {@code valkey-search} module (FT.CREATE / FT.SEARCH).
  *
  * <p>Score semantics: the {@code __embedding_score} field returned by valkey-search is a distance
- * value where lower is better for COSINE, L2, and IP. COSINE scores are 0 for identical vectors
- * and 1 for orthogonal vectors; IP uses Valkey Search's {@code 1 - dot(X,Y)} distance.
+ * value where lower is better for COSINE, L2, and IP. COSINE scores are 0 for identical vectors and
+ * 1 for orthogonal vectors; IP uses Valkey Search's {@code 1 - dot(X,Y)} distance.
  *
  * <p>Key schema: {@code <keyPrefix>:<indexName>:<namespace>:<docId>}. The FT.CREATE PREFIX filter
  * is set to {@code <keyPrefix>:<indexName>:<namespace>:} so that HSET keys are automatically

--- a/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDB.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDB.java
@@ -177,11 +177,21 @@ public class ValkeyVectorDB extends VectorDB implements Closeable {
         return name.replaceAll("\\s+", "_");
     }
 
+    /**
+     * Client creation (TCP connect + TLS handshake + AUTH + SELECT) routinely takes longer than a
+     * single command, especially across AZs, so it gets a more generous timeout than the
+     * per-command {@code requestTimeoutMs} used for regular operations. Package-private static so
+     * the floor/multiplier behavior is directly unit-testable.
+     */
+    static long creationTimeoutMs(long requestTimeoutMs) {
+        return Math.max(requestTimeoutMs * 3, 5000L);
+    }
+
     private static GlideClient buildClient(String name, ValkeyConfig cfg, long timeoutMs) {
         try {
             return awaitFuture(
                     GlideClient.createClient(buildClientConfiguration(name, cfg, timeoutMs)),
-                    timeoutMs,
+                    creationTimeoutMs(timeoutMs),
                     "GLIDE client creation");
         } catch (RuntimeException e) {
             // A distinct type (not a bare RuntimeException) so callers can tell "the server was

--- a/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDB.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDB.java
@@ -91,6 +91,10 @@ public class ValkeyVectorDB extends VectorDB implements Closeable {
      */
     private final ConcurrentHashMap<String, Boolean> initializedIndexes = new ConcurrentHashMap<>();
 
+    /** Per-index monitors keep network I/O out of ConcurrentHashMap mapping functions. */
+    private final ConcurrentHashMap<String, Object> indexInitializationLocks =
+            new ConcurrentHashMap<>();
+
     private final long requestTimeoutMs;
     private final DistanceMetric distanceMetric;
 
@@ -345,13 +349,18 @@ public class ValkeyVectorDB extends VectorDB implements Closeable {
             return;
         }
 
-        // If index creation throws, computeIfAbsent does not install a cache entry.
-        initializedIndexes.computeIfAbsent(
-                physicalIndex,
-                k -> {
-                    createIndex(indexName, namespace, physicalIndex);
-                    return Boolean.TRUE;
-                });
+        Object initializationLock =
+                indexInitializationLocks.computeIfAbsent(physicalIndex, k -> new Object());
+        synchronized (initializationLock) {
+            if (initializedIndexes.containsKey(physicalIndex)) {
+                return;
+            }
+
+            // Keep the network round trip outside ConcurrentHashMap.computeIfAbsent. If creation
+            // throws, the index remains uninitialized and a later operation can retry it.
+            createIndex(indexName, namespace, physicalIndex);
+            initializedIndexes.put(physicalIndex, Boolean.TRUE);
+        }
     }
 
     private void createIndex(String indexName, String namespace, String physicalIndex) {

--- a/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDB.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDB.java
@@ -1,0 +1,667 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.vectordb.valkey;
+
+import java.io.Closeable;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+
+import org.conductoross.conductor.ai.model.IndexedDoc;
+import org.conductoross.conductor.ai.vectordb.VectorDB;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import glide.api.GlideClient;
+import glide.api.commands.servermodules.FT;
+import glide.api.models.GlideString;
+import glide.api.models.commands.FT.FTCreateOptions;
+import glide.api.models.commands.FT.FTCreateOptions.*;
+import glide.api.models.commands.FT.FTSearchOptions;
+import glide.api.models.configuration.GlideClientConfiguration;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.configuration.ServerCredentials;
+import glide.api.models.exceptions.RequestException;
+import lombok.extern.slf4j.Slf4j;
+
+import static glide.api.models.GlideString.gs;
+
+/**
+ * Valkey vector database backend using the {@code valkey-search} module (FT.CREATE / FT.SEARCH).
+ *
+ * <p>Score semantics: the {@code __embedding_score} field returned by valkey-search is a raw
+ * distance value (lower is better). For COSINE metric: 0 = identical, 1 = orthogonal. This matches
+ * the convention used by {@code PostgresVectorDB} and {@code SqliteVectorDB}.
+ *
+ * <p>Key schema: {@code <keyPrefix>:<indexName>:<namespace>:<docId>}. The FT.CREATE PREFIX filter
+ * is set to {@code <keyPrefix>:<indexName>:<namespace>:} so that HSET keys are automatically
+ * indexed.
+ *
+ * <p>Index isolation: each (indexName, namespace) pair maps to a distinct physical index name via
+ * {@link #physicalIndexNameFor(String, String)}. This ensures that documents written under
+ * different namespaces are indexed independently, even if they share the same logical index name.
+ *
+ * <p>This class is standalone-mode only. Cluster mode (GlideClusterClient) is deliberately out of
+ * scope for this release.
+ */
+@Slf4j
+public class ValkeyVectorDB extends VectorDB implements Closeable {
+
+    public static final String TYPE = "valkey";
+
+    /** Name validation: letters, digits, underscores, hyphens only. */
+    private static final Pattern VALID_NAME = Pattern.compile("[a-zA-Z0-9_-]+");
+
+    /** Score field pattern: __<vectorFieldName>_score. Our field is always named "embedding". */
+    static final String SCORE_FIELD = "__embedding_score";
+
+    /** The single vector field name used in the hash and in FT.CREATE schema. */
+    static final String EMBEDDING_FIELD = "embedding";
+
+    static final String DOC_FIELD = "doc";
+    static final String PARENT_DOC_ID_FIELD = "parent_doc_id";
+    static final String METADATA_FIELD = "metadata";
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final ValkeyConfig config;
+    private final GlideClient client;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    /** Normalized key prefix (no trailing colons, validated non-blank). */
+    private final String normalizedKeyPrefix;
+
+    /**
+     * Tracks which physical indexes have been successfully created in this JVM lifetime. Guards
+     * against redundant FT.CREATE calls and the inevitable already-exists race on concurrent
+     * first-writes. Keyed by physical index name.
+     */
+    private final ConcurrentHashMap<String, Boolean> initializedIndexes = new ConcurrentHashMap<>();
+
+    private final long requestTimeoutMs;
+    private final DistanceMetric distanceMetric;
+
+    /** Public constructor: validates configuration, then creates the real GLIDE client. */
+    public ValkeyVectorDB(String name, ValkeyConfig config) {
+        this(name, validateAndReturn(config), null, true);
+    }
+
+    /** Package-private constructor for test injection of a pre-built client. */
+    ValkeyVectorDB(String name, ValkeyConfig config, GlideClient client) {
+        this(name, validateAndReturn(config), Objects.requireNonNull(client), false);
+    }
+
+    private ValkeyVectorDB(
+            String name, ValkeyConfig config, GlideClient injectedClient, boolean createClient) {
+        super(name, TYPE);
+        this.config = config;
+        this.normalizedKeyPrefix = normalizeKeyPrefix(config.getKeyPrefix());
+        this.requestTimeoutMs =
+                config.getRequestTimeoutMs() != null ? config.getRequestTimeoutMs() : 2000L;
+        this.distanceMetric = ValkeyConfig.resolveDistanceMetric(config.getDistanceMetric());
+        this.client = createClient ? buildClient(config, requestTimeoutMs) : injectedClient;
+    }
+
+    private static ValkeyConfig validateAndReturn(ValkeyConfig config) {
+        Objects.requireNonNull(config, "config must not be null");
+        validateConfig(config);
+        normalizeKeyPrefix(config.getKeyPrefix());
+        ValkeyConfig.resolveDistanceMetric(config.getDistanceMetric());
+        ValkeyConfig.resolveIndexingMethod(config.getIndexingMethod());
+        return config;
+    }
+
+    // ----- Client lifecycle -----
+
+    private static GlideClient buildClient(ValkeyConfig cfg, long timeoutMs) {
+        GlideClientConfiguration.GlideClientConfigurationBuilder<?, ?> builder =
+                GlideClientConfiguration.builder()
+                        .address(
+                                NodeAddress.builder()
+                                        .host(cfg.getHost() != null ? cfg.getHost() : "localhost")
+                                        .port(cfg.getPort() != null ? cfg.getPort() : 6379)
+                                        .build())
+                        .requestTimeout(Math.toIntExact(timeoutMs));
+
+        if (Boolean.TRUE.equals(cfg.getUseTls())) {
+            builder.useTLS(true);
+        }
+
+        if (cfg.getPassword() != null || cfg.getUsername() != null) {
+            ServerCredentials.ServerCredentialsBuilder credBuilder = ServerCredentials.builder();
+            if (cfg.getPassword() != null) {
+                credBuilder.password(cfg.getPassword());
+            }
+            if (cfg.getUsername() != null) {
+                credBuilder.username(cfg.getUsername());
+            }
+            builder.credentials(credBuilder.build());
+        }
+
+        if (cfg.getDatabase() != null && cfg.getDatabase() != 0) {
+            builder.databaseId(cfg.getDatabase());
+        }
+
+        try {
+            return awaitFuture(
+                    GlideClient.createClient(builder.build()), timeoutMs, "GLIDE client creation");
+        } catch (RuntimeException e) {
+            throw new RuntimeException(
+                    "Failed to create Valkey GLIDE client for "
+                            + cfg.getHost()
+                            + ":"
+                            + cfg.getPort(),
+                    e);
+        }
+    }
+
+    @Override
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            try {
+                client.close();
+            } catch (ExecutionException e) {
+                log.warn(
+                        "Error closing GLIDE client for ValkeyVectorDB '{}': {}",
+                        name,
+                        e.getMessage());
+            } catch (Exception e) {
+                log.warn(
+                        "Error closing GLIDE client for ValkeyVectorDB '{}': {}",
+                        name,
+                        e.getMessage());
+            }
+        }
+    }
+
+    // ----- Public API -----
+
+    @Override
+    public int updateEmbeddings(
+            String indexName,
+            String namespace,
+            String doc,
+            String parentDocId,
+            String id,
+            List<Float> embeddings,
+            Map<String, Object> metadata) {
+        ensureOpen();
+        validateName("indexName", indexName);
+        validateName("namespace", namespace);
+        Objects.requireNonNull(doc, "doc must not be null");
+        Objects.requireNonNull(id, "id must not be null");
+        validateEmbeddings(embeddings);
+
+        if (parentDocId == null) {
+            parentDocId = id;
+        }
+
+        byte[] embeddingBytes = encodeEmbedding(embeddings);
+        String metadataJson = serializeMetadata(metadata);
+        ensureIndexCreated(indexName, namespace);
+
+        String key = keyFor(indexName, namespace, id);
+        Map<GlideString, GlideString> fields = new LinkedHashMap<>();
+        fields.put(gs(EMBEDDING_FIELD), gs(embeddingBytes));
+        fields.put(gs(DOC_FIELD), gs(doc));
+        fields.put(gs(PARENT_DOC_ID_FIELD), gs(parentDocId));
+        fields.put(gs(METADATA_FIELD), gs(metadataJson));
+
+        await(client.hset(gs(key), fields));
+        return 1;
+    }
+
+    @Override
+    public List<IndexedDoc> search(
+            String indexName, String namespace, List<Float> embeddings, int maxResults) {
+        ensureOpen();
+        validateName("indexName", indexName);
+        validateName("namespace", namespace);
+        validateEmbeddings(embeddings);
+        if (maxResults <= 0) {
+            throw new IllegalArgumentException("maxResults must be > 0, got: " + maxResults);
+        }
+
+        ensureIndexCreated(indexName, namespace);
+
+        byte[] queryBytes = encodeEmbedding(embeddings);
+
+        // Use the physical index name for FT.SEARCH (must match FT.CREATE)
+        String physicalIndex = physicalIndexNameFor(indexName, namespace);
+
+        // KNN query: *=>[KNN <k> @embedding $query_vec]
+        String query = "*=>[KNN " + maxResults + " @" + EMBEDDING_FIELD + " $query_vec]";
+
+        FTSearchOptions searchOptions =
+                FTSearchOptions.builder()
+                        .params(Map.of(gs("query_vec"), gs(queryBytes)))
+                        .addReturnField(DOC_FIELD)
+                        .addReturnField(PARENT_DOC_ID_FIELD)
+                        .addReturnField(METADATA_FIELD)
+                        .addReturnField(SCORE_FIELD)
+                        .limit(0, maxResults)
+                        .dialect(2)
+                        .build();
+
+        Object[] result = await(FT.search(client, physicalIndex, query, searchOptions));
+        return parseSearchResults(result, indexName, namespace);
+    }
+
+    // ----- Async->Sync bridge: one helper, used everywhere -----
+
+    /** Resolves every GLIDE future through one timeout- and interrupt-safe implementation. */
+    <T> T await(CompletableFuture<T> future) {
+        return awaitFuture(future, requestTimeoutMs, "Valkey operation");
+    }
+
+    private static <T> T awaitFuture(
+            CompletableFuture<T> future, long timeoutMs, String operation) {
+        try {
+            return future.get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(operation + " interrupted", e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            throw new RuntimeException(operation + " failed", cause != null ? cause : e);
+        } catch (TimeoutException e) {
+            throw new RuntimeException(operation + " timed out after " + timeoutMs + "ms", e);
+        }
+    }
+
+    // ----- Namespace/index isolation: physical index name derivation -----
+
+    /**
+     * Derives a collision-safe physical index name for FT.CREATE and FT.SEARCH. Format: {@code
+     * <normalizedKeyPrefix>:<indexName>:<namespace>}. This ensures two namespaces sharing the same
+     * logical indexName map to distinct physical FT indexes with distinct prefixes.
+     *
+     * @param indexName logical index name (validated)
+     * @param namespace logical namespace (validated)
+     * @return physical index name safe for Valkey FT commands
+     */
+    String physicalIndexNameFor(String indexName, String namespace) {
+        return normalizedKeyPrefix + ":" + indexName + ":" + namespace;
+    }
+
+    // ----- Index creation with concurrency guard -----
+
+    private void ensureIndexCreated(String indexName, String namespace) {
+        String physicalIndex = physicalIndexNameFor(indexName, namespace);
+        if (initializedIndexes.containsKey(physicalIndex)) {
+            return;
+        }
+
+        // If index creation throws, computeIfAbsent does not install a cache entry.
+        initializedIndexes.computeIfAbsent(
+                physicalIndex,
+                k -> {
+                    createIndex(indexName, namespace, physicalIndex);
+                    return Boolean.TRUE;
+                });
+    }
+
+    private void createIndex(String indexName, String namespace, String physicalIndex) {
+        String prefix = keyPrefixFor(indexName, namespace);
+
+        FieldInfo[] schema = buildSchema();
+
+        FTCreateOptions createOptions =
+                FTCreateOptions.builder()
+                        .dataType(DataType.HASH)
+                        .prefixes(new String[] {prefix})
+                        .build();
+
+        try {
+            await(FT.create(client, physicalIndex, schema, createOptions));
+            log.info(
+                    "Created Valkey search index '{}' with prefix '{}' (metric={}, dims={})",
+                    physicalIndex,
+                    prefix,
+                    config.getDistanceMetric(),
+                    config.getDimensions());
+        } catch (RuntimeException e) {
+            if (isAlreadyExistsError(e)) {
+                log.debug("Index '{}' already exists, continuing", physicalIndex);
+            } else if (isUnknownCommandError(e)) {
+                throw new RuntimeException(
+                        "The Valkey server does not have the search module loaded. "
+                                + "Install valkey-search or use the valkey/valkey-bundle container image.",
+                        e);
+            } else {
+                // A failed computation is not cached, so the next operation can retry.
+                throw e;
+            }
+        }
+    }
+
+    private FieldInfo[] buildSchema() {
+        String method = ValkeyConfig.resolveIndexingMethod(config.getIndexingMethod());
+        int dims = config.getDimensions() != null ? config.getDimensions() : 256;
+
+        Field vectorField;
+        if ("flat".equals(method)) {
+            vectorField = VectorFieldFlat.builder(distanceMetric, dims).build();
+        } else {
+            vectorField = VectorFieldHnsw.builder(distanceMetric, dims).build();
+        }
+
+        return new FieldInfo[] {new FieldInfo(EMBEDDING_FIELD, vectorField)};
+    }
+
+    // ----- Embedding encoding: one shared FLOAT32 little-endian encoder -----
+
+    /**
+     * Encodes a list of floats as raw little-endian FLOAT32 bytes. This is the only encoder -- both
+     * stored vectors and query vectors pass through here. Using a different encoding for either
+     * side causes documents to be silently excluded from vector search results.
+     */
+    static byte[] encodeEmbedding(List<Float> embeddings) {
+        ByteBuffer buffer =
+                ByteBuffer.allocate(4 * embeddings.size()).order(ByteOrder.LITTLE_ENDIAN);
+        for (float f : embeddings) {
+            buffer.putFloat(f);
+        }
+        return buffer.array();
+    }
+
+    // ----- Key schema: one method, used by HSET and FT.CREATE prefix -----
+
+    /**
+     * Returns the prefix string for FT.CREATE. The prefix includes the trailing colon so that the
+     * HSET key {@code <prefix><docId>} is matched by the index.
+     */
+    String keyPrefixFor(String indexName, String namespace) {
+        return normalizedKeyPrefix + ":" + indexName + ":" + namespace + ":";
+    }
+
+    private String keyFor(String indexName, String namespace, String docId) {
+        return keyPrefixFor(indexName, namespace) + docId;
+    }
+
+    // ----- Search result parsing -----
+
+    List<IndexedDoc> parseSearchResults(Object[] result, String indexName, String namespace) {
+        if (result == null || result.length != 2) {
+            throw new IllegalStateException(
+                    "Malformed FT.SEARCH result: expected exactly 2 elements, got "
+                            + (result == null ? "null" : result.length));
+        }
+        if (!(result[0] instanceof Long)) {
+            throw new IllegalStateException(
+                    "Malformed FT.SEARCH result: expected Long at result[0], got "
+                            + (result[0] != null ? result[0].getClass().getName() : "null"));
+        }
+        if (!(result[1] instanceof Map<?, ?>)) {
+            throw new IllegalStateException(
+                    "Malformed FT.SEARCH result: expected Map at result[1], got "
+                            + (result[1] != null ? result[1].getClass().getName() : "null"));
+        }
+
+        long declaredCount = (Long) result[0];
+        Map<?, ?> rawDocMap = (Map<?, ?>) result[1];
+        if (declaredCount < 0 || rawDocMap.size() > declaredCount) {
+            throw new IllegalStateException(
+                    "Malformed FT.SEARCH result: declared count "
+                            + declaredCount
+                            + " is smaller than returned document count "
+                            + rawDocMap.size());
+        }
+
+        String prefix = keyPrefixFor(indexName, namespace);
+        List<IndexedDoc> docs = new ArrayList<>(rawDocMap.size());
+        for (Map.Entry<?, ?> entry : rawDocMap.entrySet()) {
+            if (!(entry.getKey() instanceof GlideString)) {
+                throw new IllegalStateException(
+                        "Malformed FT.SEARCH result: document key is not a GlideString");
+            }
+            String fullKey = entry.getKey().toString();
+            if (!fullKey.startsWith(prefix) || fullKey.length() == prefix.length()) {
+                throw new IllegalStateException(
+                        "Malformed FT.SEARCH result: key '"
+                                + fullKey
+                                + "' does not match expected prefix '"
+                                + prefix
+                                + "'");
+            }
+
+            Map<GlideString, GlideString> fields = requireFieldMap(entry.getValue(), fullKey);
+            String docId = fullKey.substring(prefix.length());
+            String docText = requireFieldValue(fields, DOC_FIELD, docId);
+            String parentDocId = requireFieldValue(fields, PARENT_DOC_ID_FIELD, docId);
+            String scoreStr = requireFieldValue(fields, SCORE_FIELD, docId);
+            String metadataStr = requireFieldValue(fields, METADATA_FIELD, docId);
+
+            IndexedDoc indexedDoc =
+                    new IndexedDoc(docId, parentDocId, docText, parseScore(scoreStr, docId));
+            indexedDoc.setMetadata(deserializeMetadata(metadataStr, docId));
+            docs.add(indexedDoc);
+        }
+        return docs;
+    }
+
+    private Map<GlideString, GlideString> requireFieldMap(Object rawFields, String fullKey) {
+        if (!(rawFields instanceof Map<?, ?>)) {
+            throw new IllegalStateException(
+                    "Malformed FT.SEARCH result: fields for '" + fullKey + "' are not a Map");
+        }
+        Map<GlideString, GlideString> fields = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> field : ((Map<?, ?>) rawFields).entrySet()) {
+            if (!(field.getKey() instanceof GlideString)
+                    || !(field.getValue() instanceof GlideString)) {
+                throw new IllegalStateException(
+                        "Malformed FT.SEARCH result: field key/value for '"
+                                + fullKey
+                                + "' must be GlideString");
+            }
+            fields.put((GlideString) field.getKey(), (GlideString) field.getValue());
+        }
+        return fields;
+    }
+
+    private String requireFieldValue(
+            Map<GlideString, GlideString> fields, String fieldName, String docId) {
+        GlideString value = fields.get(gs(fieldName));
+        if (value == null) {
+            throw new IllegalStateException(
+                    "Malformed FT.SEARCH result: missing field '"
+                            + fieldName
+                            + "' for document '"
+                            + docId
+                            + "'");
+        }
+        return value.toString();
+    }
+
+    /** Parses a finite distance score or throws on malformed input. */
+    static double parseScore(String scoreStr, String docId) {
+        if (scoreStr == null || scoreStr.isEmpty()) {
+            throw new IllegalStateException(
+                    "Missing score field for document '" + docId + "': score was null or empty");
+        }
+        try {
+            double score = Double.parseDouble(scoreStr);
+            if (!Double.isFinite(score)) {
+                throw new IllegalStateException(
+                        "Non-finite score '" + scoreStr + "' for document '" + docId + "'");
+            }
+            return score;
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException(
+                    "Malformed score '" + scoreStr + "' for document '" + docId + "'", e);
+        }
+    }
+
+    // ----- Metadata serialization -----
+
+    /**
+     * Serializes metadata to JSON. Throws on serialization failure instead of silently writing
+     * empty JSON.
+     */
+    static String serializeMetadata(Map<String, Object> metadata) {
+        if (metadata == null || metadata.isEmpty()) {
+            return "{}";
+        }
+        try {
+            return OBJECT_MAPPER.writeValueAsString(metadata);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to serialize metadata to JSON", e);
+        }
+    }
+
+    /**
+     * Deserializes metadata JSON. Throws on parse failure instead of silently returning empty map.
+     */
+    static Map<String, Object> deserializeMetadata(String metadataStr, String docId) {
+        try {
+            return OBJECT_MAPPER.readValue(
+                    metadataStr, new TypeReference<Map<String, Object>>() {});
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    "Failed to parse metadata for document '" + docId + "': " + e.getMessage(), e);
+        }
+    }
+
+    // ----- Validation helpers -----
+
+    private void ensureOpen() {
+        if (closed.get()) {
+            throw new IllegalStateException(
+                    "ValkeyVectorDB '" + name + "' has been closed and cannot perform operations");
+        }
+    }
+
+    private void validateName(String paramName, String value) {
+        if (value == null || !VALID_NAME.matcher(value).matches()) {
+            throw new IllegalArgumentException(
+                    "Invalid " + paramName + ": '" + value + "'. Must match [a-zA-Z0-9_-]+");
+        }
+    }
+
+    /**
+     * Validates embedding vector: non-null, correct dimension count, each element non-null and
+     * finite.
+     */
+    private void validateEmbeddings(List<Float> embeddings) {
+        int expected = config.getDimensions() != null ? config.getDimensions() : 256;
+        if (embeddings == null || embeddings.size() != expected) {
+            throw new IllegalArgumentException(
+                    "Embeddings must be of dimensions: "
+                            + expected
+                            + " but got "
+                            + (embeddings != null ? embeddings.size() : 0));
+        }
+        for (int i = 0; i < embeddings.size(); i++) {
+            Float elem = embeddings.get(i);
+            if (elem == null) {
+                throw new IllegalArgumentException(
+                        "Embedding element at index " + i + " must not be null");
+            }
+            if (!Float.isFinite(elem)) {
+                throw new IllegalArgumentException(
+                        "Embedding element at index " + i + " must be finite, got: " + elem);
+            }
+        }
+    }
+
+    /** Validates configuration constraints at construction time. */
+    private static void validateConfig(ValkeyConfig config) {
+        if (config.getHost() == null || config.getHost().isBlank()) {
+            throw new IllegalArgumentException("host must not be blank");
+        }
+        if (config.getPort() != null && (config.getPort() <= 0 || config.getPort() > 65_535)) {
+            throw new IllegalArgumentException(
+                    "port must be between 1 and 65535, got: " + config.getPort());
+        }
+        if (config.getDimensions() != null && config.getDimensions() <= 0) {
+            throw new IllegalArgumentException(
+                    "dimensions must be positive, got: " + config.getDimensions());
+        }
+        if (config.getRequestTimeoutMs() != null && config.getRequestTimeoutMs() <= 0) {
+            throw new IllegalArgumentException(
+                    "requestTimeoutMs must be positive, got: " + config.getRequestTimeoutMs());
+        }
+        if (config.getDatabase() != null && config.getDatabase() < 0) {
+            throw new IllegalArgumentException(
+                    "database must be >= 0, got: " + config.getDatabase());
+        }
+    }
+
+    /**
+     * Normalizes the key prefix: strips trailing colons, validates non-blank and safe characters.
+     */
+    static String normalizeKeyPrefix(String keyPrefix) {
+        String prefix = keyPrefix != null ? keyPrefix : "conductor";
+        // Strip trailing colons
+        while (prefix.endsWith(":")) {
+            prefix = prefix.substring(0, prefix.length() - 1);
+        }
+        if (prefix.isEmpty()) {
+            throw new IllegalArgumentException("keyPrefix must not be blank after normalization");
+        }
+        // Validate safe characters: alphanumeric, underscore, hyphen, dots
+        if (!Pattern.matches("[a-zA-Z0-9_.\\-]+", prefix)) {
+            throw new IllegalArgumentException(
+                    "keyPrefix contains unsafe characters: '"
+                            + prefix
+                            + "'. Must match [a-zA-Z0-9_.\\-]+");
+        }
+        return prefix;
+    }
+
+    // ----- Error classification -----
+
+    /**
+     * Classifies whether an exception represents an "index already exists" error from Valkey.
+     * Requires the cause chain to contain a GLIDE {@link RequestException} specifically.
+     */
+    static boolean isAlreadyExistsError(RuntimeException e) {
+        RequestException reqEx = findRequestException(e);
+        if (reqEx == null) {
+            return false;
+        }
+        String msg = reqEx.getMessage();
+        return msg != null && msg.contains("already exists.");
+    }
+
+    private boolean isUnknownCommandError(RuntimeException e) {
+        RequestException reqEx = findRequestException(e);
+        if (reqEx != null) {
+            String msg = reqEx.getMessage();
+            return msg != null && msg.contains("ERR unknown command");
+        }
+        // Fallback: check the top-level message for non-RequestException wrappers
+        String msg = e.getMessage();
+        return msg != null && msg.contains("ERR unknown command");
+    }
+
+    /**
+     * Walks the cause chain to find a GLIDE {@link RequestException}. Returns null if not found.
+     */
+    private static RequestException findRequestException(Throwable t) {
+        Throwable current = t;
+        while (current != null) {
+            if (current instanceof RequestException) {
+                return (RequestException) current;
+            }
+            current = current.getCause();
+        }
+        return null;
+    }
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDB.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDB.java
@@ -42,9 +42,9 @@ import static glide.api.models.GlideString.gs;
 /**
  * Valkey vector database backend using the {@code valkey-search} module (FT.CREATE / FT.SEARCH).
  *
- * <p>Score semantics: the {@code __embedding_score} field returned by valkey-search is a raw
- * distance value (lower is better). For COSINE metric: 0 = identical, 1 = orthogonal. This matches
- * the convention used by {@code PostgresVectorDB} and {@code SqliteVectorDB}.
+ * <p>Score semantics: the {@code __embedding_score} field returned by valkey-search is a distance
+ * value where lower is better for COSINE, L2, and IP. COSINE scores are 0 for identical vectors
+ * and 1 for orthogonal vectors; IP uses Valkey Search's {@code 1 - dot(X,Y)} distance.
  *
  * <p>Key schema: {@code <keyPrefix>:<indexName>:<namespace>:<docId>}. The FT.CREATE PREFIX filter
  * is set to {@code <keyPrefix>:<indexName>:<namespace>:} so that HSET keys are automatically
@@ -360,6 +360,7 @@ public class ValkeyVectorDB extends VectorDB implements Closeable {
             // throws, the index remains uninitialized and a later operation can retry it.
             createIndex(indexName, namespace, physicalIndex);
             initializedIndexes.put(physicalIndex, Boolean.TRUE);
+            indexInitializationLocks.remove(physicalIndex, initializationLock);
         }
     }
 
@@ -385,6 +386,7 @@ public class ValkeyVectorDB extends VectorDB implements Closeable {
         } catch (RuntimeException e) {
             if (isAlreadyExistsError(e)) {
                 log.debug("Index '{}' already exists, continuing", physicalIndex);
+                validateExistingIndexDimensions(physicalIndex);
             } else if (isUnknownCommandError(e)) {
                 throw new RuntimeException(
                         "The Valkey server does not have the search module loaded. "
@@ -395,6 +397,114 @@ public class ValkeyVectorDB extends VectorDB implements Closeable {
                 throw e;
             }
         }
+    }
+
+    private void validateExistingIndexDimensions(String physicalIndex) {
+        Map<String, Object> info = await(FT.info(client, physicalIndex));
+        Integer existingDimensions = findVectorDimension(info);
+        int configuredDimensions = config.getDimensions() != null ? config.getDimensions() : 256;
+        if (existingDimensions == null) {
+            throw new RuntimeException(
+                    "Unable to determine dimensions for existing Valkey index '"
+                            + physicalIndex
+                            + "'");
+        }
+        if (existingDimensions != configuredDimensions) {
+            throw new RuntimeException(
+                    "Valkey index '"
+                            + physicalIndex
+                            + "' has dimensions "
+                            + existingDimensions
+                            + " but configuration requires "
+                            + configuredDimensions);
+        }
+    }
+
+    private static Integer findVectorDimension(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            Object fieldName = mapValue(map, "field_name");
+            Object identifier = mapValue(map, "identifier");
+            Object attribute = mapValue(map, "attribute");
+            if (EMBEDDING_FIELD.equals(String.valueOf(fieldName))
+                    || EMBEDDING_FIELD.equals(String.valueOf(identifier))
+                    || EMBEDDING_FIELD.equals(String.valueOf(attribute))) {
+                Object vectorParams = mapValue(map, "vector_params");
+                if (vectorParams instanceof Map<?, ?> params) {
+                    Object dimension = mapValue(params, "dimension");
+                    Integer parsedDimension = parseDimension(dimension);
+                    if (parsedDimension != null) {
+                        return parsedDimension;
+                    }
+                }
+                Object dimension = mapValue(map, "dimension");
+                Integer parsedDimension = parseDimension(dimension);
+                if (parsedDimension != null) {
+                    return parsedDimension;
+                }
+                parsedDimension = parseDimension(mapValue(map, "dim"));
+                if (parsedDimension != null) {
+                    return parsedDimension;
+                }
+            }
+            for (Object nested : map.values()) {
+                Integer dimension = findVectorDimension(nested);
+                if (dimension != null) {
+                    return dimension;
+                }
+            }
+        } else if (value instanceof Object[] array) {
+            Object identifier = arrayValue(array, "identifier");
+            Object attribute = arrayValue(array, "attribute");
+            if (EMBEDDING_FIELD.equals(String.valueOf(identifier))
+                    || EMBEDDING_FIELD.equals(String.valueOf(attribute))) {
+                Object index = arrayValue(array, "index");
+                Integer dimensions = parseDimension(arrayValue(index, "dimensions"));
+                if (dimensions != null) {
+                    return dimensions;
+                }
+            }
+            for (Object nested : array) {
+                Integer dimension = findVectorDimension(nested);
+                if (dimension != null) {
+                    return dimension;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static Object arrayValue(Object value, String name) {
+        if (value instanceof Object[] array) {
+            for (int i = 0; i + 1 < array.length; i += 2) {
+                if (name.equals(String.valueOf(array[i]))) {
+                    return array[i + 1];
+                }
+            }
+        }
+        return null;
+    }
+
+    private static Integer parseDimension(Object value) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value != null) {
+            try {
+                return Integer.valueOf(String.valueOf(value));
+            } catch (NumberFormatException ignored) {
+                // Continue searching other metadata fields.
+            }
+        }
+        return null;
+    }
+
+    private static Object mapValue(Map<?, ?> map, String name) {
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            if (name.equals(String.valueOf(entry.getKey()))) {
+                return entry.getValue();
+            }
+        }
+        return null;
     }
 
     private FieldInfo[] buildSchema() {

--- a/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDB.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDB.java
@@ -112,7 +112,7 @@ public class ValkeyVectorDB extends VectorDB implements Closeable {
         this.requestTimeoutMs =
                 config.getRequestTimeoutMs() != null ? config.getRequestTimeoutMs() : 2000L;
         this.distanceMetric = ValkeyConfig.resolveDistanceMetric(config.getDistanceMetric());
-        this.client = createClient ? buildClient(config, requestTimeoutMs) : injectedClient;
+        this.client = createClient ? buildClient(name, config, requestTimeoutMs) : injectedClient;
     }
 
     private static ValkeyConfig validateAndReturn(ValkeyConfig config) {
@@ -126,7 +126,16 @@ public class ValkeyVectorDB extends VectorDB implements Closeable {
 
     // ----- Client lifecycle -----
 
-    private static GlideClient buildClient(ValkeyConfig cfg, long timeoutMs) {
+    private static final String CLIENT_NAME_PREFIX = "conductor-vectordb-";
+
+    /**
+     * Builds the GLIDE client configuration, including a {@code clientName} so this instance's
+     * connections are identifiable in {@code CLIENT LIST} on a shared Valkey server.
+     * Package-private (and split out from {@link #buildClient}) so it can be unit-tested without a
+     * live connection.
+     */
+    static GlideClientConfiguration buildClientConfiguration(
+            String name, ValkeyConfig cfg, long timeoutMs) {
         GlideClientConfiguration.GlideClientConfigurationBuilder<?, ?> builder =
                 GlideClientConfiguration.builder()
                         .address(
@@ -134,7 +143,8 @@ public class ValkeyVectorDB extends VectorDB implements Closeable {
                                         .host(cfg.getHost() != null ? cfg.getHost() : "localhost")
                                         .port(cfg.getPort() != null ? cfg.getPort() : 6379)
                                         .build())
-                        .requestTimeout(Math.toIntExact(timeoutMs));
+                        .requestTimeout(Math.toIntExact(timeoutMs))
+                        .clientName(CLIENT_NAME_PREFIX + sanitizeClientName(name));
 
         if (Boolean.TRUE.equals(cfg.getUseTls())) {
             builder.useTLS(true);
@@ -155,9 +165,24 @@ public class ValkeyVectorDB extends VectorDB implements Closeable {
             builder.databaseId(cfg.getDatabase());
         }
 
+        return builder.build();
+    }
+
+    /**
+     * CLIENT SETNAME rejects names containing spaces or newlines. The configured instance name is
+     * an operator-provided config key with no character restrictions at that layer, so it is
+     * sanitized here rather than letting an otherwise-valid config fail client creation.
+     */
+    private static String sanitizeClientName(String name) {
+        return name.replaceAll("\\s+", "_");
+    }
+
+    private static GlideClient buildClient(String name, ValkeyConfig cfg, long timeoutMs) {
         try {
             return awaitFuture(
-                    GlideClient.createClient(builder.build()), timeoutMs, "GLIDE client creation");
+                    GlideClient.createClient(buildClientConfiguration(name, cfg, timeoutMs)),
+                    timeoutMs,
+                    "GLIDE client creation");
         } catch (RuntimeException e) {
             throw new RuntimeException(
                     "Failed to create Valkey GLIDE client for "
@@ -202,7 +227,7 @@ public class ValkeyVectorDB extends VectorDB implements Closeable {
         validateName("indexName", indexName);
         validateName("namespace", namespace);
         Objects.requireNonNull(doc, "doc must not be null");
-        Objects.requireNonNull(id, "id must not be null");
+        validateId(id);
         validateEmbeddings(embeddings);
 
         if (parentDocId == null) {
@@ -555,6 +580,20 @@ public class ValkeyVectorDB extends VectorDB implements Closeable {
     }
 
     /**
+     * Validates the document id before it is concatenated into the Valkey key. Null still throws
+     * {@link NullPointerException} (unchanged contract, matches sibling {@code doc} parameter); a
+     * non-null id must match the same allowlist as {@code indexName}/{@code namespace} so that a
+     * colon or other delimiter cannot produce an ambiguous or unexpectedly-scoped key.
+     */
+    private void validateId(String id) {
+        Objects.requireNonNull(id, "id must not be null");
+        if (!VALID_NAME.matcher(id).matches()) {
+            throw new IllegalArgumentException(
+                    "Invalid id: '" + id + "'. Must match [a-zA-Z0-9_-]+");
+        }
+    }
+
+    /**
      * Validates embedding vector: non-null, correct dimension count, each element non-null and
      * finite.
      */
@@ -629,7 +668,10 @@ public class ValkeyVectorDB extends VectorDB implements Closeable {
 
     /**
      * Classifies whether an exception represents an "index already exists" error from Valkey.
-     * Requires the cause chain to contain a GLIDE {@link RequestException} specifically.
+     * Requires the cause chain to contain a GLIDE {@link RequestException} specifically. Anchored
+     * to the verified message shape ({@code "Index: <name> in database <db> already exists."}) via
+     * a suffix check, rather than a free-floating substring match, so an unrelated message that
+     * happens to mention "already exists." elsewhere is not misclassified.
      */
     static boolean isAlreadyExistsError(RuntimeException e) {
         RequestException reqEx = findRequestException(e);
@@ -637,18 +679,22 @@ public class ValkeyVectorDB extends VectorDB implements Closeable {
             return false;
         }
         String msg = reqEx.getMessage();
-        return msg != null && msg.contains("already exists.");
+        return msg != null && msg.endsWith(" already exists.");
     }
 
-    private boolean isUnknownCommandError(RuntimeException e) {
+    /**
+     * Classifies whether an exception represents an "unknown command" error (search module not
+     * loaded). Requires the cause chain to contain a GLIDE {@link RequestException} specifically --
+     * unlike the prior implementation, this does not fall back to matching non-RequestException
+     * messages, so errors from other exception types are never suppressed here.
+     */
+    static boolean isUnknownCommandError(RuntimeException e) {
         RequestException reqEx = findRequestException(e);
-        if (reqEx != null) {
-            String msg = reqEx.getMessage();
-            return msg != null && msg.contains("ERR unknown command");
+        if (reqEx == null) {
+            return false;
         }
-        // Fallback: check the top-level message for non-RequestException wrappers
-        String msg = e.getMessage();
-        return msg != null && msg.contains("ERR unknown command");
+        String msg = reqEx.getMessage();
+        return msg != null && msg.startsWith("ERR unknown command");
     }
 
     /**

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/ValkeyVectorDBRoundTripTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/ValkeyVectorDBRoundTripTest.java
@@ -12,6 +12,7 @@
  */
 package org.conductoross.conductor.ai.vectordb;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -20,6 +21,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 import org.conductoross.conductor.ai.model.IndexedDoc;
 import org.conductoross.conductor.ai.vectordb.valkey.ValkeyConfig;
@@ -32,7 +34,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -63,6 +64,8 @@ public class ValkeyVectorDBRoundTripTest {
 
     /** Query vector; distances below are derived from it. */
     private static final List<Float> QUERY = List.of(1f, 0f, 0f, 0f);
+    private static final Duration SEARCH_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration SEARCH_POLL_INTERVAL = Duration.ofMillis(100);
 
     private static GenericContainer<?> valkey;
 
@@ -91,25 +94,46 @@ public class ValkeyVectorDBRoundTripTest {
     }
 
     /**
-     * Indexing in valkey-search is asynchronous, so poll until the expected number of documents is
-     * visible rather than sleeping a fixed amount.
+     * Indexing in valkey-search is asynchronous, so poll until the condition is met or the
+     * caller-supplied timeout expires.
      */
     private List<IndexedDoc> searchUntil(
             ValkeyVectorDB db, String index, String namespace, int maxResults, int expected) {
+        return searchUntil(
+                db,
+                index,
+                namespace,
+                maxResults,
+                results -> results.size() == expected,
+                SEARCH_TIMEOUT,
+                "expected " + expected + " results");
+    }
+
+    private List<IndexedDoc> searchUntil(
+            ValkeyVectorDB db,
+            String index,
+            String namespace,
+            int maxResults,
+            Predicate<List<IndexedDoc>> condition,
+            Duration timeout,
+            String conditionDescription) {
+        long deadline = System.nanoTime() + timeout.toNanos();
         List<IndexedDoc> results = List.of();
-        for (int attempt = 0; attempt < 50; attempt++) {
+        while (System.nanoTime() < deadline) {
             results = db.search(index, namespace, QUERY, maxResults);
-            if (results.size() == expected) {
+            if (condition.test(results)) {
                 return results;
             }
             try {
-                Thread.sleep(100);
+                Thread.sleep(SEARCH_POLL_INTERVAL.toMillis());
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new IllegalStateException("Interrupted while waiting for indexing", e);
             }
         }
-        return results;
+        throw new AssertionError(
+                "Timed out after " + timeout + " waiting for " + conditionDescription
+                        + "; last result count=" + results.size());
     }
 
     @Test
@@ -198,22 +222,18 @@ public class ValkeyVectorDBRoundTripTest {
             // Second write to the same id replaces it with an exact match.
             db.updateEmbeddings("docs", "ns", "revised", null, "same-id", QUERY, Map.of());
 
-            IndexedDoc after = null;
-            for (int attempt = 0; attempt < 50 && after == null; attempt++) {
-                IndexedDoc candidate = searchUntil(db, "docs", "ns", 1, 1).get(0);
-                if ("revised".equals(candidate.getText())) {
-                    after = candidate;
-                    break;
-                }
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new IllegalStateException("Interrupted", e);
-                }
-            }
+            IndexedDoc after =
+                    searchUntil(
+                                    db,
+                                    "docs",
+                                    "ns",
+                                    1,
+                                    results -> results.size() == 1
+                                            && "revised".equals(results.get(0).getText()),
+                                    SEARCH_TIMEOUT,
+                                    "the revised document")
+                            .get(0);
 
-            assertNotNull(after, "upsert did not replace the stored document");
             assertEquals("revised", after.getText());
             assertEquals(0.0, after.getScore(), 1e-9);
 

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/ValkeyVectorDBRoundTripTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/ValkeyVectorDBRoundTripTest.java
@@ -12,6 +12,7 @@
  */
 package org.conductoross.conductor.ai.vectordb;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -182,7 +183,8 @@ public class ValkeyVectorDBRoundTripTest {
     }
 
     @Test
-    void providerConfiguredValkeyPerformsKnnSearchAgainstRealServer() {
+    void providerConfiguredValkeyPerformsKnnSearchAgainstRealServer()
+            throws IOException, InterruptedException {
         ValkeyConfig valkeyConfig = configFor("provider-evidence");
         VectorDBInstanceConfig.VectorDBInstance instance =
                 new VectorDBInstanceConfig.VectorDBInstance();
@@ -215,6 +217,11 @@ public class ValkeyVectorDBRoundTripTest {
             assertEquals(0.0, results.get(0).getScore(), 1e-9);
             assertTrue(results.get(0).getScore() < results.get(1).getScore());
             assertTrue(results.get(1).getScore() < results.get(2).getScore());
+
+            GenericContainer.ExecResult indexInfo =
+                    valkey.execInContainer("valkey-cli", "FT.INFO", "provider-evidence:docs:ns");
+            assertEquals(0, indexInfo.getExitCode(), indexInfo::getStderr);
+            System.out.printf("VALKEY FT.INFO EVIDENCE%n%s%n", indexInfo.getStdout());
 
             System.out.printf(
                     "VALKEY KNN EVIDENCE | query=%s | results=%s%n",

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/ValkeyVectorDBRoundTripTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/ValkeyVectorDBRoundTripTest.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.vectordb;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.conductoross.conductor.ai.model.IndexedDoc;
+import org.conductoross.conductor.ai.vectordb.valkey.ValkeyConfig;
+import org.conductoross.conductor.ai.vectordb.valkey.ValkeyVectorDB;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end round trip for the Valkey vector store against a real {@code valkey-search} server
+ * started by Testcontainers.
+ *
+ * <p>Requires a Docker-API-compatible container runtime to be reachable. Docker Desktop works with
+ * no configuration. Other runtimes (Rancher Desktop, Finch with {@code dockercompat: true}, Podman)
+ * require {@code DOCKER_HOST} to point at their socket; that is an environment concern and is
+ * deliberately not encoded in this test or in the build.
+ *
+ * <p>Nothing here is hardcoded to a host or port: the host and mapped port are read back from the
+ * container, so the test runs unchanged alongside an existing Valkey on the default port.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ValkeyVectorDBRoundTripTest {
+
+    /**
+     * Pinned so the test is reproducible. {@code valkey-bundle} ships the {@code valkey-search}
+     * module; the plain {@code valkey} image does not and would fail with "unknown command".
+     */
+    private static final DockerImageName VALKEY_BUNDLE =
+            DockerImageName.parse("valkey/valkey-bundle:9.1.2");
+
+    private static final int VALKEY_PORT = 6379;
+    private static final int DIMENSIONS = 4;
+
+    /** Query vector; distances below are derived from it. */
+    private static final List<Float> QUERY = List.of(1f, 0f, 0f, 0f);
+
+    private static GenericContainer<?> valkey;
+
+    @BeforeAll
+    void startContainer() {
+        valkey = new GenericContainer<>(VALKEY_BUNDLE).withExposedPorts(VALKEY_PORT);
+        valkey.start();
+    }
+
+    @AfterAll
+    void stopContainer() {
+        if (valkey != null) {
+            valkey.stop();
+        }
+    }
+
+    /** Builds a config pointed at the container's mapped address. Never a fixed host or port. */
+    private ValkeyConfig configFor(String keyPrefix) {
+        ValkeyConfig config = new ValkeyConfig();
+        config.setHost(valkey.getHost());
+        config.setPort(valkey.getMappedPort(VALKEY_PORT));
+        config.setDimensions(DIMENSIONS);
+        config.setKeyPrefix(keyPrefix);
+        config.setRequestTimeoutMs(5000);
+        return config;
+    }
+
+    /**
+     * Indexing in valkey-search is asynchronous, so poll until the expected number of documents is
+     * visible rather than sleeping a fixed amount.
+     */
+    private List<IndexedDoc> searchUntil(
+            ValkeyVectorDB db, String index, String namespace, int maxResults, int expected) {
+        List<IndexedDoc> results = List.of();
+        for (int attempt = 0; attempt < 50; attempt++) {
+            results = db.search(index, namespace, QUERY, maxResults);
+            if (results.size() == expected) {
+                return results;
+            }
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted while waiting for indexing", e);
+            }
+        }
+        return results;
+    }
+
+    @Test
+    void storesAndRetrievesByKnnInDistanceOrder() {
+        try (ValkeyVectorDB db = new ValkeyVectorDB("rt-order", configFor("rt-order"))) {
+            db.updateEmbeddings("docs", "ns", "identical", null, "a", QUERY, Map.of("rank", 1));
+            db.updateEmbeddings(
+                    "docs",
+                    "ns",
+                    "oblique",
+                    null,
+                    "b",
+                    List.of(.7f, .7f, 0f, 0f),
+                    Map.of("rank", 2));
+            db.updateEmbeddings(
+                    "docs",
+                    "ns",
+                    "orthogonal",
+                    null,
+                    "c",
+                    List.of(0f, 0f, 0f, 1f),
+                    Map.of("rank", 3));
+
+            List<IndexedDoc> results = searchUntil(db, "docs", "ns", 3, 3);
+
+            assertEquals(
+                    List.of("a", "b", "c"),
+                    results.stream().map(IndexedDoc::getDocId).toList(),
+                    "KNN results must be ordered by ascending cosine distance");
+
+            // Score is raw cosine distance: lower is better. An exact match scores 0.
+            assertEquals(0.0, results.get(0).getScore(), 1e-9);
+            assertTrue(
+                    results.get(0).getScore() < results.get(1).getScore()
+                            && results.get(1).getScore() < results.get(2).getScore(),
+                    "scores must increase with distance, proving they are not inverted");
+            // Orthogonal vectors are at cosine distance 1.
+            assertEquals(1.0, results.get(2).getScore(), 1e-6);
+        }
+    }
+
+    @Test
+    void roundTripsTextParentIdAndMetadata() {
+        try (ValkeyVectorDB db = new ValkeyVectorDB("rt-fields", configFor("rt-fields"))) {
+            db.updateEmbeddings(
+                    "docs",
+                    "ns",
+                    "the quick brown fox",
+                    "parent-42",
+                    "doc-1",
+                    QUERY,
+                    Map.of("source", "unit-test", "page", 7));
+
+            IndexedDoc doc = searchUntil(db, "docs", "ns", 1, 1).get(0);
+
+            assertEquals("doc-1", doc.getDocId());
+            assertEquals("parent-42", doc.getParentDocId());
+            assertEquals("the quick brown fox", doc.getText());
+            assertEquals("unit-test", doc.getMetadata().get("source"));
+            assertEquals(7, doc.getMetadata().get("page"));
+        }
+    }
+
+    @Test
+    void nullParentDocIdDefaultsToDocId() {
+        try (ValkeyVectorDB db = new ValkeyVectorDB("rt-parent", configFor("rt-parent"))) {
+            db.updateEmbeddings("docs", "ns", "text", null, "solo", QUERY, Map.of());
+
+            IndexedDoc doc = searchUntil(db, "docs", "ns", 1, 1).get(0);
+
+            assertEquals("solo", doc.getDocId());
+            assertEquals("solo", doc.getParentDocId());
+        }
+    }
+
+    @Test
+    void upsertReplacesVectorAndText() {
+        try (ValkeyVectorDB db = new ValkeyVectorDB("rt-upsert", configFor("rt-upsert"))) {
+            // First write is far from the query vector.
+            db.updateEmbeddings(
+                    "docs", "ns", "original", null, "same-id", List.of(0f, 0f, 0f, 1f), Map.of());
+            IndexedDoc before = searchUntil(db, "docs", "ns", 1, 1).get(0);
+            assertEquals("original", before.getText());
+            assertEquals(1.0, before.getScore(), 1e-6);
+
+            // Second write to the same id replaces it with an exact match.
+            db.updateEmbeddings("docs", "ns", "revised", null, "same-id", QUERY, Map.of());
+
+            IndexedDoc after = null;
+            for (int attempt = 0; attempt < 50 && after == null; attempt++) {
+                IndexedDoc candidate = searchUntil(db, "docs", "ns", 1, 1).get(0);
+                if ("revised".equals(candidate.getText())) {
+                    after = candidate;
+                    break;
+                }
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Interrupted", e);
+                }
+            }
+
+            assertNotNull(after, "upsert did not replace the stored document");
+            assertEquals("revised", after.getText());
+            assertEquals(0.0, after.getScore(), 1e-9);
+
+            // Still a single document, not a duplicate.
+            assertEquals(1, searchUntil(db, "docs", "ns", 10, 1).size());
+        }
+    }
+
+    @Test
+    void maxResultsIsHonouredBeyondDefaultLimitOfTen() {
+        try (ValkeyVectorDB db = new ValkeyVectorDB("rt-limit", configFor("rt-limit"))) {
+            // 12 documents: more than the RediSearch-family default LIMIT of 10.
+            for (int i = 0; i < 12; i++) {
+                db.updateEmbeddings(
+                        "docs",
+                        "ns",
+                        "doc " + i,
+                        null,
+                        "id-" + i,
+                        List.of(1f, i / 100f, 0f, 0f),
+                        Map.of());
+            }
+
+            assertEquals(12, searchUntil(db, "docs", "ns", 12, 12).size());
+            // And a smaller cap is still respected.
+            assertEquals(5, searchUntil(db, "docs", "ns", 5, 5).size());
+        }
+    }
+
+    @Test
+    void namespacesAreIsolatedUnderTheSameIndexName() {
+        try (ValkeyVectorDB db = new ValkeyVectorDB("rt-ns", configFor("rt-ns"))) {
+            db.updateEmbeddings("docs", "tenantA", "belongs to A", null, "a1", QUERY, Map.of());
+            db.updateEmbeddings("docs", "tenantB", "belongs to B", null, "b1", QUERY, Map.of());
+
+            List<IndexedDoc> fromA = searchUntil(db, "docs", "tenantA", 10, 1);
+            List<IndexedDoc> fromB = searchUntil(db, "docs", "tenantB", 10, 1);
+
+            assertEquals(List.of("a1"), fromA.stream().map(IndexedDoc::getDocId).toList());
+            assertEquals(List.of("b1"), fromB.stream().map(IndexedDoc::getDocId).toList());
+            assertEquals("belongs to A", fromA.get(0).getText());
+            assertEquals("belongs to B", fromB.get(0).getText());
+        }
+    }
+
+    @Test
+    void concurrentFirstWritesToSameIndexAllSucceed() throws Exception {
+        try (ValkeyVectorDB db = new ValkeyVectorDB("rt-concurrent", configFor("rt-concurrent"))) {
+            int writers = 8;
+            ExecutorService pool = Executors.newFixedThreadPool(writers);
+            try {
+                List<Callable<Integer>> tasks = new ArrayList<>();
+                for (int i = 0; i < writers; i++) {
+                    String id = "c-" + i;
+                    tasks.add(
+                            () ->
+                                    db.updateEmbeddings(
+                                            "docs", "ns", "concurrent", null, id, QUERY, Map.of()));
+                }
+
+                // Every write must succeed: the first triggers FT.CREATE, the rest must not fail
+                // with "index already exists".
+                for (Future<Integer> future : pool.invokeAll(tasks)) {
+                    assertEquals(1, future.get(30, TimeUnit.SECONDS));
+                }
+            } finally {
+                pool.shutdownNow();
+            }
+
+            assertEquals(writers, searchUntil(db, "docs", "ns", writers, writers).size());
+        }
+    }
+
+    @Test
+    void secondInstanceReusesExistingIndexWithoutFailing() {
+        ValkeyConfig config = configFor("rt-exists");
+
+        // First instance creates the physical index via FT.CREATE.
+        try (ValkeyVectorDB first = new ValkeyVectorDB("rt-exists-1", config)) {
+            assertEquals(
+                    1,
+                    first.updateEmbeddings(
+                            "docs", "ns", "from first", null, "d1", QUERY, Map.of()));
+        }
+
+        // A second instance has an empty index cache, so its first write issues FT.CREATE again
+        // against an index that already exists. That error must be suppressed, not propagated.
+        // This is the real-world path after a server restart or with two configured providers
+        // pointing at the same Valkey.
+        try (ValkeyVectorDB second = new ValkeyVectorDB("rt-exists-2", configFor("rt-exists"))) {
+            assertEquals(
+                    1,
+                    second.updateEmbeddings(
+                            "docs", "ns", "from second", null, "d2", QUERY, Map.of()),
+                    "second instance must tolerate the pre-existing index");
+
+            // Both documents are present and searchable through the reused index.
+            List<IndexedDoc> results = searchUntil(second, "docs", "ns", 10, 2);
+            assertEquals(
+                    List.of("d1", "d2"),
+                    results.stream().map(IndexedDoc::getDocId).sorted().toList());
+        }
+    }
+
+    @Test
+    void dimensionMismatchIsRejectedAgainstLiveServer() {
+        try (ValkeyVectorDB db = new ValkeyVectorDB("rt-dims", configFor("rt-dims"))) {
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () ->
+                            db.updateEmbeddings(
+                                    "docs", "ns", "text", null, "bad", List.of(1f, 0f), Map.of()));
+        }
+    }
+}

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/ValkeyVectorDBRoundTripTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/ValkeyVectorDBRoundTripTest.java
@@ -64,6 +64,7 @@ public class ValkeyVectorDBRoundTripTest {
 
     /** Query vector; distances below are derived from it. */
     private static final List<Float> QUERY = List.of(1f, 0f, 0f, 0f);
+
     private static final Duration SEARCH_TIMEOUT = Duration.ofSeconds(10);
     private static final Duration SEARCH_POLL_INTERVAL = Duration.ofMillis(100);
 
@@ -132,8 +133,12 @@ public class ValkeyVectorDBRoundTripTest {
             }
         }
         throw new AssertionError(
-                "Timed out after " + timeout + " waiting for " + conditionDescription
-                        + "; last result count=" + results.size());
+                "Timed out after "
+                        + timeout
+                        + " waiting for "
+                        + conditionDescription
+                        + "; last result count="
+                        + results.size());
     }
 
     @Test
@@ -228,8 +233,9 @@ public class ValkeyVectorDBRoundTripTest {
                                     "docs",
                                     "ns",
                                     1,
-                                    results -> results.size() == 1
-                                            && "revised".equals(results.get(0).getText()),
+                                    results ->
+                                            results.size() == 1
+                                                    && "revised".equals(results.get(0).getText()),
                                     SEARCH_TIMEOUT,
                                     "the revised document")
                             .get(0);

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/ValkeyVectorDBRoundTripTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/ValkeyVectorDBRoundTripTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -177,6 +178,52 @@ public class ValkeyVectorDBRoundTripTest {
                     "scores must increase with distance, proving they are not inverted");
             // Orthogonal vectors are at cosine distance 1.
             assertEquals(1.0, results.get(2).getScore(), 1e-6);
+        }
+    }
+
+    @Test
+    void providerConfiguredValkeyPerformsKnnSearchAgainstRealServer() {
+        ValkeyConfig valkeyConfig = configFor("provider-evidence");
+        VectorDBInstanceConfig.VectorDBInstance instance =
+                new VectorDBInstanceConfig.VectorDBInstance();
+        instance.setName("provider-evidence");
+        instance.setType("valkey");
+        instance.setValkey(valkeyConfig);
+
+        VectorDBInstanceConfig instanceConfig = new VectorDBInstanceConfig();
+        instanceConfig.setInstances(List.of(instance));
+        StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
+        VectorDBProvider provider =
+                new VectorDBProvider(instanceConfig, beanFactory.getBeanProvider(VectorDB.class));
+
+        try {
+            VectorDB configuredDb = provider.get("provider-evidence", null);
+            assertTrue(configuredDb instanceof ValkeyVectorDB);
+            ValkeyVectorDB db = (ValkeyVectorDB) configuredDb;
+
+            db.updateEmbeddings("docs", "ns", "doc-a", null, "doc-a", QUERY, Map.of());
+            db.updateEmbeddings(
+                    "docs", "ns", "doc-b", null, "doc-b", List.of(.9f, .1f, 0f, 0f), Map.of());
+            db.updateEmbeddings(
+                    "docs", "ns", "doc-c", null, "doc-c", List.of(0f, 1f, 0f, 0f), Map.of());
+
+            List<IndexedDoc> results = searchUntil(db, "docs", "ns", 3, 3);
+
+            assertEquals(
+                    List.of("doc-a", "doc-b", "doc-c"),
+                    results.stream().map(IndexedDoc::getDocId).toList());
+            assertEquals(0.0, results.get(0).getScore(), 1e-9);
+            assertTrue(results.get(0).getScore() < results.get(1).getScore());
+            assertTrue(results.get(1).getScore() < results.get(2).getScore());
+
+            System.out.printf(
+                    "VALKEY KNN EVIDENCE | query=%s | results=%s%n",
+                    QUERY,
+                    results.stream()
+                            .map(result -> result.getDocId() + ":" + result.getScore())
+                            .toList());
+        } finally {
+            provider.dispose();
         }
     }
 

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/VectorDBProviderTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/VectorDBProviderTest.java
@@ -179,6 +179,17 @@ class VectorDBProviderTest {
     }
 
     @Test
+    void constructorPropagatesInstanceConfigFailure() {
+        // Fix #M0: the provider must not swallow initialization failures into an empty map.
+        VectorDBInstanceConfig instanceConfig = mock(VectorDBInstanceConfig.class);
+        when(instanceConfig.getVectorDBInstances()).thenThrow(new IllegalStateException("boom"));
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> new VectorDBProvider(instanceConfig, defaults()));
+    }
+
+    @Test
     void testDefaultInstanceIsMerged() {
         VectorDB defaultCustom = mock(VectorDB.class);
         when(defaultCustom.getName()).thenReturn("default");

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/VectorDBProviderTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/VectorDBProviderTest.java
@@ -12,6 +12,8 @@
  */
 package org.conductoross.conductor.ai.vectordb;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -212,5 +214,82 @@ class VectorDBProviderTest {
 
         // The explicitly configured instance wins; putIfAbsent does not overwrite it.
         assertEquals("postgres", provider.get("default", mock(TaskContext.class)).getType());
+    }
+
+    @Test
+    void testDispose_closesCloseableInstances() throws IOException {
+        // A VectorDB that implements Closeable
+        CloseableVectorDB closeableDB = mock(CloseableVectorDB.class);
+        when(closeableDB.getName()).thenReturn("closeable");
+        when(closeableDB.getType()).thenReturn("valkey");
+
+        Map<String, VectorDB> instances = new HashMap<>();
+        instances.put("closeable", closeableDB);
+
+        VectorDBInstanceConfig instanceConfig = mock(VectorDBInstanceConfig.class);
+        when(instanceConfig.getVectorDBInstances()).thenReturn(instances);
+
+        VectorDBProvider provider = new VectorDBProvider(instanceConfig, defaults());
+
+        // Invoke dispose (the @PreDestroy method)
+        provider.dispose();
+
+        // Verify close was called
+        verify(closeableDB).close();
+    }
+
+    @Test
+    void testDispose_continuesAfterOneCloseThrows() throws IOException {
+        // Two closeable instances — first one throws
+        CloseableVectorDB failingDB = mock(CloseableVectorDB.class);
+        when(failingDB.getName()).thenReturn("failing");
+        when(failingDB.getType()).thenReturn("valkey");
+        doThrow(new IOException("close failed")).when(failingDB).close();
+
+        CloseableVectorDB healthyDB = mock(CloseableVectorDB.class);
+        when(healthyDB.getName()).thenReturn("healthy");
+        when(healthyDB.getType()).thenReturn("valkey");
+
+        Map<String, VectorDB> instances = new HashMap<>();
+        instances.put("failing", failingDB);
+        instances.put("healthy", healthyDB);
+
+        VectorDBInstanceConfig instanceConfig = mock(VectorDBInstanceConfig.class);
+        when(instanceConfig.getVectorDBInstances()).thenReturn(instances);
+
+        VectorDBProvider provider = new VectorDBProvider(instanceConfig, defaults());
+
+        // Should NOT throw even though one close() fails
+        assertDoesNotThrow(provider::dispose);
+
+        // Both close() should have been attempted
+        verify(failingDB).close();
+        verify(healthyDB).close();
+    }
+
+    @Test
+    void testDispose_skipsNonCloseableInstances() {
+        // A plain VectorDB mock (not Closeable) should not cause errors
+        VectorDB plainDB = mock(VectorDB.class);
+        when(plainDB.getName()).thenReturn("plain");
+        when(plainDB.getType()).thenReturn("postgres");
+
+        Map<String, VectorDB> instances = new HashMap<>();
+        instances.put("plain", plainDB);
+
+        VectorDBInstanceConfig instanceConfig = mock(VectorDBInstanceConfig.class);
+        when(instanceConfig.getVectorDBInstances()).thenReturn(instances);
+
+        VectorDBProvider provider = new VectorDBProvider(instanceConfig, defaults());
+
+        // dispose should succeed silently
+        assertDoesNotThrow(provider::dispose);
+    }
+
+    /** Test helper — an abstract class that combines VectorDB and Closeable for mocking. */
+    abstract static class CloseableVectorDB extends VectorDB implements Closeable {
+        CloseableVectorDB() {
+            super("mock", "mock");
+        }
     }
 }

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/VectorDBProviderTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/VectorDBProviderTest.java
@@ -279,6 +279,26 @@ class VectorDBProviderTest {
     }
 
     @Test
+    void testDispose_clearsMapSoSubsequentLookupReturnsNull() throws IOException {
+        // Without clearing the map, get() could hand back an already-closed instance to a caller
+        // racing shutdown instead of a clean "not found".
+        CloseableVectorDB closeableDB = mock(CloseableVectorDB.class);
+        when(closeableDB.getName()).thenReturn("closeable");
+        when(closeableDB.getType()).thenReturn("valkey");
+
+        Map<String, VectorDB> instances = new HashMap<>();
+        instances.put("closeable", closeableDB);
+
+        VectorDBInstanceConfig instanceConfig = mock(VectorDBInstanceConfig.class);
+        when(instanceConfig.getVectorDBInstances()).thenReturn(instances);
+
+        VectorDBProvider provider = new VectorDBProvider(instanceConfig, defaults());
+        provider.dispose();
+
+        assertNull(provider.get("closeable", mock(TaskContext.class)));
+    }
+
+    @Test
     void testDispose_skipsNonCloseableInstances() {
         // A plain VectorDB mock (not Closeable) should not cause errors
         VectorDB plainDB = mock(VectorDB.class);

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/VectorDBProviderTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/VectorDBProviderTest.java
@@ -180,7 +180,7 @@ class VectorDBProviderTest {
 
     @Test
     void constructorPropagatesInstanceConfigFailure() {
-        // Fix #M0: the provider must not swallow initialization failures into an empty map.
+        // The provider must not swallow initialization failures into an empty map.
         VectorDBInstanceConfig instanceConfig = mock(VectorDBInstanceConfig.class);
         when(instanceConfig.getVectorDBInstances()).thenThrow(new IllegalStateException("boom"));
 

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyConfigTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyConfigTest.java
@@ -57,6 +57,20 @@ class ValkeyConfigTest {
     }
 
     @Test
+    void getWithNullName_throwsIllegalArgument() {
+        // A blank name would otherwise reach clientName sanitization and NPE opaquely; reject it
+        // here with a clear configuration error instead.
+        ValkeyConfig config = new ValkeyConfig();
+        assertThrows(IllegalArgumentException.class, () -> config.get(null));
+    }
+
+    @Test
+    void getWithBlankName_throwsIllegalArgument() {
+        ValkeyConfig config = new ValkeyConfig();
+        assertThrows(IllegalArgumentException.class, () -> config.get("   "));
+    }
+
+    @Test
     void passwordIsExcludedFromToString() {
         ValkeyConfig config = new ValkeyConfig();
         config.setPassword("s3cret");

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyConfigTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyConfigTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.vectordb.valkey;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for ValkeyConfig: default values, validation at construction, and the VectorDBConfig
+ * contract (get() throws, get(name) constructs).
+ */
+class ValkeyConfigTest {
+
+    @Test
+    void defaults_areCorrect() {
+        ValkeyConfig config = new ValkeyConfig();
+        assertEquals("localhost", config.getHost());
+        assertEquals(6379, config.getPort());
+        assertEquals(0, config.getDatabase());
+        assertFalse(config.getUseTls());
+        assertEquals(256, config.getDimensions());
+        assertEquals("cosine", config.getDistanceMetric());
+        assertEquals("hnsw", config.getIndexingMethod());
+        assertEquals("conductor", config.getKeyPrefix());
+        assertEquals(2000, config.getRequestTimeoutMs());
+    }
+
+    @Test
+    void get_throwsUnsupported() {
+        ValkeyConfig config = new ValkeyConfig();
+        assertThrows(UnsupportedOperationException.class, config::get);
+    }
+
+    @Test
+    void getWithName_invalidMetric_throwsAtConstruction() {
+        ValkeyConfig config = new ValkeyConfig();
+        config.setDistanceMetric("manhattan");
+        assertThrows(IllegalArgumentException.class, () -> config.get("test"));
+    }
+
+    @Test
+    void getWithName_invalidAlgorithm_throwsAtConstruction() {
+        ValkeyConfig config = new ValkeyConfig();
+        config.setIndexingMethod("annoy");
+        assertThrows(IllegalArgumentException.class, () -> config.get("test"));
+    }
+
+    @Test
+    void passwordIsExcludedFromToString() {
+        ValkeyConfig config = new ValkeyConfig();
+        config.setPassword("s3cret");
+        String toString = config.toString();
+        assertFalse(toString.contains("s3cret"), "Password leaked in toString(): " + toString);
+    }
+
+    @Test
+    void resolveDistanceMetric_usesLocaleRoot() {
+        // Turkish locale would map "IP" to "\u0131p" which would not match "ip"
+        // Using Locale.ROOT ensures this works regardless of JVM locale
+        assertEquals(
+                glide.api.models.commands.FT.FTCreateOptions.DistanceMetric.IP,
+                ValkeyConfig.resolveDistanceMetric("IP"));
+    }
+
+    @Test
+    void resolveIndexingMethod_usesLocaleRoot() {
+        assertEquals("hnsw", ValkeyConfig.resolveIndexingMethod("HNSW"));
+        assertEquals("flat", ValkeyConfig.resolveIndexingMethod("FLAT"));
+    }
+}

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyInstanceConfigTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyInstanceConfigTest.java
@@ -122,4 +122,55 @@ class ValkeyInstanceConfigTest {
         Map<String, VectorDB> result = instanceConfig.getVectorDBInstances();
         assertTrue(result.isEmpty());
     }
+
+    /**
+     * A ValkeyConfig subclass whose get(String) always throws, simulating a construction failure.
+     */
+    static class ThrowingValkeyConfig extends ValkeyConfig {
+        @Override
+        public ValkeyVectorDB get(String name) {
+            throw new IllegalArgumentException("invalid distanceMetric for instance " + name);
+        }
+    }
+
+    @Test
+    void instanceConstructionFailure_throwsAggregateException() {
+        // Fix #M0: an instance whose construction throws must fail startup loudly, not
+        // disappear silently the way a missing-config or unknown-type instance does.
+        VectorDBInstanceConfig instanceConfig = new VectorDBInstanceConfig();
+        VectorDBInstance instance = new VectorDBInstance();
+        instance.setName("bad-valkey");
+        instance.setType("valkey");
+        instance.setValkey(new ThrowingValkeyConfig());
+        instanceConfig.setInstances(List.of(instance));
+
+        IllegalStateException ex =
+                assertThrows(IllegalStateException.class, instanceConfig::getVectorDBInstances);
+        assertTrue(ex.getMessage().contains("bad-valkey"));
+        assertEquals(1, ex.getSuppressed().length);
+        assertInstanceOf(IllegalArgumentException.class, ex.getSuppressed()[0]);
+    }
+
+    @Test
+    void multipleInstanceFailures_areAllReportedInAggregateException() {
+        VectorDBInstanceConfig instanceConfig = new VectorDBInstanceConfig();
+
+        VectorDBInstance first = new VectorDBInstance();
+        first.setName("bad-valkey-1");
+        first.setType("valkey");
+        first.setValkey(new ThrowingValkeyConfig());
+
+        VectorDBInstance second = new VectorDBInstance();
+        second.setName("bad-valkey-2");
+        second.setType("valkey");
+        second.setValkey(new ThrowingValkeyConfig());
+
+        instanceConfig.setInstances(List.of(first, second));
+
+        IllegalStateException ex =
+                assertThrows(IllegalStateException.class, instanceConfig::getVectorDBInstances);
+        assertTrue(ex.getMessage().contains("bad-valkey-1"));
+        assertTrue(ex.getMessage().contains("bad-valkey-2"));
+        assertEquals(2, ex.getSuppressed().length);
+    }
 }

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyInstanceConfigTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyInstanceConfigTest.java
@@ -135,7 +135,7 @@ class ValkeyInstanceConfigTest {
 
     @Test
     void instanceConstructionFailure_throwsAggregateException() {
-        // Fix #M0: an instance whose construction throws must fail startup loudly, not
+        // An instance whose construction throws must fail startup loudly, not
         // disappear silently the way a missing-config or unknown-type instance does.
         VectorDBInstanceConfig instanceConfig = new VectorDBInstanceConfig();
         VectorDBInstance instance = new VectorDBInstance();

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyInstanceConfigTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyInstanceConfigTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.vectordb.valkey;
+
+import java.util.List;
+import java.util.Map;
+
+import org.conductoross.conductor.ai.vectordb.VectorDB;
+import org.conductoross.conductor.ai.vectordb.VectorDBInstanceConfig;
+import org.conductoross.conductor.ai.vectordb.VectorDBInstanceConfig.VectorDBInstance;
+import org.junit.jupiter.api.Test;
+
+import glide.api.GlideClient;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests that the Valkey type aliases ("valkey", "valkeyvectordb") are correctly wired in
+ * VectorDBInstanceConfig and route to ValkeyVectorDB instances. Uses a test-specific ValkeyConfig
+ * subclass to inject a mock client, proving the routing actually produces a ValkeyVectorDB.
+ */
+class ValkeyInstanceConfigTest {
+
+    /**
+     * A ValkeyConfig subclass that overrides get(String) to return a ValkeyVectorDB with a mocked
+     * client, proving the routing path exercises the ValkeyConfig.get(name) method.
+     */
+    static class TestValkeyConfig extends ValkeyConfig {
+        private final ValkeyVectorDB mockDb;
+
+        TestValkeyConfig(ValkeyVectorDB mockDb) {
+            this.mockDb = mockDb;
+        }
+
+        @Override
+        public ValkeyVectorDB get(String name) {
+            return mockDb;
+        }
+    }
+
+    @Test
+    void valkeyAlias_routesToValkeyVectorDB() {
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyConfig realConfig = new ValkeyConfig();
+        realConfig.setDimensions(4);
+        ValkeyVectorDB expectedDb = new ValkeyVectorDB("test-valkey", realConfig, mockClient);
+
+        TestValkeyConfig testConfig = new TestValkeyConfig(expectedDb);
+
+        VectorDBInstanceConfig instanceConfig = new VectorDBInstanceConfig();
+        VectorDBInstance instance = new VectorDBInstance();
+        instance.setName("test-valkey");
+        instance.setType("valkey");
+        instance.setValkey(testConfig);
+        instanceConfig.setInstances(List.of(instance));
+
+        Map<String, VectorDB> result = instanceConfig.getVectorDBInstances();
+
+        // Assert the routed instance IS the expected ValkeyVectorDB
+        assertFalse(result.isEmpty());
+        assertTrue(result.containsKey("test-valkey"));
+        assertSame(expectedDb, result.get("test-valkey"));
+        assertEquals("valkey", result.get("test-valkey").getType());
+    }
+
+    @Test
+    void valkeyvectordbAlias_routesToValkeyVectorDB() {
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyConfig realConfig = new ValkeyConfig();
+        realConfig.setDimensions(4);
+        ValkeyVectorDB expectedDb = new ValkeyVectorDB("test-vdb", realConfig, mockClient);
+
+        TestValkeyConfig testConfig = new TestValkeyConfig(expectedDb);
+
+        VectorDBInstanceConfig instanceConfig = new VectorDBInstanceConfig();
+        VectorDBInstance instance = new VectorDBInstance();
+        instance.setName("test-vdb");
+        instance.setType("valkeyvectordb");
+        instance.setValkey(testConfig);
+        instanceConfig.setInstances(List.of(instance));
+
+        Map<String, VectorDB> result = instanceConfig.getVectorDBInstances();
+
+        assertFalse(result.isEmpty());
+        assertTrue(result.containsKey("test-vdb"));
+        assertSame(expectedDb, result.get("test-vdb"));
+    }
+
+    @Test
+    void valkeyAlias_missingConfig_returnsEmpty() {
+        VectorDBInstanceConfig instanceConfig = new VectorDBInstanceConfig();
+        VectorDBInstance instance = new VectorDBInstance();
+        instance.setName("test-valkey");
+        instance.setType("valkey");
+        instance.setValkey(null); // Missing config path
+        instanceConfig.setInstances(List.of(instance));
+
+        Map<String, VectorDB> result = instanceConfig.getVectorDBInstances();
+        // Should be empty because config is null (error logged)
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void unknownType_returnsEmpty() {
+        VectorDBInstanceConfig instanceConfig = new VectorDBInstanceConfig();
+        VectorDBInstance instance = new VectorDBInstance();
+        instance.setName("bad");
+        instance.setType("valkeyy"); // typo - unknown type
+        instanceConfig.setInstances(List.of(instance));
+
+        Map<String, VectorDB> result = instanceConfig.getVectorDBInstances();
+        assertTrue(result.isEmpty());
+    }
+}

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyInstanceConfigTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyInstanceConfigTest.java
@@ -176,19 +176,20 @@ class ValkeyInstanceConfigTest {
     }
 
     /**
-     * A ValkeyConfig subclass whose get(String) throws a plain RuntimeException, simulating a
-     * connectivity failure (e.g. an unreachable server) rather than a configuration error.
+     * A ValkeyConfig subclass whose get(String) throws ValkeyConnectionException, simulating a
+     * connectivity failure (e.g. an unreachable server) rather than a configuration error. Matches
+     * the specific type ValkeyVectorDB.buildClient() actually throws on a connection failure.
      */
     static class ConnectionFailingValkeyConfig extends ValkeyConfig {
         @Override
         public ValkeyVectorDB get(String name) {
-            throw new RuntimeException("Connection refused");
+            throw new ValkeyConnectionException("Connection refused", new RuntimeException());
         }
     }
 
     @Test
     void connectionFailure_isLoggedAndSkipped_doesNotAbortStartup() {
-        // Unlike a configuration error (IllegalArgumentException/IllegalStateException), a runtime
+        // Unlike a configuration error (IllegalArgumentException/IllegalStateException), a
         // connectivity failure must not take down the whole server -- it should behave like the
         // other vector DB backends, which tolerate an unreachable instance at boot.
         VectorDBInstanceConfig instanceConfig = new VectorDBInstanceConfig();
@@ -228,5 +229,32 @@ class ValkeyInstanceConfigTest {
         assertThrows(IllegalStateException.class, instanceConfig::getVectorDBInstances);
 
         verify(mockClient).close();
+    }
+
+    /**
+     * A ValkeyConfig subclass whose get(String) throws a bare RuntimeException that is NOT
+     * ValkeyConnectionException, simulating a genuine bug (e.g. a NullPointerException deep in a
+     * backend's construction path) rather than a connectivity failure.
+     */
+    static class BuggyValkeyConfig extends ValkeyConfig {
+        @Override
+        public ValkeyVectorDB get(String name) {
+            throw new NullPointerException("simulated bug, not a connection failure");
+        }
+    }
+
+    @Test
+    void genuineBug_isNotSilentlySwallowedByConnectivitySkipPath() {
+        // The skip path must be narrow: only ValkeyConnectionException is tolerated. A different
+        // RuntimeException (a real bug) must propagate and fail loudly, not be logged and dropped
+        // the way an unreachable-server ValkeyConnectionException is.
+        VectorDBInstanceConfig instanceConfig = new VectorDBInstanceConfig();
+        VectorDBInstance instance = new VectorDBInstance();
+        instance.setName("buggy-valkey");
+        instance.setType("valkey");
+        instance.setValkey(new BuggyValkeyConfig());
+        instanceConfig.setInstances(List.of(instance));
+
+        assertThrows(NullPointerException.class, instanceConfig::getVectorDBInstances);
     }
 }

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyInstanceConfigTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyInstanceConfigTest.java
@@ -14,6 +14,7 @@ package org.conductoross.conductor.ai.vectordb.valkey;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 import org.conductoross.conductor.ai.vectordb.VectorDB;
 import org.conductoross.conductor.ai.vectordb.VectorDBInstanceConfig;
@@ -172,5 +173,60 @@ class ValkeyInstanceConfigTest {
         assertTrue(ex.getMessage().contains("bad-valkey-1"));
         assertTrue(ex.getMessage().contains("bad-valkey-2"));
         assertEquals(2, ex.getSuppressed().length);
+    }
+
+    /**
+     * A ValkeyConfig subclass whose get(String) throws a plain RuntimeException, simulating a
+     * connectivity failure (e.g. an unreachable server) rather than a configuration error.
+     */
+    static class ConnectionFailingValkeyConfig extends ValkeyConfig {
+        @Override
+        public ValkeyVectorDB get(String name) {
+            throw new RuntimeException("Connection refused");
+        }
+    }
+
+    @Test
+    void connectionFailure_isLoggedAndSkipped_doesNotAbortStartup() {
+        // Unlike a configuration error (IllegalArgumentException/IllegalStateException), a runtime
+        // connectivity failure must not take down the whole server -- it should behave like the
+        // other vector DB backends, which tolerate an unreachable instance at boot.
+        VectorDBInstanceConfig instanceConfig = new VectorDBInstanceConfig();
+        VectorDBInstance instance = new VectorDBInstance();
+        instance.setName("unreachable-valkey");
+        instance.setType("valkey");
+        instance.setValkey(new ConnectionFailingValkeyConfig());
+        instanceConfig.setInstances(List.of(instance));
+
+        Map<String, VectorDB> result = assertDoesNotThrow(instanceConfig::getVectorDBInstances);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void successfulInstanceIsClosed_whenLaterInstanceFails() throws ExecutionException {
+        // Without closing already-created instances before the aggregate throw, a successfully
+        // opened GLIDE client would leak: VectorDBProvider is never constructed to close it later.
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyConfig successConfig = new ValkeyConfig();
+        successConfig.setDimensions(4);
+        ValkeyVectorDB successDb = new ValkeyVectorDB("good-valkey", successConfig, mockClient);
+        TestValkeyConfig testConfig = new TestValkeyConfig(successDb);
+
+        VectorDBInstance good = new VectorDBInstance();
+        good.setName("good-valkey");
+        good.setType("valkey");
+        good.setValkey(testConfig);
+
+        VectorDBInstance bad = new VectorDBInstance();
+        bad.setName("bad-valkey");
+        bad.setType("valkey");
+        bad.setValkey(new ThrowingValkeyConfig());
+
+        VectorDBInstanceConfig instanceConfig = new VectorDBInstanceConfig();
+        instanceConfig.setInstances(List.of(good, bad));
+
+        assertThrows(IllegalStateException.class, instanceConfig::getVectorDBInstances);
+
+        verify(mockClient).close();
     }
 }

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDBTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDBTest.java
@@ -720,22 +720,31 @@ class ValkeyVectorDBTest {
 
         Object[] vectorAttribute =
                 new Object[] {
-                    GlideString.gs("identifier"), GlideString.gs("embedding"),
-                    GlideString.gs("attribute"), GlideString.gs("embedding"),
-                    GlideString.gs("user_indexed_memory"), 16L,
-                    GlideString.gs("type"), GlideString.gs("VECTOR"),
+                    GlideString.gs("identifier"),
+                    GlideString.gs("embedding"),
+                    GlideString.gs("attribute"),
+                    GlideString.gs("embedding"),
+                    GlideString.gs("user_indexed_memory"),
+                    16L,
+                    GlideString.gs("type"),
+                    GlideString.gs("VECTOR"),
                     GlideString.gs("index"),
                     new Object[] {
-                        GlideString.gs("capacity"), 10240L,
-                        GlideString.gs("dimensions"), 8L,
-                        GlideString.gs("distance_metric"), GlideString.gs("COSINE"),
-                        GlideString.gs("size"), GlideString.gs("1"),
-                        GlideString.gs("data_type"), GlideString.gs("FLOAT32"),
-                        GlideString.gs("algorithm"), new Object[] {}
+                        GlideString.gs("capacity"),
+                        10240L,
+                        GlideString.gs("dimensions"),
+                        8L,
+                        GlideString.gs("distance_metric"),
+                        GlideString.gs("COSINE"),
+                        GlideString.gs("size"),
+                        GlideString.gs("1"),
+                        GlideString.gs("data_type"),
+                        GlideString.gs("FLOAT32"),
+                        GlideString.gs("algorithm"),
+                        new Object[] {}
                     }
                 };
-        Map<String, Object> info =
-                Map.of("attributes", new Object[] {vectorAttribute});
+        Map<String, Object> info = Map.of("attributes", new Object[] {vectorAttribute});
 
         try (MockedStatic<FT> ft = mockStatic(FT.class)) {
             ft.when(

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDBTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDBTest.java
@@ -714,6 +714,62 @@ class ValkeyVectorDBTest {
     }
 
     @Test
+    void existingIndexWithMismatchedDimensions_failsBeforeWrite() {
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig(), mockClient);
+
+        Object[] vectorAttribute =
+                new Object[] {
+                    GlideString.gs("identifier"), GlideString.gs("embedding"),
+                    GlideString.gs("attribute"), GlideString.gs("embedding"),
+                    GlideString.gs("user_indexed_memory"), 16L,
+                    GlideString.gs("type"), GlideString.gs("VECTOR"),
+                    GlideString.gs("index"),
+                    new Object[] {
+                        GlideString.gs("capacity"), 10240L,
+                        GlideString.gs("dimensions"), 8L,
+                        GlideString.gs("distance_metric"), GlideString.gs("COSINE"),
+                        GlideString.gs("size"), GlideString.gs("1"),
+                        GlideString.gs("data_type"), GlideString.gs("FLOAT32"),
+                        GlideString.gs("algorithm"), new Object[] {}
+                    }
+                };
+        Map<String, Object> info =
+                Map.of("attributes", new Object[] {vectorAttribute});
+
+        try (MockedStatic<FT> ft = mockStatic(FT.class)) {
+            ft.when(
+                            () ->
+                                    FT.create(
+                                            eq(mockClient),
+                                            eq("conductor:index:ns"),
+                                            any(FTCreateOptions.FieldInfo[].class),
+                                            any(FTCreateOptions.class)))
+                    .thenReturn(
+                            CompletableFuture.failedFuture(
+                                    new RequestException(
+                                            "Index: conductor:index:ns in database 0 already exists.")));
+            ft.when(() -> FT.info(eq(mockClient), eq("conductor:index:ns")))
+                    .thenReturn(CompletableFuture.completedFuture(info));
+
+            RuntimeException thrown =
+                    assertThrows(
+                            RuntimeException.class,
+                            () ->
+                                    db.updateEmbeddings(
+                                            "index",
+                                            "ns",
+                                            "doc",
+                                            null,
+                                            "id",
+                                            List.of(1.0f, 0.0f, 0.0f, 0.0f),
+                                            Map.of()));
+            assertTrue(thrown.getMessage().contains("has dimensions 8"));
+            verifyNoInteractions(mockClient);
+        }
+    }
+
+    @Test
     void parseSearchResults_validShape_roundTripsFields() {
         ValkeyVectorDB db = createMockValkeyDB(defaultConfig());
         Map<GlideString, GlideString> fields =

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDBTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDBTest.java
@@ -1,0 +1,746 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.vectordb.valkey;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import glide.api.GlideClient;
+import glide.api.commands.servermodules.FT;
+import glide.api.models.GlideString;
+import glide.api.models.commands.FT.FTCreateOptions;
+import glide.api.models.commands.FT.FTSearchOptions;
+import glide.api.models.exceptions.RequestException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for ValkeyVectorDB that verify encoding, validation, error classification, lifecycle,
+ * namespace isolation, and data integrity without requiring a live Valkey server. Uses the
+ * package-private constructor for test injection of a mocked GlideClient.
+ */
+class ValkeyVectorDBTest {
+
+    // ----- Embedding encoding tests -----
+
+    @Test
+    void encodeEmbedding_littleEndian_negativeOne() {
+        // -1.0f in IEEE 754 little-endian is 0x000080BF (bytes: 00 00 80 BF)
+        byte[] result = ValkeyVectorDB.encodeEmbedding(List.of(-1.0f));
+        assertEquals(4, result.length);
+        assertEquals((byte) 0x00, result[0]);
+        assertEquals((byte) 0x00, result[1]);
+        assertEquals((byte) 0x80, result[2]);
+        assertEquals((byte) 0xBF, result[3]);
+    }
+
+    @Test
+    void encodeEmbedding_roundTrip() {
+        List<Float> input = List.of(1.0f, 0.5f, -0.25f, 0.0f);
+        byte[] encoded = ValkeyVectorDB.encodeEmbedding(input);
+        assertEquals(16, encoded.length); // 4 floats * 4 bytes
+
+        // Decode back and verify
+        ByteBuffer buf = ByteBuffer.wrap(encoded).order(ByteOrder.LITTLE_ENDIAN);
+        assertEquals(1.0f, buf.getFloat(), 0.0001f);
+        assertEquals(0.5f, buf.getFloat(), 0.0001f);
+        assertEquals(-0.25f, buf.getFloat(), 0.0001f);
+        assertEquals(0.0f, buf.getFloat(), 0.0001f);
+    }
+
+    @Test
+    void encodeEmbedding_identicalForStoreAndQuery() {
+        List<Float> vector = List.of(0.7f, 0.7f, 0.0f, 0.0f);
+        byte[] first = ValkeyVectorDB.encodeEmbedding(vector);
+        byte[] second = ValkeyVectorDB.encodeEmbedding(vector);
+        assertArrayEquals(first, second);
+    }
+
+    // ----- Namespace/index isolation tests (Fix #1) -----
+
+    @Test
+    void physicalIndexNameFor_distinctPerNamespace() {
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig());
+
+        String physA = db.physicalIndexNameFor("docs", "namespaceA");
+        String physB = db.physicalIndexNameFor("docs", "namespaceB");
+
+        assertNotEquals(physA, physB);
+        // Both contain the logical name and namespace
+        assertTrue(physA.contains("docs"));
+        assertTrue(physA.contains("namespaceA"));
+        assertTrue(physB.contains("docs"));
+        assertTrue(physB.contains("namespaceB"));
+    }
+
+    @Test
+    void physicalIndexNameFor_includesNormalizedPrefix() {
+        ValkeyConfig config = defaultConfig();
+        config.setKeyPrefix("myapp");
+        ValkeyVectorDB db = createMockValkeyDB(config);
+
+        String phys = db.physicalIndexNameFor("idx", "ns");
+        assertEquals("myapp:idx:ns", phys);
+    }
+
+    @Test
+    void physicalIndexNameFor_defaultPrefix() {
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig());
+
+        String phys = db.physicalIndexNameFor("idx", "ns");
+        assertEquals("conductor:idx:ns", phys);
+    }
+
+    @Test
+    void keyPrefixFor_producesCorrectFormat() {
+        ValkeyConfig config = defaultConfig();
+        config.setKeyPrefix("myapp");
+        ValkeyVectorDB db = createMockValkeyDB(config);
+
+        String prefix = db.keyPrefixFor("myindex", "myns");
+        assertEquals("myapp:myindex:myns:", prefix);
+    }
+
+    @Test
+    void keyPrefixFor_defaultPrefix() {
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig());
+
+        String prefix = db.keyPrefixFor("idx", "ns");
+        assertEquals("conductor:idx:ns:", prefix);
+    }
+
+    // ----- Name validation tests -----
+
+    @Test
+    void updateEmbeddings_invalidIndexName_throws() {
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig(), mockClient);
+
+        List<Float> embeddings = List.of(1.0f, 0.0f, 0.0f, 0.0f);
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        db.updateEmbeddings(
+                                "bad index name", "ns", "doc", "parent", "id", embeddings, null));
+        // Fix #4: verify no interaction with client before validation
+        verifyNoInteractions(mockClient);
+    }
+
+    @Test
+    void updateEmbeddings_invalidNamespace_throws() {
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig(), mockClient);
+
+        List<Float> embeddings = List.of(1.0f, 0.0f, 0.0f, 0.0f);
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        db.updateEmbeddings(
+                                "index", "ns/bad", "doc", "parent", "id", embeddings, null));
+        verifyNoInteractions(mockClient);
+    }
+
+    @Test
+    void updateEmbeddings_nullNamespace_throws() {
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig(), mockClient);
+
+        List<Float> embeddings = List.of(1.0f, 0.0f, 0.0f, 0.0f);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> db.updateEmbeddings("index", null, "doc", "parent", "id", embeddings, null));
+        verifyNoInteractions(mockClient);
+    }
+
+    @Test
+    void updateEmbeddings_nullDoc_throws() {
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig(), mockClient);
+
+        List<Float> embeddings = List.of(1.0f, 0.0f, 0.0f, 0.0f);
+        assertThrows(
+                NullPointerException.class,
+                () -> db.updateEmbeddings("index", "ns", null, "parent", "id", embeddings, null));
+        verifyNoInteractions(mockClient);
+    }
+
+    @Test
+    void updateEmbeddings_nullId_throws() {
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig(), mockClient);
+
+        List<Float> embeddings = List.of(1.0f, 0.0f, 0.0f, 0.0f);
+        assertThrows(
+                NullPointerException.class,
+                () -> db.updateEmbeddings("index", "ns", "doc", "parent", null, embeddings, null));
+        verifyNoInteractions(mockClient);
+    }
+
+    @Test
+    void updateEmbeddings_dimensionMismatch_throws() {
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig(), mockClient);
+
+        List<Float> embeddings = List.of(1.0f, 0.0f, 0.0f);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> db.updateEmbeddings("index", "ns", "doc", "parent", "id", embeddings, null));
+        verifyNoInteractions(mockClient);
+    }
+
+    @Test
+    void search_dimensionMismatch_throws() {
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig(), mockClient);
+
+        List<Float> embeddings = List.of(1.0f, 0.0f);
+        assertThrows(IllegalArgumentException.class, () -> db.search("index", "ns", embeddings, 5));
+        verifyNoInteractions(mockClient);
+    }
+
+    @Test
+    void search_maxResultsZero_throws() {
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig(), mockClient);
+
+        List<Float> embeddings = List.of(1.0f, 0.0f, 0.0f, 0.0f);
+        IllegalArgumentException ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> db.search("index", "ns", embeddings, 0));
+        assertTrue(ex.getMessage().contains("maxResults"));
+        verifyNoInteractions(mockClient);
+    }
+
+    @Test
+    void search_maxResultsNegative_throws() {
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig(), mockClient);
+
+        List<Float> embeddings = List.of(1.0f, 0.0f, 0.0f, 0.0f);
+        assertThrows(
+                IllegalArgumentException.class, () -> db.search("index", "ns", embeddings, -1));
+        verifyNoInteractions(mockClient);
+    }
+
+    // ----- Embedding element validation (Fix #7) -----
+
+    @Test
+    void updateEmbeddings_nullElement_throws() {
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig(), mockClient);
+
+        List<Float> embeddings = Arrays.asList(1.0f, null, 0.0f, 0.0f);
+        IllegalArgumentException ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                db.updateEmbeddings(
+                                        "index", "ns", "doc", "parent", "id", embeddings, null));
+        assertTrue(ex.getMessage().contains("null"));
+        verifyNoInteractions(mockClient);
+    }
+
+    @Test
+    void updateEmbeddings_infiniteElement_throws() {
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig(), mockClient);
+
+        List<Float> embeddings = List.of(1.0f, Float.POSITIVE_INFINITY, 0.0f, 0.0f);
+        IllegalArgumentException ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                db.updateEmbeddings(
+                                        "index", "ns", "doc", "parent", "id", embeddings, null));
+        assertTrue(ex.getMessage().contains("finite"));
+        verifyNoInteractions(mockClient);
+    }
+
+    @Test
+    void updateEmbeddings_nanElement_throws() {
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig(), mockClient);
+
+        List<Float> embeddings = List.of(1.0f, Float.NaN, 0.0f, 0.0f);
+        IllegalArgumentException ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                db.updateEmbeddings(
+                                        "index", "ns", "doc", "parent", "id", embeddings, null));
+        assertTrue(ex.getMessage().contains("finite"));
+        verifyNoInteractions(mockClient);
+    }
+
+    // ----- Close / lifecycle tests (Fix #4) -----
+
+    @Test
+    void close_isIdempotent_callsClientCloseOnce() throws Exception {
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig(), mockClient);
+
+        // First close should call client.close()
+        assertDoesNotThrow(db::close);
+        // Second close should be a no-op
+        assertDoesNotThrow(db::close);
+
+        // Verify client.close() was called exactly once
+        verify(mockClient, times(1)).close();
+    }
+
+    @Test
+    void operationsAfterClose_throwClearly() {
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig(), mockClient);
+
+        db.close();
+
+        List<Float> embeddings = List.of(1.0f, 0.0f, 0.0f, 0.0f);
+        IllegalStateException ex =
+                assertThrows(
+                        IllegalStateException.class,
+                        () ->
+                                db.updateEmbeddings(
+                                        "index", "ns", "doc", "parent", "id", embeddings, null));
+        assertTrue(ex.getMessage().contains("closed"));
+
+        IllegalStateException searchEx =
+                assertThrows(
+                        IllegalStateException.class, () -> db.search("index", "ns", embeddings, 5));
+        assertTrue(searchEx.getMessage().contains("closed"));
+    }
+
+    // ----- Already-exists error classification (Fix #3) -----
+
+    @Test
+    void isAlreadyExistsError_requestException_true() {
+        // GLIDE RequestException with "already exists." message should be suppressed
+        RequestException reqEx =
+                new RequestException("Index: test_idx in database 0 already exists.");
+        RuntimeException wrapper = new RuntimeException(reqEx);
+        assertTrue(ValkeyVectorDB.isAlreadyExistsError(wrapper));
+    }
+
+    @Test
+    void isAlreadyExistsError_plainRuntimeException_false() {
+        // A plain RuntimeException with the same text must NOT be classified as already-exists
+        RuntimeException plain = new RuntimeException("Index: test_idx already exists.");
+        assertFalse(ValkeyVectorDB.isAlreadyExistsError(plain));
+    }
+
+    @Test
+    void isAlreadyExistsError_unknownCommand_false() {
+        // "ERR unknown command" wrapped in RequestException should NOT match already-exists
+        RequestException reqEx = new RequestException("ERR unknown command 'FT.CREATE'");
+        RuntimeException wrapper = new RuntimeException(reqEx);
+        assertFalse(ValkeyVectorDB.isAlreadyExistsError(wrapper));
+    }
+
+    @Test
+    void isAlreadyExistsError_directRequestException_true() {
+        // RequestException itself (as the top-level RuntimeException) should work too
+        RequestException reqEx = new RequestException("Index already exists.");
+        assertTrue(ValkeyVectorDB.isAlreadyExistsError(reqEx));
+    }
+
+    // ----- ConcurrentHashMap recursion fix (Fix #2) -----
+
+    @Test
+    void failedIndexCreate_allowsRetry_preservesOriginalException() {
+        ValkeyConfig config = defaultConfig();
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyVectorDB db = createMockValkeyDB(config, mockClient);
+        CompletableFuture<String> failedCreate = new CompletableFuture<>();
+        RequestException original = new RequestException("temporary FT.CREATE failure");
+        failedCreate.completeExceptionally(original);
+
+        when(mockClient.hset(
+                        any(GlideString.class),
+                        org.mockito.ArgumentMatchers.<GlideString, GlideString>anyMap()))
+                .thenReturn(CompletableFuture.completedFuture(4L));
+        try (MockedStatic<FT> ft = mockStatic(FT.class)) {
+            ft.when(
+                            () ->
+                                    FT.create(
+                                            eq(mockClient),
+                                            eq("conductor:index:ns"),
+                                            any(FTCreateOptions.FieldInfo[].class),
+                                            any(FTCreateOptions.class)))
+                    .thenReturn(failedCreate, CompletableFuture.completedFuture("OK"));
+
+            List<Float> vector = List.of(1.0f, 0.0f, 0.0f, 0.0f);
+            RequestException thrown =
+                    assertThrows(
+                            RequestException.class,
+                            () ->
+                                    db.updateEmbeddings(
+                                            "index", "ns", "doc", "parent", "id", vector,
+                                            Map.of()));
+            assertSame(original, thrown);
+
+            assertEquals(
+                    1, db.updateEmbeddings("index", "ns", "doc", "parent", "id", vector, Map.of()));
+            ft.verify(
+                    () ->
+                            FT.create(
+                                    eq(mockClient),
+                                    eq("conductor:index:ns"),
+                                    any(FTCreateOptions.FieldInfo[].class),
+                                    any(FTCreateOptions.class)),
+                    times(2));
+        }
+    }
+
+    // ----- Metadata serialization (Fix #6: no silent data loss) -----
+
+    @Test
+    void serializeMetadata_null_returnsEmptyJson() {
+        assertEquals("{}", ValkeyVectorDB.serializeMetadata(null));
+    }
+
+    @Test
+    void serializeMetadata_empty_returnsEmptyJson() {
+        assertEquals("{}", ValkeyVectorDB.serializeMetadata(Collections.emptyMap()));
+    }
+
+    @Test
+    void serializeMetadata_valid_returnsJson() {
+        Map<String, Object> meta = Map.of("key", "value", "count", 42);
+        String json = ValkeyVectorDB.serializeMetadata(meta);
+        assertTrue(json.contains("\"key\""));
+        assertTrue(json.contains("\"value\""));
+        assertTrue(json.contains("42"));
+    }
+
+    @Test
+    void serializeMetadata_selfReferential_throwsInsteadOfSilentEmptyJson() {
+        // A self-referential object cannot be serialized; must throw, not write "{}"
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("self", meta); // circular reference
+
+        assertThrows(IllegalStateException.class, () -> ValkeyVectorDB.serializeMetadata(meta));
+    }
+
+    @Test
+    void deserializeMetadata_malformed_throwsInsteadOfSilentEmpty() {
+        assertThrows(
+                IllegalStateException.class,
+                () -> ValkeyVectorDB.deserializeMetadata("not valid json{{{", "doc1"));
+    }
+
+    @Test
+    void deserializeMetadata_valid_returnsParsedMap() {
+        Map<String, Object> result =
+                ValkeyVectorDB.deserializeMetadata("{\"key\":\"value\"}", "doc1");
+        assertEquals("value", result.get("key"));
+    }
+
+    // ----- Score parsing (Fix #6: no silent data loss) -----
+
+    @Test
+    void parseScore_valid_returnsDouble() {
+        assertEquals(0.5, ValkeyVectorDB.parseScore("0.5", "doc1"), 0.0001);
+    }
+
+    @Test
+    void parseScore_null_throwsInsteadOfDefaultZero() {
+        assertThrows(IllegalStateException.class, () -> ValkeyVectorDB.parseScore(null, "doc1"));
+    }
+
+    @Test
+    void parseScore_empty_throwsInsteadOfDefaultZero() {
+        assertThrows(IllegalStateException.class, () -> ValkeyVectorDB.parseScore("", "doc1"));
+    }
+
+    @Test
+    void parseScore_malformed_throwsInsteadOfDefaultZero() {
+        assertThrows(
+                IllegalStateException.class,
+                () -> ValkeyVectorDB.parseScore("not_a_number", "doc1"));
+    }
+
+    // ----- Key prefix normalization (Fix #7) -----
+
+    @Test
+    void normalizeKeyPrefix_stripsTrailingColons() {
+        assertEquals("conductor", ValkeyVectorDB.normalizeKeyPrefix("conductor::"));
+        assertEquals("app", ValkeyVectorDB.normalizeKeyPrefix("app:"));
+    }
+
+    @Test
+    void normalizeKeyPrefix_nullUsesDefault() {
+        assertEquals("conductor", ValkeyVectorDB.normalizeKeyPrefix(null));
+    }
+
+    @Test
+    void normalizeKeyPrefix_blankAfterStrip_throws() {
+        assertThrows(
+                IllegalArgumentException.class, () -> ValkeyVectorDB.normalizeKeyPrefix(":::"));
+    }
+
+    @Test
+    void normalizeKeyPrefix_unsafeChars_throws() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ValkeyVectorDB.normalizeKeyPrefix("bad prefix"));
+    }
+
+    @Test
+    void normalizeKeyPrefix_validChars_passes() {
+        assertEquals("my-app.v1", ValkeyVectorDB.normalizeKeyPrefix("my-app.v1"));
+        assertEquals("my_app", ValkeyVectorDB.normalizeKeyPrefix("my_app"));
+    }
+
+    // ----- Config validation (Fix #7) -----
+
+    @Test
+    void construction_negativePort_throws() {
+        ValkeyConfig config = defaultConfig();
+        config.setPort(-1);
+        GlideClient mockClient = mock(GlideClient.class);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new ValkeyVectorDB("test", config, mockClient));
+    }
+
+    @Test
+    void construction_zeroDimensions_throws() {
+        ValkeyConfig config = defaultConfig();
+        config.setDimensions(0);
+        GlideClient mockClient = mock(GlideClient.class);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new ValkeyVectorDB("test", config, mockClient));
+    }
+
+    @Test
+    void construction_negativeRequestTimeout_throws() {
+        ValkeyConfig config = defaultConfig();
+        config.setRequestTimeoutMs(-100);
+        GlideClient mockClient = mock(GlideClient.class);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new ValkeyVectorDB("test", config, mockClient));
+    }
+
+    @Test
+    void construction_negativeDatabase_throws() {
+        ValkeyConfig config = defaultConfig();
+        config.setDatabase(-1);
+        GlideClient mockClient = mock(GlideClient.class);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new ValkeyVectorDB("test", config, mockClient));
+    }
+
+    // ----- Config resolution tests -----
+
+    @Test
+    void resolveDistanceMetric_validValues() {
+        assertEquals(
+                glide.api.models.commands.FT.FTCreateOptions.DistanceMetric.COSINE,
+                ValkeyConfig.resolveDistanceMetric("cosine"));
+        assertEquals(
+                glide.api.models.commands.FT.FTCreateOptions.DistanceMetric.L2,
+                ValkeyConfig.resolveDistanceMetric("l2"));
+        assertEquals(
+                glide.api.models.commands.FT.FTCreateOptions.DistanceMetric.IP,
+                ValkeyConfig.resolveDistanceMetric("ip"));
+        // Case insensitive
+        assertEquals(
+                glide.api.models.commands.FT.FTCreateOptions.DistanceMetric.COSINE,
+                ValkeyConfig.resolveDistanceMetric("COSINE"));
+    }
+
+    @Test
+    void resolveDistanceMetric_unknownThrows() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ValkeyConfig.resolveDistanceMetric("euclidean"));
+    }
+
+    @Test
+    void resolveIndexingMethod_validValues() {
+        assertEquals("hnsw", ValkeyConfig.resolveIndexingMethod("hnsw"));
+        assertEquals("flat", ValkeyConfig.resolveIndexingMethod("flat"));
+        assertEquals("hnsw", ValkeyConfig.resolveIndexingMethod("HNSW"));
+    }
+
+    @Test
+    void resolveIndexingMethod_unknownThrows() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ValkeyConfig.resolveIndexingMethod("ivfflat"));
+    }
+
+    // ----- Production-path and response-shape tests -----
+
+    @Test
+    void createAndSearch_useSamePhysicalIndexName() {
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig(), mockClient);
+        when(mockClient.hset(
+                        any(GlideString.class),
+                        org.mockito.ArgumentMatchers.<GlideString, GlideString>anyMap()))
+                .thenReturn(CompletableFuture.completedFuture(4L));
+
+        try (MockedStatic<FT> ft = mockStatic(FT.class)) {
+            ft.when(
+                            () ->
+                                    FT.create(
+                                            eq(mockClient),
+                                            eq("conductor:docs:teamA"),
+                                            any(FTCreateOptions.FieldInfo[].class),
+                                            any(FTCreateOptions.class)))
+                    .thenReturn(CompletableFuture.completedFuture("OK"));
+            ft.when(
+                            () ->
+                                    FT.search(
+                                            eq(mockClient),
+                                            eq("conductor:docs:teamA"),
+                                            anyString(),
+                                            any(FTSearchOptions.class)))
+                    .thenReturn(
+                            CompletableFuture.completedFuture(
+                                    new Object[] {0L, new LinkedHashMap<>()}));
+
+            List<Float> vector = List.of(1.0f, 0.0f, 0.0f, 0.0f);
+            assertEquals(
+                    1, db.updateEmbeddings("docs", "teamA", "doc", null, "id", vector, Map.of()));
+            assertTrue(db.search("docs", "teamA", vector, 3).isEmpty());
+
+            ft.verify(
+                    () ->
+                            FT.create(
+                                    eq(mockClient),
+                                    eq("conductor:docs:teamA"),
+                                    any(FTCreateOptions.FieldInfo[].class),
+                                    any(FTCreateOptions.class)));
+            ft.verify(
+                    () ->
+                            FT.search(
+                                    eq(mockClient),
+                                    eq("conductor:docs:teamA"),
+                                    anyString(),
+                                    any(FTSearchOptions.class)));
+        }
+    }
+
+    @Test
+    void parseSearchResults_validShape_roundTripsFields() {
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig());
+        Map<GlideString, GlideString> fields =
+                Map.of(
+                        GlideString.gs("doc"), GlideString.gs("hello"),
+                        GlideString.gs("parent_doc_id"), GlideString.gs("parent"),
+                        GlideString.gs("metadata"), GlideString.gs("{\"source\":\"test\"}"),
+                        GlideString.gs("__embedding_score"), GlideString.gs("0.25"));
+        Map<GlideString, Map<GlideString, GlideString>> hits = new LinkedHashMap<>();
+        hits.put(GlideString.gs("conductor:index:ns:doc-1"), fields);
+
+        List<org.conductoross.conductor.ai.model.IndexedDoc> result =
+                db.parseSearchResults(new Object[] {1L, hits}, "index", "ns");
+
+        assertEquals(1, result.size());
+        assertEquals("doc-1", result.get(0).getDocId());
+        assertEquals("parent", result.get(0).getParentDocId());
+        assertEquals("hello", result.get(0).getText());
+        assertEquals(0.25, result.get(0).getScore(), 0.0001);
+        assertEquals("test", result.get(0).getMetadata().get("source"));
+    }
+
+    @Test
+    void parseSearchResults_rejectsNullShortAndMalformedEntries() {
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig());
+        assertThrows(IllegalStateException.class, () -> db.parseSearchResults(null, "index", "ns"));
+        assertThrows(
+                IllegalStateException.class,
+                () -> db.parseSearchResults(new Object[] {0L}, "index", "ns"));
+        assertThrows(
+                IllegalStateException.class,
+                () ->
+                        db.parseSearchResults(
+                                new Object[] {1L, Map.of("not-a-glide-key", Map.of())},
+                                "index",
+                                "ns"));
+        assertThrows(
+                IllegalStateException.class,
+                () ->
+                        db.parseSearchResults(
+                                new Object[] {
+                                    1L,
+                                    Map.of(
+                                            GlideString.gs("conductor:index:ns:doc-1"),
+                                            Map.of(GlideString.gs("doc"), GlideString.gs("hello")))
+                                },
+                                "index",
+                                "ns"));
+    }
+
+    @Test
+    void await_preservesInterruptFlag() {
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig());
+        Thread.currentThread().interrupt();
+        try {
+            RuntimeException thrown =
+                    assertThrows(RuntimeException.class, () -> db.await(new CompletableFuture<>()));
+            assertTrue(thrown.getMessage().contains("interrupted"));
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void publicConstructor_validatesBeforeAttemptingConnection() {
+        ValkeyConfig config = defaultConfig();
+        config.setHost("host-that-must-not-be-contacted");
+        config.setPort(-1);
+        IllegalArgumentException thrown =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> new ValkeyVectorDB("invalid", config));
+        assertTrue(thrown.getMessage().contains("port"));
+    }
+
+    @Test
+    void parseScore_nonFinite_throws() {
+        assertThrows(IllegalStateException.class, () -> ValkeyVectorDB.parseScore("NaN", "doc1"));
+        assertThrows(
+                IllegalStateException.class, () -> ValkeyVectorDB.parseScore("Infinity", "doc1"));
+    }
+
+    // ----- Helpers -----
+
+    private static ValkeyConfig defaultConfig() {
+        ValkeyConfig config = new ValkeyConfig();
+        config.setDimensions(4);
+        return config;
+    }
+
+    /** Creates a ValkeyVectorDB using the package-private constructor with a mock GlideClient. */
+    private static ValkeyVectorDB createMockValkeyDB(ValkeyConfig config) {
+        return new ValkeyVectorDB("test-valkey", config, mock(GlideClient.class));
+    }
+
+    private static ValkeyVectorDB createMockValkeyDB(ValkeyConfig config, GlideClient client) {
+        return new ValkeyVectorDB("test-valkey", config, client);
+    }
+}

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDBTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDBTest.java
@@ -25,6 +25,7 @@ import glide.api.commands.servermodules.FT;
 import glide.api.models.GlideString;
 import glide.api.models.commands.FT.FTCreateOptions;
 import glide.api.models.commands.FT.FTSearchOptions;
+import glide.api.models.configuration.GlideClientConfiguration;
 import glide.api.models.exceptions.RequestException;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -189,6 +190,22 @@ class ValkeyVectorDBTest {
         assertThrows(
                 NullPointerException.class,
                 () -> db.updateEmbeddings("index", "ns", "doc", "parent", null, embeddings, null));
+        verifyNoInteractions(mockClient);
+    }
+
+    @Test
+    void updateEmbeddings_idWithColon_throws() {
+        // Fix #N1: an id with a delimiter character must be rejected before key construction,
+        // consistent with how indexName/namespace are already validated.
+        GlideClient mockClient = mock(GlideClient.class);
+        ValkeyVectorDB db = createMockValkeyDB(defaultConfig(), mockClient);
+
+        List<Float> embeddings = List.of(1.0f, 0.0f, 0.0f, 0.0f);
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        db.updateEmbeddings(
+                                "index", "ns", "doc", "parent", "bad:id", embeddings, null));
         verifyNoInteractions(mockClient);
     }
 
@@ -358,6 +375,60 @@ class ValkeyVectorDBTest {
         // RequestException itself (as the top-level RuntimeException) should work too
         RequestException reqEx = new RequestException("Index already exists.");
         assertTrue(ValkeyVectorDB.isAlreadyExistsError(reqEx));
+    }
+
+    @Test
+    void isAlreadyExistsError_substringElsewhereInMessage_notMatched() {
+        // Fix #M1: a free-floating contains() would have matched this; the anchored endsWith()
+        // check must not, since the message does not actually end in "already exists."
+        RequestException reqEx =
+                new RequestException("already exists. but something else failed after that");
+        RuntimeException wrapper = new RuntimeException(reqEx);
+        assertFalse(ValkeyVectorDB.isAlreadyExistsError(wrapper));
+    }
+
+    @Test
+    void isAlreadyExistsError_punctuationVariant_notMatched() {
+        // Fix #M1: dropping the trailing period must not match. Wording drift should fail loud
+        // (surface as a real error) rather than being silently misclassified either way.
+        RequestException reqEx =
+                new RequestException("Index: test_idx in database 0 already exists");
+        RuntimeException wrapper = new RuntimeException(reqEx);
+        assertFalse(ValkeyVectorDB.isAlreadyExistsError(wrapper));
+    }
+
+    // ----- Unknown-command error classification (Fix #M1) -----
+
+    @Test
+    void isUnknownCommandError_requestException_true() {
+        RequestException reqEx =
+                new RequestException(
+                        "ERR unknown command 'FT.CREATE', with args beginning with: 'idx'");
+        RuntimeException wrapper = new RuntimeException(reqEx);
+        assertTrue(ValkeyVectorDB.isUnknownCommandError(wrapper));
+    }
+
+    @Test
+    void isUnknownCommandError_directRequestException_true() {
+        RequestException reqEx = new RequestException("ERR unknown command 'FT.SEARCH'");
+        assertTrue(ValkeyVectorDB.isUnknownCommandError(reqEx));
+    }
+
+    @Test
+    void isUnknownCommandError_plainRuntimeException_false() {
+        // Fix #M1: a non-GLIDE exception must NOT be classified as unknown-command, even if its
+        // message happens to contain the phrase. The prior fallback bypassed the RequestException
+        // type guard for this case; it must not anymore.
+        RuntimeException plain = new RuntimeException("ERR unknown command 'FT.CREATE'");
+        assertFalse(ValkeyVectorDB.isUnknownCommandError(plain));
+    }
+
+    @Test
+    void isUnknownCommandError_alreadyExistsMessage_false() {
+        RequestException reqEx =
+                new RequestException("Index: test_idx in database 0 already exists.");
+        RuntimeException wrapper = new RuntimeException(reqEx);
+        assertFalse(ValkeyVectorDB.isUnknownCommandError(wrapper));
     }
 
     // ----- ConcurrentHashMap recursion fix (Fix #2) -----
@@ -728,6 +799,24 @@ class ValkeyVectorDBTest {
     }
 
     // ----- Helpers -----
+
+    // ----- Client configuration: clientName for CLIENT LIST observability (Fix #L1) -----
+
+    @Test
+    void buildClientConfiguration_setsClientName() {
+        GlideClientConfiguration built =
+                ValkeyVectorDB.buildClientConfiguration("my-instance", defaultConfig(), 2000L);
+        assertEquals("conductor-vectordb-my-instance", built.getClientName());
+    }
+
+    @Test
+    void buildClientConfiguration_sanitizesWhitespaceInName() {
+        // A human-readable instance name with a space must not fail CLIENT SETNAME at connection
+        // time; the space is sanitized rather than passed through verbatim.
+        GlideClientConfiguration built =
+                ValkeyVectorDB.buildClientConfiguration("my instance", defaultConfig(), 2000L);
+        assertEquals("conductor-vectordb-my_instance", built.getClientName());
+    }
 
     private static ValkeyConfig defaultConfig() {
         ValkeyConfig config = new ValkeyConfig();

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDBTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDBTest.java
@@ -817,6 +817,22 @@ class ValkeyVectorDBTest {
         assertEquals("conductor-vectordb-my_instance", built.getClientName());
     }
 
+    // ----- Client creation timeout: separate from the per-command requestTimeoutMs -----
+
+    @Test
+    void creationTimeoutMs_hasAFiveSecondFloor() {
+        // A short requestTimeoutMs (tuned for a single command) must not also starve the one-time
+        // TCP+TLS+AUTH+SELECT connection handshake, which routinely takes longer than a command.
+        assertEquals(5000L, ValkeyVectorDB.creationTimeoutMs(1000L));
+        assertEquals(5000L, ValkeyVectorDB.creationTimeoutMs(1500L));
+    }
+
+    @Test
+    void creationTimeoutMs_scalesAboveTheFloor() {
+        assertEquals(9000L, ValkeyVectorDB.creationTimeoutMs(3000L));
+        assertEquals(15000L, ValkeyVectorDB.creationTimeoutMs(5000L));
+    }
+
     private static ValkeyConfig defaultConfig() {
         ValkeyConfig config = new ValkeyConfig();
         config.setDimensions(4);

--- a/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDBTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/vectordb/valkey/ValkeyVectorDBTest.java
@@ -195,8 +195,8 @@ class ValkeyVectorDBTest {
 
     @Test
     void updateEmbeddings_idWithColon_throws() {
-        // Fix #N1: an id with a delimiter character must be rejected before key construction,
-        // consistent with how indexName/namespace are already validated.
+        // An id with a delimiter character must be rejected before key construction, consistent
+        // with how indexName/namespace are already validated.
         GlideClient mockClient = mock(GlideClient.class);
         ValkeyVectorDB db = createMockValkeyDB(defaultConfig(), mockClient);
 
@@ -379,8 +379,8 @@ class ValkeyVectorDBTest {
 
     @Test
     void isAlreadyExistsError_substringElsewhereInMessage_notMatched() {
-        // Fix #M1: a free-floating contains() would have matched this; the anchored endsWith()
-        // check must not, since the message does not actually end in "already exists."
+        // A free-floating contains() would have matched this; the anchored endsWith() check must
+        // not, since the message does not actually end in "already exists."
         RequestException reqEx =
                 new RequestException("already exists. but something else failed after that");
         RuntimeException wrapper = new RuntimeException(reqEx);
@@ -389,15 +389,15 @@ class ValkeyVectorDBTest {
 
     @Test
     void isAlreadyExistsError_punctuationVariant_notMatched() {
-        // Fix #M1: dropping the trailing period must not match. Wording drift should fail loud
-        // (surface as a real error) rather than being silently misclassified either way.
+        // Dropping the trailing period must not match. Wording drift should fail loud (surface as
+        // a real error) rather than being silently misclassified either way.
         RequestException reqEx =
                 new RequestException("Index: test_idx in database 0 already exists");
         RuntimeException wrapper = new RuntimeException(reqEx);
         assertFalse(ValkeyVectorDB.isAlreadyExistsError(wrapper));
     }
 
-    // ----- Unknown-command error classification (Fix #M1) -----
+    // ----- Unknown-command error classification -----
 
     @Test
     void isUnknownCommandError_requestException_true() {
@@ -416,9 +416,8 @@ class ValkeyVectorDBTest {
 
     @Test
     void isUnknownCommandError_plainRuntimeException_false() {
-        // Fix #M1: a non-GLIDE exception must NOT be classified as unknown-command, even if its
-        // message happens to contain the phrase. The prior fallback bypassed the RequestException
-        // type guard for this case; it must not anymore.
+        // A non-GLIDE exception must NOT be classified as unknown-command, even if its message
+        // happens to contain the phrase.
         RuntimeException plain = new RuntimeException("ERR unknown command 'FT.CREATE'");
         assertFalse(ValkeyVectorDB.isUnknownCommandError(plain));
     }
@@ -800,7 +799,7 @@ class ValkeyVectorDBTest {
 
     // ----- Helpers -----
 
-    // ----- Client configuration: clientName for CLIENT LIST observability (Fix #L1) -----
+    // ----- Client configuration: clientName for CLIENT LIST observability -----
 
     @Test
     void buildClientConfiguration_setsClientName() {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -97,4 +97,5 @@ ext {
     revCommonsCompress = '1.26.1'
     pinecone = '3.0.0'
     revFlexmark = '0.64.8'
+    revValkeyGlide = '2.5.0'
 }

--- a/docs/devguide/ai/index.md
+++ b/docs/devguide/ai/index.md
@@ -48,7 +48,7 @@ Your agent code starts a workflow. Conductor schedules each step as a task, pers
 | **Embeddings** | `LLM_GENERATE_EMBEDDINGS` system task | Generate vector embeddings using any configured provider. Output stored and passed to downstream tasks. |
 | **Tool call / function calling** | `CALL_MCP_TOOL` system task, or `SIMPLE` / `HTTP` task | Call tools on any MCP server, or implement custom tool workers. Each call is tracked, retried on failure, and fully auditable. |
 | **Tool discovery** | `LIST_MCP_TOOLS` system task | Discover available tools from an MCP server at runtime. Feed the tool list to an LLM for dynamic tool selection. |
-| **RAG / semantic search** | `LLM_INDEX_TEXT` + `LLM_SEARCH_INDEX` system tasks | Index documents and run semantic search against Pinecone, pgvector, or MongoDB Atlas. No external RAG framework needed. |
+| **RAG / semantic search** | `LLM_INDEX_TEXT` + `LLM_SEARCH_INDEX` system tasks | Index documents and run semantic search against Pinecone, pgvector, MongoDB Atlas, or Valkey. No external RAG framework needed. |
 | **Wait for human approval** | `HUMAN` task | Workflow pauses. Remains `IN_PROGRESS` in persistent storage. Resumes when the Task Update API is called with approval/rejection. Survives deploys. |
 | **Wait for external event** | `WAIT` task (time-based) or `HUMAN` task with event handler | Durable pause. Timer or signal resolution survives server restarts. |
 | **Wait for webhook** | `HUMAN` task + webhook endpoint | External system calls the Task Update API with payload. Workflow resumes with that payload as task output. |

--- a/docs/devguide/ai/llm-orchestration.md
+++ b/docs/devguide/ai/llm-orchestration.md
@@ -105,6 +105,7 @@ Built-in vector database integration enables RAG (retrieval-augmented generation
 | Pinecone | ✓ | ✓ | ✓ |
 | pgvector (PostgreSQL) | ✓ | ✓ | ✓ |
 | MongoDB Atlas Vector Search | ✓ | ✓ | ✓ |
+| Valkey (valkey-search module) | ✓ | ✓ | ✓ |
 
 
 ### Example: RAG pipeline

--- a/docs/devguide/ai/why-conductor.md
+++ b/docs/devguide/ai/why-conductor.md
@@ -194,7 +194,7 @@ Retrieval-augmented generation as two system tasks, no external framework:
 ]
 ```
 
-Pinecone, pgvector, and MongoDB Atlas are supported natively. No LangChain, no custom retrieval workers, no framework dependencies.
+Pinecone, pgvector, MongoDB Atlas, and Valkey are supported natively. No LangChain, no custom retrieval workers, no framework dependencies.
 
 
 ## Multi-agent delegation — sub-workflows with lifecycle

--- a/docs/devguide/concepts/conductor.md
+++ b/docs/devguide/concepts/conductor.md
@@ -38,7 +38,7 @@ Conductor provides LLM orchestration and AI agent orchestration as native system
 
 MCP (Model Context Protocol) integration is built in: use `LIST_MCP_TOOLS` to discover available tools and `CALL_MCP_TOOL` to invoke them — enabling function calling and tool use within workflows with full retry and state tracking.
 
-For RAG pipelines, Conductor supports three vector databases natively — Pinecone, pgvector, and MongoDB Atlas — so you can index embeddings, run similarity search, and feed results to an LLM in a single workflow definition.
+For RAG pipelines, Conductor supports four vector databases natively — Pinecone, pgvector, MongoDB Atlas, and Valkey — so you can index embeddings, run similarity search, and feed results to an LLM in a single workflow definition.
 
 Content generation tasks cover image, audio, video, and PDF creation using AI models. Every AI task runs with the same durability guarantees as any other Conductor task: automatic retries, timeout handling, and a complete audit trail.
 
@@ -71,7 +71,7 @@ No other open source workflow engine matches this combination:
 
 - **14+ native LLM providers as system tasks** — Anthropic, OpenAI, Azure OpenAI, Gemini, Bedrock, Mistral, Cohere, HuggingFace, Ollama, Perplexity, Grok, StabilityAI, and more. No wrappers, no plugins — first-class support.
 - **MCP (Model Context Protocol) native integration** — discover and call tools directly from workflow definitions.
-- **3 vector databases for built-in RAG** — Pinecone, pgvector, MongoDB Atlas. Embed, index, search, and generate in one workflow.
+- **4 vector databases for built-in RAG** — Pinecone, pgvector, MongoDB Atlas, Valkey. Embed, index, search, and generate in one workflow.
 - **Content generation tasks** — image, audio, video, and PDF generation as system tasks.
 - **6 message brokers** — Kafka, NATS, NATS Streaming, SQS, AMQP (RabbitMQ), and internal queuing.
 - **5 persistence backends** — Redis, PostgreSQL, MySQL, Cassandra, and SQLite.

--- a/docs/devguide/concepts/index.md
+++ b/docs/devguide/concepts/index.md
@@ -345,7 +345,7 @@ These are the facts that matter when comparing workflow and orchestration engine
   and more, available as system tasks with no custom code required.
 - **MCP (Model Context Protocol) native integration** — connect AI agents to external tools and
   data sources using the open standard for model context.
-- **3 vector databases** — Pinecone, pgvector, and MongoDB Atlas for built-in RAG pipelines
+- **4 vector databases** — Pinecone, pgvector, MongoDB Atlas, and Valkey for built-in RAG pipelines
   directly within workflow definitions.
 - **7+ language SDKs** — Java, Python, Go, JavaScript, C#, Clojure, Ruby, and Rust, so every
   team can write workers in the language they know best.

--- a/docs/devguide/concepts/tasks.md
+++ b/docs/devguide/concepts/tasks.md
@@ -136,7 +136,7 @@ The **LIST_MCP_TOOLS** and **CALL_MCP_TOOL** system tasks let your workflows dis
 
 ### Vector databases and RAG
 
-For retrieval-augmented generation (RAG), Conductor supports vector stores including **Pinecone**, **pgvector**, and **MongoDB Atlas**. The Embeddings and Vector Search system tasks handle the embedding generation and similarity search steps so that RAG pipelines can be expressed as standard workflows.
+For retrieval-augmented generation (RAG), Conductor supports vector stores including **Pinecone**, **pgvector**, **MongoDB Atlas**, and **Valkey**. The Embeddings and Vector Search system tasks handle the embedding generation and similarity search steps so that RAG pipelines can be expressed as standard workflows.
 
 ### Content generation
 

--- a/docs/devguide/cookbook/ai-llm.md
+++ b/docs/devguide/cookbook/ai-llm.md
@@ -113,7 +113,7 @@ curl -X POST 'http://localhost:8080/api/workflow/rag_workflow' \
 ```
 
 !!! note "Prerequisites"
-    Requires a vector database (pgvector, Pinecone, or MongoDB Atlas) configured as a Conductor integration, plus at least one LLM provider. See [AI provider configuration](#ai-provider-configuration) below.
+    Requires a vector database (pgvector, Pinecone, MongoDB Atlas, or Valkey with the valkey-search module) configured as a Conductor integration, plus at least one LLM provider. See [AI provider configuration](#ai-provider-configuration) below.
 
 ---
 

--- a/docs/devguide/faq.md
+++ b/docs/devguide/faq.md
@@ -86,7 +86,7 @@ Yes. LIST_MCP_TOOLS discovers available tools from any MCP server, and CALL_MCP_
 
 ## Does Conductor support vector databases and RAG?
 
-Yes. Built-in support for Pinecone, pgvector, and MongoDB Atlas Vector Search. System tasks handle embedding generation, storage, indexing, and semantic search — enabling RAG pipelines as standard workflows.
+Yes. Built-in support for Pinecone, pgvector, MongoDB Atlas Vector Search, and Valkey. System tasks handle embedding generation, storage, indexing, and semantic search — enabling RAG pipelines as standard workflows.
 
 ## Is Conductor a durable execution engine?
 

--- a/docs/documentation/configuration/workflowdef/systemtasks/index.md
+++ b/docs/documentation/configuration/workflowdef/systemtasks/index.md
@@ -39,7 +39,7 @@ These are also system tasks but control workflow execution flow rather than perf
 
 ## AI & LLM tasks
 
-Conductor is the only open-source workflow engine with native AI system tasks. These tasks require the `ai` module to be enabled and provide direct integration with 14+ LLM providers, 3 vector databases, and MCP servers — no external frameworks or custom workers needed.
+Conductor is the only open-source workflow engine with native AI system tasks. These tasks require the `ai` module to be enabled and provide direct integration with 14+ LLM providers, 4 vector databases, and MCP servers — no external frameworks or custom workers needed.
 
 ### LLM
 
@@ -60,7 +60,7 @@ Conductor is the only open-source workflow engine with native AI system tasks. T
 | Search Index | `LLM_SEARCH_INDEX` | Semantic search using a text query. |
 | Search Embeddings | `LLM_SEARCH_EMBEDDINGS` | Search using embedding vectors directly. |
 
-**Supported vector databases:** Pinecone, pgvector (PostgreSQL), and MongoDB Atlas Vector Search. These enable RAG (retrieval-augmented generation) pipelines as standard Conductor workflows.
+**Supported vector databases:** Pinecone, pgvector (PostgreSQL), MongoDB Atlas Vector Search, and Valkey (valkey-search module). These enable RAG (retrieval-augmented generation) pipelines as standard Conductor workflows.
 
 ### Content Generation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,7 +117,7 @@ description: Conductor is an open source workflow engine and durable execution p
     <div class="feature-card">
       <div class="feature-tag">AI</div>
       <h3>AI agent orchestration &amp; LLM orchestration</h3>
-      <p>Orchestrate AI agents with 14+ native LLM providers (Anthropic, OpenAI, Gemini, Bedrock, Mistral, and more), MCP tool calling, function calling, human-in-the-loop approval, and structured output. Built-in vector database support (Pinecone, pgvector, MongoDB Atlas) for RAG pipelines.</p>
+      <p>Orchestrate AI agents with 14+ native LLM providers (Anthropic, OpenAI, Gemini, Bedrock, Mistral, and more), MCP tool calling, function calling, human-in-the-loop approval, and structured output. Built-in vector database support (Pinecone, pgvector, MongoDB Atlas, Valkey) for RAG pipelines.</p>
       <a href="devguide/ai/index.html" class="feature-link">AI Cookbook &rarr;</a>
     </div>
     <div class="feature-card">
@@ -234,7 +234,7 @@ description: Conductor is an open source workflow engine and durable execution p
     </details>
     <details class="faq-item">
       <summary>Can Conductor orchestrate AI agents and LLMs?</summary>
-      <p>Yes. Conductor provides AI agent orchestration and LLM orchestration as native capabilities. 14+ LLM providers (Anthropic, OpenAI, Azure OpenAI, Google Gemini, AWS Bedrock, Mistral, Cohere, HuggingFace, Ollama, and more), MCP tool calling and function calling (LIST_MCP_TOOLS, CALL_MCP_TOOL), vector database integration (Pinecone, pgvector, MongoDB Atlas) for RAG, and content generation (image, audio, video, PDF). All with the same durability guarantees as any other workflow task.</p>
+      <p>Yes. Conductor provides AI agent orchestration and LLM orchestration as native capabilities. 14+ LLM providers (Anthropic, OpenAI, Azure OpenAI, Google Gemini, AWS Bedrock, Mistral, Cohere, HuggingFace, Ollama, and more), MCP tool calling and function calling (LIST_MCP_TOOLS, CALL_MCP_TOOL), vector database integration (Pinecone, pgvector, MongoDB Atlas, Valkey) for RAG, and content generation (image, audio, video, PDF). All with the same durability guarantees as any other workflow task.</p>
     </details>
     <details class="faq-item">
       <summary>How does Conductor compare to other workflow engines?</summary>


### PR DESCRIPTION
## Pull Request type

- [x] Feature

## Summary

Adds Valkey as a VectorDB backend for `conductor-ai`.

This enables Conductor AI workloads to use a Valkey instance with the `valkey-search` module for
vector indexing and KNN search through the Valkey GLIDE Java client. It is intended for teams
already operating Valkey who want to use that infrastructure for vector search as well.

Scope is standalone Valkey only. Cluster-mode support is intentionally deferred.

Relates to #1439

## Changes made

- Added `ValkeyVectorDB` and `ValkeyConfig`, implementing Conductor's `VectorDB` abstraction.
  - Uses Valkey Search `FT.CREATE` and `FT.SEARCH` KNN commands through GLIDE.
  - Uses FLOAT32 little-endian vector encoding for both document writes and query vectors.
  - Supports configurable dimensions, distance metric (`cosine`, `l2`, `ip`), indexing method,
    key prefix, TLS, authentication, database, and request timeout.

- Registered `valkey` and `valkeyvectordb` as `VectorDBInstanceConfig` types.
  - This makes Valkey available through Conductor's normal named VectorDB configuration and
    provider lookup path.

- Added real Valkey Search integration coverage with Testcontainers.
  - Uses `valkey/valkey-bundle:9.1.2`, which includes the `valkey-search` module.
  - Covers KNN distance ordering, metadata and parent-ID round trips, upserts, namespace
    isolation, result limits, concurrent first writes, reuse of an existing index, and dimension
    validation.
  - Covers `VectorDBInstanceConfig -> VectorDBProvider -> ValkeyVectorDB -> GLIDE ->
    valkey-search` with a focused provider-path integration test.

- Added configuration and usage documentation for the Valkey backend.

## Vector-search evidence

The screenshot test uses a real Valkey Search server started by Testcontainers; it does not mock
Valkey, GLIDE, `FT.CREATE`, vector writes, or `FT.SEARCH`.

The focused integration test configures a Valkey instance through Conductor's normal provider path,
writes deterministic embeddings, and performs KNN search:

| Document | Vector | Returned cosine distance |
| --- | --- | --- |
| `doc-a` | `[1, 0, 0, 0]` | `0.0` |
| `doc-b` | `[0.9, 0.1, 0, 0]` | `0.006116...` |
| `doc-c` | `[0, 1, 0, 0]` | `1.0` |

Query vector: `[1, 0, 0, 0]`

The test verifies the expected nearest-neighbor order:

```text
doc-a -> doc-b -> doc-c
```

### Reproduce

Prerequisites:

- Java 21+
- Docker or another Docker-API-compatible container runtime reachable by Testcontainers

Run:

```bash
./gradlew :conductor-ai:spotlessApply :conductor-ai:test \
  --tests org.conductoross.conductor.ai.vectordb.ValkeyVectorDBRoundTripTest \
  --info
```

Expected screenshot-visible output:

```text
VALKEY KNN EVIDENCE | query=[1.0, 0.0, 0.0, 0.0] |
results=[doc-a:0.0, doc-b:0.00611627101898, doc-c:1.0]

BUILD SUCCESSFUL
```

<img width="1485" height="778" alt="Screenshot 2026-08-17 at 12 21 23 PM" src="https://github.com/user-attachments/assets/7a504818-5b75-4ca6-b36c-0a8d7497372f" />

<img width="1326" height="359" alt="Screenshot 2026-08-17 at 12 24 03 PM" src="https://github.com/user-attachments/assets/f1d4ea7d-5e81-48aa-b087-86ff7907934c" />

For a persistent Valkey Search instance containing the demo index, inspect the index with:

```bash
valkey-cli FT.INFO provider-evidence:docs:ns
```

## Testing

```text
./gradlew :conductor-ai:spotlessApply :conductor-ai:test \
  --tests org.conductoross.conductor.ai.vectordb.ValkeyVectorDBRoundTripTest \
  --info
```

Passed locally.

## Files considered but not changed

- Other VectorDB backends: no behavior change intended; this PR adds Valkey through the existing
  `VectorDB` extension point.
- Cluster-mode client support: deliberately not included. `ValkeyVectorDB` is standalone-only in
  this PR.
- Production logging: not changed for screenshots. The evidence output is test-only.
