### PR TITLE
fix(core): correct getTaskDuration over-counting and guard malformed retry chains

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/WorkflowExecutorOps.java
@@ -1966,12 +1966,17 @@ public class WorkflowExecutorOps implements WorkflowExecutor {
     }
 
     private long getTaskDuration(long s, TaskModel task) {
-        long duration = task.getEndTime() - task.getStartTime();
-        s += duration;
-        if (task.getRetriedTaskId() == null) {
-            return s;
+        // Walk the retriedTaskId chain iteratively. The recursive version re-added the running sum
+        // at every hop, overstating a retried task's duration (10+20 reported 40, 10+20+30 reported
+        // 100), and a malformed chain — self-reference, cycle — overflowed the stack. The visited
+        // set makes any such chain harmless.
+        Set<String> visited = new HashSet<>();
+        for (TaskModel current = task; current != null && visited.add(current.getTaskId()); ) {
+            s += current.getEndTime() - current.getStartTime();
+            String retriedId = current.getRetriedTaskId();
+            current = retriedId == null ? null : executionDAOFacade.getTaskModel(retriedId);
         }
-        return s + getTaskDuration(s, executionDAOFacade.getTaskModel(task.getRetriedTaskId()));
+        return s;
     }
 
     @VisibleForTesting


### PR DESCRIPTION
`getTaskDuration` recursed down the `retriedTaskId` chain as `return s + getTaskDuration(s, ...)`, passing the running sum down and then adding it again, so every hop double-counted everything before it.

| retry chain durations | reported | correct |
|---|---|---|
| 10, 20 | 40 | 30 |
| 10, 20, 30 | 100 | 60 |

The value feeds `Monitors.recordTaskExecutionTime(..., includeRetries=true)`, so that metric is inflated by a compounding factor for every retried task.

Now walks the chain iteratively and sums once. A visited set makes a malformed chain harmless — a self-reference or cycle previously recursed until the stack overflowed, killing the thread mid task-update.