### PR TITLE
[CCOR-13413]enh: add boolean filter control and rename Substring to Contains in DatatableFilter

### DIFF
--- a/ui-next/src/components/ui/DataTable/Filter.test.tsx
+++ b/ui-next/src/components/ui/DataTable/Filter.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * CCOR-13413: the "Matched" boolean column was searched as free text. The
+ * filter regex-tests String(value), so the haystack is "true"/"false" — a user
+ * had to guess those words, and single characters matched nonsense ("e" is in
+ * both). Boolean columns now get an Any/Yes/No control instead.
+ */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Provider as ThemeProvider } from "theme/material/provider";
+import { Filter } from "./Filter";
+import { ColumnCustomType, RenderableColumn } from "./types";
+
+const columns = [
+  { id: "eventId", name: "eventId", label: "Event id" },
+  {
+    id: "matched",
+    name: "matched",
+    label: "Matched",
+    type: ColumnCustomType.BOOLEAN,
+  },
+] as RenderableColumn[];
+
+// The popover lays out Field first, then the value control. The OSS Select
+// renders a bare InputLabel, so its label is not queryable by association.
+const valueControl = () => screen.getAllByRole("combobox")[1];
+const textInput = () => screen.queryByLabelText("Contains");
+
+const renderFilter = (columnName: string, substring = "") => {
+  const setFilterObj = vi.fn();
+  render(
+    <ThemeProvider>
+      <Filter
+        columns={columns}
+        filterObj={{ columnName, substring }}
+        setFilterObj={setFilterObj}
+      />
+    </ThemeProvider>,
+  );
+  fireEvent.click(screen.getByRole("button", { name: /search/i }));
+  return { setFilterObj };
+};
+
+describe("DataTable Filter", () => {
+  it("offers Any/Yes/No for a boolean column", () => {
+    renderFilter("matched");
+
+    fireEvent.mouseDown(valueControl());
+
+    expect(screen.getByRole("option", { name: "Any" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Yes" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "No" })).toBeInTheDocument();
+    // No free-text box to guess "true" into.
+    expect(textInput()).not.toBeInTheDocument();
+  });
+
+  // Each case must be a real transition — MUI fires no change event when the
+  // already-selected option is clicked.
+  it.each([
+    ["Yes", "true", ""],
+    ["No", "false", ""],
+    ["Any", "", "true"],
+  ])(
+    "stores %s as %s so the existing filter matches",
+    (label, stored, from) => {
+      const { setFilterObj } = renderFilter("matched", from);
+
+      fireEvent.mouseDown(valueControl());
+      fireEvent.click(screen.getByRole("option", { name: label }));
+
+      expect(setFilterObj).toHaveBeenCalledWith({
+        columnName: "matched",
+        substring: stored,
+      });
+    },
+  );
+
+  it("keeps a text box for a non-boolean column, labelled Contains", () => {
+    renderFilter("eventId");
+
+    expect(textInput()).toBeInTheDocument();
+    // Only the Field select — no second combobox.
+    expect(screen.getAllByRole("combobox")).toHaveLength(1);
+  });
+});

--- a/ui-next/src/components/ui/DataTable/Filter.tsx
+++ b/ui-next/src/components/ui/DataTable/Filter.tsx
@@ -7,7 +7,13 @@ import _isNil from "lodash/isNil";
 import { FunctionComponent, useState } from "react";
 import { getColumnId, getColumnLabel, getColumnLabelById } from "./helpers";
 import { FilterObjectItem } from "./state";
-import { RenderableColumn } from "./types";
+import { ColumnCustomType, RenderableColumn } from "./types";
+
+const BOOLEAN_OPTIONS = [
+  { value: "", label: "Any" },
+  { value: "true", label: "Yes" },
+  { value: "false", label: "No" },
+];
 
 export interface FilterProps {
   columns: RenderableColumn[];
@@ -36,6 +42,11 @@ export const Filter: FunctionComponent<FilterProps> = ({
       substring: v,
     });
   };
+
+  const selectedColumn = columns.find(
+    (col) => getColumnId(col) === filterObj?.columnName,
+  );
+  const isBooleanColumn = selectedColumn?.type === ColumnCustomType.BOOLEAN;
 
   const handleColumnChange = (c: string) => {
     setFilterObj({
@@ -92,12 +103,31 @@ export const Filter: FunctionComponent<FilterProps> = ({
               </MenuItem>
             ))}
         </Select>
-        <Input
-          clearable
-          label="Substring"
-          value={filterObj!.substring}
-          onChange={handleValueChange}
-        />
+        {isBooleanColumn ? (
+          <Select
+            label="Value"
+            sx={{ width: 200 }}
+            onChange={(e: any) => handleValueChange(e.target.value)}
+            value={filterObj!.substring}
+            renderValue={(v: any) =>
+              BOOLEAN_OPTIONS.find((option) => option.value === v)?.label
+            }
+            displayEmpty={true}
+          >
+            {BOOLEAN_OPTIONS.map(({ value, label }) => (
+              <MenuItem value={value} key={label}>
+                {label}
+              </MenuItem>
+            ))}
+          </Select>
+        ) : (
+          <Input
+            clearable
+            label="Contains"
+            value={filterObj!.substring}
+            onChange={handleValueChange}
+          />
+        )}
       </Popover>
     </>
   );

--- a/ui-next/src/components/ui/DataTable/booleanFilter.test.tsx
+++ b/ui-next/src/components/ui/DataTable/booleanFilter.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * CCOR-13413: proves the Any/Yes/No values actually filter rows. The filter
+ * engine was left untouched — it regex-tests String(selector(row)), and a
+ * boolean column's selector returns the raw boolean, so "true"/"false" match.
+ */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Provider as ThemeProvider } from "theme/material/provider";
+import DataTable from "./DataTable";
+import { ColumnCustomType } from "./types";
+
+const columns = [
+  { id: "eventId", name: "eventId", label: "Event id" },
+  {
+    id: "matched",
+    name: "matched",
+    label: "Matched",
+    type: ColumnCustomType.BOOLEAN,
+    renderer: (val: boolean) => (val ? "hit" : "miss"),
+  },
+];
+
+const data = [
+  { eventId: "evt-matched", matched: true },
+  { eventId: "evt-unmatched", matched: false },
+];
+
+const openFilterOnMatched = () => {
+  fireEvent.click(screen.getByRole("button", { name: /search/i }));
+  fireEvent.mouseDown(screen.getAllByRole("combobox")[0]);
+  fireEvent.click(screen.getByRole("option", { name: "Matched" }));
+};
+
+const chooseValue = (label: string) => {
+  fireEvent.mouseDown(screen.getAllByRole("combobox")[1]);
+  fireEvent.click(screen.getByRole("option", { name: label }));
+};
+
+describe("boolean column filtering", () => {
+  const renderTable = () =>
+    render(
+      <ThemeProvider>
+        <DataTable data={data} columns={columns} keyField="eventId" />
+      </ThemeProvider>,
+    );
+
+  it("shows both rows before filtering", () => {
+    renderTable();
+
+    expect(screen.getByText("evt-matched")).toBeInTheDocument();
+    expect(screen.getByText("evt-unmatched")).toBeInTheDocument();
+  });
+
+  it("Yes keeps only matched rows", () => {
+    renderTable();
+    openFilterOnMatched();
+
+    chooseValue("Yes");
+
+    expect(screen.getByText("evt-matched")).toBeInTheDocument();
+    expect(screen.queryByText("evt-unmatched")).not.toBeInTheDocument();
+  });
+
+  it("No keeps only unmatched rows", () => {
+    renderTable();
+    openFilterOnMatched();
+
+    chooseValue("No");
+
+    expect(screen.getByText("evt-unmatched")).toBeInTheDocument();
+    expect(screen.queryByText("evt-matched")).not.toBeInTheDocument();
+  });
+
+  it("Any clears the filter", () => {
+    renderTable();
+    openFilterOnMatched();
+    chooseValue("Yes");
+
+    chooseValue("Any");
+
+    expect(screen.getByText("evt-matched")).toBeInTheDocument();
+    expect(screen.getByText("evt-unmatched")).toBeInTheDocument();
+  });
+});

--- a/ui-next/src/components/ui/DataTable/types.ts
+++ b/ui-next/src/components/ui/DataTable/types.ts
@@ -8,6 +8,7 @@ export type PaginationChangePage = (page: number, totalRows: number) => void;
 export enum ColumnCustomType {
   DATE = "date",
   JSON = "json",
+  BOOLEAN = "boolean",
 }
 
 export interface LegacyColumn extends TableColumn<any> {


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
## Fixes
[CCOR-13413](https://orkes.atlassian.net/browse/CCOR-13413?atlOrigin=eyJpIjoiMjQ1OWNkOGMzNDk2NGJhNjhlYThhNDAxMzkxNDE1ZTciLCJwIjoiaiJ9)Webhook executions history search: "Matched" field search UX is not user-friendly

- [x] enh: add boolean filter control and rename Substring to Contains

## Related conductor-ui PR : https://github.com/orkes-io/conductor-ui/pull/4412


## Demo
<img width="1512" height="796" alt="Screen Recording 2026-09-08 at 5 06 23 PM" src="https://github.com/user-attachments/assets/de576b06-8a52-4652-8701-ab74cf357eab" />


Enterprise UI Playwright Tests
----
Every PR automatically triggers the enterprise UI Playwright E2E test suite.
Tests run against conductor-ui `main` by default. To test against a different
conductor-ui branch, add this line anywhere in the PR description:

```
conductor-ui-branch: my-feature-branch
```
