### PR TITLE
[CCOR-13474]fix: copy token via sidebar user block extension point

### DIFF
--- a/ui-next/src/components/providers/sidebar/Sidebar.tsx
+++ b/ui-next/src/components/providers/sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { Backdrop, Box, Drawer, alpha, useTheme } from "@mui/material";
-import { useMemo, useState } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import { useAuth } from "components/features/auth";
 import { colors } from "theme/tokens/variables";
 import { Auth0User } from "types/User";
@@ -22,6 +22,12 @@ interface SidebarProps {
   isMobile?: boolean;
   toggleMenu?: () => void;
   onSearchClick?: () => void;
+  /**
+   * Replaces the built-in user block in the footer. Lets a consumer supply its
+   * own account section — including features OSS has no implementation for,
+   * such as copying an auth token.
+   */
+  customUserBlock?: ReactNode;
 }
 
 export const Sidebar = ({
@@ -35,6 +41,7 @@ export const Sidebar = ({
   isMobile = false,
   toggleMenu,
   onSearchClick,
+  customUserBlock,
 }: SidebarProps) => {
   const theme = useTheme();
   const [internalOpen, setInternalOpen] = useState(true);
@@ -147,6 +154,7 @@ export const Sidebar = ({
         logOut={logOut}
         conductorVersion={conductorVersion}
         uiVersion={uiVersion}
+        customUserBlock={customUserBlock}
         showCopyAlert={showCopyAlert}
         setShowCopyAlert={setShowCopyAlert}
       />

--- a/ui-next/src/components/providers/sidebar/SidebarFooter.tsx
+++ b/ui-next/src/components/providers/sidebar/SidebarFooter.tsx
@@ -13,9 +13,10 @@ import { SnackbarMessage } from "components/ui/SnackbarMessage";
 import { SidebarVersionBlock } from "./SidebarVersionBlock";
 import TokenIcon from "images/svg/token.svg";
 import { getAccessToken } from "components/features/auth/tokenManagerJotai";
+import { logger } from "utils/logger";
 import { Auth0User } from "types/User";
 import { FEATURES, featureFlags } from "utils";
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 
 const isPlayground = featureFlags.isEnabled(FEATURES.PLAYGROUND);
 
@@ -49,6 +50,7 @@ export const SidebarFooter = ({
   customUserBlock,
 }: SidebarFooterProps) => {
   const theme = useTheme();
+  const [copyError, setCopyError] = useState<string | null>(null);
 
   if (customUserBlock != null) {
     return (
@@ -206,11 +208,24 @@ export const SidebarFooter = ({
                   const copyTokenButton = (
                     <Button
                       id="user-info-copy-token-btn"
-                      onClick={() => {
-                        setShowCopyAlert(true);
+                      onClick={async () => {
+                        // Only report success once the write has actually
+                        // happened: the toast used to fire first, so a missing
+                        // token or a rejected write still looked like a copy.
                         const accessToken = getAccessToken();
-                        if (accessToken) {
-                          navigator.clipboard.writeText(accessToken);
+                        if (!accessToken) {
+                          setCopyError("No access token to copy.");
+                          return;
+                        }
+                        try {
+                          await navigator.clipboard.writeText(accessToken);
+                          setShowCopyAlert(true);
+                        } catch (error) {
+                          logger.error(
+                            "[CopyToken] Clipboard write failed",
+                            error,
+                          );
+                          setCopyError("Could not copy to clipboard.");
                         }
                       }}
                       variant="outlined"
@@ -278,6 +293,16 @@ export const SidebarFooter = ({
               message="Copied to Clipboard"
               severity="success"
               onDismiss={() => setShowCopyAlert(false)}
+              anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
+            />
+          )}
+
+          {copyError && (
+            <SnackbarMessage
+              id="copy-clipboard-error-popup"
+              message={copyError}
+              severity="error"
+              onDismiss={() => setCopyError(null)}
               anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
             />
           )}

--- a/ui-next/src/components/providers/sidebar/UiSidebar.tsx
+++ b/ui-next/src/components/providers/sidebar/UiSidebar.tsx
@@ -18,7 +18,7 @@ import { Sidebar } from "components/providers/sidebar";
 import { useAnnouncementBanner } from "components/layout/header/bannerUtils";
 import { MenuItemType } from "components/providers/sidebar/types";
 import { pluginRegistry } from "plugins/registry";
-import { FunctionComponent, useContext, useMemo } from "react";
+import { FunctionComponent, useContext, useMemo, type ReactNode } from "react";
 import { FEATURES, featureFlags } from "utils";
 import { SidebarContext } from "./context/SidebarContext";
 import { useAuth } from "components/features/auth";
@@ -31,11 +31,14 @@ type UISidebarProps = {
   /** undefined = loading (skeleton), null = error/unavailable, string = loaded */
   apiVersion?: string | null;
   releaseVersion?: string;
+  /** Replaces the built-in user block in the footer. See Sidebar. */
+  customUserBlock?: ReactNode;
 };
 
 export const UISidebar: FunctionComponent<UISidebarProps> = ({
   apiVersion,
   releaseVersion,
+  customUserBlock,
 }) => {
   const {
     open,
@@ -78,6 +81,7 @@ export const UISidebar: FunctionComponent<UISidebarProps> = ({
         (showBanner && isBannerOpen) || showAiStudioBanner
       }
       onSearchClick={() => setSearchModal(true)}
+      customUserBlock={customUserBlock}
     />
   );
 };

--- a/ui-next/src/components/providers/sidebar/__tests__/SidebarFooter.copyToken.test.tsx
+++ b/ui-next/src/components/providers/sidebar/__tests__/SidebarFooter.copyToken.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * CCOR-13474: "Copy Token" showed a success toast every time while the
+ * clipboard was never written. The toast fired before the token was even read,
+ * so a missing token or a rejected write still looked like a copy.
+ */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Provider as ThemeProvider } from "theme/material/provider";
+import { getAccessToken } from "components/features/auth/tokenManagerJotai";
+import { SidebarFooter } from "../SidebarFooter";
+
+vi.mock("components/features/auth/tokenManagerJotai", () => ({
+  getAccessToken: vi.fn(),
+}));
+
+vi.mock("../SidebarVersionBlock", () => ({
+  SidebarVersionBlock: () => null,
+}));
+
+vi.mock("utils", () => ({
+  FEATURES: { COPY_TOKEN: "COPY_TOKEN", PLAYGROUND: "PLAYGROUND" },
+  featureFlags: { isEnabled: () => false },
+}));
+
+vi.mock("utils/logger", () => ({ logger: { error: vi.fn() } }));
+
+vi.mock("components/ui/SnackbarMessage", () => ({
+  SnackbarMessage: ({ id, message, severity }: any) => (
+    <div data-testid={id} data-severity={severity}>
+      {message}
+    </div>
+  ),
+}));
+
+const mockedGetAccessToken = getAccessToken as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+const renderFooter = () => {
+  const setShowCopyAlert = vi.fn();
+  render(
+    <ThemeProvider>
+      <SidebarFooter
+        open
+        isAuthenticated
+        isMobile={false}
+        user={{ given_name: "Dana" } as never}
+        conductorUser={{ id: "dana@orkes.io" }}
+        uiVersion="1.0.0"
+        showCopyAlert={false}
+        setShowCopyAlert={setShowCopyAlert}
+      />
+    </ThemeProvider>,
+  );
+  return { setShowCopyAlert };
+};
+
+const copyButton = () => document.querySelector("#user-info-copy-token-btn")!;
+
+describe("SidebarFooter — Copy Token", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it("writes the token and only then reports success", async () => {
+    mockedGetAccessToken.mockReturnValue("a-real-token");
+    const { setShowCopyAlert } = renderFooter();
+
+    fireEvent.click(copyButton());
+
+    await waitFor(() =>
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        "a-real-token",
+      ),
+    );
+    expect(setShowCopyAlert).toHaveBeenCalledWith(true);
+  });
+
+  it("reports an error instead of success when there is no token", async () => {
+    mockedGetAccessToken.mockReturnValue(null);
+    const { setShowCopyAlert } = renderFooter();
+
+    fireEvent.click(copyButton());
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("copy-clipboard-error-popup"),
+      ).toHaveTextContent("No access token to copy."),
+    );
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    expect(setShowCopyAlert).not.toHaveBeenCalled();
+  });
+
+  it("reports an error when the clipboard write is rejected", async () => {
+    mockedGetAccessToken.mockReturnValue("a-real-token");
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+    const { setShowCopyAlert } = renderFooter();
+
+    fireEvent.click(copyButton());
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("copy-clipboard-error-popup"),
+      ).toHaveTextContent("Could not copy to clipboard."),
+    );
+    expect(setShowCopyAlert).not.toHaveBeenCalled();
+  });
+});

--- a/ui-next/src/components/providers/sidebar/__tests__/customUserBlock.test.tsx
+++ b/ui-next/src/components/providers/sidebar/__tests__/customUserBlock.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Guards the footer extension point end to end.
+ *
+ * customUserBlock existed on SidebarFooter and SidebarMenu but not on the two
+ * components consumers actually render, so an enterprise footer passed to
+ * UISidebar was silently dropped — which is how Copy Token stopped working
+ * (CCOR-13474). Every link in the chain has to forward it.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { Sidebar } from "../Sidebar";
+
+vi.mock("components/features/auth", () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    user: { given_name: "Test" },
+    conductorUser: { id: "test@example.com" },
+    logOut: vi.fn(),
+    isTrialExpired: false,
+    trialExpiryDate: undefined,
+    isAnnouncementBannerDismissed: true,
+  }),
+}));
+
+const SENTINEL = "enterprise-account-block";
+
+describe("sidebar footer extension point", () => {
+  it("renders a consumer's user block instead of the built-in one", () => {
+    render(
+      <MemoryRouter>
+        <Sidebar menuItems={[]} open customUserBlock={<div>{SENTINEL}</div>} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(SENTINEL)).toBeInTheDocument();
+    // The built-in block is replaced, not stacked on top of.
+    expect(screen.queryByText("Copy Token")).not.toBeInTheDocument();
+  });
+
+  it("renders the built-in user block when no block is supplied", () => {
+    render(
+      <MemoryRouter>
+        <Sidebar menuItems={[]} open />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText(SENTINEL)).not.toBeInTheDocument();
+    expect(screen.getByText("Copy Token")).toBeInTheDocument();
+  });
+
+  it("UISidebar forwards the block down to Sidebar", async () => {
+    const seen: Record<string, unknown>[] = [];
+    vi.doMock("components/providers/sidebar", () => ({
+      Sidebar: (props: Record<string, unknown>) => {
+        seen.push(props);
+        return null;
+      },
+    }));
+    const { UISidebar } = await import("../UiSidebar");
+
+    render(<UISidebar customUserBlock={<div>{SENTINEL}</div>} />);
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].customUserBlock).toBeDefined();
+    vi.doUnmock("components/providers/sidebar");
+  });
+});


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
## Fixes
[CCOR-13474](https://orkes.atlassian.net/browse/CCOR-13474) "Copy Token" shows a success toast but doesn't actually copy a real token to the clipboard

The footer's `customUserBlock` slot was built halfway — `SidebarFooter` and `SidebarMenu` accepted it, but `Sidebar` and `UISidebar` never forwarded it, so a consumer's footer was dropped and the built-in one ran with the OSS token stub
(always `null`).

- forward `customUserBlock` through `Sidebar` and `UISidebar`
- built-in handler now awaits the write and reports failure

6 tests, mutation-checked.

## Demo
<img width="1512" height="837" alt="Screen Recording 2026-09-07 at 10 21 18 PM" src="https://github.com/user-attachments/assets/eb329785-39be-418c-8878-c84155c6fee4" />


Enterprise UI Playwright Tests
----
Every PR automatically triggers the enterprise UI Playwright E2E test suite.
Tests run against conductor-ui `main` by default. To test against a different
conductor-ui branch, add this line anywhere in the PR description:

```
conductor-ui-branch: my-feature-branch
```
