### PR TITLE
Keep top tab bar visible on narrow screens

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -109,6 +109,15 @@ body {
   -webkit-backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--c-border);
 }
+/* Material hides the tab bar below 76.25em and falls back to the drawer, but
+   the home page hides drawer navigation (hide: navigation), leaving that page
+   with no navigation at all on narrow screens. The tab list is natively a
+   scrollable nowrap flex row, so keep the bar visible as a swipeable strip. */
+@media screen and (max-width: 76.234375em) {
+  .md-tabs {
+    display: block;
+  }
+}
 .md-tabs__link {
   font-family: var(--font-body) !important;
   font-size: 14px;


### PR DESCRIPTION
Fixes the navigation dead end reported in #general after the site cutover: Material hides the top tab bar below its 76.25em (1220px) breakpoint and falls back to the drawer, but the docs home intentionally sets hide: navigation for the full-width landing layout — so on narrow windows, zoomed browsers, and phones the home page had no navigation at all, and inner pages buried the global tabs inside the drawer.

Material's tab list is already a nowrap flex row with overflow scrolling and hidden scrollbars, so the fix is a single override in the shared custom.css: keep .md-tabs displayed below the breakpoint, yielding a swipeable tab strip at every width. No nav structure, content, or wide-screen rendering changes. The enterprise build inherits the shared stylesheet automatically.

Verified with local builds at 1100px and 400px on the home page and an inner page: tab bar present and scrollable, drawer behavior unchanged, wide-screen layout identical.