### PR TITLE
feat: delegated OAuth access for workflow runs

### DIFF
--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/controller/AgentController.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/controller/AgentController.java
@@ -137,9 +137,18 @@ public class AgentController {
         agentService.pushFrameworkEvent(executionId, event);
     }
 
-    /** List all registered agents. */
+    /**
+     * List agents. When {@code endpoint} is provided, returns agents discovered from that Microsoft
+     * Foundry project URL instead of the local registry. {@code credentialRef} names the secret
+     * holding auth credentials (API key or Service Principal JSON); omit to use ambient identity.
+     */
     @GetMapping("/list")
-    public List<AgentSummary> listAgents() {
+    public List<AgentSummary> listAgents(
+            @RequestParam(name = "endpoint", required = false) String endpoint,
+            @RequestParam(name = "credentialRef", required = false) String credentialRef) {
+        if (endpoint != null && !endpoint.isBlank()) {
+            return agentService.listExternalAgents(credentialRef, endpoint);
+        }
         return agentService.listAgents();
     }
 

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/controller/OAuthController.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/controller/OAuthController.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.agentspan.runtime.controller;
+
+import java.util.List;
+
+import org.conductoross.conductor.ai.agentspan.runtime.service.OAuthTokenService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Endpoints for the delegated-access OAuth 2.0 flow.
+ *
+ * <ul>
+ *   <li>{@code GET /api/oauth/authorize} — returns the provider authorization URL for the UI to
+ *       open as a popup
+ *   <li>{@code GET /api/oauth/callback} — receives the authorization code from the provider,
+ *       exchanges it for a refresh token, stores it as a secret, and closes the popup
+ * </ul>
+ */
+@RestController
+@RequestMapping("/api/oauth")
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "conductor.integrations.ai.enabled", havingValue = "true")
+public class OAuthController {
+
+    private static final Logger log = LoggerFactory.getLogger(OAuthController.class);
+
+    private final OAuthTokenService oAuthTokenService;
+
+    /**
+     * Returns the Microsoft authorization URL the UI should open as a popup.
+     *
+     * @param key       the {@code key} field from the workflow's {@code requiredDelegations} entry
+     * @param secretRef the secret name where the refresh token will be stored
+     * @param scopes    space-separated OAuth scopes (e.g. {@code "https://ai.azure.com/.default offline_access"})
+     */
+    @GetMapping("/authorize")
+    public ResponseEntity<String> authorize(
+            @RequestParam("key") String key,
+            @RequestParam("secretRef") String secretRef,
+            @RequestParam("scopes") String scopes) {
+
+        List<String> scopeList = List.of(scopes.split("\\s+"));
+        String url = oAuthTokenService.buildAuthorizationUrl(key, secretRef, scopeList);
+        return ResponseEntity.ok(url);
+    }
+
+    /**
+     * OAuth callback — Microsoft redirects here after the user consents. Exchanges the code for a
+     * refresh token, stores it, and serves a small HTML page that notifies the opener popup and
+     * closes itself.
+     */
+    @GetMapping(value = "/callback", produces = MediaType.TEXT_HTML_VALUE)
+    public ResponseEntity<String> callback(
+            @RequestParam(value = "code", required = false) String code,
+            @RequestParam(value = "state", required = false) String state,
+            @RequestParam(value = "error", required = false) String error,
+            @RequestParam(value = "error_description", required = false) String errorDescription) {
+
+        if (error != null) {
+            log.warn("OAuth callback received error: {} — {}", error, errorDescription);
+            return ResponseEntity.ok(closePopupHtml(false, null, error));
+        }
+
+        try {
+            String decoded = oAuthTokenService.handleCallback(code, state);
+            String key = decoded.split(":", 2)[0];
+            return ResponseEntity.ok(closePopupHtml(true, key, null));
+        } catch (Exception e) {
+            log.error("OAuth callback failed", e);
+            return ResponseEntity.ok(closePopupHtml(false, null, e.getMessage()));
+        }
+    }
+
+    /**
+     * Serves a minimal HTML page that posts a message to the parent window and closes the popup.
+     * The UI listens for {@code window.addEventListener('message', ...)} to detect completion.
+     */
+    private String closePopupHtml(boolean success, String key, String errorMsg) {
+        String payload = success
+                ? "{\"type\":\"oauth-complete\",\"success\":true,\"key\":\"" + key + "\"}"
+                : "{\"type\":\"oauth-complete\",\"success\":false,\"error\":\"" + escapeJson(errorMsg) + "\"}";
+
+        return "<!DOCTYPE html><html><body><script>"
+                + "try { window.opener.postMessage(" + payload + ", '*'); } catch(e) {}"
+                + "window.close();"
+                + "</script><p>"
+                + (success ? "Authorization complete. You may close this window." : "Authorization failed: " + escapeHtml(errorMsg))
+                + "</p></body></html>";
+    }
+
+    private static String escapeJson(String s) {
+        return s == null ? "" : s.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    private static String escapeHtml(String s) {
+        return s == null ? "" : s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+    }
+}

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentService.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentService.java
@@ -344,6 +344,26 @@ public class AgentService {
 
     // ── Agent discovery ─────────────────────────────────────────────
 
+    /**
+     * List agents from a specific Microsoft Foundry project URL. Used by the UI agent picker to
+     * populate the agent dropdown when the user enters a project endpoint.
+     *
+     * @param credentialRef secret name holding auth creds (API key or SP JSON); null = ambient identity
+     * @param endpoint Foundry project URL, e.g. {@code https://x.services.ai.azure.com/api/projects/y}
+     */
+    public List<AgentSummary> listExternalAgents(String credentialRef, String endpoint) {
+        if (azureFoundryAgentClient == null) {
+            log.warn("Microsoft Foundry agent client not available");
+            return List.of();
+        }
+        try {
+            return azureFoundryAgentClient.listExternalAgents(credentialRef, endpoint);
+        } catch (Exception e) {
+            log.warn("Failed to list agents from endpoint '{}': {}", endpoint, e.getMessage());
+            return List.of();
+        }
+    }
+
     /** List all registered agents (workflow defs with agent_sdk metadata). */
     public List<AgentSummary> listAgents() {
         // Use the portable getAllWorkflowDefs() (present across Conductor cores, incl. orkes'

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AzureFoundryAgentClient.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AzureFoundryAgentClient.java
@@ -435,23 +435,44 @@ public class AzureFoundryAgentClient implements ConductorAgentClient {
     }
 
     // Auth detection order:
-    //   0. useCallerIdentity + callerEntraToken + SP creds → OBO bearer (enterprise only)
-    //   1. apiKey in secret          → API key header (no SDK)
-    //   2. client_id/secret/tenant   → ClientSecretCredential (Service Principal)
-    //   3. clientId only             → ManagedIdentityCredential (user-assigned)
-    //   4. no credentialRef or empty → DefaultAzureCredential (env vars → MI → CLI)
+    //   0. accessToken set directly   → use as bearer (delegated/offline flow)
+    //   1. useCallerIdentity + callerEntraToken + SP creds → OBO bearer (enterprise only)
+    // Resolves a single field from credentialRef, which may be either:
+    //   a) a secret name ("shailesh-ai") → delegates to credentialResolutionService
+    //   b) an already-resolved JSON blob ({"apiKey":"..."}) → parses directly
+    // Case (b) occurs when the task stores ${workflow.secrets.X} and Conductor substitutes the
+    // secret value before the worker receives the request.
+    private String resolveCredField(String credentialRef, String field) {
+        if (credentialRef != null && credentialRef.startsWith("{")) {
+            try {
+                return MAPPER.readTree(credentialRef).path(field).asText(null);
+            } catch (Exception e) {
+                log.debug("credentialRef looks like JSON but could not be parsed: {}", e.getMessage());
+            }
+        }
+        return credentialResolutionService.resolve(credentialRef + "." + field);
+    }
+
+    //   2. apiKey in secret          → API key header (no SDK)
+    //   3. client_id/secret/tenant   → ClientSecretCredential (Service Principal)
+    //   4. clientId only             → ManagedIdentityCredential (user-assigned)
+    //   5. no credentialRef or empty → DefaultAzureCredential (env vars → MI → CLI)
     AuthState buildAuthState(ConductorAgentStartRequest request, String endpoint) {
         String scope = resolveScope(request, endpoint);
         String credentialRef = request.getCredentialRef();
+
+        if (StringUtils.isNotBlank(request.getAccessToken())) {
+            log.debug("Using pre-obtained access_token for delegated access");
+            return AuthState.ofBearer(request.getAccessToken());
+        }
 
         // OBO: exchange caller's Entra SSO token for a Foundry-scoped token.
         // Only activates when all three are present: flag, user assertion, and SP credentials.
         if (request.isUseCallerIdentity() && StringUtils.isNotBlank(request.getUserAssertion())) {
             if (StringUtils.isNotBlank(credentialRef)) {
-                String tenantId = credentialResolutionService.resolve(credentialRef + ".tenant_id");
-                String clientId = credentialResolutionService.resolve(credentialRef + ".client_id");
-                String clientSecret =
-                        credentialResolutionService.resolve(credentialRef + ".client_secret");
+                String tenantId = resolveCredField(credentialRef, "tenant_id");
+                String clientId = resolveCredField(credentialRef, "client_id");
+                String clientSecret = resolveCredField(credentialRef, "client_secret");
                 if (StringUtils.isNoneBlank(tenantId, clientId, clientSecret)) {
                     String foundryToken =
                             exchangeOboToken(
@@ -470,16 +491,15 @@ public class AzureFoundryAgentClient implements ConductorAgentClient {
 
         if (StringUtils.isNotBlank(credentialRef)) {
             // API key
-            String apiKey = credentialResolutionService.resolve(credentialRef + ".apiKey");
+            String apiKey = resolveCredField(credentialRef, "apiKey");
             if (StringUtils.isNotBlank(apiKey)) {
                 return new AuthState(apiKey);
             }
 
             // Service Principal (client credentials)
-            String clientId = credentialResolutionService.resolve(credentialRef + ".client_id");
-            String clientSecret =
-                    credentialResolutionService.resolve(credentialRef + ".client_secret");
-            String tenantId = credentialResolutionService.resolve(credentialRef + ".tenant_id");
+            String clientId = resolveCredField(credentialRef, "client_id");
+            String clientSecret = resolveCredField(credentialRef, "client_secret");
+            String tenantId = resolveCredField(credentialRef, "tenant_id");
             if (StringUtils.isNoneBlank(clientId, clientSecret, tenantId)) {
                 TokenCredential cred =
                         new ClientSecretCredentialBuilder()
@@ -491,7 +511,7 @@ public class AzureFoundryAgentClient implements ConductorAgentClient {
             }
 
             // User-assigned managed identity
-            String miClientId = credentialResolutionService.resolve(credentialRef + ".clientId");
+            String miClientId = resolveCredField(credentialRef, "clientId");
             if (StringUtils.isNotBlank(miClientId)) {
                 TokenCredential cred =
                         new ManagedIdentityCredentialBuilder().clientId(miClientId).build();
@@ -509,8 +529,7 @@ public class AzureFoundryAgentClient implements ConductorAgentClient {
                 StringUtils.defaultIfBlank(
                         rawConfig(request, "scope"),
                         StringUtils.isNotBlank(request.getCredentialRef())
-                                ? credentialResolutionService.resolve(
-                                        request.getCredentialRef() + ".scope")
+                                ? resolveCredField(request.getCredentialRef(), "scope")
                                 : null);
         if (StringUtils.isNotBlank(scope)) return scope;
 
@@ -801,12 +820,14 @@ public class AzureFoundryAgentClient implements ConductorAgentClient {
                         AgentSummary.builder()
                                 .name(name)
                                 .version(1)
-                                .type("azure-foundry")
+                                .type("microsoft-foundry")
+                                .endpoint(endpoint)
+                                .credentialRef(credentialRef)
                                 .description(description)
                                 .createTime(createdAt)
                                 .build());
             }
-            log.debug("Discovered {} Azure agents from {}", result.size(), endpoint);
+            log.debug("Discovered {} Microsoft Foundry agents from {}", result.size(), endpoint);
             return result;
         } catch (Exception e) {
             log.warn("Failed to list Azure agents from {}: {}", endpoint, e.getMessage());

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/OAuthTokenService.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/OAuthTokenService.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.agentspan.runtime.service;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.conductoross.conductor.dao.SecretsDAO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Handles the Microsoft OAuth 2.0 authorization code flow for delegated access.
+ *
+ * <p>Builds authorization URLs and exchanges auth codes for refresh tokens, which are stored as
+ * Conductor secrets so workflows can act on behalf of consenting users even in scheduled/background
+ * runs.
+ */
+@Service
+@ConditionalOnProperty(name = "conductor.integrations.ai.enabled", havingValue = "true")
+public class OAuthTokenService {
+
+    private static final Logger log = LoggerFactory.getLogger(OAuthTokenService.class);
+
+    private static final String MS_AUTH_BASE = "https://login.microsoftonline.com";
+
+    @Value("${conductor.oauth.microsoft.tenant-id:common}")
+    private String tenantId;
+
+    @Value("${conductor.oauth.microsoft.client-id:}")
+    private String clientId;
+
+    @Value("${conductor.oauth.microsoft.client-secret:}")
+    private String clientSecret;
+
+    @Value("${conductor.oauth.base-redirect-url:http://localhost:8080}")
+    private String baseRedirectUrl;
+
+    private final SecretsDAO secretsDAO;
+    private final ObjectMapper objectMapper;
+    private final HttpClient httpClient;
+
+    public OAuthTokenService(SecretsDAO secretsDAO, ObjectMapper objectMapper) {
+        this.secretsDAO = secretsDAO;
+        this.objectMapper = objectMapper;
+        this.httpClient = HttpClient.newHttpClient();
+    }
+
+    /**
+     * Builds the Microsoft authorization URL that the UI opens as a popup. The {@code secretRef}
+     * and {@code key} are encoded in the {@code state} parameter so the callback knows where to
+     * store the resulting refresh token.
+     */
+    public String buildAuthorizationUrl(String key, String secretRef, List<String> scopes) {
+        String scopeStr = String.join(" ", scopes);
+        if (!scopeStr.contains("offline_access")) {
+            scopeStr += " offline_access";
+        }
+
+        String state = Base64.getUrlEncoder().encodeToString(
+                (key + ":" + secretRef).getBytes(StandardCharsets.UTF_8));
+
+        return MS_AUTH_BASE + "/" + tenantId + "/oauth2/v2.0/authorize"
+                + "?client_id=" + encode(clientId)
+                + "&response_type=code"
+                + "&redirect_uri=" + encode(callbackUrl())
+                + "&scope=" + encode(scopeStr)
+                + "&response_mode=query"
+                + "&state=" + encode(state);
+    }
+
+    /**
+     * Handles the OAuth callback: exchanges the authorization code for tokens, stores the refresh
+     * token as a Conductor secret, and returns the key+secretRef from the state so the UI can
+     * confirm which delegation was completed.
+     *
+     * @return decoded state string in {@code "key:secretRef"} format
+     */
+    public String handleCallback(String code, String state) {
+        String decoded = new String(Base64.getUrlDecoder().decode(state), StandardCharsets.UTF_8);
+        String[] parts = decoded.split(":", 2);
+        if (parts.length != 2) {
+            throw new IllegalArgumentException("Invalid state parameter");
+        }
+        String key = parts[0];
+        String secretRef = parts[1];
+
+        String refreshToken = exchangeCodeForRefreshToken(code);
+        secretsDAO.putSecret(secretRef, refreshToken);
+        log.info("Stored delegated refresh token under secret '{}' for key '{}'", secretRef, key);
+
+        return decoded;
+    }
+
+    private String exchangeCodeForRefreshToken(String code) {
+        Map<String, String> params = Map.of(
+                "grant_type", "authorization_code",
+                "code", code,
+                "redirect_uri", callbackUrl(),
+                "client_id", clientId,
+                "client_secret", clientSecret);
+
+        String body = params.entrySet().stream()
+                .map(e -> encode(e.getKey()) + "=" + encode(e.getValue()))
+                .collect(Collectors.joining("&"));
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(MS_AUTH_BASE + "/" + tenantId + "/oauth2/v2.0/token"))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+
+        try {
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                throw new RuntimeException("Token exchange failed: " + response.statusCode() + " " + response.body());
+            }
+            JsonNode json = objectMapper.readTree(response.body());
+            JsonNode refreshToken = json.get("refresh_token");
+            if (refreshToken == null || refreshToken.isNull()) {
+                throw new RuntimeException("No refresh_token in response — ensure offline_access scope was requested");
+            }
+            return refreshToken.asText();
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Token exchange request failed", e);
+        }
+    }
+
+    private String callbackUrl() {
+        return baseRedirectUrl + "/api/oauth/callback";
+    }
+
+    private static String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/ai/src/main/java/org/conductoross/conductor/ai/a2a/A2AService.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/a2a/A2AService.java
@@ -84,7 +84,7 @@ public class A2AService {
     public static final String AGENT_TYPE_BEDROCK = "bedrock";
 
     /** Selects the Azure AI Foundry runtime (Entra ID auth, A2A protocol). */
-    public static final String AGENT_TYPE_AZURE_FOUNDRY = "azure-foundry";
+    public static final String AGENT_TYPE_AZURE_FOUNDRY = "microsoft-foundry";
 
     /** Whether {@code agentType} selects the A2A runtime — null/blank defaults to A2A. */
     public static boolean isA2aAgentType(String agentType) {

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/DelegationRequirement.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/DelegationRequirement.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.common.metadata.workflow;
+
+import java.util.List;
+
+/**
+ * Declares that a workflow requires delegated access to an external provider before it can run.
+ *
+ * <p>When present in {@link WorkflowDef#getRequiredDelegations()}, the Run Workflow UI renders an
+ * "Authorize" button for each entry. Clicking it opens an OAuth popup; after the user consents, the
+ * resulting refresh token is stored as a Conductor secret under {@code secretRef}. Subsequent runs
+ * find the secret already present and skip the popup.
+ *
+ * <p>The workflow itself references the stored token via an HTTP task that exchanges it for a
+ * short-lived access token before calling downstream agents.
+ */
+public class DelegationRequirement {
+
+    /** Unique identifier within the workflow definition (e.g. {@code "microsoft"}). */
+    private String key;
+
+    /**
+     * OAuth provider. Currently only {@code "microsoft"} is supported; reserved for future
+     * providers (e.g. {@code "google"}).
+     */
+    private String provider;
+
+    /**
+     * Human-readable label shown in the UI (e.g. {@code "Microsoft Account"}). Defaults to {@code
+     * provider} if omitted.
+     */
+    private String label;
+
+    /**
+     * OAuth scopes to request. Should include {@code offline_access} to obtain a refresh token.
+     * Example: {@code ["https://ai.azure.com/.default", "offline_access"]}.
+     */
+    private List<String> scopes;
+
+    /**
+     * Name under which the refresh token is stored as a Conductor secret. Referenced by the
+     * workflow via {@code ${workflow.secrets.<secretRef>}}. Example: {@code
+     * "alice-ms-delegated-token"}.
+     */
+    private String secretRef;
+
+    public DelegationRequirement() {}
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    public String getLabel() {
+        return label != null ? label : provider;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public List<String> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(List<String> scopes) {
+        this.scopes = scopes;
+    }
+
+    public String getSecretRef() {
+        return secretRef;
+    }
+
+    public void setSecretRef(String secretRef) {
+        this.secretRef = secretRef;
+    }
+}

--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
@@ -119,6 +119,16 @@ public class WorkflowDef extends Auditable {
     @ProtoField(id = 24)
     private List<String> maskedFields = new ArrayList<>();
 
+    private List<DelegationRequirement> requiredDelegations = new ArrayList<>();
+
+    public List<DelegationRequirement> getRequiredDelegations() {
+        return requiredDelegations;
+    }
+
+    public void setRequiredDelegations(List<DelegationRequirement> requiredDelegations) {
+        this.requiredDelegations = requiredDelegations;
+    }
+
     public static String getKey(String name, int version) {
         return name + "." + version;
     }

--- a/common/src/main/java/org/conductoross/conductor/common/metadata/agent/AgentSummary.java
+++ b/common/src/main/java/org/conductoross/conductor/common/metadata/agent/AgentSummary.java
@@ -31,6 +31,10 @@ public class AgentSummary {
     private String name;
     private int version;
     private String type;
+    /** Provider-specific connection target: Foundry project URL, Bedrock region, etc. */
+    private String endpoint;
+    /** Conductor secret name used to authenticate with this agent's provider. */
+    private String credentialRef;
     private List<String> tags;
     private Long createTime;
     private Long updateTime;

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -282,3 +282,11 @@ conductor.ai.gemini.location=${GOOGLE_CLOUD_LOCATION:us-central1}
 
 # Ollama (local inference server)
 conductor.ai.ollama.base-url=${OLLAMA_HOST:http://localhost:11434}
+
+# Delegated OAuth (for requiredDelegations in workflow definitions)
+# Set these to enable the Authorize button on the Run Workflow page.
+conductor.oauth.microsoft.tenant-id=${OAUTH_MS_TENANT_ID:common}
+conductor.oauth.microsoft.client-id=${OAUTH_MS_CLIENT_ID:}
+conductor.oauth.microsoft.client-secret=${OAUTH_MS_CLIENT_SECRET:}
+# Base URL of this Conductor server — used as the OAuth redirect_uri prefix
+conductor.oauth.base-redirect-url=${CONDUCTOR_BASE_URL:http://localhost:8080}

--- a/ui-next/src/pages/agent/AgentDefinitions.tsx
+++ b/ui-next/src/pages/agent/AgentDefinitions.tsx
@@ -35,11 +35,11 @@ import { tryToJson } from "utils/utils";
 import CloneAgentDialog from "./CloneAgentDialog";
 import { AgentSummary } from "./types";
 
-const EXTERNAL_TYPES = new Set(["azure-foundry", "bedrock"]);
+const EXTERNAL_TYPES = new Set(["microsoft-foundry", "bedrock"]);
 
 function providerLabel(type?: string | null): string {
   switch (type) {
-    case "azure-foundry": return "Azure Foundry";
+    case "microsoft-foundry": return "Microsoft Foundry";
     case "bedrock": return "Bedrock";
     default: return "Conductor";
   }
@@ -47,7 +47,7 @@ function providerLabel(type?: string | null): string {
 
 function providerColor(type?: string | null): string {
   switch (type) {
-    case "azure-foundry": return "#0078d4";
+    case "microsoft-foundry": return "#0078d4";
     case "bedrock": return "#e07730";
     default: return "#1565c0";
   }
@@ -55,7 +55,7 @@ function providerColor(type?: string | null): string {
 
 function providerIcon(type?: string | null): string {
   switch (type) {
-    case "azure-foundry": return AzureIcon;
+    case "microsoft-foundry": return AzureIcon;
     case "bedrock": return BedrockIcon;
     default: return OrkesIcon;
   }

--- a/ui-next/src/pages/agent/types.ts
+++ b/ui-next/src/pages/agent/types.ts
@@ -7,6 +7,10 @@ export interface AgentSummary {
   name: string;
   version: number;
   type?: string;
+  /** Provider-specific connection target: Foundry project URL, Bedrock region, etc. */
+  endpoint?: string;
+  /** Conductor secret name used to authenticate with this agent's provider. */
+  credentialRef?: string;
   tags?: string[];
   createTime?: number;
   updateTime?: number;

--- a/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/AgentTaskForm.tsx
+++ b/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/AgentTaskForm.tsx
@@ -40,7 +40,7 @@ import { TaskFormProps } from "./types";
 const AGENT_TYPES = [
   { value: "a2a", label: "A2A" },
   { value: "conductor", label: "Conductor" },
-  { value: "azure-foundry", label: "Azure Foundry" },
+  { value: "microsoft-foundry", label: "Microsoft Foundry" },
   { value: "bedrock", label: "Bedrock" },
 ];
 
@@ -67,7 +67,7 @@ export const AgentTaskForm = ({ task, onChange }: TaskFormProps) => {
 
   const agentType = (get("inputParameters.agentType") as string) || "a2a";
   const isConductor = agentType === "conductor";
-  const isAzureFoundry = agentType === "azure-foundry";
+  const isMicrosoftFoundry = agentType === "microsoft-foundry";
   const agentName = get("inputParameters.name") as string | undefined;
   const taskInput = (task.inputParameters ?? {}) as AgentTaskInput;
   const sourceKey = agentSourceKey(taskInput);
@@ -188,15 +188,27 @@ export const AgentTaskForm = ({ task, onChange }: TaskFormProps) => {
         ? rawMessage
         : JSON.stringify(rawMessage, null, 2);
 
-  const { data: agentDefinitions } = useFetch<AgentSummary[]>("/agent/list", {
-    enabled: isConductor,
+  const { data: agentDefinitions, isFetching: agentListFetching } = useFetch<AgentSummary[]>("/agent/list", {
+    enabled: isConductor || isMicrosoftFoundry,
   });
   const agentNameOptions = useMemo(
     () =>
       Array.isArray(agentDefinitions)
-        ? Array.from(new Set(agentDefinitions.map((a) => a.name))).sort()
+        ? Array.from(new Set(agentDefinitions.filter(a => !a.type || a.type === "conductor").map((a) => a.name))).sort()
         : [],
     [agentDefinitions],
+  );
+
+  const foundryAgents = useMemo(
+    () => Array.isArray(agentDefinitions)
+      ? agentDefinitions.filter((a) => a.type === "microsoft-foundry")
+      : [],
+    [agentDefinitions],
+  );
+
+  const foundryAgentOptions = useMemo(
+    () => foundryAgents.map((a) => a.name),
+    [foundryAgents],
   );
 
   return (
@@ -280,6 +292,69 @@ export const AgentTaskForm = ({ task, onChange }: TaskFormProps) => {
                 />
               </Grid>
             </>
+          ) : isMicrosoftFoundry ? (
+            <>
+              <Grid size={12}>
+                <Box display="flex" alignItems="center" gap={1}>
+                  <Box flex={1}>
+                    <ConductorAutocompleteVariables
+                      label="Agent"
+                      value={
+                        (
+                          get("inputParameters.rawConfig") as
+                            | Record<string, unknown>
+                            | undefined
+                        )?.assistantId as string | undefined
+                      }
+                      onChange={(v) => {
+                        const agent = foundryAgents.find((a) => a.name === v);
+                        const credRef = agent?.credentialRef
+                          ? `\${workflow.secrets.${agent.credentialRef}}`
+                          : undefined;
+                        const raw =
+                          (get("inputParameters.rawConfig") as Record<string, unknown>) ?? {};
+                        const updated = updateField(
+                          "inputParameters.credentialRef", credRef,
+                          updateField(
+                            "inputParameters.agentUrl", agent?.endpoint,
+                            updateField("inputParameters.rawConfig", { ...raw, assistantId: v }, task),
+                          ),
+                        ) as Partial<TaskDef>;
+                        const input = (updated.inputParameters ?? {}) as AgentTaskInput;
+                        onChange(
+                          withAgentSnapshot(
+                            updated as Partial<TaskDef> & { metadata?: Record<string, unknown> },
+                            createUnresolvedAgentSnapshot(input),
+                          ),
+                        );
+                      }}
+                      otherOptions={foundryAgentOptions}
+                      placeholder={
+                        agentListFetching
+                          ? "Loading agents…"
+                          : foundryAgents.length === 0
+                            ? "No agents found — add a secret with {endpoint:…} key"
+                            : "Select agent"
+                      }
+                      openOnFocus
+                    />
+                  </Box>
+                  {agentListFetching && <CircularProgress size={18} />}
+                </Box>
+              </Grid>
+              <Grid size={12}>
+                <ConductorInput
+                  label="Prompt"
+                  name="prompt"
+                  value={(get("inputParameters.prompt") as string) || ""}
+                  onTextInputChange={(v) => set("inputParameters.prompt", v)}
+                  multiline
+                  rows={6}
+                  fullWidth
+                  placeholder="Message to send to the agent"
+                />
+              </Grid>
+            </>
           ) : (
             <>
               <Grid size={12}>
@@ -306,30 +381,34 @@ export const AgentTaskForm = ({ task, onChange }: TaskFormProps) => {
           )}
           <Grid size={12}>
             <Box display="flex" alignItems="center" gap={1} flexWrap="wrap">
-              <Button
-                variant="outlined"
-                size="small"
-                disabled={
-                  isResolving ||
-                  !(isConductor
-                    ? taskInput.agentType === "conductor" && taskInput.name
-                    : taskInput.agentType !== "conductor" && taskInput.agentUrl)
-                }
-                onClick={() => void resolveSnapshot(taskInput)}
-              >
-                Refresh agent details
-              </Button>
-              {isResolving && <CircularProgress size={18} />}
-              {!isResolving && snapshot && (
-                <Typography variant="caption" color="text.secondary">
-                  {isConductor
-                    ? snapshot.resolved
-                      ? "Details loaded"
-                      : "Details unavailable"
-                    : snapshot.resolved
-                      ? "Resolved"
-                      : "Unresolved"}
-                </Typography>
+              {!isMicrosoftFoundry && (
+                <>
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    disabled={
+                      isResolving ||
+                      !(isConductor
+                        ? taskInput.agentType === "conductor" && taskInput.name
+                        : taskInput.agentType !== "conductor" && taskInput.agentUrl)
+                    }
+                    onClick={() => void resolveSnapshot(taskInput)}
+                  >
+                    Refresh agent details
+                  </Button>
+                  {isResolving && <CircularProgress size={18} />}
+                  {!isResolving && snapshot && (
+                    <Typography variant="caption" color="text.secondary">
+                      {isConductor
+                        ? snapshot.resolved
+                          ? "Details loaded"
+                          : "Details unavailable"
+                        : snapshot.resolved
+                          ? "Resolved"
+                          : "Unresolved"}
+                    </Typography>
+                  )}
+                </>
               )}
             </Box>
           </Grid>
@@ -364,7 +443,7 @@ export const AgentTaskForm = ({ task, onChange }: TaskFormProps) => {
       {!isConductor && (
         <TaskFormSection title="Execution mode">
           <Box display="flex" flexDirection="column" mb={3}>
-            {isAzureFoundry && (
+            {isMicrosoftFoundry && (
               <FormControlLabel
                 control={
                   <Switch
@@ -374,7 +453,7 @@ export const AgentTaskForm = ({ task, onChange }: TaskFormProps) => {
                     }
                   />
                 }
-                label="Use caller identity (OBO) — pass the triggering user's Entra token to Azure Foundry"
+                label="Use caller identity (OBO) — pass the triggering user's Entra token to Microsoft Foundry"
               />
             )}
             <FormControlLabel

--- a/ui-next/src/pages/runWorkflow/DelegatedAuthSection.tsx
+++ b/ui-next/src/pages/runWorkflow/DelegatedAuthSection.tsx
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useState } from "react";
+import { Box, Chip, CircularProgress, Typography } from "@mui/material";
+import { Button } from "components";
+import { DelegationRequirement } from "types/WorkflowDef";
+
+interface AuthState {
+  authorized: boolean;
+  loading: boolean;
+}
+
+interface Props {
+  delegations: DelegationRequirement[];
+  onAuthStateChange: (allAuthorized: boolean) => void;
+}
+
+async function checkSecretExists(secretRef: string): Promise<boolean> {
+  try {
+    const res = await fetch(`/api/secrets/${encodeURIComponent(secretRef)}/exists`);
+    if (!res.ok) return false;
+    return await res.json();
+  } catch {
+    return false;
+  }
+}
+
+async function fetchAuthorizationUrl(delegation: DelegationRequirement): Promise<string> {
+  const params = new URLSearchParams({
+    key: delegation.key,
+    secretRef: delegation.secretRef,
+    scopes: delegation.scopes.join(" "),
+  });
+  const res = await fetch(`/api/oauth/authorize?${params}`);
+  if (!res.ok) throw new Error("Failed to get authorization URL");
+  return res.text();
+}
+
+export function DelegatedAuthSection({ delegations, onAuthStateChange }: Props) {
+  const [authStates, setAuthStates] = useState<Record<string, AuthState>>(() =>
+    Object.fromEntries(delegations.map((d) => [d.key, { authorized: false, loading: true }])),
+  );
+
+  const checkAll = useCallback(async () => {
+    const results = await Promise.all(
+      delegations.map(async (d) => {
+        const authorized = await checkSecretExists(d.secretRef);
+        return { key: d.key, authorized };
+      }),
+    );
+    const next: Record<string, AuthState> = {};
+    for (const r of results) {
+      next[r.key] = { authorized: r.authorized, loading: false };
+    }
+    setAuthStates(next);
+    onAuthStateChange(results.every((r) => r.authorized));
+  }, [delegations, onAuthStateChange]);
+
+  useEffect(() => {
+    checkAll();
+  }, [checkAll]);
+
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      if (event.data?.type !== "oauth-complete") return;
+      if (event.data.success) {
+        checkAll();
+      }
+    };
+    window.addEventListener("message", handler);
+    return () => window.removeEventListener("message", handler);
+  }, [checkAll]);
+
+  const handleAuthorize = async (delegation: DelegationRequirement) => {
+    setAuthStates((prev) => ({
+      ...prev,
+      [delegation.key]: { ...prev[delegation.key], loading: true },
+    }));
+    try {
+      const url = await fetchAuthorizationUrl(delegation);
+      const popup = window.open(url, "oauth-popup", "width=600,height=700,noopener");
+      if (!popup) {
+        alert("Popup was blocked. Please allow popups for this site and try again.");
+      }
+    } catch {
+      setAuthStates((prev) => ({
+        ...prev,
+        [delegation.key]: { authorized: false, loading: false },
+      }));
+    }
+  };
+
+  const handleDisconnect = async (delegation: DelegationRequirement) => {
+    await fetch(`/api/secrets/${encodeURIComponent(delegation.secretRef)}`, { method: "DELETE" });
+    setAuthStates((prev) => ({
+      ...prev,
+      [delegation.key]: { authorized: false, loading: false },
+    }));
+    onAuthStateChange(false);
+  };
+
+  if (!delegations.length) return null;
+
+  return (
+    <Box>
+      <Typography
+        variant="caption"
+        sx={{ display: "block", fontWeight: 600, color: "#767676", mb: 1 }}
+      >
+        Required authorization
+      </Typography>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+        {delegations.map((delegation) => {
+          const state = authStates[delegation.key] ?? { authorized: false, loading: false };
+          const label = delegation.label ?? delegation.provider;
+
+          return (
+            <Box
+              key={delegation.key}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1.5,
+                padding: "8px 12px",
+                border: "1px solid",
+                borderColor: state.authorized ? "success.light" : "divider",
+                borderRadius: "4px",
+                backgroundColor: state.authorized ? "success.50" : "background.paper",
+              }}
+            >
+              {state.loading ? (
+                <CircularProgress size={16} />
+              ) : state.authorized ? (
+                <Chip label="Connected" color="success" size="small" />
+              ) : (
+                <Chip label="Not authorized" size="small" />
+              )}
+
+              <Typography variant="body2" sx={{ flex: 1 }}>
+                {label}
+              </Typography>
+
+              {!state.loading && (
+                state.authorized ? (
+                  <Button
+                    variant="text"
+                    size="small"
+                    onClick={() => handleDisconnect(delegation)}
+                  >
+                    Disconnect
+                  </Button>
+                ) : (
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={() => handleAuthorize(delegation)}
+                  >
+                    Authorize ▸
+                  </Button>
+                )
+              )}
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}

--- a/ui-next/src/pages/runWorkflow/RunWorkflow.tsx
+++ b/ui-next/src/pages/runWorkflow/RunWorkflow.tsx
@@ -14,7 +14,7 @@ import {
   IdempotencyStrategyEnum,
   IdempotencyValuesProp,
 } from "pages/definition/RunWorkflow/state";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Helmet } from "react-helmet";
 import { useLocation, useNavigate } from "react-router";
 import { useQueryState } from "react-router-use-location-state";
@@ -32,9 +32,12 @@ import {
   RunWorkflowApiSearchModal,
 } from "./RunWorkflowApiSearchModal";
 import { getTemplateFromInputParams } from "./runWorkflowUtils";
+import { DelegatedAuthSection } from "./DelegatedAuthSection";
+import { DelegationRequirement } from "types/WorkflowDef";
 
 type InputParameterType = {
   inputParameters: string[];
+  requiredDelegations?: DelegationRequirement[];
 };
 
 type CommonProperties = {
@@ -238,6 +241,12 @@ export function RunWorkflow() {
     useState<RunWorkflowState>(memorizedState);
   const [errorMessage, setErrorMessage] = useState("");
   const [showCodeDialog, setShowCodeDialog] = useQueryState("displayCode", "");
+  const [delegations, setDelegations] = useState<DelegationRequirement[]>([]);
+  const [delegationsAuthorized, setDelegationsAuthorized] = useState(true);
+
+  const handleDelegationAuthChange = useCallback((allAuthorized: boolean) => {
+    setDelegationsAuthorized(allAuthorized);
+  }, []);
 
   const runWorkflowAction = useAction(
     "/workflow",
@@ -327,6 +336,7 @@ export function RunWorkflow() {
         workflowInputParams: def["inputParameters"],
         workflowInputTemplate: templateFromInputParams,
       };
+      setDelegations(def["requiredDelegations"] || []);
     }
 
     setRunWorkflowState({
@@ -354,6 +364,7 @@ export function RunWorkflow() {
     const templateFromInputParams = getTemplateFromInputParams(
       def["inputParameters"],
     );
+    setDelegations(def["requiredDelegations"] || []);
     setRunWorkflowState({
       ...runWorkflowState,
       workflowVersion: workflowVersion,
@@ -569,7 +580,7 @@ export function RunWorkflow() {
                       },
                     ]}
                     primaryOnClick={runThisWorkflow}
-                    disabled={isTrialExpired}
+                    disabled={isTrialExpired || (delegations.length > 0 && !delegationsAuthorized)}
                   >
                     Run workflow
                   </SplitButton>
@@ -655,6 +666,14 @@ export function RunWorkflow() {
                         value={runWorkflowState.workflowVersion}
                       />
                     </Grid>
+                    {delegations.length > 0 && (
+                      <Grid size={12}>
+                        <DelegatedAuthSection
+                          delegations={delegations}
+                          onAuthStateChange={handleDelegationAuthChange}
+                        />
+                      </Grid>
+                    )}
                     <Grid size={12}>
                       <ConductorCodeBlockInput
                         label="Input params"

--- a/ui-next/src/types/AgentTaskMetadata.ts
+++ b/ui-next/src/types/AgentTaskMetadata.ts
@@ -1,4 +1,4 @@
-export type AgentRuntimeType = "a2a" | "conductor" | "bedrock" | "azure-foundry";
+export type AgentRuntimeType = "a2a" | "conductor" | "bedrock" | "microsoft-foundry";
 
 export interface A2AAgentInterface {
   url?: string;

--- a/ui-next/src/types/WorkflowDef.ts
+++ b/ui-next/src/types/WorkflowDef.ts
@@ -27,10 +27,19 @@ export interface WorkflowMetadataI {
   outputSchema?: Record<string, unknown>;
   enforceSchema?: boolean;
 }
+export interface DelegationRequirement {
+  key: string;
+  provider: string;
+  label?: string;
+  scopes: string[];
+  secretRef: string;
+}
+
 export type WorkflowDef = {
   failureWorkflow: string;
   schemaVersion: number;
   tasks: TaskDef[];
   tags?: TagDto[];
   inputSchema?: Record<string, unknown>;
+  requiredDelegations?: DelegationRequirement[];
 } & WorkflowMetadataI;

--- a/ui-next/src/utils/agentMetadata.ts
+++ b/ui-next/src/utils/agentMetadata.ts
@@ -36,14 +36,23 @@ export const agentRuntimeType = (input: unknown): AgentRuntimeType => {
   const t = input.agentType;
   if (t === "conductor") return "conductor";
   if (t === "bedrock") return "bedrock";
-  if (t === "azure-foundry") return "azure-foundry";
+  if (t === "microsoft-foundry") return "microsoft-foundry";
   return "a2a";
 };
 
 export const agentSourceIdentity = (input: unknown): string => {
   if (!isRecord(input)) return "";
-  const identity =
-    agentRuntimeType(input) === "conductor" ? input.name : input.agentUrl;
+  const type = agentRuntimeType(input);
+  let identity: unknown;
+  if (type === "conductor") {
+    identity = input.name;
+  } else if (type === "microsoft-foundry") {
+    identity =
+      (isRecord(input.rawConfig) ? input.rawConfig.assistantId : undefined) ||
+      input.agentUrl;
+  } else {
+    identity = input.agentUrl;
+  }
   return String(identity ?? "").trim();
 };
 
@@ -185,7 +194,9 @@ export async function resolveAgentSnapshot(
     return createUnresolvedAgentSnapshot(input);
   }
 
-  if (agentRuntimeType(input) === "conductor") {
+  const type = agentRuntimeType(input);
+
+  if (type === "conductor") {
     const version =
       "version" in input && typeof input.version === "number"
         ? `?version=${encodeURIComponent(input.version)}`
@@ -194,6 +205,16 @@ export async function resolveAgentSnapshot(
       `/agent/definitions/${encodeURIComponent(identity)}${version}`,
     )) as AgentWorkflowDefinition;
     return buildConductorAgentSnapshot(input, definition);
+  }
+
+  if (type === "microsoft-foundry") {
+    return {
+      schemaVersion: AGENT_SNAPSHOT_SCHEMA_VERSION,
+      agentType: "microsoft-foundry",
+      displayName: identity,
+      source: { url: identity },
+      resolved: true,
+    };
   }
 
   const inputRecord = input as unknown as Record<string, unknown>;
@@ -259,7 +280,7 @@ export async function resolveAgentSnapshotsInWorkflow(
 }
 
 export interface AgentTaskPresentation {
-  badge: "A2A AGENT" | "CONDUCTOR AGENT" | "BEDROCK AGENT" | "AZURE FOUNDRY AGENT";
+  badge: "A2A AGENT" | "CONDUCTOR AGENT" | "BEDROCK AGENT" | "MICROSOFT FOUNDRY AGENT";
   name: string;
   taskReferenceName: string;
 }
@@ -268,14 +289,14 @@ const AGENT_RUNTIME_BADGE: Record<AgentRuntimeType, AgentTaskPresentation["badge
   conductor: "CONDUCTOR AGENT",
   a2a: "A2A AGENT",
   bedrock: "BEDROCK AGENT",
-  "azure-foundry": "AZURE FOUNDRY AGENT",
+  "microsoft-foundry": "MICROSOFT FOUNDRY AGENT",
 };
 
 const AGENT_RUNTIME_DISPLAY_NAME: Record<AgentRuntimeType, string> = {
   conductor: "Conductor agent",
   a2a: "A2A agent",
   bedrock: "Bedrock agent",
-  "azure-foundry": "Azure Foundry agent",
+  "microsoft-foundry": "Microsoft Foundry agent",
 };
 
 // Resolution only ever runs through the workflow editor's save flow — a workflow


### PR DESCRIPTION
Stacked on #1447.

Adds delegated OAuth access so workflows can require a user to authorize an external provider (e.g. Microsoft) before running. User clicks Authorize once, consents via popup, and the refresh token gets stored as a Conductor secret. All subsequent runs — including scheduled ones — just pick it up from there, no re-auth needed.

On the Run Workflow page, each required delegation shows as an Authorize / Connected / Disconnect row. The Run button stays disabled until everything is authorized.

Config needed: set `conductor.oauth.microsoft.{tenant-id,client-id,client-secret}` and register `{base-url}/api/oauth/callback` as a redirect URI in your Azure app registration.