### PR TITLE
feat(common): add TaskDef.regionDurable and RerunWorkflowRequest.rerunParentDownstreamTasks flags

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
@@ -157,6 +157,7 @@ public class TaskDef extends Auditable {
      * before the caller is acked (falling back to asynchronous convergence if the sync quorum is
      * missed). Defaults to false (locally durable only).
      */
+    @ProtoField(id = 26)
     private boolean regionDurable;
 
     public TaskDef() {}

--- a/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/tasks/TaskDef.java
@@ -151,6 +151,14 @@ public class TaskDef extends Auditable {
     private SchemaDef outputSchema;
     private boolean enforceSchema;
 
+    /**
+     * When true, updates to tasks of this type are replicated region-durably in an active-active
+     * deployment: the update is committed locally and synchronously confirmed to the peer region(s)
+     * before the caller is acked (falling back to asynchronous convergence if the sync quorum is
+     * missed). Defaults to false (locally durable only).
+     */
+    private boolean regionDurable;
+
     public TaskDef() {}
 
     public TaskDef(String name) {
@@ -527,6 +535,14 @@ public class TaskDef extends Auditable {
 
     public void setEnforceSchema(boolean enforceSchema) {
         this.enforceSchema = enforceSchema;
+    }
+
+    public boolean isRegionDurable() {
+        return regionDurable;
+    }
+
+    public void setRegionDurable(boolean regionDurable) {
+        this.regionDurable = regionDurable;
     }
 
     public long getTotalTimeoutSeconds() {

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/RerunWorkflowRequest.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/RerunWorkflowRequest.java
@@ -35,6 +35,13 @@ public class RerunWorkflowRequest {
     @ProtoField(id = 5)
     private String correlationId;
 
+    /**
+     * When rerunning from a task inside a sub-workflow, also re-run the downstream tasks of each
+     * ancestor workflow. Off by default: only the workflow named in the request is re-run, and
+     * already-completed tasks in its ancestors are left as they are.
+     */
+    private boolean rerunParentDownstreamTasks;
+
     public String getReRunFromWorkflowId() {
         return reRunFromWorkflowId;
     }
@@ -65,6 +72,14 @@ public class RerunWorkflowRequest {
 
     public void setTaskInput(Map<String, Object> taskInput) {
         this.taskInput = taskInput;
+    }
+
+    public boolean isRerunParentDownstreamTasks() {
+        return rerunParentDownstreamTasks;
+    }
+
+    public void setRerunParentDownstreamTasks(boolean rerunParentDownstreamTasks) {
+        this.rerunParentDownstreamTasks = rerunParentDownstreamTasks;
     }
 
     public String getCorrelationId() {

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/RerunWorkflowRequest.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/RerunWorkflowRequest.java
@@ -40,6 +40,7 @@ public class RerunWorkflowRequest {
      * ancestor workflow. Off by default: only the workflow named in the request is re-run, and
      * already-completed tasks in its ancestors are left as they are.
      */
+    @ProtoField(id = 6)
     private boolean rerunParentDownstreamTasks;
 
     public String getReRunFromWorkflowId() {

--- a/common/src/test/java/com/netflix/conductor/common/tasks/TaskDefTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/tasks/TaskDefTest.java
@@ -27,6 +27,7 @@ import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -1039,6 +1039,7 @@ public abstract class AbstractProtoMapper {
         }
         to.setTotalTimeoutSeconds( from.getTotalTimeoutSeconds() );
         to.setTaskStatusListenerEnabled( from.isTaskStatusListenerEnabled() );
+        to.setRegionDurable( from.isRegionDurable() );
         return to.build();
     }
 
@@ -1072,6 +1073,7 @@ public abstract class AbstractProtoMapper {
         to.setBaseType( from.getBaseType() );
         to.setTotalTimeoutSeconds( from.getTotalTimeoutSeconds() );
         to.setTaskStatusListenerEnabled( from.getTaskStatusListenerEnabled() );
+        to.setRegionDurable( from.getRegionDurable() );
         return to;
     }
 

--- a/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
+++ b/grpc/src/main/java/com/netflix/conductor/grpc/AbstractProtoMapper.java
@@ -605,6 +605,7 @@ public abstract class AbstractProtoMapper {
         if (from.getCorrelationId() != null) {
             to.setCorrelationId( from.getCorrelationId() );
         }
+        to.setRerunParentDownstreamTasks( from.isRerunParentDownstreamTasks() );
         return to.build();
     }
 
@@ -623,6 +624,7 @@ public abstract class AbstractProtoMapper {
         }
         to.setTaskInput(taskInputMap);
         to.setCorrelationId( from.getCorrelationId() );
+        to.setRerunParentDownstreamTasks( from.getRerunParentDownstreamTasks() );
         return to;
     }
 

--- a/grpc/src/main/proto/model/rerunworkflowrequest.proto
+++ b/grpc/src/main/proto/model/rerunworkflowrequest.proto
@@ -13,4 +13,5 @@ message RerunWorkflowRequest {
     string re_run_from_task_id = 3;
     map<string, google.protobuf.Value> task_input = 4;
     string correlation_id = 5;
+    bool rerun_parent_downstream_tasks = 6;
 }

--- a/grpc/src/main/proto/model/taskdef.proto
+++ b/grpc/src/main/proto/model/taskdef.proto
@@ -42,4 +42,5 @@ message TaskDef {
     string base_type = 21;
     int64 total_timeout_seconds = 22;
     bool task_status_listener_enabled = 23;
+    bool region_durable = 26;
 }


### PR DESCRIPTION
Two independent request/definition flags, both defaulting to `false` so existing behaviour is unchanged. Neither does anything on its own — each is read by the engine path that implements it.

### `TaskDef.regionDurable`

Marks a task type whose updates should be replicated region-durably in an active-active deployment — committed locally and synchronously confirmed to the peer region(s) before ack, with asynchronous convergence as fallback.

### `RerunWorkflowRequest.rerunParentDownstreamTasks`

Rerunning from a task inside a sub-workflow can either re-run just that workflow, or also re-run the downstream tasks of every ancestor. The second is useful when a corrected result has to flow up through the parents, but it re-runs tasks that already **completed**, so it cannot be the default. With the flag off, a rerun continues to touch only the workflow named in the request, leaving ancestors' completed tasks alone.

### Note on proto

Neither field is annotated `@ProtoField`, matching the existing `enforceSchema` precedent. An annotated field needs a matching entry in its `.proto` and in `AbstractProtoMapper`; adding the annotation without both would silently drop the value over gRPC. Both flags are JSON/REST-only for now.