### PR TITLE
Docs: match Search executions to ui-next and document reasonForIncompletion

### DIFF
--- a/docs/devguide/how-tos/Workflows/debugging-workflows.md
+++ b/docs/devguide/how-tos/Workflows/debugging-workflows.md
@@ -21,7 +21,7 @@ The following tab views or fields in the task details are useful for debugging:
 
 | Field or Tab Name                                      | Description                                                                                                                   |
 |-------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
-| _Reason for Incompletion_ in **Task Detail** > **Summary**  | Contains the exception message thrown by the task worker.                    |
+| _Reason for Incompletion_ in **Task Detail** > **Summary**  | The worker's error message, or the engine's message when the task timed out or was terminated. See [Understanding reasonForIncompletion](#understanding-reasonforincompletion). |
 | _Worker_ in **Task Detail** > **Summary**                   | Contains the worker instance ID where the failure occurred. Useful for digging up detailed logs, if it has not already captured by Conductor.                    |
 | **Task Detail** > **Input**                           | Useful for verifying if the task inputs were correctly computed and provided to the task.                       |
 | **Task Detail** > **Output**                        | Useful for verifying what the task produced as output.                         |
@@ -30,6 +30,42 @@ The following tab views or fields in the task details are useful for debugging:
 
 
 ![Debugging Workflow Execution](workflow_debugging.png)
+
+## Understanding reasonForIncompletion
+
+`reasonForIncompletion` is a free-text field on both task and workflow executions. It is empty while an execution is healthy and is filled in when the execution stops without succeeding. The UI shows it as **Reason for Incompletion** in the task summary and at the top of the workflow execution view, and search results (`WorkflowSummary`, `TaskSummary`) include it.
+
+### Who writes it
+
+| Writer | What it contains |
+|---|---|
+| Your worker | Whatever the worker sets in `TaskResult.reasonForIncompletion` when it returns `FAILED` or `FAILED_WITH_TERMINAL_ERROR`. The SDKs set it to the exception message when a worker throws. |
+| Event handler `fail_task` action | The action's `reasonForIncompletion` value; empty if the action does not set one. |
+| System tasks | Their own error text. For example the HTTP task records the response body on a non-2xx response, `No response from the remote service`, `Missing HTTP URI.  See documentation for HttpTask for required input parameters`, or `Failed to invoke HTTP task due to: <exception>`. |
+| The engine | Timeouts, terminations, and definition errors, using the templates below. |
+
+### Engine-generated messages
+
+| Situation | Message |
+|---|---|
+| Task exceeded `timeoutSeconds` | `Task timed out after {elapsed} seconds. Timeout configured as {timeoutSeconds} seconds. Timeout policy configured to {timeoutPolicy}` |
+| Task not polled within `pollTimeoutSeconds` | `Task poll timed out after {elapsed} seconds. Poll timeout configured as {pollTimeoutSeconds} seconds. Timeout policy configured to {timeoutPolicy}` |
+| Worker stopped updating the task (`responseTimeoutSeconds`) | `responseTimeout: {responseTimeoutSeconds} exceeded for the taskId: {taskId} with Task Definition: {taskDefName}` |
+| Retries exhausted the total budget (`totalTimeoutSeconds`) | `Task {taskDefName}/{taskId} exceeded total timeout of {totalTimeoutSeconds} seconds (elapsed {elapsed} seconds across all attempts including retry delays). Timeout policy: {timeoutPolicy}` |
+| Workflow exceeded its `timeoutSeconds` | `Workflow timed out after {elapsed} seconds. Timeout configured as {timeoutSeconds} seconds. Timeout policy configured to {timeoutPolicy}` |
+| A task failure fails the workflow | On the workflow: `Task {taskId} failed with status: {status} and reason: '{task reasonForIncompletion}'`. A failed `JOIN` carries the concatenated reasons of its failed forked tasks. |
+| Sub-workflow ended unsuccessfully | On the `SUB_WORKFLOW` task: `Sub workflow {subWorkflowId} failure reason: {sub-workflow reasonForIncompletion}` |
+| `TERMINATE` task | The task's `terminationReason` input, or `Workflow is {terminationStatus} by TERMINATE task: {taskId}` when none is given. Set even when `terminationStatus` is `COMPLETED`. |
+| Terminate API | The `reason` query parameter of `DELETE /api/workflow/{workflowId}`. |
+| Task definition missing | `Invalid task specified. Cannot find task by name {name} in the task definitions` |
+
+Timeout fields are described in [Task Lifecycle](../../architecture/tasklifecycle.md#timeout-scenarios).
+
+### Lifecycle and limits
+
+* Retry, restart, and rerun clear the workflow's reason and start the new task attempt with an empty reason. The original attempt keeps its reason; open it from **Retried Task** in the task details.
+* On tasks the value is capped at 500 characters; longer messages are cut. Workflow-level reasons are not capped.
+* The field is stored with the execution and returned by `GET /api/workflow/{workflowId}`, `GET /api/tasks/{taskId}`, and the search APIs.
 
 ## Recovering from failure
 

--- a/docs/devguide/how-tos/Workflows/searching-workflows.md
+++ b/docs/devguide/how-tos/Workflows/searching-workflows.md
@@ -43,7 +43,7 @@ For structured/free-text or task-based searches beyond CLI flags, use `GET /api/
 
 ## Search with the UI
 
-Go to **[Executions > Workflow](http://localhost:8080/executions)** in the Conductor UI. Fill in one or more filters and select **Search**. Results can be sorted by column, and **Show as code** displays the equivalent `GET /api/workflow/search` call for the current filters.
+Go to **Executions > Workflow** in the Conductor UI. Fill in one or more filters and select **Search**. Results can be sorted by column, and **Show as code** displays the equivalent `GET /api/workflow/search` call for the current filters.
 
 ### Filters
 

--- a/docs/devguide/how-tos/Workflows/searching-workflows.md
+++ b/docs/devguide/how-tos/Workflows/searching-workflows.md
@@ -1,5 +1,5 @@
 ---
-description: "Searching Workflows — find Conductor workflow executions by name, status, time range, or task parameters in the UI."
+description: "Searching Workflows — find Conductor workflow executions by name, status, correlation ID, or time range from the CLI, API, or UI."
 ---
 # Search executions
 
@@ -43,53 +43,30 @@ For structured/free-text or task-based searches beyond CLI flags, use `GET /api/
 
 ## Search with the UI
 
-The UI has two modes:
+Go to **[Executions > Workflow](http://localhost:8080/executions)** in the Conductor UI. Fill in one or more filters and select **Search**. Results can be sorted by column, and **Show as code** displays the equivalent `GET /api/workflow/search` call for the current filters.
 
-* **Workflows** tab — Search using workflow parameters.
-* **Tasks** tab — Search workflows by tasks.
+### Filters
 
-**To search workflow executions:**
+| Filter | Description |
+|---|---|
+| Workflow name | One or more workflow definition names. |
+| Workflow id | A specific workflow execution ID. |
+| Correlation id | One or more correlation IDs. Press Enter after each value. |
+| Idempotency key | One or more idempotency keys. Press Enter after each value. |
+| Status | One or more of `RUNNING`, `COMPLETED`, `FAILED`, `TIMED_OUT`, `TERMINATED`, `PAUSED`. |
+| Start / End | Only executions that started within the selected time range. |
+| Free text search | Full-text query over indexed workflow data such as input and output values. Requires indexing to be enabled on the server. |
 
-1. Go to **[Executions](http://localhost:8080/executions)** in the Conductor UI.
-2. Configure the [search parameters](#search-parameters).
-3. Select **Search**.
+### SQL format
 
-Once the search results are displayed, you can sort the results by different column values and select additional columns to display.
+Turn on **SQL format** to replace the filter form with a query box that accepts the same SQL-like expressions as the `query` parameter of the search API, for example `workflowType = 'order_processing' AND status = 'FAILED'`. See [Query syntax](../../../documentation/api/workflow.md#query-syntax).
 
+### Searching by task
 
-## Search parameters
+The open-source UI searches workflow executions only. To find workflows by the tasks they contain, or to search task executions directly, use the API:
 
-Here are the search parameters for each search mode.
-
-### Search by workflows
-The following fields are available for searching workflows in the **Workflows** tab.
-
-| Search Field Name | Description                                                                                             |
-|-------------------|---------------------------------------------------------------------------------------------------------|
-| Workflow Name     | Filters workflow executions by its name.                                   |
-| Workflow ID       | Filters to a specific workflow execution by its execution ID.                                               |
-| Status            | Filters workflow executions by its status (RUNNING, COMPLETED, FAILED, TIMED_OUT, TERMINATED, PAUSED).      |
-| Start Time - From | Filters workflow executions that started on or after the specified time.                          |
-| Start Time - To   | Filters workflow executions that started on or before the specified time.                         |
-| Lookback (days)   | Filters workflow executions that ran in the last given number of days.                            |
-| Lucene-syntax Query (Double-quote strings for Free Text)  | (If indexing is enabled) Filters workflow executions by querying workflow input and output values. |
-
-
-### Search workflows by tasks
-
-The following fields are available for searching workflows by its tasks in the **Tasks** tab.
-
-| Search Field Name  | Description                                                                                                  |
-|--------------------|--------------------------------------------------------------------------------------------------------------|
-| Task Name  | Filters workflow executions by its task name.                                        |
-| Task ID    | Filters to a specific workflow execution that contains this task execution ID.                                |
-| Task Status | Filters workflow executions by its task status (IN_PROGRESS, CANCELED, FAILED, FAILED_WITH_TERMINAL_ERROR, COMPLETED, COMPLETED_WITH_ERRORS, SCHEDULED, TIMED_OUT, SKIPPED).  |
-| Task Type  | Filters workflow executions by its task type. |
-| Workflow Name | Filters workflow executions by its workflow name.       |
-| Update Time - From   | Filters workflow executions by tasks that started on or after the specified time.                         |
-| Update Time - To   | Filters workflow executions by tasks that started on or before the specified time.                         |
-| Lookback (days)   | Filters workflow executions by tasks that ran in the last given number of days.                          |
-| Lucene-syntax Query (Double-quote strings for Free Text) | (If indexing is enabled) Filters workflow executions by querying task input and output values. |
+* `GET /api/workflow/search-by-tasks` — workflows filtered by task attributes. See [Search by Tasks](../../../documentation/api/workflow.md#search-by-tasks).
+* `GET /api/tasks/search` — task executions. See [Search Tasks](../../../documentation/api/task.md#search-tasks).
 
 ## Limitations and next step
 

--- a/docs/documentation/api/task.md
+++ b/docs/documentation/api/task.md
@@ -53,6 +53,20 @@ curl 'http://localhost:8080/api/tasks/a1b2c3d4-5678-90ab-cdef-111111111111'
 }
 ```
 
+**Status and failure fields**
+
+| Field | Description |
+|---|---|
+| `status` | Current task status. See [Task statuses](../../devguide/architecture/tasklifecycle.md#task-statuses). |
+| `reasonForIncompletion` | Why the task stopped without succeeding. Empty while healthy. Written by the worker, the system task, or the engine; truncated to 500 characters. See [Understanding reasonForIncompletion](../../devguide/how-tos/Workflows/debugging-workflows.md#understanding-reasonforincompletion). |
+| `retryCount` | Attempt number, starting at `0`. |
+| `retried` | `true` when a later attempt was scheduled for this task. |
+| `retriedTaskId` | ID of the earlier attempt that this task retries. |
+| `workerId` | Worker instance that last polled or updated the task. |
+| `pollCount` | Number of times the task was polled. |
+| `callbackAfterSeconds` | Delay before the task is offered to workers again after an `IN_PROGRESS` update. |
+| `scheduledTime`, `startTime`, `endTime`, `updateTime` | Epoch milliseconds for this attempt. |
+
 ---
 
 ## Poll and Update Tasks
@@ -151,7 +165,7 @@ curl -X POST 'http://localhost:8080/api/tasks' \
 | `taskId` | Task ID | Yes |
 | `status` | `IN_PROGRESS`, `COMPLETED`, `FAILED`, or `FAILED_WITH_TERMINAL_ERROR` | Yes |
 | `outputData` | JSON map of output data | No |
-| `reasonForIncompletion` | Reason for failure (when status is `FAILED`) | No |
+| `reasonForIncompletion` | Free-text explanation recorded on the task when `status` is `FAILED` or `FAILED_WITH_TERMINAL_ERROR`. Truncated to 500 characters. See [Understanding reasonForIncompletion](../../devguide/how-tos/Workflows/debugging-workflows.md#understanding-reasonforincompletion). | No |
 | `callbackAfterSeconds` | Callback delay — task will be put back in queue after this time | No |
 | `logs` | List of log entries to append | No |
 

--- a/docs/documentation/api/workflow.md
+++ b/docs/documentation/api/workflow.md
@@ -81,6 +81,19 @@ curl 'http://localhost:8080/api/workflow/3a5b8c2d-1234-5678-9abc-def012345678'
 }
 ```
 
+**Status and failure fields**
+
+| Field | Description |
+|---|---|
+| `status` | `RUNNING`, `PAUSED`, `COMPLETED`, `FAILED`, `TIMED_OUT`, or `TERMINATED`. |
+| `reasonForIncompletion` | Why the workflow stopped without completing: the failing task's reason, a timeout message, or the reason passed to terminate. Empty while running; cleared by retry, restart, and rerun. See [Understanding reasonForIncompletion](../../devguide/how-tos/Workflows/debugging-workflows.md#understanding-reasonforincompletion). |
+| `failedReferenceTaskNames` | Reference names of the tasks that failed. |
+| `failedTaskNames` | Definition names of the tasks that failed. |
+| `lastRetriedTime` | Epoch milliseconds of the most recent retry; `0` if never retried. |
+| `reRunFromWorkflowId` | Set when this execution was rerun from another execution. |
+| `parentWorkflowId`, `parentWorkflowTaskId` | Present on sub-workflows: the parent execution and its `SUB_WORKFLOW` task. |
+| `event` | Name of the event that started the workflow, when started by an event handler. |
+
 ### Get Workflow Status Summary
 
 ```http


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [x] Other (please describe): Documentation only

Changes in this PR
----

- `docs/devguide/how-tos/Workflows/searching-workflows.md`
  - The new UI has a single **Executions > Workflow** search with different filters and a SQL format toggle, and no task search page. Rewrote the section to match this new UI
- `docs/devguide/how-tos/Workflows/debugging-workflows.md`
  - Adds new "Understanding reasonForIncompletion" section
- `docs/documentation/api/task.md` and `docs/documentation/api/workflow.md`
  -  Adds "Status and failure fields" tables after the `get-task` and `get-workflow responses` 
  - Corrected Update Task row for `reasonForIncompletion`.
