### PR TITLE
Fix tool-call selection and naming in the agent event listener

### DIFF
--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/ToolCompiler.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/ToolCompiler.java
@@ -170,7 +170,7 @@ public class ToolCompiler {
      * all. {@code SimpleTaskMapper} rewrites an executed SIMPLE task's type to the task's own name,
      * so a worker tool is recognised by that instead.
      */
-    public static final Set<String> TOOL_TASK_TYPES =
+    public static final Set<String> COMPILED_TOOL_TASK_TYPES =
             Stream.concat(
                             TYPE_MAP.values().stream(),
                             MEDIA_TOOL_TYPES.stream().map(t -> t.toUpperCase(Locale.ROOT)))

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/ToolCompiler.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/ToolCompiler.java
@@ -156,19 +156,8 @@ public class ToolCompiler {
                     Map.entry("pull_workflow_messages", "PULL_WORKFLOW_MESSAGES"));
 
     /**
-     * Conductor task types a declared tool compiles to, for consumers that have to tell a tool
-     * invocation apart from the rest of a compiled agent workflow.
-     *
-     * <p>Derived from {@link #TYPE_MAP} and from the media types that fall back to their own
-     * upper-cased name, so adding a tool kind to the map extends this set with it.
-     *
-     * <p>It is a floor rather than the closed set of what a tool can compile to. A media or RAG
-     * tool's own config may name its task type, which nothing static can enumerate; those tasks
-     * carry the dispatch script's {@code _agent_tool_name} input instead.
-     *
-     * <p>{@code SIMPLE} is deliberately excluded: a worker tool is not identifiable by task type at
-     * all. {@code SimpleTaskMapper} rewrites an executed SIMPLE task's type to the task's own name,
-     * so a worker tool is recognised by that instead.
+     * Task types a declared tool compiles to. Excludes SIMPLE, whose executed task carries the
+     * tool's own name as its type.
      */
     public static final Set<String> COMPILED_TOOL_TASK_TYPES =
             Stream.concat(

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/ToolCompiler.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/ToolCompiler.java
@@ -18,9 +18,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.conductoross.conductor.ai.agentspan.runtime.util.JavaScriptBuilder;
 import org.conductoross.conductor.common.metadata.agent.GuardrailConfig;
@@ -151,6 +154,28 @@ public class ToolCompiler {
                     Map.entry("rag_index", "LLM_INDEX_TEXT"),
                     Map.entry("rag_search", "LLM_SEARCH_INDEX"),
                     Map.entry("pull_workflow_messages", "PULL_WORKFLOW_MESSAGES"));
+
+    /**
+     * Conductor task types a declared tool compiles to, for consumers that have to tell a tool
+     * invocation apart from the rest of a compiled agent workflow.
+     *
+     * <p>Derived from {@link #TYPE_MAP} and from the media types that fall back to their own
+     * upper-cased name, so adding a tool kind to the map extends this set with it.
+     *
+     * <p>It is a floor rather than the closed set of what a tool can compile to. A media or RAG
+     * tool's own config may name its task type, which nothing static can enumerate; those tasks
+     * carry the dispatch script's {@code _agent_tool_name} input instead.
+     *
+     * <p>{@code SIMPLE} is deliberately excluded: a worker tool is not identifiable by task type at
+     * all. {@code SimpleTaskMapper} rewrites an executed SIMPLE task's type to the task's own name,
+     * so a worker tool is recognised by that instead.
+     */
+    public static final Set<String> TOOL_TASK_TYPES =
+            Stream.concat(
+                            TYPE_MAP.values().stream(),
+                            MEDIA_TOOL_TYPES.stream().map(t -> t.toUpperCase(Locale.ROOT)))
+                    .filter(taskType -> !"SIMPLE".equals(taskType))
+                    .collect(Collectors.toUnmodifiableSet());
 
     // ── Public API ───────────────────────────────────────────────────────
 

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/ToolCompiler.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/compiler/ToolCompiler.java
@@ -157,7 +157,8 @@ public class ToolCompiler {
 
     /**
      * Task types a declared tool compiles to. Excludes SIMPLE, whose executed task carries the
-     * tool's own name as its type.
+     * tool's own name as its type. A floor, not a closed set: a media or RAG tool's config may name
+     * its own task type.
      */
     public static final Set<String> COMPILED_TOOL_TASK_TYPES =
             Stream.concat(

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentEventListener.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentEventListener.java
@@ -415,9 +415,10 @@ public class AgentEventListener implements TaskStatusListener, WorkflowStatusLis
      * worker tasks an agent workflow is otherwise made of.
      *
      * <p>Three ways in, in order: the dispatch script's {@code _agent_tool_name} input; an
-     * allowlist over {@link ToolCompiler#TOOL_TASK_TYPES}, the task types a declared tool compiles
-     * to; and the worker case. Nothing is a tool by default, so a task type the agent runtime gains
-     * later is reported as a tool only once it is a tool kind the compiler knows about.
+     * allowlist over {@link ToolCompiler#COMPILED_TOOL_TASK_TYPES}, the task types a declared tool
+     * compiles to; and the worker case. Nothing is a tool by default, so a task type the agent
+     * runtime gains later is reported as a tool only once it is a tool kind the compiler knows
+     * about.
      */
     private boolean isToolTask(TaskModel task) {
         String taskType = task.getTaskType();
@@ -439,7 +440,7 @@ public class AgentEventListener implements TaskStatusListener, WorkflowStatusLis
             // script never saw it — and a handoff is not a tool call.
             return false;
         }
-        if (ToolCompiler.TOOL_TASK_TYPES.contains(taskType)) {
+        if (ToolCompiler.COMPILED_TOOL_TASK_TYPES.contains(taskType)) {
             return true;
         }
         // Worker tools compile to SIMPLE, whose mapper rewrites the executed task's type to the

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentEventListener.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentEventListener.java
@@ -54,13 +54,7 @@ public class AgentEventListener implements TaskStatusListener, WorkflowStatusLis
 
     /**
      * Input key naming the tool a task was dispatched for, set by {@code
-     * JavaScriptBuilder.enrichToolsScript} on every task it emits for a tool call. Absent on
-     * anything the agent compiler emitted statically — the multi-agent strategies' handoff
-     * sub-workflows among them — which is what tells an agent-as-tool call apart from a handoff.
-     *
-     * <p>The second dispatch script, {@code enrichToolsScriptDynamic}, deliberately does not set it
-     * (removed in {@code 09842ab16}), so its tools are selected by task type and named from {@code
-     * method} or {@code taskDefName} instead.
+     * JavaScriptBuilder.enrichToolsScript}. Absent on statically compiled tasks.
      */
     private static final String AGENT_TOOL_NAME = "_agent_tool_name";
 
@@ -410,16 +404,7 @@ public class AgentEventListener implements TaskStatusListener, WorkflowStatusLis
         }
     }
 
-    /**
-     * Determine if a completed task is a tool invocation rather than one of the orchestration or
-     * worker tasks an agent workflow is otherwise made of.
-     *
-     * <p>Three ways in, in order: the dispatch script's {@code _agent_tool_name} input; an
-     * allowlist over {@link ToolCompiler#COMPILED_TOOL_TASK_TYPES}, the task types a declared tool
-     * compiles to; and the worker case. Nothing is a tool by default, so a task type the agent
-     * runtime gains later is reported as a tool only once it is a tool kind the compiler knows
-     * about.
-     */
+    /** Whether a completed task is a tool invocation rather than orchestration or plumbing. */
     private boolean isToolTask(TaskModel task) {
         String taskType = task.getTaskType();
         if (taskType == null) return false;
@@ -429,41 +414,25 @@ public class AgentEventListener implements TaskStatusListener, WorkflowStatusLis
         }
         Map<String, Object> input = task.getInputData();
         if (input != null && input.containsKey(AGENT_TOOL_NAME)) {
-            // The dispatch script marks every task it emits for a tool call, whatever type the
-            // tool compiled to. That covers the one kind no allowlist can enumerate: a media or
-            // RAG tool whose own config names its task type.
+            // Covers tool kinds whose own config names the task type, which no allowlist can list.
             return true;
         }
         if (TaskType.TASK_TYPE_SUB_WORKFLOW.equals(taskType)) {
-            // SUB_WORKFLOW carries both agent-as-tool calls and the handoffs of the multi-agent
-            // strategies. Unmarked, this is a handoff — statically compiled, so the dispatch
-            // script never saw it — and a handoff is not a tool call.
+            // SUB_WORKFLOW is also the multi-agent handoff. Unmarked means handoff, not a tool.
             return false;
         }
         if (ToolCompiler.COMPILED_TOOL_TASK_TYPES.contains(taskType)) {
             return true;
         }
-        // Worker tools compile to SIMPLE, whose mapper rewrites the executed task's type to the
-        // task's own name, so a type matching taskDefName is the worker signature. A platform task
-        // type never is a tool however it is named, and LIST_MCP_TOOLS — the discovery task
-        // compiled into every MCP-using agent, and a worker task that does reach this listener —
-        // is named after its own type, so the two conditions are both needed.
+        // SimpleTaskMapper rewrites an executed SIMPLE task's type to the task's own name.
+        // USER_DEFINED then excludes platform types named after themselves, like LIST_MCP_TOOLS.
         return taskType.equals(task.getTaskDefName())
                 && TaskType.of(taskType) == TaskType.USER_DEFINED;
     }
 
     /**
-     * Resolve the tool name a completed task was dispatched for.
-     *
-     * <p>{@code _agent_tool_name} is the only key the primary dispatch script sets for every tool.
-     * {@code method} carries the tool name for MCP and for the kinds that merge the LLM's own
-     * tool-call inputs — which is what names a tool off the second dispatch script — but the
-     * enrichment script replaces {@code inputParameters} wholesale for an HTTP tool, where {@code
-     * http_request.method} is the HTTP verb rather than a name. {@code taskDefName} is last because
-     * it is the compiled task's name, which for an agent-as-tool is the sub-workflow's name.
-     *
-     * <p>The task reference name is deliberately not consulted, even as a last resort: references
-     * carry provider-controlled data, notably the LLM's own {@code call_} prefixed tool-call ids.
+     * Tool name for a dispatched task. Never the reference name, which carries the provider's own
+     * tool-call ids.
      */
     private String resolveToolName(TaskModel task) {
         Map<String, Object> input = task.getInputData();

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentEventListener.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentEventListener.java
@@ -56,7 +56,7 @@ public class AgentEventListener implements TaskStatusListener, WorkflowStatusLis
      * Input key naming the tool a task was dispatched for, set by {@code
      * JavaScriptBuilder.enrichToolsScript}. Absent on statically compiled tasks.
      */
-    private static final String AGENT_TOOL_NAME = "_agent_tool_name";
+    private static final String AGENT_TOOL_NAME_KEY = "_agent_tool_name";
 
     private final AgentStreamRegistry streamRegistry;
     private final MeterRegistry meterRegistry;
@@ -413,7 +413,7 @@ public class AgentEventListener implements TaskStatusListener, WorkflowStatusLis
             return false;
         }
         Map<String, Object> input = task.getInputData();
-        if (input != null && input.containsKey(AGENT_TOOL_NAME)) {
+        if (input != null && input.containsKey(AGENT_TOOL_NAME_KEY)) {
             // Covers tool kinds whose own config names the task type, which no allowlist can list.
             return true;
         }
@@ -424,10 +424,9 @@ public class AgentEventListener implements TaskStatusListener, WorkflowStatusLis
         if (ToolCompiler.COMPILED_TOOL_TASK_TYPES.contains(taskType)) {
             return true;
         }
-        // SimpleTaskMapper rewrites an executed SIMPLE task's type to the task's own name.
-        // USER_DEFINED then excludes platform types named after themselves, like LIST_MCP_TOOLS.
-        return taskType.equals(task.getTaskDefName())
-                && TaskType.of(taskType) == TaskType.USER_DEFINED;
+        // A custom type is the user's own worker, or a tool whose config named the type. Every
+        // platform type is a TaskType constant, LIST_MCP_TOOLS included.
+        return TaskType.of(taskType) == TaskType.USER_DEFINED;
     }
 
     /**
@@ -437,7 +436,7 @@ public class AgentEventListener implements TaskStatusListener, WorkflowStatusLis
     private String resolveToolName(TaskModel task) {
         Map<String, Object> input = task.getInputData();
         if (input != null) {
-            Object toolName = input.get(AGENT_TOOL_NAME);
+            Object toolName = input.get(AGENT_TOOL_NAME_KEY);
             if (toolName != null) {
                 return String.valueOf(toolName);
             }

--- a/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentEventListener.java
+++ b/agentspan/src/main/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentEventListener.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.conductoross.conductor.ai.agentspan.runtime.compiler.ToolCompiler;
 import org.conductoross.conductor.common.metadata.agent.AgentSSEEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,6 +26,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
+import com.netflix.conductor.common.metadata.tasks.TaskType;
 import com.netflix.conductor.core.listener.TaskStatusListener;
 import com.netflix.conductor.core.listener.WorkflowStatusListener;
 import com.netflix.conductor.model.TaskModel;
@@ -49,6 +51,18 @@ public class AgentEventListener implements TaskStatusListener, WorkflowStatusLis
     /** Conductor AI task types that consume LLM/generation API calls. */
     private static final Set<String> AI_TASK_TYPES =
             Set.of("LLM_CHAT_COMPLETE", "GENERATE_IMAGE", "GENERATE_AUDIO", "GENERATE_VIDEO");
+
+    /**
+     * Input key naming the tool a task was dispatched for, set by {@code
+     * JavaScriptBuilder.enrichToolsScript} on every task it emits for a tool call. Absent on
+     * anything the agent compiler emitted statically — the multi-agent strategies' handoff
+     * sub-workflows among them — which is what tells an agent-as-tool call apart from a handoff.
+     *
+     * <p>The second dispatch script, {@code enrichToolsScriptDynamic}, deliberately does not set it
+     * (removed in {@code 09842ab16}), so its tools are selected by task type and named from {@code
+     * method} or {@code taskDefName} instead.
+     */
+    private static final String AGENT_TOOL_NAME = "_agent_tool_name";
 
     private final AgentStreamRegistry streamRegistry;
     private final MeterRegistry meterRegistry;
@@ -397,8 +411,13 @@ public class AgentEventListener implements TaskStatusListener, WorkflowStatusLis
     }
 
     /**
-     * Determine if a completed task is a tool invocation (not an internal system task like SWITCH,
-     * DO_WHILE, INLINE, etc.).
+     * Determine if a completed task is a tool invocation rather than one of the orchestration or
+     * worker tasks an agent workflow is otherwise made of.
+     *
+     * <p>Three ways in, in order: the dispatch script's {@code _agent_tool_name} input; an
+     * allowlist over {@link ToolCompiler#TOOL_TASK_TYPES}, the task types a declared tool compiles
+     * to; and the worker case. Nothing is a tool by default, so a task type the agent runtime gains
+     * later is reported as a tool only once it is a tool kind the compiler knows about.
      */
     private boolean isToolTask(TaskModel task) {
         String taskType = task.getTaskType();
@@ -407,57 +426,57 @@ public class AgentEventListener implements TaskStatusListener, WorkflowStatusLis
         if (task.getReferenceTaskName() != null && task.getReferenceTaskName().startsWith("_fw_")) {
             return false;
         }
-        // System task types that are NOT tool invocations
-        switch (taskType) {
-            case "LLM_CHAT_COMPLETE":
-            case "SWITCH":
-            case "DO_WHILE":
-            case "INLINE":
-            case "SET_VARIABLE":
-            case "FORK_JOIN_DYNAMIC":
-            case "JOIN":
-            case "SUB_WORKFLOW":
-            case "HUMAN":
-            case "TERMINATE":
-            case "HTTP":
-            case "CALL_MCP_TOOL":
-                return false;
-            default:
-                // SIMPLE or other user-defined task types = tool invocation
-                return "SIMPLE".equals(taskType) || task.getTaskDefinition().isPresent();
+        Map<String, Object> input = task.getInputData();
+        if (input != null && input.containsKey(AGENT_TOOL_NAME)) {
+            // The dispatch script marks every task it emits for a tool call, whatever type the
+            // tool compiled to. That covers the one kind no allowlist can enumerate: a media or
+            // RAG tool whose own config names its task type.
+            return true;
         }
+        if (TaskType.TASK_TYPE_SUB_WORKFLOW.equals(taskType)) {
+            // SUB_WORKFLOW carries both agent-as-tool calls and the handoffs of the multi-agent
+            // strategies. Unmarked, this is a handoff — statically compiled, so the dispatch
+            // script never saw it — and a handoff is not a tool call.
+            return false;
+        }
+        if (ToolCompiler.TOOL_TASK_TYPES.contains(taskType)) {
+            return true;
+        }
+        // Worker tools compile to SIMPLE, whose mapper rewrites the executed task's type to the
+        // task's own name, so a type matching taskDefName is the worker signature. A platform task
+        // type never is a tool however it is named, and LIST_MCP_TOOLS — the discovery task
+        // compiled into every MCP-using agent, and a worker task that does reach this listener —
+        // is named after its own type, so the two conditions are both needed.
+        return taskType.equals(task.getTaskDefName())
+                && TaskType.of(taskType) == TaskType.USER_DEFINED;
     }
 
     /**
-     * Resolve the actual tool/function name from a task.
+     * Resolve the tool name a completed task was dispatched for.
      *
-     * <p>Server-compiled workflows use SIMPLE tasks where the actual tool name is stored in {@code
-     * inputData.method} (set by the enrichment script). Locally-compiled workflows use SIMPLE tasks
-     * with a dispatch pattern where the function name is stored in the output data. SDK-compiled
-     * worker tasks use a custom task type matching the function name.
+     * <p>{@code _agent_tool_name} is the only key the primary dispatch script sets for every tool.
+     * {@code method} carries the tool name for MCP and for the kinds that merge the LLM's own
+     * tool-call inputs — which is what names a tool off the second dispatch script — but the
+     * enrichment script replaces {@code inputParameters} wholesale for an HTTP tool, where {@code
+     * http_request.method} is the HTTP verb rather than a name. {@code taskDefName} is last because
+     * it is the compiled task's name, which for an agent-as-tool is the sub-workflow's name.
+     *
+     * <p>The task reference name is deliberately not consulted, even as a last resort: references
+     * carry provider-controlled data, notably the LLM's own {@code call_} prefixed tool-call ids.
      */
     private String resolveToolName(TaskModel task) {
-        String taskType = task.getTaskType();
-
-        // Server-compiled SIMPLE tasks: tool name is in inputData.method
         Map<String, Object> input = task.getInputData();
-        if (input != null && input.containsKey("method")) {
-            return String.valueOf(input.get("method"));
+        if (input != null) {
+            Object toolName = input.get(AGENT_TOOL_NAME);
+            if (toolName != null) {
+                return String.valueOf(toolName);
+            }
+            Object method = input.get("method");
+            if (method != null) {
+                return String.valueOf(method);
+            }
         }
-
-        // Locally-compiled (dispatch): function name in output data
-        Map<String, Object> output = task.getOutputData();
-        if (output != null && output.containsKey("function")) {
-            return String.valueOf(output.get("function"));
-        }
-
-        // SDK-compiled workers: taskType is the function name (e.g. "get_weather")
-        if (!"SIMPLE".equals(taskType) && taskType != null) {
-            return taskType.toLowerCase();
-        }
-
-        // Fallback to task reference name
-        return task.getReferenceTaskName();
+        return task.getTaskDefName() != null ? task.getTaskDefName() : task.getTaskType();
     }
 
     /**

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentEventListenerTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentEventListenerTest.java
@@ -39,6 +39,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class AgentEventListenerTest {
 
+    private static final String AGENT_TOOL_NAME_KEY = "_agent_tool_name";
+
     @Test
     void scheduledLlmAndCompletedToolPublishOrderedEventsToTheRealStream() {
         AgentStreamRegistry registry = new AgentStreamRegistry();
@@ -91,7 +93,7 @@ class AgentEventListenerTest {
         AgentSSEEvent done = next(parentStream);
         assertThat(done.getType()).isEqualTo("done");
         assertThat(done.getOutput()).isEqualTo(Map.of("result", "complete"));
-        assertThat(next(parentStream)).isNull();
+        assertNoEvent(parentStream);
     }
 
     @Test
@@ -126,7 +128,7 @@ class AgentEventListenerTest {
 
         TaskModel human = task("wf-tools", "HUMAN", "ask_question_0");
         human.setTaskDefName("ask_question");
-        human.setInputData(Map.of("_agent_tool_name", "ask_question"));
+        human.setInputData(Map.of(AGENT_TOOL_NAME_KEY, "ask_question"));
         human.setOutputData(Map.of("result", "yes"));
         listener.onTaskCompleted(human);
 
@@ -150,7 +152,7 @@ class AgentEventListenerTest {
                 Map.of(
                         "http_request",
                         Map.of("uri", "https://example.test/weather", "method", "GET"),
-                        "_agent_tool_name",
+                        AGENT_TOOL_NAME_KEY,
                         "get_weather"));
         http.setOutputData(Map.of("result", "72F"));
         listener.onTaskCompleted(http);
@@ -175,7 +177,7 @@ class AgentEventListenerTest {
 
         TaskModel agentTool = task("wf-sub", "SUB_WORKFLOW", "research_0");
         agentTool.setTaskDefName("research_agent_wf");
-        agentTool.setInputData(Map.of("_agent_tool_name", "research", "prompt", "hi"));
+        agentTool.setInputData(Map.of(AGENT_TOOL_NAME_KEY, "research", "prompt", "hi"));
         agentTool.setOutputData(Map.of("result", "done"));
         listener.onTaskCompleted(agentTool);
 
@@ -199,7 +201,7 @@ class AgentEventListenerTest {
         discovery.setOutputData(Map.of("tools", List.of()));
         listener.onTaskCompleted(discovery);
 
-        assertThat(next(stream)).isNull();
+        assertNoEvent(stream);
         stream.close();
     }
 
@@ -224,9 +226,8 @@ class AgentEventListenerTest {
             plumbing.setTaskDefName(taskType);
             plumbing.setOutputData(Map.of("result", "x"));
             listener.onTaskCompleted(plumbing);
+            assertThat(read(stream, 200)).as("%s reported as a tool call", taskType).isNull();
         }
-
-        assertThat(next(stream)).isNull();
         stream.close();
     }
 
@@ -239,7 +240,7 @@ class AgentEventListenerTest {
         // A media tool may carry taskType in its own config, so no static allowlist covers it.
         TaskModel media = task("wf-media", "GENERATE_DIAGRAM", "make_diagram_0");
         media.setTaskDefName("generate_diagram");
-        media.setInputData(Map.of("prompt", "a box", "_agent_tool_name", "make_diagram"));
+        media.setInputData(Map.of("prompt", "a box", AGENT_TOOL_NAME_KEY, "make_diagram"));
         media.setOutputData(Map.of("result", "diagram.png"));
         listener.onTaskCompleted(media);
 
@@ -251,25 +252,56 @@ class AgentEventListenerTest {
     }
 
     @Test
+    void anUnmarkedToolWhoseConfigNamedItsTaskTypeIsStillAToolCall() {
+        AgentStreamRegistry registry = new AgentStreamRegistry();
+        AgentEventListener listener = listener(registry);
+        AgentEventStream stream = registry.openStream("wf-dynamic", null);
+
+        // enrichToolsScriptDynamic sets no _agent_tool_name, so selection is on task type alone.
+        TaskModel media = task("wf-dynamic", "GENERATE_DIAGRAM", "make_diagram_0");
+        media.setTaskDefName("make_diagram");
+        media.setInputData(Map.of("prompt", "a box", "method", "make_diagram"));
+        media.setOutputData(Map.of("result", "diagram.png"));
+        listener.onTaskCompleted(media);
+
+        AgentSSEEvent toolCall = next(stream);
+        assertThat(toolCall.getType()).isEqualTo("tool_call");
+        assertThat(toolCall.getToolName()).isEqualTo("make_diagram");
+        stream.close();
+    }
+
+    @Test
     void frameworkPassthroughWrappersStayOffTheStream() {
         AgentStreamRegistry registry = new AgentStreamRegistry();
         AgentEventListener listener = listener(registry);
         AgentEventStream stream = registry.openStream("wf-fw", null);
 
         TaskModel wrapper = workerTask("wf-fw", "get_weather", "_fw_get_weather_0");
-        wrapper.setInputData(Map.of("_agent_tool_name", "get_weather"));
+        wrapper.setInputData(Map.of(AGENT_TOOL_NAME_KEY, "get_weather"));
         wrapper.setOutputData(Map.of("result", "72F"));
         listener.onTaskCompleted(wrapper);
 
-        assertThat(next(stream)).isNull();
+        assertNoEvent(stream);
         stream.close();
     }
 
-    /** Next event, or {@code null} if none. The bound stops a blocking take hanging the test. */
+    /** Next event. The generous bound only stops a missing event hanging the suite. */
     private static AgentSSEEvent next(AgentEventStream stream) {
+        return read(stream, 5000);
+    }
+
+    /**
+     * Asserts the stream carries no further event. Events are queued synchronously by the listener,
+     * so a short bound is enough: anything coming has already arrived.
+     */
+    private static void assertNoEvent(AgentEventStream stream) {
+        assertThat(read(stream, 200)).isNull();
+    }
+
+    private static AgentSSEEvent read(AgentEventStream stream, long timeoutMillis) {
         ExecutorService reader = Executors.newSingleThreadExecutor();
         try {
-            return reader.submit(stream::nextEvent).get(500, TimeUnit.MILLISECONDS);
+            return reader.submit(stream::nextEvent).get(timeoutMillis, TimeUnit.MILLISECONDS);
         } catch (TimeoutException e) {
             return null;
         } catch (InterruptedException e) {

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentEventListenerTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentEventListenerTest.java
@@ -137,11 +137,7 @@ class AgentEventListenerTest {
         stream.close();
     }
 
-    /**
-     * HTTP and SUB_WORKFLOW tools complete as async system tasks, which do not notify this listener
-     * today. The selection and naming rules are pinned here regardless, so that the change adding
-     * that notification does not have to rediscover them.
-     */
+    /** HTTP tools complete as async system tasks and do not reach this listener yet. */
     @Test
     void httpToolIsNamedByItsToolNameRatherThanItsHttpVerb() {
         AgentStreamRegistry registry = new AgentStreamRegistry();
@@ -269,12 +265,7 @@ class AgentEventListenerTest {
         stream.close();
     }
 
-    /**
-     * The next event, or {@code null} when the stream carries none. Events are emitted
-     * synchronously, so anything the listener produced is queued before the read; the bound is only
-     * there to keep {@code nextEvent}'s blocking take from turning an absent event into a hung
-     * test.
-     */
+    /** Next event, or {@code null} if none. The bound stops a blocking take hanging the test. */
     private static AgentSSEEvent next(AgentEventStream stream) {
         ExecutorService reader = Executors.newSingleThreadExecutor();
         try {
@@ -311,9 +302,8 @@ class AgentEventListenerTest {
     }
 
     /**
-     * A scheduled task as the decider leaves it. The task definition matters: {@code
-     * MetadataMapperService} synthesizes an ad-hoc one for every named task whatever its type, so a
-     * definition being present says nothing about whether the task is a tool.
+     * A scheduled task with a {@code TaskDef} present, as {@code MetadataMapperService} leaves
+     * every named task.
      */
     private static TaskModel task(String workflowId, String type, String reference) {
         TaskModel task = new TaskModel();

--- a/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentEventListenerTest.java
+++ b/agentspan/src/test/java/org/conductoross/conductor/ai/agentspan/runtime/service/AgentEventListenerTest.java
@@ -12,12 +12,20 @@
  */
 package org.conductoross.conductor.ai.agentspan.runtime.service;
 
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.conductoross.conductor.ai.agent.AgentEventStream;
 import org.conductoross.conductor.common.metadata.agent.AgentSSEEvent;
 import org.junit.jupiter.api.Test;
 
+import com.netflix.conductor.common.metadata.tasks.TaskDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.model.TaskModel;
 import com.netflix.conductor.model.WorkflowModel;
 
@@ -34,19 +42,19 @@ class AgentEventListenerTest {
     @Test
     void scheduledLlmAndCompletedToolPublishOrderedEventsToTheRealStream() {
         AgentStreamRegistry registry = new AgentStreamRegistry();
-        AgentEventListener listener = new AgentEventListener(registry, new SimpleMeterRegistry());
+        AgentEventListener listener = listener(registry);
         AgentEventStream stream = registry.openStream("wf-events", null);
 
         TaskModel llm = task("wf-events", "LLM_CHAT_COMPLETE", "agent_llm");
         listener.onTaskScheduled(llm);
-        TaskModel tool = task("wf-events", "SIMPLE", "call_abc123__1");
+        TaskModel tool = workerTask("wf-events", "get_weather", "call_abc123_0");
         tool.setInputData(Map.of("method", "get_weather", "city", "NYC"));
         tool.setOutputData(Map.of("result", "72F and sunny"));
         listener.onTaskCompleted(tool);
 
-        AgentSSEEvent thinking = stream.nextEvent();
-        AgentSSEEvent toolCall = stream.nextEvent();
-        AgentSSEEvent toolResult = stream.nextEvent();
+        AgentSSEEvent thinking = next(stream);
+        AgentSSEEvent toolCall = next(stream);
+        AgentSSEEvent toolResult = next(stream);
         assertThat(thinking.getType()).isEqualTo("thinking");
         assertThat(thinking.getContent()).isEqualTo("agent_llm");
         assertThat(toolCall.getType()).isEqualTo("tool_call");
@@ -59,19 +67,19 @@ class AgentEventListenerTest {
     @Test
     void handoffAliasForwardsChildEventsAndRootCompletionClosesTheRealStream() {
         AgentStreamRegistry registry = new AgentStreamRegistry();
-        AgentEventListener listener = new AgentEventListener(registry, new SimpleMeterRegistry());
+        AgentEventListener listener = listener(registry);
         AgentEventStream parentStream = registry.openStream("parent", null);
 
         WorkflowModel child = workflow("child", "support_wf");
         child.setParentWorkflowId("parent");
         listener.onWorkflowStartedIfEnabled(child);
-        TaskModel childTool = task("child", "SIMPLE", "child_lookup");
+        TaskModel childTool = workerTask("child", "child_lookup", "child_lookup_0");
         childTool.setOutputData(Map.of("result", "found"));
         listener.onTaskCompleted(childTool);
 
-        AgentSSEEvent handoff = parentStream.nextEvent();
-        AgentSSEEvent toolCall = parentStream.nextEvent();
-        AgentSSEEvent toolResult = parentStream.nextEvent();
+        AgentSSEEvent handoff = next(parentStream);
+        AgentSSEEvent toolCall = next(parentStream);
+        AgentSSEEvent toolResult = next(parentStream);
         assertThat(handoff.getType()).isEqualTo("handoff");
         assertThat(handoff.getTarget()).isEqualTo("support");
         assertThat(toolCall.getExecutionId()).isEqualTo("child");
@@ -80,27 +88,27 @@ class AgentEventListenerTest {
         WorkflowModel root = workflow("parent", "parent_agent");
         root.setOutput(Map.of("result", "complete"));
         listener.onWorkflowCompletedIfEnabled(root);
-        AgentSSEEvent done = parentStream.nextEvent();
+        AgentSSEEvent done = next(parentStream);
         assertThat(done.getType()).isEqualTo("done");
         assertThat(done.getOutput()).isEqualTo(Map.of("result", "complete"));
-        assertThat(parentStream.nextEvent()).isNull();
+        assertThat(next(parentStream)).isNull();
     }
 
     @Test
     void guardrailFailuresAndTaskFailuresReachTheSdkStream() {
         AgentStreamRegistry registry = new AgentStreamRegistry();
-        AgentEventListener listener = new AgentEventListener(registry, new SimpleMeterRegistry());
+        AgentEventListener listener = listener(registry);
         AgentEventStream stream = registry.openStream("wf-errors", null);
 
         TaskModel guardrail = task("wf-errors", "INLINE", "safety_guardrail");
         guardrail.setOutputData(Map.of("passed", false, "message", "Unsafe content"));
         listener.onTaskCompleted(guardrail);
-        TaskModel failed = task("wf-errors", "SIMPLE", "lookup");
+        TaskModel failed = workerTask("wf-errors", "lookup", "lookup_0");
         failed.setReasonForIncompletion("Connection timeout");
         listener.onTaskFailed(failed);
 
-        AgentSSEEvent guardrailEvent = stream.nextEvent();
-        AgentSSEEvent failure = stream.nextEvent();
+        AgentSSEEvent guardrailEvent = next(stream);
+        AgentSSEEvent failure = next(stream);
         assertThat(guardrailEvent.getType()).isEqualTo("guardrail_fail");
         assertThat(guardrailEvent.getContent()).isEqualTo("Unsafe content");
         assertThat(failure.getType()).isEqualTo("error");
@@ -108,11 +116,216 @@ class AgentEventListenerTest {
         stream.close();
     }
 
+    @Test
+    void mcpAndHumanToolCompletionsAreReportedUnderTheirDeclaredToolNames() {
+        AgentStreamRegistry registry = new AgentStreamRegistry();
+        AgentEventListener listener = listener(registry);
+        AgentEventStream stream = registry.openStream("wf-tools", null);
+
+        listener.onTaskCompleted(mcpToolCall("wf-tools"));
+
+        TaskModel human = task("wf-tools", "HUMAN", "ask_question_0");
+        human.setTaskDefName("ask_question");
+        human.setInputData(Map.of("_agent_tool_name", "ask_question"));
+        human.setOutputData(Map.of("result", "yes"));
+        listener.onTaskCompleted(human);
+
+        assertThat(next(stream).getToolName()).isEqualTo("math_add");
+        assertThat(next(stream).getToolName()).isEqualTo("math_add");
+        assertThat(next(stream).getToolName()).isEqualTo("ask_question");
+        assertThat(next(stream).getToolName()).isEqualTo("ask_question");
+        stream.close();
+    }
+
+    /**
+     * HTTP and SUB_WORKFLOW tools complete as async system tasks, which do not notify this listener
+     * today. The selection and naming rules are pinned here regardless, so that the change adding
+     * that notification does not have to rediscover them.
+     */
+    @Test
+    void httpToolIsNamedByItsToolNameRatherThanItsHttpVerb() {
+        AgentStreamRegistry registry = new AgentStreamRegistry();
+        AgentEventListener listener = listener(registry);
+        AgentEventStream stream = registry.openStream("wf-http", null);
+
+        TaskModel http = task("wf-http", "HTTP", "get_weather_0");
+        http.setTaskDefName("get_weather");
+        http.setInputData(
+                Map.of(
+                        "http_request",
+                        Map.of("uri", "https://example.test/weather", "method", "GET"),
+                        "_agent_tool_name",
+                        "get_weather"));
+        http.setOutputData(Map.of("result", "72F"));
+        listener.onTaskCompleted(http);
+
+        AgentSSEEvent toolCall = next(stream);
+        assertThat(toolCall.getType()).isEqualTo("tool_call");
+        assertThat(toolCall.getToolName()).isEqualTo("get_weather");
+        assertThat(next(stream).getToolName()).isEqualTo("get_weather");
+        stream.close();
+    }
+
+    @Test
+    void agentAsToolIsAToolCallWhileAStrategyHandoffIsNot() {
+        AgentStreamRegistry registry = new AgentStreamRegistry();
+        AgentEventListener listener = listener(registry);
+        AgentEventStream stream = registry.openStream("wf-sub", null);
+
+        TaskModel handoff = task("wf-sub", "SUB_WORKFLOW", "support_handoff_billing");
+        handoff.setTaskDefName("billing_wf");
+        handoff.setOutputData(Map.of("result", "handled"));
+        listener.onTaskCompleted(handoff);
+
+        TaskModel agentTool = task("wf-sub", "SUB_WORKFLOW", "research_0");
+        agentTool.setTaskDefName("research_agent_wf");
+        agentTool.setInputData(Map.of("_agent_tool_name", "research", "prompt", "hi"));
+        agentTool.setOutputData(Map.of("result", "done"));
+        listener.onTaskCompleted(agentTool);
+
+        // The handoff emitted nothing, so the first event on the stream is the agent tool's.
+        AgentSSEEvent toolCall = next(stream);
+        assertThat(toolCall.getType()).isEqualTo("tool_call");
+        assertThat(toolCall.getToolName()).isEqualTo("research");
+        assertThat(next(stream).getType()).isEqualTo("tool_result");
+        stream.close();
+    }
+
+    @Test
+    void theMcpDiscoveryTaskIsNotReportedAsAToolCall() {
+        AgentStreamRegistry registry = new AgentStreamRegistry();
+        AgentEventListener listener = listener(registry);
+        AgentEventStream stream = registry.openStream("wf-discovery", null);
+
+        TaskModel discovery = task("wf-discovery", "LIST_MCP_TOOLS", "list_tools_ref");
+        discovery.setTaskDefName("LIST_MCP_TOOLS");
+        discovery.setInputData(Map.of("mcpServer", "http://mcp"));
+        discovery.setOutputData(Map.of("tools", List.of()));
+        listener.onTaskCompleted(discovery);
+
+        assertThat(next(stream)).isNull();
+        stream.close();
+    }
+
+    @Test
+    void orchestrationTasksAreNotReportedAsToolCalls() {
+        AgentStreamRegistry registry = new AgentStreamRegistry();
+        AgentEventListener listener = listener(registry);
+        AgentEventStream stream = registry.openStream("wf-plumbing", null);
+
+        for (String taskType :
+                List.of(
+                        "SWITCH",
+                        "DO_WHILE",
+                        "INLINE",
+                        "SET_VARIABLE",
+                        "FORK_JOIN_DYNAMIC",
+                        "JOIN",
+                        "TERMINATE",
+                        "LLM_CHAT_COMPLETE",
+                        "AGENT")) {
+            TaskModel plumbing = task("wf-plumbing", taskType, taskType.toLowerCase() + "_ref");
+            plumbing.setTaskDefName(taskType);
+            plumbing.setOutputData(Map.of("result", "x"));
+            listener.onTaskCompleted(plumbing);
+        }
+
+        assertThat(next(stream)).isNull();
+        stream.close();
+    }
+
+    @Test
+    void aToolWhoseConfigNamesItsOwnTaskTypeIsStillAToolCall() {
+        AgentStreamRegistry registry = new AgentStreamRegistry();
+        AgentEventListener listener = listener(registry);
+        AgentEventStream stream = registry.openStream("wf-media", null);
+
+        // A media tool may carry taskType in its own config, so no static allowlist covers it.
+        TaskModel media = task("wf-media", "GENERATE_DIAGRAM", "make_diagram_0");
+        media.setTaskDefName("generate_diagram");
+        media.setInputData(Map.of("prompt", "a box", "_agent_tool_name", "make_diagram"));
+        media.setOutputData(Map.of("result", "diagram.png"));
+        listener.onTaskCompleted(media);
+
+        AgentSSEEvent toolCall = next(stream);
+        assertThat(toolCall.getType()).isEqualTo("tool_call");
+        assertThat(toolCall.getToolName()).isEqualTo("make_diagram");
+        assertThat(next(stream).getToolName()).isEqualTo("make_diagram");
+        stream.close();
+    }
+
+    @Test
+    void frameworkPassthroughWrappersStayOffTheStream() {
+        AgentStreamRegistry registry = new AgentStreamRegistry();
+        AgentEventListener listener = listener(registry);
+        AgentEventStream stream = registry.openStream("wf-fw", null);
+
+        TaskModel wrapper = workerTask("wf-fw", "get_weather", "_fw_get_weather_0");
+        wrapper.setInputData(Map.of("_agent_tool_name", "get_weather"));
+        wrapper.setOutputData(Map.of("result", "72F"));
+        listener.onTaskCompleted(wrapper);
+
+        assertThat(next(stream)).isNull();
+        stream.close();
+    }
+
+    /**
+     * The next event, or {@code null} when the stream carries none. Events are emitted
+     * synchronously, so anything the listener produced is queued before the read; the bound is only
+     * there to keep {@code nextEvent}'s blocking take from turning an absent event into a hung
+     * test.
+     */
+    private static AgentSSEEvent next(AgentEventStream stream) {
+        ExecutorService reader = Executors.newSingleThreadExecutor();
+        try {
+            return reader.submit(stream::nextEvent).get(500, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            return null;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
+        } catch (ExecutionException e) {
+            throw new AssertionError(e.getCause());
+        } finally {
+            reader.shutdownNow();
+        }
+    }
+
+    private static TaskModel mcpToolCall(String workflowId) {
+        TaskModel mcp = task(workflowId, "CALL_MCP_TOOL", "math_call_0");
+        mcp.setTaskDefName("call_mcp_tool");
+        mcp.setInputData(Map.of("mcpServer", "http://mcp", "method", "math_add"));
+        mcp.setOutputData(Map.of("result", 5));
+        return mcp;
+    }
+
+    private static AgentEventListener listener(AgentStreamRegistry registry) {
+        return new AgentEventListener(registry, new SimpleMeterRegistry());
+    }
+
+    /** A worker tool: {@code SimpleTaskMapper} sets the executed task's type to its own name. */
+    private static TaskModel workerTask(String workflowId, String name, String reference) {
+        TaskModel task = task(workflowId, name, reference);
+        task.setTaskDefName(name);
+        return task;
+    }
+
+    /**
+     * A scheduled task as the decider leaves it. The task definition matters: {@code
+     * MetadataMapperService} synthesizes an ad-hoc one for every named task whatever its type, so a
+     * definition being present says nothing about whether the task is a tool.
+     */
     private static TaskModel task(String workflowId, String type, String reference) {
         TaskModel task = new TaskModel();
         task.setWorkflowInstanceId(workflowId);
         task.setTaskType(type);
         task.setReferenceTaskName(reference);
+        WorkflowTask workflowTask = new WorkflowTask();
+        workflowTask.setName(type);
+        workflowTask.setType(type);
+        workflowTask.setTaskReferenceName(reference);
+        workflowTask.setTaskDefinition(new TaskDef(type));
+        task.setWorkflowTask(workflowTask);
         return task;
     }
 


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

## Summary

- `isToolTask` identified a tool call by exclusion: twelve task types denylisted, everything else a tool. It was wrong in both directions.
- Root cause: four denylist entries are real tool kinds, since `ToolCompiler.TYPE_MAP` compiles `mcp`, `human`, `http`/`api` and `agent_tool` onto `CALL_MCP_TOOL`, `HUMAN`, `HTTP` and `SUB_WORKFLOW`. The default branch then filtered nothing, because `getTaskDefinition().isPresent()` is true for any named task once `MetadataMapperService` synthesizes an ad-hoc `TaskDef`.
- Fix: allowlist on `_agent_tool_name`, the task types a declared tool compiles to, and the worker case. Naming reads `_agent_tool_name`, then `method`, then `taskDefName`, never the reference name, which carries provider-controlled ids. An unmarked `SUB_WORKFLOW` counts as a strategy handoff rather than an agent-as-tool call, the one type here meaning two things. Compile-time markers were tried and reverted in `09842ab16`, so this stays a selection change.

## User impact

A human tool ran and returned its answer without ever appearing as a tool call in the agent's event stream. One `human` tool named `ask_human`, same agent, against servers built from this branch and from its merge-base:

| | events for the turn |
|---|---|
| before | `thinking`, `waiting`, `thinking`, `done` |
| after | `thinking`, `waiting`, `tool_call` (`ask_human`), `tool_result` (`ask_human`), `thinking`, `done` |

Worker tools are unaffected: `get_weather` reports the same pair either side.

## Changes

- `ToolCompiler.java`: add `COMPILED_TOOL_TASK_TYPES`, derived from `TYPE_MAP` and the media types that fall back to their own upper-cased name, excluding `SIMPLE`. The name is qualified because `AgentChatCompleteTaskMapper` holds a private `TOOL_TASK_TYPES` that does include `SIMPLE`, for a different decision.
- `AgentEventListener.java`: swap the denylist for that allowlist plus any custom task type, `TaskType.of` reporting `USER_DEFINED`. That covers worker tools and tools whose config names their own type, and excludes every platform type, `LIST_MCP_TOOLS` included. Reorder `resolveToolName` and drop the reference-name fallback.
- `AgentEventListenerTest.java`: eight cases over MCP and HUMAN naming, the discovery task, agent-as-tool against a handoff, a config-named task type both with and without the dispatch marker, nine orchestration types, and `_fw_` wrappers.

Fixes #1584
