### PR TITLE
Fix #1569 Postgres metadata 404/409 status codes

### DIFF
--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAO.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import javax.sql.DataSource;
 
@@ -28,11 +29,13 @@ import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDefSummary;
 import com.netflix.conductor.core.exception.ConflictException;
+import com.netflix.conductor.core.exception.NonTransientException;
 import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.dao.EventHandlerDAO;
 import com.netflix.conductor.dao.MetadataDAO;
 import com.netflix.conductor.metrics.Monitors;
 import com.netflix.conductor.postgres.config.PostgresProperties;
+import com.netflix.conductor.postgres.util.ExecuteFunction;
 import com.netflix.conductor.postgres.util.ExecutorsUtil;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -117,7 +120,7 @@ public class PostgresMetadataDAO extends PostgresBaseDAO implements MetadataDAO,
     public void removeTaskDef(String name) {
         final String DELETE_TASKDEF_QUERY = "DELETE FROM meta_task_def WHERE name = ?";
 
-        executeWithTransaction(
+        executeWithMetadataTransaction(
                 DELETE_TASKDEF_QUERY,
                 q -> {
                     if (!q.addParameter(name).executeDelete()) {
@@ -132,7 +135,7 @@ public class PostgresMetadataDAO extends PostgresBaseDAO implements MetadataDAO,
     public void createWorkflowDef(WorkflowDef def) {
         validate(def);
 
-        withTransaction(
+        withMetadataTransaction(
                 tx -> {
                     if (workflowExists(tx, def)) {
                         throw new ConflictException(
@@ -179,7 +182,7 @@ public class PostgresMetadataDAO extends PostgresBaseDAO implements MetadataDAO,
         final String DELETE_WORKFLOW_QUERY =
                 "DELETE from meta_workflow_def WHERE name = ? AND version = ?";
 
-        withTransaction(
+        withMetadataTransaction(
                 tx -> {
                     // remove specified workflow
                     execute(
@@ -283,7 +286,7 @@ public class PostgresMetadataDAO extends PostgresBaseDAO implements MetadataDAO,
                 "INSERT INTO meta_event_handler (name, event, active, json_data) "
                         + "VALUES (?, ?, ?, ?)";
 
-        withTransaction(
+        withMetadataTransaction(
                 tx -> {
                     if (getEventHandler(tx, eventHandler.getName()) != null) {
                         throw new ConflictException(
@@ -315,7 +318,7 @@ public class PostgresMetadataDAO extends PostgresBaseDAO implements MetadataDAO,
                         + "modified_on = CURRENT_TIMESTAMP WHERE name = ?";
         // @formatter:on
 
-        withTransaction(
+        withMetadataTransaction(
                 tx -> {
                     EventHandler existing = getEventHandler(tx, eventHandler.getName());
                     if (existing == null) {
@@ -339,7 +342,7 @@ public class PostgresMetadataDAO extends PostgresBaseDAO implements MetadataDAO,
     public void removeEventHandler(String name) {
         final String DELETE_EVENT_HANDLER_QUERY = "DELETE FROM meta_event_handler WHERE name = ?";
 
-        withTransaction(
+        withMetadataTransaction(
                 tx -> {
                     EventHandler existing = getEventHandler(tx, name);
                     if (existing == null) {
@@ -579,6 +582,33 @@ public class PostgresMetadataDAO extends PostgresBaseDAO implements MetadataDAO,
         return queryWithTransaction(
                 READ_ONE_TASKDEF_QUERY,
                 q -> q.addParameter(name).executeAndFetchFirst(TaskDef.class));
+    }
+
+    private void withMetadataExceptionHandling(Runnable runnable) {
+        try {
+            runnable.run();
+        } catch (NonTransientException e) {
+            throw unwrapMetadataException(e);
+        }
+    }
+
+    private RuntimeException unwrapMetadataException(NonTransientException exception) {
+        Throwable current = exception;
+        while (current != null) {
+            if (current instanceof ConflictException || current instanceof NotFoundException) {
+                return (RuntimeException) current;
+            }
+            current = current.getCause();
+        }
+        return exception;
+    }
+
+    private void withMetadataTransaction(Consumer<Connection> consumer) {
+        withMetadataExceptionHandling(() -> withTransaction(consumer));
+    }
+
+    private void executeWithMetadataTransaction(String query, ExecuteFunction function) {
+        withMetadataExceptionHandling(() -> executeWithTransaction(query, function));
     }
 
     private String insertOrUpdateTaskDef(TaskDef taskDef) {

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAOTest.java
@@ -39,7 +39,8 @@ import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDefSummary;
-import com.netflix.conductor.core.exception.NonTransientException;
+import com.netflix.conductor.core.exception.ConflictException;
+import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.postgres.config.PostgresConfiguration;
 
 import static org.junit.Assert.assertEquals;
@@ -78,18 +79,17 @@ public class PostgresMetadataDAOTest {
 
         metadataDAO.createWorkflowDef(def);
 
-        NonTransientException applicationException =
-                assertThrows(NonTransientException.class, () -> metadataDAO.createWorkflowDef(def));
+        ConflictException applicationException =
+                assertThrows(ConflictException.class, () -> metadataDAO.createWorkflowDef(def));
         assertEquals(
                 "Workflow with testDuplicate.1 already exists!", applicationException.getMessage());
     }
 
     @Test
     public void testRemoveNotExistingWorkflowDef() {
-        NonTransientException applicationException =
+        NotFoundException applicationException =
                 assertThrows(
-                        NonTransientException.class,
-                        () -> metadataDAO.removeWorkflowDef("test", 1));
+                        NotFoundException.class, () -> metadataDAO.removeWorkflowDef("test", 1));
         assertEquals(
                 "No such workflow definition: test version: 1", applicationException.getMessage());
     }
@@ -234,9 +234,9 @@ public class PostgresMetadataDAOTest {
 
     @Test
     public void testRemoveNotExistingTaskDef() {
-        NonTransientException applicationException =
+        NotFoundException applicationException =
                 assertThrows(
-                        NonTransientException.class,
+                        NotFoundException.class,
                         () -> metadataDAO.removeTaskDef("test" + UUID.randomUUID().toString()));
         assertEquals("No such task definition", applicationException.getMessage());
     }
@@ -257,6 +257,13 @@ public class PostgresMetadataDAOTest {
         eventHandler.setEvent(event1);
 
         metadataDAO.addEventHandler(eventHandler);
+        ConflictException conflictException =
+                assertThrows(
+                        ConflictException.class, () -> metadataDAO.addEventHandler(eventHandler));
+        assertEquals(
+                "EventHandler with name " + eventHandler.getName() + " already exists!",
+                conflictException.getMessage());
+
         List<EventHandler> all = metadataDAO.getAllEventHandlers();
         assertNotNull(all);
         assertEquals(1, all.size());
@@ -282,6 +289,29 @@ public class PostgresMetadataDAOTest {
         byEvents = metadataDAO.getEventHandlersForEvent(event2, true);
         assertNotNull(byEvents);
         assertEquals(1, byEvents.size());
+    }
+
+    @Test
+    public void testMissingEventHandlerOperations() {
+        EventHandler eventHandler = new EventHandler();
+        eventHandler.setName(UUID.randomUUID().toString());
+        eventHandler.setEvent("SQS::arn:account090:missing");
+
+        NotFoundException updateException =
+                assertThrows(
+                        NotFoundException.class,
+                        () -> metadataDAO.updateEventHandler(eventHandler));
+        assertEquals(
+                "EventHandler with name " + eventHandler.getName() + " not found!",
+                updateException.getMessage());
+
+        NotFoundException removeException =
+                assertThrows(
+                        NotFoundException.class,
+                        () -> metadataDAO.removeEventHandler(eventHandler.getName()));
+        assertEquals(
+                "EventHandler with name " + eventHandler.getName() + " not found!",
+                removeException.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #1569.

Postgres metadata operations can intentionally throw metadata domain exceptions, such as `ConflictException` and `NotFoundException`, from inside transaction callbacks. Today those exceptions can be wrapped by the Postgres transaction helper as `NonTransientException`, so the API exception mapper sees a generic server error and returns 500 instead of the intended 409/404.

This PR takes a conservative, metadata-scoped approach.

A broader fix in `PostgresBaseDAO` would arguably be cleaner because it would avoid wrapping these domain exceptions in the first place, rather than unwrapping them later in `PostgresMetadataDAO`. However, changing the base transaction wrapper would affect all Postgres DAO implementations, including execution, queue, rate limiting, locking, and other persistence paths. That broader exception behavior change seems too risky for this bug fix.

Instead, this PR keeps the existing `PostgresBaseDAO` behavior unchanged and only restores the expected `ConflictException` / `NotFoundException` behavior for metadata operations affected by #1569.

## Changes

- Add metadata-scoped transaction helpers in `PostgresMetadataDAO`
- Unwrap only metadata `ConflictException` / `NotFoundException` causes
- Keep `PostgresBaseDAO` transaction wrapping behavior unchanged
- Cover duplicate workflow/event handler metadata cases
- Cover missing workflow/task/event handler metadata cases