### PR TITLE
Fix references to design docs removed from the repo

### DIFF
--- a/ai/src/test/java/org/conductoross/conductor/ai/a2a/A2ADurabilityTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/a2a/A2ADurabilityTest.java
@@ -41,9 +41,9 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.spy;
 
 /**
- * Durability test-harness — validates the proof obligations from {@code
- * design/a2a/09-durable-a2a.md} by injecting failures against a real embedded A2A agent and the
- * real annotation-backed {@link A2AWorkers} / {@link A2AService} logic.
+ * Durability test-harness — validates the P1–P3 durability proof obligations tabulated below by
+ * injecting failures against a real embedded A2A agent and the real annotation-backed {@link
+ * A2AWorkers} / {@link A2AService} logic.
  *
  * <table>
  *   <tr><td>T1</td><td>{@link #t1_crashRecovery_resumesOnAFreshInstance()}</td><td>P1 crash-safe resume</td></tr>

--- a/ai/src/test/resources/a2a/durable-demo/README.md
+++ b/ai/src/test/resources/a2a/durable-demo/README.md
@@ -64,7 +64,8 @@ Tunables: `SELLER_DELAY` (seconds the order stays in preparation; default 45).
 The A2A protocol is stateless request/response; **durability is a property of the orchestrator,
 not the protocol**. Run the same concierge pattern on an in-memory host and the crash loses the
 order — there is no resume. On Conductor, the agent interaction is a persisted, resumable task.
-That is the "durable A2A" claim, demonstrated (see `design/a2a/09-durable-a2a.md`).
+That is the "durable A2A" claim, demonstrated (the proof obligations behind it are exercised by
+`ai/src/test/java/org/conductoross/conductor/ai/a2a/A2ADurabilityTest.java`).
 
 ## Notes
 

--- a/docs/documentation/advanced/file-storage.md
+++ b/docs/documentation/advanced/file-storage.md
@@ -235,8 +235,6 @@ attempt each.
   after a complete response.
 - Content URLs are redacted from errors. When signing is enabled, URLs are bearer credentials.
 
-The detailed component and lifecycle rationale is in the [file storage design document](https://github.com/conductor-oss/conductor/blob/main/design/file-storage.md) in the repository.
-
 ## Migration from smart file objects
 
 The current contract replaces `FileHandler`, `ManagedFileHandler`, `FileUploader`, and


### PR DESCRIPTION
The `design/` folder is no longer tracked (it came out with the `agent_docs` merge, #1406), which left three pointers into it dangling.

- `A2ADurabilityTest` javadoc cited `design/a2a/09-durable-a2a.md` as the source of its proof obligations. The P1–P3 obligations are already tabulated in the javadoc itself, so it now cites that table.
- `ai/src/test/resources/a2a/durable-demo/README.md` pointed at the same file; it now points at `A2ADurabilityTest`, which actually exercises the claim.
- `docs/documentation/advanced/file-storage.md` linked to `https://github.com/conductor-oss/conductor/blob/main/design/file-storage.md`. That link 404s and always did — the file only ever existed on a branch, never on `main`. Dropped the sentence; the bullets above it already carry the component and lifecycle detail.

## Verification

- `./gradlew :conductor-ai:spotlessApply` — clean, no reformatting of the edited file
- `./gradlew :conductor-ai:compileTestJava` — BUILD SUCCESSFUL
- `PYTHONPATH=. python3 -m mkdocs build --strict` — passes
- `python3 scripts/check-workflows-docs.py` — passes
- `git grep` confirms no `design/` or `blob/main/design` references remain in tracked files

Note: the docs deploy on `main` is currently broken for an unrelated reason (run 32411004435 — `cannot find module 'main'` from `mkdocs.yml:283`). That needs a separate one-line workflow fix, which can't be pushed without a token carrying the `workflow` scope.