### PR TITLE
fix(agentspan): agent loops on Anthropic models run without conversation history

### DIFF
--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/ai/AgentChatCompleteTaskMapper.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/ai/AgentChatCompleteTaskMapper.java
@@ -364,9 +364,18 @@ public class AgentChatCompleteTaskMapper extends AIModelTaskMapper<ChatCompletio
         }
 
         String previousResponseId = chatCompletion.getPreviousResponseId();
+        // Suppress prior same-refName loop iterations only when previousResponseId
+        // is in play (the provider's server-side store already owns those turns).
+        //
+        // Unlike the base ChatCompleteTaskMapper, providerSupportsAssistantPrefill
+        // is deliberately NOT consulted here. Prefill only concerns a *trailing*
+        // assistant message, and this mapper's ensureEndsWithUserMessage guarantees
+        // the conversation never ends assistant-side. Suppressing loop history for
+        // no-prefill providers (all Anthropic models) left agent loops amnesiac:
+        // the model never saw its own prior tool calls/results and repeated its
+        // first action every turn until maxTurns.
         boolean suppressLoopAssistantHistory =
-                (previousResponseId != null && !previousResponseId.isBlank())
-                        || !providerSupportsAssistantPrefill(chatCompletion);
+                previousResponseId != null && !previousResponseId.isBlank();
 
         List<ChatMessage> history = new ArrayList<>();
 

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/ai/AgentChatCompleteTaskMapperTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/ai/AgentChatCompleteTaskMapperTest.java
@@ -160,6 +160,56 @@ class AgentChatCompleteTaskMapperTest {
         assertThat(result.getMessage()).isEqualTo("Alice");
     }
 
+    @Test
+    void loopHistoryIsIncludedForProvidersWithoutPrefillSupport() throws Exception {
+        // Regression: agent loops on Anthropic models ran amnesiac. getHistory
+        // suppressed all prior same-refName loop iterations whenever the provider
+        // declared supportsAssistantPrefill() == false (all Anthropic models).
+        // Prefill only concerns a TRAILING assistant message — which
+        // ensureEndsWithUserMessage already prevents — so mid-conversation loop
+        // history must be included regardless of prefill support.
+        String llmRef = "agent_llm";
+
+        TaskModel priorLlm = new TaskModel();
+        WorkflowTask priorLlmTask = workflowTask(llmRef);
+        priorLlmTask.setType("LLM_CHAT_COMPLETE");
+        priorLlm.setWorkflowTask(priorLlmTask);
+        priorLlm.setTaskType("LLM_CHAT_COMPLETE");
+        priorLlm.setStatus(TaskModel.Status.COMPLETED);
+        priorLlm.setIteration(1);
+        priorLlm.setOutputData(Map.of("result", "I created the scratch directory."));
+
+        WorkflowModel workflow = new WorkflowModel();
+        workflow.setTasks(List.of(priorLlm));
+        TaskModel currentLlm = new TaskModel();
+        currentLlm.setWorkflowTask(workflowTask(llmRef));
+
+        // Provider stack that rejects assistant prefill, as Anthropic does.
+        org.conductoross.conductor.ai.AIModel noPrefillModel =
+                org.mockito.Mockito.mock(org.conductoross.conductor.ai.AIModel.class);
+        org.mockito.Mockito.when(noPrefillModel.supportsAssistantPrefill()).thenReturn(false);
+        org.conductoross.conductor.ai.AIModelProvider provider =
+                org.mockito.Mockito.mock(org.conductoross.conductor.ai.AIModelProvider.class);
+        org.mockito.Mockito.when(provider.getModel(org.mockito.Mockito.any(ChatCompletion.class)))
+                .thenReturn(noPrefillModel);
+        java.lang.reflect.Field field =
+                AgentChatCompleteTaskMapper.class.getDeclaredField("aiModelProvider");
+        field.setAccessible(true);
+        field.set(mapper, provider);
+
+        ChatCompletion completion = new ChatCompletion();
+        completion.setLlmProvider("anthropic");
+        invokeGetHistory(workflow, currentLlm, completion);
+
+        assertThat(completion.getMessages())
+                .anySatisfy(
+                        m -> {
+                            assertThat(m.getRole()).isEqualTo(ChatMessage.Role.assistant);
+                            assertThat(m.getMessage())
+                                    .isEqualTo("I created the scratch directory.");
+                        });
+    }
+
     // ── Context condensation tests ─────────────────────────────────
 
     @Test


### PR DESCRIPTION
Agent loops on any Anthropic model are amnesiac: `AgentChatCompleteTaskMapper` suppresses all prior loop iterations whenever the provider declares `supportsAssistantPrefill() = false`, so the model never sees its own previous tool calls/results and repeats its first action every turn until `maxTurns`.

The suppression protects nothing in this mapper — prefill only concerns a *trailing* assistant message, which `ensureEndsWithUserMessage` already prevents. Mid-conversation assistant/tool turns are fully supported by the Anthropic API.

**Change:** suppress loop history only for `previousResponseId` (server-side response store); stop consulting prefill support. The base `ChatCompleteTaskMapper` (no trailing-turn guard) is untouched, as is `Anthropic.supportsAssistantPrefill()` itself.

**Verified:** regression test fails without the fix, passes with it (35/35 mapper tests). End-to-end on a local build: a claude-sonnet-4-6 multi-agent pipeline that previously repeated `mktemp` 25× now threads history (2→4→6→9→11 messages per turn) and completes issue→commit→PR.