### PR TITLE
[CCOR-13460]fix: open sub-workflow definition when the version is blank

### DIFF
--- a/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/SubWorkflowOperatorForm/SubWorkflowOperatorForm.test.tsx
+++ b/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/SubWorkflowOperatorForm/SubWorkflowOperatorForm.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * CCOR-13460: the backend resolves the latest sub-workflow definition when the
+ * version is left blank, but the UI disabled Open unless a version was set —
+ * so selecting a version and then clearing it left the button dead. Clearing
+ * also wrote an explicit null into the definition instead of dropping the key,
+ * which would pin the version rather than letting the backend decide.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { TaskDef, TaskType } from "types";
+import { SubWorkflowOperatorForm } from "./SubWorkflowOperatorForm";
+
+const WORKFLOW = "child_flow";
+const OPTIONS = [WORKFLOW, "other_flow"];
+
+vi.mock("@xstate/react", () => ({
+  useInterpret: () => ({}),
+  useSelector: () => undefined,
+  useActor: () => [{ context: {} }, vi.fn()],
+}));
+
+vi.mock("../StartWorkflowTaskForm/state/hook", () => ({
+  useStartSubWfNameVersionMachine: () => [
+    { wfNameOptions: OPTIONS, availableVersions: [1, 2, 3], isFetching: false },
+    { handleSelectWorkflowName: vi.fn() },
+  ],
+}));
+
+vi.mock("utils/query", () => ({
+  useAuthHeaders: () => ({ "X-Authorization": "ui-token" }),
+}));
+
+vi.mock("pages/definition/commonService", () => ({
+  getWorkflowDefinitionByNameAndVersion: vi.fn(async () => ({
+    inputParameters: [],
+  })),
+}));
+
+vi.mock("components/FlatMapForm/ConductorAutocompleteVariables", () => ({
+  ConductorAutocompleteVariables: ({ label, value, onInputChange }: any) => (
+    <input
+      aria-label={String(label)}
+      value={value ?? ""}
+      onChange={(event) => onInputChange(event.target.value)}
+    />
+  ),
+}));
+
+/** Exposes the version field's onChange so clearing can be triggered. */
+vi.mock("components/ui/inputs/ConductorAutoComplete", () => ({
+  ConductorAutoComplete: ({ label, value, onChange }: any) => (
+    <div>
+      <span data-testid="version-value">{value ?? "(none)"}</span>
+      <button type="button" onClick={() => onChange(null, 2)}>
+        {`set ${label}`}
+      </button>
+      <button type="button" onClick={() => onChange(null, null)}>
+        {`clear ${label}`}
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("components/ui/buttons/MuiButton", () => ({
+  default: ({ children, disabled, onClick, id }: any) => (
+    <button type="button" id={id} disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("components/FlatMapForm/ConductorFlatMapForm", () => ({
+  ConductorFlatMapFormBase: () => null,
+}));
+vi.mock("../ConductorObjectOrStringInput", () => ({
+  ConductorObjectOrStringInput: () => null,
+}));
+vi.mock("../OptionalFieldForm", () => ({ Optional: () => null }));
+vi.mock("pages/runWorkflow/IdempotencyForm", () => ({ default: () => null }));
+vi.mock("components/ui/MuiCheckbox", () => ({ default: () => null }));
+
+const openButton = () =>
+  document.querySelector("#sub-workflow-main-form-workflow-open-btn");
+
+const renderForm = (task: Partial<TaskDef>) => {
+  const onChange = vi.fn();
+  render(
+    <SubWorkflowOperatorForm task={task as TaskDef} onChange={onChange} />,
+  );
+  return { onChange };
+};
+
+const taskWith = (subWorkflowParam: Record<string, unknown>) =>
+  ({
+    name: "sub",
+    taskReferenceName: "sub_ref",
+    type: TaskType.SUB_WORKFLOW,
+    subWorkflowParam,
+  }) as unknown as Partial<TaskDef>;
+
+describe("SubWorkflowOperatorForm — Open with a blank version", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("enables Open when a known workflow has no version", () => {
+    renderForm(taskWith({ name: WORKFLOW }));
+
+    expect(openButton()).not.toBeDisabled();
+  });
+
+  it("enables Open when a version is set", () => {
+    renderForm(taskWith({ name: WORKFLOW, version: 2 }));
+
+    expect(openButton()).not.toBeDisabled();
+  });
+
+  it("keeps Open disabled for a name that is not a known workflow", () => {
+    // Free text, or a definition that no longer exists.
+    renderForm(taskWith({ name: "typed_by_hand" }));
+
+    expect(openButton()).toBeDisabled();
+  });
+
+  it("keeps Open disabled when there is no name at all", () => {
+    renderForm(taskWith({}));
+
+    expect(openButton()).toBeDisabled();
+  });
+
+  it("opens the definition without a version segment, so the latest is shown", () => {
+    const open = vi.fn();
+    vi.stubGlobal("open", open);
+    renderForm(taskWith({ name: WORKFLOW }));
+
+    fireEvent.click(openButton()!);
+
+    expect(open).toHaveBeenCalledWith(`/workflowDef/${WORKFLOW}`);
+    vi.unstubAllGlobals();
+  });
+
+  it("opens the selected version when one is set", () => {
+    const open = vi.fn();
+    vi.stubGlobal("open", open);
+    renderForm(taskWith({ name: WORKFLOW, version: 2 }));
+
+    fireEvent.click(openButton()!);
+
+    expect(open).toHaveBeenCalledWith(`/workflowDef/${WORKFLOW}/2`);
+    vi.unstubAllGlobals();
+  });
+
+  it("treats a blank version string as no version", () => {
+    const open = vi.fn();
+    vi.stubGlobal("open", open);
+    renderForm(taskWith({ name: WORKFLOW, version: "" }));
+
+    fireEvent.click(openButton()!);
+
+    expect(open).toHaveBeenCalledWith(`/workflowDef/${WORKFLOW}`);
+    vi.unstubAllGlobals();
+  });
+
+  it("escapes a name that needs encoding", () => {
+    const open = vi.fn();
+    vi.stubGlobal("open", open);
+    renderForm(taskWith({ name: OPTIONS[1], version: 3 }));
+
+    fireEvent.click(openButton()!);
+
+    expect(open).toHaveBeenCalledWith(`/workflowDef/${OPTIONS[1]}/3`);
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("SubWorkflowOperatorForm — clearing the version", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("drops the version key rather than writing null", async () => {
+    const { onChange } = renderForm(taskWith({ name: WORKFLOW, version: 2 }));
+
+    fireEvent.click(screen.getByRole("button", { name: "clear Version" }));
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+
+    // An explicit "version": null would pin the field instead of letting the
+    // backend resolve the latest.
+    const updated = onChange.mock.calls.at(-1)?.[0];
+    expect(updated.subWorkflowParam).not.toHaveProperty("version");
+    expect(updated.subWorkflowParam.name).toBe(WORKFLOW);
+  });
+
+  it("still records a version that was chosen", async () => {
+    const { onChange } = renderForm(taskWith({ name: WORKFLOW }));
+
+    fireEvent.click(screen.getByRole("button", { name: "set Version" }));
+    // Choosing a version fetches that definition to seed inputParameters, so
+    // the change lands asynchronously.
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+
+    const updated = onChange.mock.calls.at(-1)?.[0];
+    expect(updated.subWorkflowParam.version).toBe(2);
+  });
+});
+
+describe("SubWorkflowOperatorForm — clearing the name", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("clears the version too, so it cannot attach to the next workflow", () => {
+    const { onChange } = renderForm(taskWith({ name: WORKFLOW, version: 2 }));
+
+    fireEvent.change(screen.getByLabelText("Workflow name"), {
+      target: { value: "" },
+    });
+
+    const updated = onChange.mock.calls.at(-1)?.[0];
+    expect(updated.subWorkflowParam).not.toHaveProperty("version");
+  });
+
+  it("keeps the version while the name is still being edited", () => {
+    const { onChange } = renderForm(taskWith({ name: WORKFLOW, version: 2 }));
+
+    fireEvent.change(screen.getByLabelText("Workflow name"), {
+      target: { value: "child" },
+    });
+
+    const updated = onChange.mock.calls.at(-1)?.[0];
+    expect(updated.subWorkflowParam.version).toBe(2);
+    expect(updated.subWorkflowParam.name).toBe("child");
+  });
+
+  it("treats a whitespace-only name as cleared", () => {
+    const { onChange } = renderForm(taskWith({ name: WORKFLOW, version: 2 }));
+
+    fireEvent.change(screen.getByLabelText("Workflow name"), {
+      target: { value: "   " },
+    });
+
+    const updated = onChange.mock.calls.at(-1)?.[0];
+    expect(updated.subWorkflowParam).not.toHaveProperty("version");
+  });
+});

--- a/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/SubWorkflowOperatorForm/SubWorkflowOperatorForm.tsx
+++ b/ui-next/src/pages/definition/EditorPanel/TaskFormTab/forms/SubWorkflowOperatorForm/SubWorkflowOperatorForm.tsx
@@ -100,20 +100,15 @@ export const SubWorkflowOperatorForm = ({
     { handleSelectWorkflowName },
   ] = useStartSubWfNameVersionMachine(startSubWfNameVersionActor);
 
+  // A blank version is valid: it opens the latest, so only the name matters.
   const isOpenButtonDisabled = useMemo(
     () =>
       !(
         task?.subWorkflowParam?.name &&
         options?.includes(task?.subWorkflowParam?.name) &&
-        task?.subWorkflowParam?.version &&
         !isFetching
       ),
-    [
-      task?.subWorkflowParam?.name,
-      options,
-      task?.subWorkflowParam?.version,
-      isFetching,
-    ],
+    [task?.subWorkflowParam?.name, options, isFetching],
   );
 
   const isPriorityError =
@@ -151,7 +146,20 @@ export const SubWorkflowOperatorForm = ({
                     }
                   }}
                   onInputChange={(val) => {
-                    onChange(updateField("subWorkflowParam.name", val, task));
+                    const updated = updateField(
+                      "subWorkflowParam.name",
+                      val,
+                      task,
+                    );
+                    if (!val?.trim()) {
+                      // A version belongs to a name; kept, it would apply to
+                      // whichever workflow is chosen next.
+                      const { version: _cleared, ...subWorkflowParam } =
+                        updated.subWorkflowParam ?? {};
+                      onChange({ ...updated, subWorkflowParam });
+                      return;
+                    }
+                    onChange(updated);
                   }}
                   value={task.subWorkflowParam?.name}
                   otherOptions={options}
@@ -172,13 +180,17 @@ export const SubWorkflowOperatorForm = ({
                     // Convert the value to an integer if it's not already
                     const version =
                       typeof val === "string" ? parseInt(val, 10) : val;
-
+                    // Clearing drops the key: an explicit null would pin the
+                    // version, where an absent one lets the backend resolve
+                    // the latest.
+                    const { version: _cleared, ...subWorkflowParam } =
+                      task.subWorkflowParam ?? {};
                     const taskJson = {
                       ...task,
-                      subWorkflowParam: {
-                        ...task.subWorkflowParam,
-                        version,
-                      },
+                      subWorkflowParam:
+                        version == null || Number.isNaN(version)
+                          ? subWorkflowParam
+                          : { ...subWorkflowParam, version },
                     };
                     updateInputParametersCommon(
                       taskJson,
@@ -202,10 +214,16 @@ export const SubWorkflowOperatorForm = ({
                   disabled={isOpenButtonDisabled}
                   sx={{ fontSize: "12px" }}
                   onClick={() => {
+                    // Omitting the segment resolves the latest.
+                    const version = task?.subWorkflowParam?.version;
+                    const versionSegment =
+                      version == null || String(version).trim() === ""
+                        ? ""
+                        : `/${encodeURIComponent(String(version))}`;
                     window.open(
                       `${WORKFLOW_DEFINITION_URL.BASE}/${encodeURIComponent(
                         task?.subWorkflowParam?.name ?? "",
-                      )}`,
+                      )}${versionSegment}`,
                     );
                   }}
                   startIcon={


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

## Fixes
[CCOR-13460](https://orkes.atlassian.net/browse/CCOR-13460) Open sub-workflow definition when the version is blank

- Open no longer requires a version — a valid name is enough
- Open honours a selected version (`/workflowDef/{name}/{version}`); it previously dropped the segment, so it never opened a specific version
- Clearing the version removes the key instead of writing `null`, letting the backend resolve the latest rather than pinning it
- Clearing the name clears the version too, so it can't attach to the next workflow picked

## Demo
<img width="1512" height="837" alt="Screen Recording 2026-09-07 at 1 47 15 PM" src="https://github.com/user-attachments/assets/e4d7680e-9eef-4169-8d38-2cce8f6e8fc5" />


Enterprise UI Playwright Tests
----
Every PR automatically triggers the enterprise UI Playwright E2E test suite.
Tests run against conductor-ui `main` by default. To test against a different
conductor-ui branch, add this line anywhere in the PR description:

```
conductor-ui-branch: my-feature-branch
```
