### PR TITLE
fix(deps): bump amqp-client to 5.35.0 and httpcore5 to 5.4.3 (#1528)

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -74,7 +74,10 @@ ext {
     revSpotifyCompletableFutures = '0.3.3'
     revTestContainer = '1.21.4'
     revFasterXml = '2.15.3'
-    revAmqpClient = '5.13.0'
+    // amqp-client is BOM-managed (rabbit-amqp-client.version); the Spring Boot 3.5 BOM pins 5.25.0,
+    // which carries CVE-2026-63337 / CVE-2026-69219 / CVE-2026-69220. 5.35.0 clears all three.
+    // The override that actually forces this into the shaded jar lives in springboot-bom-overrides.gradle.
+    revAmqpClient = '5.35.0'
     revKafka = '3.9.1'
     // micrometer-core carries CVE-2026-40983 / CVE-2026-40984, fixed in 1.15.12.
     revMicrometer = '1.15.12'

--- a/springboot-bom-overrides.gradle
+++ b/springboot-bom-overrides.gradle
@@ -25,6 +25,14 @@ ext['netty.version'] = '4.1.136.Final'
 // server/build.gradle and must NOT be bumped through this property — see dependencies.gradle.
 ext['micrometer.version'] = revMicrometer
 ext['kafka.version'] = '3.9.1'
+// The Spring Boot 3.5 BOM pins com.rabbitmq:amqp-client to 5.25.0, which carries
+// CVE-2026-63337 / CVE-2026-69219 / CVE-2026-69220. This property is what actually forces
+// revAmqpClient (5.35.0) into the shaded jar — the amqp module's explicit version is otherwise
+// overridden back down to the BOM version by the dependency-management plugin.
+ext['rabbit-amqp-client.version'] = revAmqpClient
+// httpcore5 / httpcore5-h2 are BOM-managed at 5.3.6, which carries CVE-2026-54399. 5.4.3 is the
+// latest stable in the 5.4 line (5.5.x is alpha/beta) and clears it. Shared by both artifacts.
+ext['httpcore5.version'] = '5.4.3'
 
 // Conductor's default is ES6, but SB brings in ES7
 ext['elasticsearch.version'] = revElasticSearch7


### PR DESCRIPTION
Two more of the callouts from Peter's fresh 3.32.1 CVE scan in conductor-oss/conductor#1528, targeting the quick 3.32.2 follow-on release. Both packages are managed by the Spring Boot 3.5 BOM, so the actual fix is a BOM property override in `springboot-bom-overrides.gradle` — editing only the module's declared version silently no-ops, because the `io.spring.dependency-management` plugin overrides it back down to the BOM version (this is exactly why the scan saw amqp-client 5.25.0 even though the `amqp` module declared 5.13.0).

## Changes

| Package | Was (BOM) | Now | CVEs cleared |
|---|---|---|---|
| `com.rabbitmq:amqp-client` | 5.25.0 | **5.35.0** | CVE-2026-63337, CVE-2026-69219, CVE-2026-69220 |
| `org.apache.httpcomponents.core5:httpcore5` + `httpcore5-h2` | 5.3.6 | **5.4.3** | CVE-2026-54399 |

- **amqp-client** → bumped via `rabbit-amqp-client.version`. `revAmqpClient` in `dependencies.gradle` was also updated to 5.35.0 so the module declaration and the override share one source of truth.
- **httpcore5 / httpcore5-h2** → both bumped via the shared `httpcore5.version`. 5.4.3 is the latest *stable* release in the 5.4 line (the only newer artifacts are 5.5 alpha/beta, which are not appropriate for a security patch release).

## Verification

- `./gradlew :conductor-amqp:dependencyInsight --dependency amqp-client` → resolves to `5.35.0 (selected by rule)`.
- `./gradlew :conductor-server:dependencyInsight --dependency httpcore5` → both `httpcore5` and `httpcore5-h2` resolve to `5.4.3 (selected by rule)`, overriding the `5.3.6` requested transitively by httpclient5 5.5.2.
- `./gradlew :conductor-amqp:compileJava :conductor-amqp:compileTestJava` → BUILD SUCCESSFUL (RabbitMQ client 5.25→5.35 introduces no source breakage in the amqp module).

## Not included here

- **spring-security** (CVE-2026-59270, also flagged in #1528): the recommended `6.5.12` is not published to OSS Maven Central (latest OSS 6.5.x is `6.5.11`, which is already pinned). The other suggested targets (`7.0.6.1`, `7.1.0.1`) are Spring Framework 7 / Spring Boot 4, out of scope for this patch line — deferring to the Spring Boot 4 upgrade track (#1573).
- **elasticsearch 7.x** (CVE-2025-37731): a backend migration, not a version pin — out of scope for a quick follow-on.
- **Base-image OS packages** (nginx / perl / libssh2): require a base-image change (Peter suggests `eclipse-temurin:21-jre-alpine`); tracked separately.

Regarding the reporter's note that the rc.25 security cleanup didn't make it into `3.32.0`: that regression was fixed forward and is already present as of `v3.32.2` (spring-framework 6.2.19, spring-security 6.5.11, log4j2 2.25.4, netty 4.1.136.Final, micrometer 1.15.12, etc.), so a follow-on cut from 3.32.2 inherits it — no re-application needed.

**User impact:** Operators scanning the Conductor server image will see four fewer high-severity CVEs (three in the RabbitMQ client, one in Apache HttpCore5) with no behavioral change — both are drop-in compatible bumps within the same major line.

Fixes part of conductor-oss/conductor#1528.