### PR TITLE
feat(common): add rerunParentDownstreamTasks to RerunWorkflowRequest

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/RerunWorkflowRequest.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/RerunWorkflowRequest.java
@@ -35,6 +35,14 @@ public class RerunWorkflowRequest {
     @ProtoField(id = 5)
     private String correlationId;
 
+    /**
+     * When rerunning from a task inside a sub-workflow, also re-run the downstream tasks of each
+     * ancestor workflow. Off by default: only the workflow named in the request is re-run, and
+     * already-completed tasks in its ancestors are left as they are.
+     */
+    @ProtoField(id = 6)
+    private boolean rerunParentDownstreamTasks;
+
     public String getReRunFromWorkflowId() {
         return reRunFromWorkflowId;
     }
@@ -65,6 +73,14 @@ public class RerunWorkflowRequest {
 
     public void setTaskInput(Map<String, Object> taskInput) {
         this.taskInput = taskInput;
+    }
+
+    public boolean isRerunParentDownstreamTasks() {
+        return rerunParentDownstreamTasks;
+    }
+
+    public void setRerunParentDownstreamTasks(boolean rerunParentDownstreamTasks) {
+        this.rerunParentDownstreamTasks = rerunParentDownstreamTasks;
     }
 
     public String getCorrelationId() {


### PR DESCRIPTION
Rerunning from a task inside a sub-workflow can either re-run just that workflow, or also re-run the downstream tasks of every ancestor. The second is useful when a corrected result has to flow up through the parents, but it re-runs tasks that already completed, so it can't be the default.

Adds the flag with `@ProtoField(id = 6)`, defaulting to `false` — the existing behaviour. No engine change here; this only makes the option expressible on the request.