### PR TITLE
convert everything that is put as chat message into string

### DIFF
--- a/ai/src/main/java/org/conductoross/conductor/ai/model/ChatMessage.java
+++ b/ai/src/main/java/org/conductoross/conductor/ai/model/ChatMessage.java
@@ -15,14 +15,21 @@ package org.conductoross.conductor.ai.model;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.netflix.conductor.common.config.ObjectMapperProvider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Data
+@Slf4j
 @AllArgsConstructor
 @NoArgsConstructor
 public class ChatMessage {
+
+    private static final ObjectMapper mapper = new ObjectMapperProvider().getObjectMapper();
 
     public enum Role {
         user,
@@ -49,5 +56,19 @@ public class ChatMessage {
     public ChatMessage(Role role, ToolCall toolCall) {
         this.role = role;
         this.toolCalls = List.of(toolCall);
+    }
+
+    public void setMessage(Object message) {
+        if (message == null || message instanceof String) {
+            // keep the same behaviour on null and avoid having quotes when it's a String
+            this.message = (String) message;
+            return;
+        }
+        try {
+            this.message = mapper.writeValueAsString(message);
+        } catch (Exception e) {
+            log.error("Failed to deserialize chat message: ", e);
+            this.message = message.toString();
+        }
     }
 }

--- a/ai/src/test/java/org/conductoross/conductor/ai/models/ChatMessageTest.java
+++ b/ai/src/test/java/org/conductoross/conductor/ai/models/ChatMessageTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.conductoross.conductor.ai.models;
+
+import java.util.List;
+import java.util.Map;
+
+import org.conductoross.conductor.ai.model.ChatCompletion;
+import org.conductoross.conductor.ai.model.ChatMessage;
+import org.junit.jupiter.api.Test;
+
+import com.netflix.conductor.common.config.ObjectMapperProvider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ChatMessageTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().getObjectMapper();
+
+    @Test
+    void objectMessageIsSerializedToJson() {
+        Map<String, Object> input =
+                Map.of(
+                        "messages",
+                        List.of(Map.of("role", "user", "message", Map.of("randomInt", 42))));
+
+        ChatCompletion chatCompletion = objectMapper.convertValue(input, ChatCompletion.class);
+
+        assertEquals("{\"randomInt\":42}", chatCompletion.getMessages().get(0).getMessage());
+    }
+
+    @Test
+    void stringMessageIsUnchanged() {
+        Map<String, Object> input =
+                Map.of("messages", List.of(Map.of("role", "user", "message", "hello")));
+
+        ChatCompletion chatCompletion = objectMapper.convertValue(input, ChatCompletion.class);
+
+        assertEquals("hello", chatCompletion.getMessages().get(0).getMessage());
+    }
+
+    @Test
+    void listMessageIsSerializedToJson() {
+        Map<String, Object> input =
+                Map.of("messages", List.of(Map.of("role", "user", "message", List.of(1, 2))));
+
+        ChatCompletion chatCompletion = objectMapper.convertValue(input, ChatCompletion.class);
+
+        assertEquals("[1,2]", chatCompletion.getMessages().get(0).getMessage());
+    }
+
+    @Test
+    void nullMessageStaysNull() {
+        ChatMessage message = new ChatMessage();
+        message.setMessage((Object) null);
+        assertNull(message.getMessage());
+    }
+}


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Someone wants this to work in chat completion task, so there's now a setter that converts JSON objects into text:
```
{
            "role": "user",
            "message": "${task_ref_name.output}"
}
```
