### PR TITLE
Docs refresh work

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -1423,7 +1423,7 @@ body {
   display: flex;
   min-height: 102px;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 6px;
   padding: 16px;
   border: 1px solid var(--c-border);

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -3138,6 +3138,21 @@ code.hero-terminal {
   border-radius: 0;
   padding: 0;
 }
+/* Mermaid diagrams are baked with the light workflow palette at build time
+   (main.py MERMAID_WORKFLOW_INIT), while their HTML labels pick up Material's
+   dark-scheme colors — white text on light fills, unreadable. Keep the diagram
+   card light in dark mode and re-pin the label variables so the diagram
+   renders exactly as in light mode, on a light card. */
+[data-md-color-scheme="slate"] .md-typeset .workflow-diagram {
+  background: linear-gradient(135deg, rgba(25, 118, 210, 0.07), transparent 52%), #f8f9fa;
+  border-color: #e8ebf0;
+  color: #1e293b;
+  --md-mermaid-label-fg-color: #1e293b;
+  --md-mermaid-label-bg-color: transparent;
+  --md-mermaid-edge-color: #1e3a8a;
+  --md-mermaid-node-fg-color: #1e293b;
+  --md-mermaid-node-bg-color: #eef2ff;
+}
 
 /* ---------- Durable Adaptive Graphs hero (dynamic-workflows.md inline SVG) ---------- */
 .dag-hero {

--- a/docs/devguide/ai/agent-framework-recipes.md
+++ b/docs/devguide/ai/agent-framework-recipes.md
@@ -1,11 +1,11 @@
 ---
-description: "Choose the supported Conductor bridge for an existing framework agent, then deploy it as a durable, reusable Conductor Agent."
+description: "Bring an agent from OpenAI Agents, Google ADK, LangChain, LangGraph, or Vercel AI SDK and run it as a durable, reusable Conductor Agent."
 ---
 
-# Framework Agent Bridges
+# Framework Agents
 
-<section class="framework-hero" aria-label="Framework bridges">
-  <p>A <strong>bridge</strong> is the SDK adapter that lets Conductor run an agent authored in another framework, such as OpenAI Agents, LangChain, LangGraph, or Google ADK. You keep the agent object your framework defines, and the bridge compiles and runs it as a durable Conductor execution. This page is the reference for the bridges: which frameworks and languages are supported, how a bridged agent becomes a deployable Conductor Agent, and where the maintained examples live for each pairing.</p>
+<section class="framework-hero" aria-label="Framework agents">
+  <p>You can bring an agent authored in another framework, such as OpenAI Agents, LangChain, LangGraph, or Google ADK. You keep the agent object your framework defines, and the Conductor SDK compiles and runs it as a durable Conductor execution. This page is the reference: which frameworks and languages are supported, how a framework agent becomes a deployable Conductor Agent, and where the maintained examples live for each pairing.</p>
   <div class="framework-logo-grid">
     <a class="framework-logo-card" href="../../quickstart/framework-agents.html#openai-agents-sdk" aria-label="OpenAI Agents quickstart">
       <img class="framework-logo framework-logo--wide" src="../../assets/images/frameworks/openai.svg" alt="" />
@@ -34,7 +34,7 @@ description: "Choose the supported Conductor bridge for an existing framework ag
   </div>
 </section>
 
-## Choose your bridge
+## Choose your framework
 
 | Framework | Start here |
 |---|---|
@@ -45,27 +45,27 @@ description: "Choose the supported Conductor bridge for an existing framework ag
 | Vercel AI SDK | [Vercel AI SDK examples on GitHub](https://github.com/conductor-oss/javascript-sdk/tree/main/examples/agents/vercel-ai) |
 | Conductor Agents | [Your First Agent](../../quickstart/first-agent.md) |
 
-Each route keeps the framework-specific code, dependencies, and executable examples in the owning Conductor SDK. The bridge is the boundary: your framework remains the authoring surface, while Conductor provides durable execution around it.
+Each route keeps the framework-specific code, dependencies, and executable examples in the owning Conductor SDK. The SDK is the boundary: your framework remains the authoring surface, while Conductor provides durable execution around it.
 
 ## From framework object to workflow step
 
-Every bridge follows the same path from your code to a reusable workflow step:
+Every framework follows the same path from your code to a reusable workflow step:
 
 ```mermaid
 flowchart LR
-    obj["Your framework<br/>agent object"] --> bridge["SDK bridge<br/>compiles it to a workflow graph"]
-    bridge -- "run (develop)" --> devrun["One durable execution<br/>visible in the UI"]
-    bridge -- "deploy (release)" --> deployed["Deployed Conductor Agent<br/>named and versioned"]
+    obj["Your framework<br/>agent object"] --> sdk["The Conductor SDK<br/>compiles it to a workflow graph"]
+    sdk -- "run (develop)" --> devrun["One durable execution<br/>visible in the UI"]
+    sdk -- "deploy (release)" --> deployed["Deployed Conductor Agent<br/>named and versioned"]
     workers["serve: worker process<br/>executes the tools"] -.- deployed
     parent["Parent workflow<br/>AGENT task"] -- "invoke" --> deployed
 ```
 
-1. **Run it while you iterate.** Pass your framework's agent object to the SDK bridge and run it. The bridge compiles the agent and executes it on Conductor, so the durable execution is visible in the UI from the first run.
+1. **Run it while you iterate.** Pass your framework's agent object to the Conductor SDK and run it. The SDK compiles the agent and executes it on Conductor, so the durable execution is visible in the UI from the first run.
 2. **Deploy it when it stabilizes.** Deploying registers the compiled agent on the server as a named, versioned Conductor Agent. Callers can then invoke it without importing your framework or its dependencies.
-3. **Serve its workers.** Where the bridge runs your tools as local functions, a worker process must be running to execute them. Keep it running for as long as the deployed agent is in use.
+3. **Serve its workers.** Where the SDK runs your tools as local functions, a worker process must be running to execute them. Keep it running for as long as the deployed agent is in use.
 4. **Invoke it from a workflow.** A parent workflow calls the deployed agent with an `AGENT` task, the same way it calls any other durable step.
 
-In the Python SDK, those steps are four calls on the same runtime. Here they are with the LangChain bridge:
+In the Python SDK, those steps are four calls on the same runtime. Here they are with LangChain:
 
 ```python
 from conductor.ai.agents import AgentRuntime

--- a/docs/devguide/ai/conductor-agents.md
+++ b/docs/devguide/ai/conductor-agents.md
@@ -13,7 +13,7 @@ description: "Conductor Agents — compile SDK-authored agents into durable, ins
     </a>
     <a class="integration-action-card" href="agent-framework-recipes.html">
       <span class="integration-action-card__title">Bring a framework agent</span>
-      <span>Choose a bridge for OpenAI Agents, Google ADK, LangChain, LangGraph, or more.</span>
+      <span>Run an agent built with OpenAI Agents, Google ADK, LangChain, LangGraph, or more.</span>
     </a>
     <a class="integration-action-card" href="#use-a-deployed-agent-in-a-workflow">
       <span class="integration-action-card__title">Use it in a workflow</span>
@@ -22,7 +22,7 @@ description: "Conductor Agents — compile SDK-authored agents into durable, ins
   </div>
 </section>
 
-A **Conductor Agent** is an agent you author in code and register on the server. You write it with a Conductor SDK, or bring it from a supported framework through a bridge, and Conductor compiles it into an ordinary workflow definition. Because the compiled agent is a workflow, every LLM call, tool invocation, wait, retry, and branch is visible in the UI and API, and the agent composes with everything else a workflow can contain: other tasks, branching, schedules, human approval, and cancellation. Conductor Agents are available in Python, Java, TypeScript/JavaScript, and C#.
+A **Conductor Agent** is an agent you author in code and register on the server. You build it with a Conductor SDK, or bring it from a supported agent framework, and Conductor compiles it into an ordinary workflow definition. Because the compiled agent is a workflow, every LLM call, tool invocation, wait, retry, and branch is visible in the UI and API, and the agent composes with everything else a workflow can contain: other tasks, branching, schedules, human approval, and cancellation. Conductor Agents are available in Python, Java, TypeScript/JavaScript, and C#.
 
 Conductor Agents are one of two ways to build AI behavior. The other is a [declarative AI workflow](llm-orchestration.md), where you place LLM, MCP, and control-flow tasks directly in the workflow definition. Choose the declarative path when the orchestration itself is what you are building. Choose a Conductor Agent when the agent logic lives in code and you want to run it inside a durable process.
 
@@ -43,12 +43,12 @@ Every Conductor Agent moves through the same five operations, and the names belo
 1. **Create**: define the agent in code, from the SDK's own `Agent` class or from a supported framework object.
 2. **Plan**: inspect the workflow graph the agent will compile to. Useful during development and in CI, before anything is deployed.
 3. **Deploy**: register the compiled agent on the server as a reusable, versioned Conductor Agent.
-4. **Serve**: start the worker process that executes the agent's tools, where the bridge requires one.
+4. **Serve**: start the worker process that executes the agent's tools, where the framework requires one.
 5. **Run**: execute the agent. During development, `run` compiles and runs it in one step. In production, workflows invoke the deployed agent by name through an `AGENT` task.
 
 In short: use `run` while you iterate, then `deploy` and `serve` so workflows and other callers can start the stable deployed version.
 
-For framework-specific code, package versions, and runnable examples, see [Framework Agent Bridges](agent-framework-recipes.md). For server setup and credentials, complete [Connect to Conductor](../../quickstart/connect.md).
+For framework-specific code, package versions, and runnable examples, see [Framework Agents](agent-framework-recipes.md). For server setup and credentials, complete [Connect to Conductor](../../quickstart/connect.md).
 
 ## Use a deployed agent in a workflow
 
@@ -57,7 +57,7 @@ For framework-specific code, package versions, and runnable examples, see [Frame
 - `agentType: "a2a"` (default) calls a remote A2A endpoint.
 - `agentType: "conductor"` runs a deployed Conductor Agent selected by `name`.
 
-OpenAI Agents, Google ADK, LangGraph, and other supported bridges are SDK authoring paths. They are not `agentType` values.
+OpenAI Agents, Google ADK, LangGraph, and other supported frameworks are SDK authoring paths. They are not `agentType` values.
 
 ```json
 {
@@ -116,7 +116,7 @@ Before promotion, evaluate the recorded agent behavior—not only its final text
 
 ## Workflow-integration recipes
 
-These repository examples deliberately contain only the stable workflow contract. They are framework-agnostic; create and deploy `planner` / `researcher` with the SDK bridge appropriate to your framework.
+These repository examples deliberately contain only the stable workflow contract. They are framework-agnostic; create and deploy `planner` / `researcher` with the Conductor SDK for your framework.
 
 | Recipe | What it demonstrates |
 |---|---|
@@ -125,4 +125,4 @@ These repository examples deliberately contain only the stable workflow contract
 | [`33-conductor-agent-multi-agent.json`](https://github.com/conductor-oss/conductor/blob/main/ai/examples/33-conductor-agent-multi-agent.json) | Parallel specialist agents inside a `FORK_JOIN` / `JOIN` graph. |
 | [`34-conductor-agent-cancel.json`](https://github.com/conductor-oss/conductor/blob/main/ai/examples/34-conductor-agent-cancel.json) | Cancellation propagation from the parent graph. |
 
-Next: choose a framework route in [Framework Agent Bridges](agent-framework-recipes.md), compose the deployed agent in [Build Your First Agentic Workflow Graph](first-ai-agent.md), then use the [Production Agent Architecture](production-agent-architecture.md) for governance, evaluation, deployment, recovery, and operations.
+Next: choose a framework route in [Framework Agents](agent-framework-recipes.md), compose the deployed agent in [Build Your First Agentic Workflow Graph](first-ai-agent.md), then use the [Production Agent Architecture](production-agent-architecture.md) for governance, evaluation, deployment, recovery, and operations.

--- a/docs/devguide/ai/conductor-for-ai-assistants.md
+++ b/docs/devguide/ai/conductor-for-ai-assistants.md
@@ -15,7 +15,7 @@ Conductor supports two complementary AI paths:
 - **Native AI workflows:** compose LLM, MCP, vector, human approval, and control-flow system tasks in a workflow definition.
 - **Framework-authored agents:** compile a supported SDK or framework agent—such as OpenAI Agents, Google ADK, LangChain, or LangGraph—into a Conductor graph, then use it in a larger workflow.
 
-Use the [Agents & AI overview](index.md) for the product map and [framework agent recipes](agent-framework-recipes.md) for supported bridges.
+Use the [Agents & AI overview](index.md) for the product map and [framework agent recipes](agent-framework-recipes.md) for supported frameworks.
 
 ## Safe authoring rules
 
@@ -33,7 +33,7 @@ Use the [Agents & AI overview](index.md) for the product map and [framework agen
 |---|---|
 | Create a durable service workflow | [First workflow](../../quickstart/first-workflow.md) |
 | Build a governed plan/act/evaluate loop | [Durable Adaptive Graphs](dynamic-workflows.md) |
-| Bring an existing framework agent (LangChain, ADK, and more) | [Framework Agent Bridges](agent-framework-recipes.md) |
+| Bring an existing framework agent (LangChain, ADK, and more) | [Framework Agents](agent-framework-recipes.md) |
 | Add policy and approval | [Agent Guardrails](agent-guardrails.md) |
 | Test routes, tools, and output quality | [Agent Evals](agent-evals.md) |
 | Design a production agent system | [Production Agent Architecture](production-agent-architecture.md) |

--- a/docs/devguide/ai/cookbook/agent-tool-calling.md
+++ b/docs/devguide/ai/cookbook/agent-tool-calling.md
@@ -213,7 +213,7 @@ Save the agent above as `weather_agent.py`, `weather-agent.ts`, `SimpleToolAgent
 
 === "Python"
 
-    The core agent API ships in the base package. The `[agents]` extra is only needed for the LangChain, ADK, and OpenAI Agents bridges.
+    The core agent API ships in the base package. The `[agents]` extra is only needed for LangChain, ADK, and OpenAI Agents framework support.
 
     ```bash
     python -m pip install conductor-python

--- a/docs/devguide/ai/cookbook/google-adk-order-triage.md
+++ b/docs/devguide/ai/cookbook/google-adk-order-triage.md
@@ -2,16 +2,16 @@
 
 ```mermaid
 flowchart LR
-  G(["Written with Google ADK"]) --> B("Deployed through<br/>the Conductor bridge")
+  G(["Written with Google ADK"]) --> B("Deployed with<br/>the Conductor SDK")
   B --> A("Called like any<br/>other agent")
   A --> O(["Triage recommendation"])
 ```
 
 **Outcome:** author a non-mutating order-exception triage agent with Google ADK and invoke it through Conductor.
 
-## Prerequisites and authoring bridge
+## Prerequisites and authoring path
 
-The current Python SDK quickstart uses `python -m pip install 'conductor-python[adk]'`, `google.adk.agents.Agent`, and `AgentRuntime`. Verify the owning [Python SDK framework guide](https://github.com/conductor-oss/python-sdk/blob/main/docs/agents/framework-agents.md) before changing installation or bridge calls.
+The current Python SDK quickstart uses `python -m pip install 'conductor-python[adk]'`, `google.adk.agents.Agent`, and `AgentRuntime`. Verify the owning [Python SDK framework guide](https://github.com/conductor-oss/python-sdk/blob/main/docs/agents/framework-agents.md) before changing installation or framework-agent calls.
 
 ```python
 from conductor.ai.agents import AgentRuntime
@@ -28,7 +28,7 @@ with AgentRuntime() as runtime:
     runtime.run(agent, "Order O-42 arrived damaged.")
 ```
 
-Download the companion [`deploy_local_cookbook_agents.py`](assets/deploy_local_cookbook_agents.py) into your working directory; it creates this ADK-authored capability. Deploy once and keep the bridge worker running before invoking the parent:
+Download the companion [`deploy_local_cookbook_agents.py`](assets/deploy_local_cookbook_agents.py) into your working directory; it creates this ADK-authored capability. Deploy once and keep the tool worker running before invoking the parent:
 
 ```bash
 python3 deploy_local_cookbook_agents.py deploy
@@ -54,7 +54,7 @@ conductor workflow start -w google_adk_order_exception_triage --sync -i '{"order
 
 ## Production notes
 
-- **`agentType` is `conductor`, not `adk`.** The bridge runs it.
+- **`agentType` is `conductor`, not `adk`.** The Conductor SDK runs it.
 - **Use a model your server actually has configured** — `gemini-2.0-flash` if Gemini is set up.
 - **Cap tool access and the iteration budget in the deployment.**
 - **This recommends a disposition; it never applies one.** Route the action through an approval.

--- a/docs/devguide/ai/cookbook/index.md
+++ b/docs/devguide/ai/cookbook/index.md
@@ -61,7 +61,7 @@ Each of these carries the control that makes the pattern safe to run for real �
 
 ## AI Agents
 
-An agent owns its own reasoning loop: it decides which tool to call and when it is done. You author it with a Conductor SDK in Python, TypeScript, Java, or C#, or bring one written in LangChain or Google ADK through the Conductor bridge. Conductor supplies what the loop cannot give itself — every tool call is a durable, individually retryable task, and approval and cancellation are boundaries the agent cannot skip.
+An agent owns its own reasoning loop: it decides which tool to call and when it is done. You author it with a Conductor SDK in Python, TypeScript, Java, or C#, or bring one written in LangChain or Google ADK through the Conductor SDK. Conductor supplies what the loop cannot give itself — every tool call is a durable, individually retryable task, and approval and cancellation are boundaries the agent cannot skip.
 
 | Recipe | Outcome | Built from |
 |---|---|---|
@@ -72,8 +72,8 @@ An agent owns its own reasoning loop: it decides which tool to call and when it 
 | [Agent with CLI tools](agent-cli-tools.md) | Run real shell commands, restricted to an allowlist. | `cli_allowed_commands` |
 | [Massively parallel agents](agent-scatter-gather.md) | Fan out to 100 sub-agents and synthesize the results. | `scatter_gather()` |
 | [Conductor agent](reusable-conductor-agent.md) | Invoke a stable deployed capability from another workflow. | `AGENT` (`conductor`) |
-| [LangChain investigator](langchain-entitlement-investigator.md) | Author with LangChain and invoke through the Conductor bridge. | `AGENT` (`conductor`) |
-| [ADK triage](google-adk-order-triage.md) | Author with ADK and invoke through the Conductor bridge. | `AGENT` (`conductor`) |
+| [LangChain investigator](langchain-entitlement-investigator.md) | Author with LangChain and invoke through the Conductor SDK. | `AGENT` (`conductor`) |
+| [ADK triage](google-adk-order-triage.md) | Author with ADK and invoke through the Conductor SDK. | `AGENT` (`conductor`) |
 | [Specialist review](parallel-specialist-review.md) | Collect independent reviews with durable fan-out and join. | `AGENT`, `FORK_JOIN`, `JOIN` |
 | [Agent approval](human-approved-action.md) | Pause a deployed agent at its durable approval boundary. | `AGENT`, `SWITCH`, `HUMAN` |
 | [Agent cancellation](conductor-agent-cancellation.md) | Propagate parent termination to a long-running deployed agent. | `AGENT`, `FORK_JOIN`, `TERMINATE` |

--- a/docs/devguide/ai/cookbook/langchain-entitlement-investigator.md
+++ b/docs/devguide/ai/cookbook/langchain-entitlement-investigator.md
@@ -2,16 +2,16 @@
 
 ```mermaid
 flowchart LR
-  L(["Written with LangChain"]) --> B("Deployed through<br/>the Conductor bridge")
+  L(["Written with LangChain"]) --> B("Deployed with<br/>the Conductor SDK")
   B --> A("Called like any<br/>other agent")
   A --> O(["Investigation"])
 ```
 
-**Outcome:** author an entitlement investigator with LangChain, deploy it through the Conductor bridge, and invoke it as a durable capability.
+**Outcome:** author an entitlement investigator with LangChain, deploy it with the Conductor SDK, and invoke it as a durable capability.
 
-## Prerequisites and authoring bridge
+## Prerequisites and authoring path
 
-The current Python SDK quickstart documents the bridge installation as `pip install 'conductor-python[langchain]'`, `AgentRuntime`, and `runtime.run(agent, input)`. Verify the owning [Python SDK framework guide](https://github.com/conductor-oss/python-sdk/blob/main/docs/agents/framework-agents.md) before upgrading packages or bridge APIs.
+The current Python SDK quickstart documents the installation as `pip install 'conductor-python[langchain]'`, `AgentRuntime`, and `runtime.run(agent, input)`. Verify the owning [Python SDK framework guide](https://github.com/conductor-oss/python-sdk/blob/main/docs/agents/framework-agents.md) before upgrading packages or framework-agent APIs.
 
 ```python
 from langchain.agents import create_agent
@@ -24,7 +24,7 @@ agent = create_agent(
 )
 ```
 
-Download the companion [`deploy_local_cookbook_agents.py`](assets/deploy_local_cookbook_agents.py) into your working directory; it creates this LangChain-authored capability and its read-only fixture tool. Deploy once and keep the bridge worker running before invoking the parent:
+Download the companion [`deploy_local_cookbook_agents.py`](assets/deploy_local_cookbook_agents.py) into your working directory; it creates this LangChain-authored capability and its read-only fixture tool. Deploy once and keep the tool worker running before invoking the parent:
 
 ```bash
 python3 deploy_local_cookbook_agents.py deploy
@@ -50,8 +50,8 @@ conductor workflow start -w langchain_entitlement_investigator --sync -i '{"cust
 
 ## Production notes
 
-- **`agentType` is `conductor`, not `langchain`.** The bridge runs it; the protocol doesn't change.
+- **`agentType` is `conductor`, not `langchain`.** The Conductor SDK runs it; the protocol doesn't change.
 - **Bound tokens and tool calls in the deployed agent,** where the loop actually runs.
 - **Pass document references, not payloads.**
 - **Reconcile duplicate runs by customer ID plus request ID.**
-- **Check the SDK source before bumping package versions.** The bridge API moves.
+- **Check the SDK source before bumping package versions.** The framework-agent API moves.

--- a/docs/devguide/ai/cookbook/reusable-conductor-agent.md
+++ b/docs/devguide/ai/cookbook/reusable-conductor-agent.md
@@ -40,7 +40,7 @@ with AgentRuntime() as runtime:
     runtime.run(agent, "Summarize the incident and notify ops.").print_result()
 ```
 
-For a runnable local deployment, download the companion [`deploy_local_cookbook_agents.py`](assets/deploy_local_cookbook_agents.py) into your working directory. It deploys this capability as `guarded-incident-planner` and keeps its bridge worker available:
+For a runnable local deployment, download the companion [`deploy_local_cookbook_agents.py`](assets/deploy_local_cookbook_agents.py) into your working directory. It deploys this capability as `guarded-incident-planner` and keeps its tool worker available:
 
 ```bash
 python3 deploy_local_cookbook_agents.py deploy

--- a/docs/devguide/ai/first-ai-agent.md
+++ b/docs/devguide/ai/first-ai-agent.md
@@ -42,7 +42,7 @@ Start with one of these maintained, runnable SDK paths:
 
 - [Run Your First Conductor Agent](../../quickstart/first-agent.md) — Python example; Conductor Agents also support Java, TypeScript/JavaScript, and C#.
 - [Framework Agent Quickstarts](../../quickstart/framework-agents.md) — OpenAI Agents, Google ADK, LangChain/LangChain4j, LangGraph/LangGraph4j, and Vercel AI SDK.
-- [Framework Agent Bridges](agent-framework-recipes.md) — the supported SDK, lifecycle, and executable example for every bridge.
+- [Framework Agents](agent-framework-recipes.md) — the supported SDK, lifecycle, and executable example for every framework.
 
 For this tutorial, deploy an agent named `greeter`. The agent takes a prompt and returns a concise answer. The framework code belongs in the maintained SDK example; the workflow below needs only the stable deployed-agent contract.
 
@@ -176,6 +176,6 @@ From here, add ordinary Conductor capabilities around the same agent: a `HUMAN` 
 ## Next steps
 
 - [Conductor Agents](conductor-agents.md) — complete `AGENT` input, output, wait/resume, timeout, and cancellation contract.
-- [Framework Agent Bridges](agent-framework-recipes.md) — choose the supported SDK bridge for your framework.
+- [Framework Agents](agent-framework-recipes.md) — choose the supported Conductor SDK for your framework.
 - [Human-in-the-Loop](human-in-the-loop.md) — pause a graph for review and resume an agent safely.
 - [A2A Integration](a2a-integration.md) — use a remote A2A agent instead of an SDK-authored Conductor Agent.

--- a/docs/devguide/ai/index.md
+++ b/docs/devguide/ai/index.md
@@ -103,7 +103,7 @@ Conductor applies the same durable execution model to adaptive agents and ordina
   <div class="agent-overview-card"><strong>Policy and guardrails</strong><span>Validate model proposals and constrain tools, inputs, fan-out, time, and cost before execution.</span></div>
   <div class="agent-overview-card"><strong>Turn-by-turn observability</strong><span>Inspect the durable record of decisions, policy outcomes, task data, timing, and failures.</span></div>
   <div class="agent-overview-card"><strong>Human control</strong><span>Pause without losing state, collect review or input, then resume the same execution.</span></div>
-  <div class="agent-overview-card"><strong>Framework and protocol interoperability</strong><span>Use supported framework bridges, MCP tools, and remote A2A agents behind stable workflow boundaries.</span></div>
+  <div class="agent-overview-card"><strong>Framework and protocol interoperability</strong><span>Use supported agent frameworks, MCP tools, and remote A2A agents behind stable workflow boundaries.</span></div>
   <div class="agent-overview-card"><strong>Ordinary workflow composition</strong><span>Place agents beside APIs, workers, branching, schedules, notifications, and compensation logic.</span></div>
 </div>
 

--- a/docs/devguide/ai/production-agent-architecture.md
+++ b/docs/devguide/ai/production-agent-architecture.md
@@ -74,7 +74,7 @@ Every path starts and ends in the parent workflow: validate the request, choose 
 The parent workflow can use one or more of these execution paths. Choose the path based on where the agent behavior belongs; all three participate in the same durable business process.
 
 - **Native AI tasks** run directly in the workflow graph. Use `LLM_CHAT_COMPLETE`, MCP tasks, `HUMAN`, and control-flow tasks when the workflow definition is the agent implementation.
-- **Deployed Conductor Agents** run through an `AGENT` task with `agentType: "conductor"`. They include agents authored with a Conductor SDK or framework bridges for OpenAI Agents, Google ADK, LangChain, LangGraph, and Vercel AI SDK. Conductor compiles these agents into deployed workflow graphs.
+- **Deployed Conductor Agents** run through an `AGENT` task with `agentType: "conductor"`. They include agents authored with a Conductor SDK or brought from OpenAI Agents, Google ADK, LangChain, LangGraph, and Vercel AI SDK. Conductor compiles these agents into deployed workflow graphs.
 - **Remote A2A agents** run through an `AGENT` task with `agentType: "a2a"`. This is a durable handoff to an independently deployed Agent2Agent service: Conductor manages the parent-workflow lifecycle, while the remote service keeps its own implementation and internals.
 
 `agentType` selects the execution mode; it does not name an authoring framework. Use `SUB_WORKFLOW` or `START_WORKFLOW` to compose child workflows, and use `AGENT` when the parent invokes an agent runtime.
@@ -82,7 +82,7 @@ The parent workflow can use one or more of these execution paths. Choose the pat
 | Boundary | Use it when | Execution and observability |
 |---|---|---|
 | Native tasks | The workflow graph owns the orchestration and agent behavior. | Native system tasks execute and are observable in Conductor. |
-| `AGENT` / `agentType: "conductor"` | The agent is authored in a Conductor SDK or a supported framework bridge: OpenAI Agents, Google ADK, LangChain, LangGraph, or Vercel AI SDK. | Conductor compiles and runs the deployed agent graph, so its execution is observable in Conductor. |
+| `AGENT` / `agentType: "conductor"` | The agent is authored in a Conductor SDK or brought from a supported framework: OpenAI Agents, Google ADK, LangChain, LangGraph, or Vercel AI SDK. | Conductor compiles and runs the deployed agent graph, so its execution is observable in Conductor. |
 | `AGENT` / `agentType: "a2a"` | A specialist is independently deployed as a remote A2A service. | Conductor observes the durable handoff, lifecycle, and returned artifacts; the remote agent owns its private internals. |
 | `SUB_WORKFLOW` / `START_WORKFLOW` | You are composing another Conductor workflow, synchronously or fire-and-forget. | These compose workflow definitions; they do not invoke either `AGENT` runtime mode. |
 
@@ -104,7 +104,7 @@ The parent workflow can use one or more of these execution paths. Choose the pat
 - Run one recovery drill: interrupt a safe execution, locate it by correlation ID, retry, resume, or terminate as appropriate, and verify the audit trail.
 - Keep releases KISS: test the changed path against sandbox tools, deploy it, and retain a known-good definition for rollback.
 
-For implementation details, see [Conductor Agents](conductor-agents.md), [Framework Agent Bridges](agent-framework-recipes.md), [A2A Integration](a2a-integration.md), [Guardrails](agent-guardrails.md), [Evals](agent-evals.md), [Failure Semantics](failure-semantics.md), and [Durable Adaptive Graphs](dynamic-workflows.md).
+For implementation details, see [Conductor Agents](conductor-agents.md), [Framework Agents](agent-framework-recipes.md), [A2A Integration](a2a-integration.md), [Guardrails](agent-guardrails.md), [Evals](agent-evals.md), [Failure Semantics](failure-semantics.md), and [Durable Adaptive Graphs](dynamic-workflows.md).
 
 ## Native-task implementation: architecture diagram
 
@@ -600,7 +600,7 @@ The parent waits for the child workflow to complete. If it fails, the parent's f
 ## Next steps
 
 - **[Conductor Agents](conductor-agents.md)** — Use this architecture around a deployed SDK-authored agent graph.
-- **[Framework Agent Bridges](agent-framework-recipes.md)** — Supported framework routes and maintained SDK examples.
+- **[Framework Agents](agent-framework-recipes.md)** — Supported framework routes and maintained SDK examples.
 - **[A2A Integration](a2a-integration.md)** — Hand off to independently deployed A2A agents while retaining a durable parent-workflow boundary.
 - **[Failure Semantics for AI Agents](failure-semantics.md)** — The exact failure contract: what happens under crashes, retries, duplicates, and long waits.
 - **[Why Conductor for Agents](why-conductor.md)** — What Conductor gives you out of the box for agentic workflows.

--- a/docs/devguide/ai/why-conductor.md
+++ b/docs/devguide/ai/why-conductor.md
@@ -309,7 +309,7 @@ Every agentic pattern maps to a specific Conductor primitive:
 ## Next steps
 
 - **[Conductor Agents](conductor-agents.md)** — Author Conductor Agents or bring existing framework agents into durable Conductor graphs.
-- **[Framework Agent Bridges](agent-framework-recipes.md)** — Supported SDK paths for OpenAI Agents, Google ADK, LangChain, LangGraph, Vercel AI SDK, and Conductor Agents.
+- **[Framework Agents](agent-framework-recipes.md)** — Supported SDK paths for OpenAI Agents, Google ADK, LangChain, LangGraph, Vercel AI SDK, and Conductor Agents.
 - **[Production Agent Architecture](production-agent-architecture.md)** — The canonical end-to-end agent pattern, fully wired.
 - **[Failure Semantics for AI Agents](failure-semantics.md)** — The exact failure contract under every scenario.
 - **[Build Your First Agentic Workflow Graph](first-ai-agent.md)** — Compose an SDK-authored agent with durable workflow tasks.

--- a/docs/documentation/api/agents.md
+++ b/docs/documentation/api/agents.md
@@ -26,7 +26,7 @@ http://localhost:8080/api/agent
 | `GET` | `/{name}?version=` | Get a registered agent definition. |
 | `DELETE` | `/{name}?version=` | Delete a registered agent definition. |
 
-`/compile`, `/deploy`, and `/start` accept an `AgentStartRequest`. To use a previously deployed agent, provide `name` and optionally `version`. To create an agent inline, provide either `agentConfig` for a Conductor Agent or `framework` plus framework-specific `rawConfig` for a supported bridge.
+`/compile`, `/deploy`, and `/start` accept an `AgentStartRequest`. To use a previously deployed agent, provide `name` and optionally `version`. To create an agent inline, provide either `agentConfig` for a Conductor Agent or `framework` plus framework-specific `rawConfig` for a supported framework.
 
 ```json
 {
@@ -96,5 +96,5 @@ The skill endpoints are present only when skill packages are enabled on the serv
 ## Related guides
 
 - [Conductor Agents](../../devguide/ai/conductor-agents.md) — SDK creation, deploy/serve lifecycle, and use as an `AGENT` task.
-- [Framework Agent Bridges](../../devguide/ai/agent-framework-recipes.md) — OpenAI Agents, Google ADK, LangChain, LangGraph, Vercel AI SDK, and Conductor Agent paths.
+- [Framework Agents](../../devguide/ai/agent-framework-recipes.md) — OpenAI Agents, Google ADK, LangChain, LangGraph, Vercel AI SDK, and Conductor Agent paths.
 - [A2A Integration](../../devguide/ai/a2a-integration.md) — Remote A2A agents; this is a separate `AGENT` mode.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,22 +31,22 @@ description: Conductor is an open-source platform for building production-grade 
       <span>Get started with a free hosted version of Conductor.</span>
       <span class="home-card-cta">Start for free &rarr;</span>
     </a>
-    <a class="integration-action-card" href="quickstart/connect.html">
-      <span class="home-card-icon"><svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M4.5 16.5c-1.5 1.3-2 5-2 5s3.7-.5 5-2c.7-.8.7-2 0-2.8-.8-.7-2.2-.7-3 .8Z"/><path d="m12 15-3-3a22 22 0 0 1 2-3.9A12.7 12.7 0 0 1 21.5 2.5c0 2.7-.8 7.5-5.6 10.5a22.4 22.4 0 0 1-3.9 2Z"/><path d="M9 12H4s.5-3 2-4c1.6-1.1 5 0 5 0"/><path d="M12 15v5s3-.5 4-2c1.1-1.6 0-5 0-5"/></svg></span>
-      <span class="integration-action-card__title">Deploy Conductor in minutes</span>
-      <span>Install conductor and quickly deploy your first agents and workflows.</span>
-      <span class="home-card-cta">Set up Conductor &rarr;</span>
+    <a class="integration-action-card" href="devguide/how-tos/conductor-skills.html">
+      <span class="home-card-icon"><svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3 1.9 5.1L19 10l-5.1 1.9L12 17l-1.9-5.1L5 10l5.1-1.9Z"/><path d="m19 15 .8 2.2L22 18l-2.2.8L19 21l-.8-2.2L16 18l2.2-.8Z"/></svg></span>
+      <span class="integration-action-card__title">Conductor Skills</span>
+      <span>Using an AI coding agent? Install Conductor Skills so it can build and operate workflows.</span>
+      <span class="home-card-cta">Install skills &rarr;</span>
     </a>
-    <a class="integration-action-card" href="https://github.com/conductor-oss/conductor/releases">
-      <span class="home-card-icon"><svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></span>
-      <span class="integration-action-card__title">Download Conductor OSS</span>
-      <span>Download and install the latest release from the official GitHub repo.</span>
-      <span class="home-card-cta">Install Conductor &rarr;</span>
+    <a class="integration-action-card" href="devguide/ai/cookbook/index.html">
+      <span class="home-card-icon"><svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg></span>
+      <span class="integration-action-card__title">AI Cookbook</span>
+      <span>Complete, runnable AI workflow recipes: agents, tools, approvals, and delivery.</span>
+      <span class="home-card-cta">Open the cookbook &rarr;</span>
     </a>
     <a class="integration-action-card" href="devguide/running/deploy.html">
       <span class="home-card-icon"><svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v14a9 3 0 0 0 18 0V5"/><path d="M3 12a9 3 0 0 0 18 0"/></svg></span>
       <span class="integration-action-card__title">Self-hosting</span>
-      <span>Deploy Conductor OSS with Docker, shared persistence, and production-ready topology.</span>
+      <span>Install the latest release and deploy Conductor OSS with Docker, shared persistence, and production-ready topology.</span>
       <span class="home-card-cta">Deploy OSS &rarr;</span>
     </a>
     <a class="integration-action-card" href="devguide/cookbook/index.html">

--- a/docs/quickstart/framework-agents.md
+++ b/docs/quickstart/framework-agents.md
@@ -6,7 +6,7 @@ description: Run an existing OpenAI Agents, Google ADK, LangChain, or LangGraph 
 
 **Outcome:** your framework agent runs through Conductor and produces an inspectable execution.
 
-This page is for agents you have already built in another framework, such as OpenAI Agents, LangChain, LangGraph, or Google ADK. A **bridge** is the SDK adapter that lets Conductor run such an agent: you keep the agent object your framework already defines, and the bridge runs it as a durable, inspectable Conductor execution. If you are starting from scratch instead, build a native agent with [Your First Agent](first-agent.md).
+This page is for agents you have already built in another framework, such as OpenAI Agents, LangChain, LangGraph, or Google ADK. You keep the agent object your framework already defines, and the Conductor SDK compiles and runs it as a durable, inspectable Conductor execution. If you are starting from scratch instead, build a native agent with [Your First Agent](first-agent.md).
 
 <section class="framework-hero" aria-labelledby="framework-quickstarts-title">
   <h2 id="framework-quickstarts-title">Bring your existing agent.</h2>
@@ -32,11 +32,11 @@ This page is for agents you have already built in another framework, such as Ope
 
 ## Prerequisites
 
-First, complete [Connect to Conductor](connect.md) so the runtime can reach your server. Then make sure the server can call your model provider. On Developer Edition, add the provider as an [AI/LLM integration](https://orkes.io/content/category/integrations/ai-llm); on a local server, [export the provider API key](../devguide/ai/llm-orchestration.md#supported-llm-providers) before starting it. Each framework section below begins with the install command for its bridge. Most examples use an OpenAI model, and the Google ADK example uses Gemini, so supply the matching credentials.
+First, complete [Connect to Conductor](connect.md) so the runtime can reach your server. Then make sure the server can call your model provider. On Developer Edition, add the provider as an [AI/LLM integration](https://orkes.io/content/category/integrations/ai-llm); on a local server, [export the provider API key](../devguide/ai/llm-orchestration.md#supported-llm-providers) before starting it. Each framework section below begins with its install command. Most examples use an OpenAI model, and the Google ADK example uses Gemini, so supply the matching credentials.
 
 ## OpenAI Agents SDK
 
-Install the agent bridge and OpenAI Agents SDK:
+Install the Conductor SDK with OpenAI Agents support:
 
 ```bash
 pip install conductor-python
@@ -67,7 +67,7 @@ Run `python openai_agent.py`, then verify the output and execution in the UI. Th
 
 ## LangChain
 
-Install the LangChain bridge:
+Install the Conductor SDK with LangChain support:
 
 ```bash
 pip install 'conductor-python[langchain]'
@@ -93,7 +93,7 @@ with AgentRuntime() as runtime:
 
 ## LangGraph
 
-Install the LangGraph bridge:
+Install the Conductor SDK with LangGraph support:
 
 ```bash
 pip install 'conductor-python[langgraph]'
@@ -122,7 +122,7 @@ with AgentRuntime() as runtime:
 
 ## Google ADK
 
-Install the Google ADK bridge:
+Install the Conductor SDK with Google ADK support:
 
 ```bash
 python -m pip install 'conductor-python[adk]'
@@ -147,13 +147,13 @@ Save the file as `adk_agent.py` and run `python adk_agent.py`.
 
 ## Verify and recover
 
-For every bridge, verify the printed result and find the corresponding execution in the Conductor UI. If it fails, first check the runtime server URL, framework package, and provider credentials; then inspect the failed task before retrying. Do not retry an agent action that may have performed an external side effect until its idempotency and recovery policy are clear.
+For every framework, verify the printed result and find the corresponding execution in the Conductor UI. If it fails, first check the runtime server URL, framework package, and provider credentials; then inspect the failed task before retrying. Do not retry an agent action that may have performed an external side effect until its idempotency and recovery policy are clear.
 
 ## Next production step
 
 **Next:** every entry in [Design Patterns → Agent Recipes](../devguide/ai/cookbook/index.md) is a complete, runnable example — handoffs, memory, guardrails, parallel agents, and more.
 
-Use the [production agent architecture](../devguide/ai/production-agent-architecture.md) to add governance, evaluations, deployment, composition, and operations. The [Python SDK framework-agent guide](https://github.com/conductor-oss/python-sdk/blob/main/docs/agents/framework-agents.md) remains the source for the current bridge API and support matrix.
+Use the [production agent architecture](../devguide/ai/production-agent-architecture.md) to add governance, evaluations, deployment, composition, and operations. The [Python SDK framework-agent guide](https://github.com/conductor-oss/python-sdk/blob/main/docs/agents/framework-agents.md) remains the source for the current framework-agent API and support matrix.
 
 ## SDK examples
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,7 +62,7 @@ nav:
     - Your First Agent: /conductor/quickstart/first-agent.html?nav=agents-ai
     - Build:
       - Conductor Agents: devguide/ai/conductor-agents.md
-      - Framework Agent Bridges: devguide/ai/agent-framework-recipes.md
+      - Framework Agents: devguide/ai/agent-framework-recipes.md
       - Build Agentic Workflow Graph: devguide/ai/first-ai-agent.md
       - LLM Orchestration: devguide/ai/llm-orchestration.md
       - Durable Adaptive Graphs: devguide/ai/dynamic-workflows.md


### PR DESCRIPTION
- Make docs illustrations readable in dark mode 
- Fix repeated content blocks and add a Conductor Skills reference 
- Scrub "bridge" / "Framework Agent bridge" wording everywhere
- Fix misaligned headlines on the AI devguide page 
- Add redirects for the handful of restructured legacy /content/* URLs that now 404