### PR TITLE
perf(metadata): add lightweight /metadata/workflow/list endpoint for the Workflow Definitions UI

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDefListItem.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDefListItem.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.common.metadata.workflow;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Read-only list projection of {@link WorkflowDef} used by the Workflow Definitions list UI.
+ *
+ * <p>This DTO deliberately omits the full task blueprint ({@code tasks}) and instead exposes only
+ * lightweight summary fields plus derived {@code taskTypes} and {@code taskCount}. It exists to
+ * avoid shipping very large responses when listing workflow definitions.
+ *
+ * <p>This projection must never be used to register or execute a workflow: it does not carry the
+ * complete definition and is not a substitute for {@link WorkflowDef}.
+ *
+ * <p>Fields can be populated either by the {@link #fromWorkflowDef(WorkflowDef)} factory or by the
+ * persistence layer setting them field-by-field from a query result row; the public setters are
+ * retained for that reason.
+ */
+public class WorkflowDefListItem {
+
+    private String name;
+
+    private String description;
+
+    private int version;
+
+    private Long createTime;
+
+    private int schemaVersion;
+
+    private boolean restartable;
+
+    private boolean workflowStatusListenerEnabled;
+
+    private String ownerEmail;
+
+    private List<String> inputParameters;
+
+    private Map<String, Object> outputParameters;
+
+    private WorkflowDef.TimeoutPolicy timeoutPolicy;
+
+    private long timeoutSeconds;
+
+    private Set<String> taskTypes;
+
+    private int taskCount;
+
+    private String failureWorkflow;
+
+    private String classifier;
+
+    public static WorkflowDefListItem fromWorkflowDef(WorkflowDef def) {
+        WorkflowDefListItem item = new WorkflowDefListItem();
+        item.setName(def.getName());
+        item.setDescription(def.getDescription());
+        item.setVersion(def.getVersion());
+        item.setCreateTime(def.getCreateTime());
+        item.setSchemaVersion(def.getSchemaVersion());
+        item.setRestartable(def.isRestartable());
+        item.setWorkflowStatusListenerEnabled(def.isWorkflowStatusListenerEnabled());
+        item.setOwnerEmail(def.getOwnerEmail());
+        item.setInputParameters(def.getInputParameters());
+        item.setOutputParameters(def.getOutputParameters());
+        item.setTimeoutPolicy(def.getTimeoutPolicy());
+        item.setTimeoutSeconds(def.getTimeoutSeconds());
+        item.setFailureWorkflow(def.getFailureWorkflow());
+        item.setClassifier(WorkflowClassifier.classifierOf(def));
+
+        List<WorkflowTask> tasks = def.getTasks();
+        Set<String> taskTypes = new TreeSet<>();
+        if (tasks == null) {
+            item.setTaskTypes(taskTypes);
+            item.setTaskCount(0);
+        } else {
+            for (WorkflowTask task : tasks) {
+                if (task != null && task.getType() != null) {
+                    taskTypes.add(task.getType());
+                }
+            }
+            item.setTaskTypes(taskTypes);
+            item.setTaskCount(tasks.size());
+        }
+        return item;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public Long getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(Long createTime) {
+        this.createTime = createTime;
+    }
+
+    public int getSchemaVersion() {
+        return schemaVersion;
+    }
+
+    public void setSchemaVersion(int schemaVersion) {
+        this.schemaVersion = schemaVersion;
+    }
+
+    public boolean isRestartable() {
+        return restartable;
+    }
+
+    public void setRestartable(boolean restartable) {
+        this.restartable = restartable;
+    }
+
+    public boolean isWorkflowStatusListenerEnabled() {
+        return workflowStatusListenerEnabled;
+    }
+
+    public void setWorkflowStatusListenerEnabled(boolean workflowStatusListenerEnabled) {
+        this.workflowStatusListenerEnabled = workflowStatusListenerEnabled;
+    }
+
+    public String getOwnerEmail() {
+        return ownerEmail;
+    }
+
+    public void setOwnerEmail(String ownerEmail) {
+        this.ownerEmail = ownerEmail;
+    }
+
+    public List<String> getInputParameters() {
+        return inputParameters;
+    }
+
+    public void setInputParameters(List<String> inputParameters) {
+        this.inputParameters = inputParameters;
+    }
+
+    public Map<String, Object> getOutputParameters() {
+        return outputParameters;
+    }
+
+    public void setOutputParameters(Map<String, Object> outputParameters) {
+        this.outputParameters = outputParameters;
+    }
+
+    public WorkflowDef.TimeoutPolicy getTimeoutPolicy() {
+        return timeoutPolicy;
+    }
+
+    public void setTimeoutPolicy(WorkflowDef.TimeoutPolicy timeoutPolicy) {
+        this.timeoutPolicy = timeoutPolicy;
+    }
+
+    public long getTimeoutSeconds() {
+        return timeoutSeconds;
+    }
+
+    public void setTimeoutSeconds(long timeoutSeconds) {
+        this.timeoutSeconds = timeoutSeconds;
+    }
+
+    public Set<String> getTaskTypes() {
+        return taskTypes;
+    }
+
+    public void setTaskTypes(Set<String> taskTypes) {
+        this.taskTypes = taskTypes;
+    }
+
+    public int getTaskCount() {
+        return taskCount;
+    }
+
+    public void setTaskCount(int taskCount) {
+        this.taskCount = taskCount;
+    }
+
+    public String getFailureWorkflow() {
+        return failureWorkflow;
+    }
+
+    public void setFailureWorkflow(String failureWorkflow) {
+        this.failureWorkflow = failureWorkflow;
+    }
+
+    public String getClassifier() {
+        return classifier;
+    }
+
+    public void setClassifier(String classifier) {
+        this.classifier = classifier;
+    }
+}

--- a/common/src/test/java/com/netflix/conductor/common/metadata/workflow/WorkflowDefListItemTest.java
+++ b/common/src/test/java/com/netflix/conductor/common/metadata/workflow/WorkflowDefListItemTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.common.metadata.workflow;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class WorkflowDefListItemTest {
+
+    @Test
+    public void fromWorkflowDefCopiesListFieldsAndDerivesTaskTypesAndCount() {
+        WorkflowTask t1 = new WorkflowTask();
+        t1.setType("SIMPLE");
+        WorkflowTask t2 = new WorkflowTask();
+        t2.setType("HTTP");
+        WorkflowTask t3 = new WorkflowTask();
+        t3.setType("SIMPLE"); // duplicate type must dedupe
+
+        WorkflowDef def = new WorkflowDef();
+        def.setName("payment_flow");
+        def.setDescription("desc");
+        def.setVersion(4);
+        def.setCreateTime(123L);
+        def.setSchemaVersion(2);
+        def.setRestartable(true);
+        def.setWorkflowStatusListenerEnabled(true);
+        def.setOwnerEmail("owner@example.com");
+        def.setInputParameters(List.of("in1"));
+        def.setOutputParameters(Map.of("out1", "v"));
+        def.setTimeoutPolicy(WorkflowDef.TimeoutPolicy.TIME_OUT_WF);
+        def.setTimeoutSeconds(60L);
+        def.setFailureWorkflow("failFlow");
+        def.setTasks(List.of(t1, t2, t3));
+
+        WorkflowDefListItem item = WorkflowDefListItem.fromWorkflowDef(def);
+
+        assertEquals("payment_flow", item.getName());
+        assertEquals("desc", item.getDescription());
+        assertEquals(4, item.getVersion());
+        assertEquals(Long.valueOf(123L), item.getCreateTime());
+        assertEquals(2, item.getSchemaVersion());
+        assertTrue(item.isRestartable());
+        assertTrue(item.isWorkflowStatusListenerEnabled());
+        assertEquals("owner@example.com", item.getOwnerEmail());
+        assertEquals(List.of("in1"), item.getInputParameters());
+        assertEquals(Map.of("out1", "v"), item.getOutputParameters());
+        assertEquals(WorkflowDef.TimeoutPolicy.TIME_OUT_WF, item.getTimeoutPolicy());
+        assertEquals(60L, item.getTimeoutSeconds());
+        assertEquals(2, item.getTaskTypes().size());
+        assertTrue(item.getTaskTypes().contains("SIMPLE"));
+        assertTrue(item.getTaskTypes().contains("HTTP"));
+        // tasks were declared out of alphabetical order (SIMPLE, HTTP, SIMPLE); the
+        // taskTypes set must iterate alphabetically to match the Postgres path.
+        assertEquals(List.of("HTTP", "SIMPLE"), new ArrayList<>(item.getTaskTypes()));
+        assertEquals(3, item.getTaskCount());
+        assertEquals("failFlow", item.getFailureWorkflow());
+        // no metadata on this def -> plain workflow classifier
+        assertEquals("workflow", item.getClassifier());
+    }
+
+    @Test
+    public void fromWorkflowDefDerivesAgentClassifierFromMetadata() {
+        WorkflowDef def = new WorkflowDef();
+        def.setName("agent_flow");
+        def.setVersion(1);
+        def.setMetadata(Map.of("agent_sdk", "x"));
+
+        WorkflowDefListItem item = WorkflowDefListItem.fromWorkflowDef(def);
+
+        assertEquals("agent", item.getClassifier());
+    }
+
+    @Test
+    public void fromWorkflowDefHandlesNullTasks() {
+        WorkflowDef def = new WorkflowDef();
+        def.setName("empty");
+        def.setVersion(1);
+        def.setTasks(null);
+
+        WorkflowDefListItem item = WorkflowDefListItem.fromWorkflowDef(def);
+
+        assertEquals(0, item.getTaskCount());
+        assertEquals(0, item.getTaskTypes().size());
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/dao/MetadataDAO.java
+++ b/core/src/main/java/com/netflix/conductor/dao/MetadataDAO.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDefListItem;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDefSummary;
 
 /** Data access layer for the workflow metadata - task definitions and workflow definitions */
@@ -123,6 +124,20 @@ public interface MetadataDAO {
                             summary.setCreateTime(def.getCreateTime());
                             return summary;
                         })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns a lightweight list projection of the latest version of every workflow definition,
+     * omitting full task blueprints. Persistence modules should override this with a query that
+     * projects list fields from json_data server-side. The default fallback maps the existing
+     * latest-version definitions in Java, so backends without an optimized query still work.
+     *
+     * @return list items for the latest version of each workflow, one per name
+     */
+    default List<WorkflowDefListItem> getWorkflowDefListItems() {
+        return getAllWorkflowDefsLatestVersions().stream()
+                .map(WorkflowDefListItem::fromWorkflowDef)
                 .collect(Collectors.toList());
     }
 }

--- a/core/src/main/java/com/netflix/conductor/service/MetadataService.java
+++ b/core/src/main/java/com/netflix/conductor/service/MetadataService.java
@@ -21,6 +21,7 @@ import org.springframework.validation.annotation.Validated;
 import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDefListItem;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDefSummary;
 import com.netflix.conductor.common.model.BulkResponse;
 
@@ -160,6 +161,12 @@ public interface MetadataService {
             boolean activeOnly);
 
     List<WorkflowDef> getWorkflowDefsLatestVersions();
+
+    /**
+     * @return Returns lightweight list items for the latest version of each workflow definition (no
+     *     full definition bodies)
+     */
+    List<WorkflowDefListItem> getWorkflowDefListItems();
 
     /**
      * @return Returns distinct workflow definition names (no versions, no definition bodies)

--- a/core/src/main/java/com/netflix/conductor/service/MetadataServiceImpl.java
+++ b/core/src/main/java/com/netflix/conductor/service/MetadataServiceImpl.java
@@ -27,6 +27,7 @@ import com.netflix.conductor.common.constraints.OwnerEmailMandatoryConstraint;
 import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDefListItem;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDefSummary;
 import com.netflix.conductor.common.model.BulkResponse;
 import com.netflix.conductor.core.WorkflowContext;
@@ -240,6 +241,11 @@ public class MetadataServiceImpl implements MetadataService {
     @Override
     public List<WorkflowDef> getWorkflowDefsLatestVersions() {
         return metadataDAO.getAllWorkflowDefsLatestVersions();
+    }
+
+    @Override
+    public List<WorkflowDefListItem> getWorkflowDefListItems() {
+        return metadataDAO.getWorkflowDefListItems();
     }
 
     public Map<String, ? extends Iterable<WorkflowDefSummary>> getWorkflowNamesAndVersions() {

--- a/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
+++ b/core/src/test/java/com/netflix/conductor/service/MetadataServiceTest.java
@@ -28,6 +28,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDefListItem;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDefSummary;
 import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.common.model.BulkResponse;
@@ -589,5 +590,19 @@ public class MetadataServiceTest {
             assertNotNull(summary.getCreateTime());
         }
         verify(metadataDAO, times(1)).getWorkflowVersions("test_workflow_def");
+    }
+
+    @Test
+    public void testGetWorkflowDefListItemsDelegatesToDao() {
+        WorkflowDefListItem item = new WorkflowDefListItem();
+        item.setName("wf");
+        item.setVersion(2);
+        when(metadataDAO.getWorkflowDefListItems()).thenReturn(List.of(item));
+
+        List<WorkflowDefListItem> result = metadataService.getWorkflowDefListItems();
+
+        assertEquals(1, result.size());
+        assertEquals("wf", result.get(0).getName());
+        verify(metadataDAO, times(1)).getWorkflowDefListItems();
     }
 }

--- a/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAO.java
+++ b/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAO.java
@@ -12,7 +12,10 @@
  */
 package com.netflix.conductor.postgres.dao;
 
+import java.sql.Array;
 import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -27,6 +30,7 @@ import org.springframework.retry.support.RetryTemplate;
 import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDefListItem;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDefSummary;
 import com.netflix.conductor.core.exception.ConflictException;
 import com.netflix.conductor.core.exception.NonTransientException;
@@ -230,6 +234,68 @@ public class PostgresMetadataDAO extends PostgresBaseDAO implements MetadataDAO,
         return queryWithTransaction(
                 GET_ALL_WORKFLOW_DEF_LATEST_VERSIONS_QUERY,
                 q -> q.executeAndFetch(WorkflowDef.class));
+    }
+
+    @Override
+    public List<WorkflowDefListItem> getWorkflowDefListItems() {
+        // json_data (TEXT) is cast to jsonb and parsed ONCE per row via a LATERAL cast (x.jd).
+        // `x.jd - 'tasks'` strips the task blueprint so Java deserializes only the lightweight
+        // def (WorkflowDef.fromWorkflowDef maps all scalar/collection fields + classifier).
+        // task_count and task_types are derived in a LEFT JOIN LATERAL aggregate rather than a
+        // per-row SELECT-list scalar subquery. Latest-version filtering uses the maintained
+        // latest_version column (same idiom as getAllLatest). PG11-compatible (no jsonb_path_*).
+        final String QUERY =
+                """
+                SELECT
+                  x.jd - 'tasks'                                   AS def_light,
+                  COALESCE(jsonb_array_length(x.jd -> 'tasks'), 0) AS task_count,
+                  tt.task_types                                    AS task_types
+                FROM meta_workflow_def m
+                CROSS JOIN LATERAL (SELECT m.json_data::jsonb AS jd) x
+                LEFT JOIN LATERAL (
+                    SELECT array_agg(DISTINCT e ->> 'type' ORDER BY e ->> 'type') AS task_types
+                    FROM jsonb_array_elements(x.jd -> 'tasks') AS e
+                ) tt ON true
+                WHERE m.version = m.latest_version
+                ORDER BY m.name""";
+
+        return queryWithTransaction(
+                QUERY,
+                q ->
+                        q.executeAndFetch(
+                                rs -> {
+                                    List<WorkflowDefListItem> items = new ArrayList<>();
+                                    while (rs.next()) {
+                                        WorkflowDef def =
+                                                readValue(
+                                                        rs.getString("def_light"),
+                                                        WorkflowDef.class);
+                                        WorkflowDefListItem item =
+                                                WorkflowDefListItem.fromWorkflowDef(def);
+                                        // tasks were stripped in SQL, so override the two
+                                        // task-derived fields with the SQL-computed values.
+                                        item.setTaskCount(rs.getInt("task_count"));
+                                        item.setTaskTypes(readTaskTypes(rs));
+                                        items.add(item);
+                                    }
+                                    return items;
+                                }));
+    }
+
+    private Set<String> readTaskTypes(ResultSet rs) throws SQLException {
+        Set<String> types = new TreeSet<>();
+        Array array = rs.getArray("task_types");
+        if (array != null) {
+            String[] values = (String[]) array.getArray();
+            if (values != null) {
+                for (String type : values) {
+                    if (type != null && !type.isEmpty()) {
+                        types.add(type);
+                    }
+                }
+            }
+        }
+        return types;
     }
 
     public List<WorkflowDef> getAllLatest() {

--- a/postgres-persistence/src/main/resources/db/migration_postgres/V20__workflow_def_latest_version_index.sql
+++ b/postgres-persistence/src/main/resources/db/migration_postgres/V20__workflow_def_latest_version_index.sql
@@ -1,0 +1,16 @@
+-- getWorkflowDefListItems() (GET /api/metadata/workflow/list) selects the latest version of every
+-- workflow with `WHERE version = latest_version ORDER BY name`. Without support that predicate is a
+-- column = column comparison the existing unique_name_version(name, version) and
+-- workflow_def_name_index(name) indexes cannot satisfy, forcing a full scan of every version row
+-- plus a sort.
+--
+-- A partial index keyed on name and restricted to the latest-version rows serves both needs in one
+-- index-ordered scan: the WHERE predicate matches the partial condition exactly, and the name key
+-- provides the ORDER BY ordering, so only latest rows are visited and no explicit sort is needed.
+--
+-- Plain (non-CONCURRENT) CREATE INDEX is used deliberately: meta_workflow_def holds workflow
+-- definitions (thousands of rows), so the build and the brief lock are negligible, and it keeps the
+-- migration runnable inside Flyway's transaction (CREATE INDEX CONCURRENTLY cannot run in one).
+CREATE INDEX IF NOT EXISTS meta_workflow_def_latest_name_idx
+    ON meta_workflow_def (name)
+    WHERE version = latest_version;

--- a/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAOTest.java
+++ b/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresMetadataDAOTest.java
@@ -38,7 +38,9 @@ import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
 import com.netflix.conductor.common.metadata.events.EventHandler;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDefListItem;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDefSummary;
+import com.netflix.conductor.common.metadata.workflow.WorkflowTask;
 import com.netflix.conductor.core.exception.ConflictException;
 import com.netflix.conductor.core.exception.NotFoundException;
 import com.netflix.conductor.postgres.config.PostgresConfiguration;
@@ -374,6 +376,104 @@ public class PostgresMetadataDAOTest {
         assertTrue(names.contains("names_wf_alpha"));
         assertTrue(names.contains("names_wf_beta"));
         assertTrue(names.indexOf("names_wf_alpha") < names.indexOf("names_wf_beta"));
+    }
+
+    @Test
+    public void testGetWorkflowDefListItems() {
+        WorkflowDef def = new WorkflowDef();
+        def.setName("listA");
+        def.setVersion(1);
+        def.setDescription("v1 desc");
+        def.setOwnerEmail("a@example.com");
+        def.setCreateTime(1L);
+        WorkflowTask ta = new WorkflowTask();
+        ta.setName("t");
+        ta.setTaskReferenceName("t");
+        ta.setType("SIMPLE");
+        def.setTasks(java.util.List.of(ta));
+        metadataDAO.createWorkflowDef(def);
+
+        def.setVersion(2);
+        def.setDescription("v2 desc");
+        WorkflowTask tb = new WorkflowTask();
+        tb.setName("h");
+        tb.setTaskReferenceName("h");
+        tb.setType("HTTP");
+        def.setTasks(java.util.List.of(ta, tb));
+        metadataDAO.createWorkflowDef(def);
+
+        def.setVersion(3);
+        def.setCreateTime(4200L);
+        def.setInputParameters(java.util.List.of("p1", "p2"));
+        def.setFailureWorkflow("cleanup_flow");
+        java.util.Map<String, Object> out = new java.util.HashMap<>();
+        out.put("res", "${t.output.x}");
+        def.setOutputParameters(out);
+        metadataDAO.createWorkflowDef(def);
+
+        WorkflowDef other = new WorkflowDef();
+        other.setName("listB");
+        other.setVersion(1);
+        other.setCreateTime(1L);
+        other.setTasks(java.util.List.of(ta));
+        metadataDAO.createWorkflowDef(other);
+
+        WorkflowDef agent = new WorkflowDef();
+        agent.setName("listAgent");
+        agent.setVersion(1);
+        agent.setCreateTime(1L);
+        agent.setTasks(java.util.List.of(ta));
+        agent.setMetadata(java.util.Map.of("agent_sdk", "x"));
+        metadataDAO.createWorkflowDef(agent);
+
+        List<WorkflowDefListItem> items = metadataDAO.getWorkflowDefListItems();
+
+        Map<String, WorkflowDefListItem> byName =
+                items.stream().collect(Collectors.toMap(WorkflowDefListItem::getName, i -> i));
+        assertTrue(byName.containsKey("listA"));
+        assertTrue(byName.containsKey("listB"));
+
+        WorkflowDefListItem a = byName.get("listA");
+        assertEquals(3, a.getVersion()); // latest version only
+        assertEquals("v2 desc", a.getDescription());
+        assertEquals(2, a.getTaskCount());
+        assertTrue(a.getTaskTypes().contains("SIMPLE"));
+        assertTrue(a.getTaskTypes().contains("HTTP"));
+        // taskTypes must iterate alphabetically (TreeSet / array_agg ORDER BY),
+        // regardless of task declaration order (SIMPLE was declared before HTTP).
+        assertEquals(
+                java.util.List.of("HTTP", "SIMPLE"), new java.util.ArrayList<>(a.getTaskTypes()));
+        // createTime comes from json_data (Auditable), not the server-side created_on column
+        assertEquals(Long.valueOf(4200L), a.getCreateTime());
+        assertEquals(java.util.List.of("p1", "p2"), a.getInputParameters());
+        assertEquals("${t.output.x}", a.getOutputParameters().get("res"));
+        // failureWorkflow projected from json_data
+        assertEquals("cleanup_flow", a.getFailureWorkflow());
+        // plain (untagged) defs resolve to the "workflow" classifier
+        assertEquals("workflow", a.getClassifier());
+        assertEquals("workflow", byName.get("listB").getClassifier());
+        // agent-stamped metadata resolves to the "agent" classifier
+        assertTrue(byName.containsKey("listAgent"));
+        assertEquals("agent", byName.get("listAgent").getClassifier());
+    }
+
+    @Test
+    public void testGetWorkflowDefListItemsNoTasks() {
+        WorkflowDef def = new WorkflowDef();
+        def.setName("noTasksWf");
+        def.setVersion(1);
+        def.setCreateTime(1L);
+        // tasks left unset/empty — exercises the string_agg NULL branch
+        metadataDAO.createWorkflowDef(def);
+
+        List<WorkflowDefListItem> items = metadataDAO.getWorkflowDefListItems();
+        Map<String, WorkflowDefListItem> byName =
+                items.stream().collect(Collectors.toMap(WorkflowDefListItem::getName, i -> i));
+
+        WorkflowDefListItem item = byName.get("noTasksWf");
+        assertNotNull(item);
+        assertEquals(0, item.getTaskCount());
+        assertTrue(item.getTaskTypes().isEmpty());
     }
 
     @Test

--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/ApplicationExceptionMapper.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/ApplicationExceptionMapper.java
@@ -25,6 +25,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import com.netflix.conductor.common.validation.ErrorResponse;
@@ -62,6 +63,21 @@ public class ApplicationExceptionMapper {
         EXCEPTION_STATUS_MAP.put(SchemaValidationException.class, HttpStatus.BAD_REQUEST);
         EXCEPTION_STATUS_MAP.put(
                 HttpRequestMethodNotSupportedException.class, HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    /**
+     * A client disconnect (broken pipe) during response serialization surfaces as
+     * AsyncRequestNotUsableException. The response can no longer be written, so we must NOT attempt
+     * to serialize an error body (that would trigger a second broken-pipe write) and must NOT count
+     * it as a Conductor 5xx business error. We only record it quietly for diagnostics.
+     */
+    @ExceptionHandler(AsyncRequestNotUsableException.class)
+    public void handleClientDisconnect(
+            HttpServletRequest request, AsyncRequestNotUsableException ex) {
+        LOGGER.warn(
+                "Client disconnected before response was written. url: '{}', exception: {}",
+                request.getRequestURI(),
+                ex.getClass().getSimpleName());
     }
 
     @ExceptionHandler(Throwable.class)

--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/MetadataResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/MetadataResource.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowClassifier;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDefListItem;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDefSummary;
 import com.netflix.conductor.common.model.BulkResponse;
 import com.netflix.conductor.core.exception.ConflictException;
@@ -133,6 +134,25 @@ public class MetadataResource {
     @GetMapping("/workflow/latest-versions")
     public List<WorkflowDef> getAllWorkflowsWithLatestVersions() {
         return metadataService.getWorkflowDefsLatestVersions();
+    }
+
+    @Operation(
+            summary =
+                    "Returns a lightweight list projection (latest version per workflow, no task blueprints), optionally filtered by classifier")
+    @GetMapping("/workflow/list")
+    public List<WorkflowDefListItem> getWorkflowListItems(
+            @RequestParam(value = "classifier", required = false) String classifier) {
+        List<WorkflowDefListItem> all = metadataService.getWorkflowDefListItems();
+        // Optional classifier filter mirroring getAll: "workflow" matches untagged (plain)
+        // defs; any other value matches the derived tag literally. Uses the classifier
+        // precomputed on each item rather than recomputing it here.
+        if (classifier == null || classifier.isBlank()) {
+            return all;
+        }
+        String wanted = classifier.trim();
+        return all.stream()
+                .filter(item -> wanted.equalsIgnoreCase(item.getClassifier()))
+                .toList();
     }
 
     @DeleteMapping("/workflow/{name}/{version}")

--- a/rest/src/main/java/com/netflix/conductor/rest/controllers/MetadataResource.java
+++ b/rest/src/main/java/com/netflix/conductor/rest/controllers/MetadataResource.java
@@ -150,9 +150,7 @@ public class MetadataResource {
             return all;
         }
         String wanted = classifier.trim();
-        return all.stream()
-                .filter(item -> wanted.equalsIgnoreCase(item.getClassifier()))
-                .toList();
+        return all.stream().filter(item -> wanted.equalsIgnoreCase(item.getClassifier())).toList();
     }
 
     @DeleteMapping("/workflow/{name}/{version}")

--- a/rest/src/test/java/com/netflix/conductor/rest/controllers/ApplicationExceptionMapperTest.java
+++ b/rest/src/test/java/com/netflix/conductor/rest/controllers/ApplicationExceptionMapperTest.java
@@ -154,6 +154,35 @@ public class ApplicationExceptionMapperTest {
                 new HttpRequestMethodNotSupportedException("GET"), status().isMethodNotAllowed());
     }
 
+    @Test
+    public void testClientDisconnectNotLoggedAsError() throws Exception {
+        var disconnect =
+                new org.springframework.web.context.request.async.AsyncRequestNotUsableException(
+                        "ServletOutputStream failed to write");
+        doThrow(disconnect).when(this.queueAdminResource).update(any(), any(), any(), any());
+
+        this.mockMvc
+                .perform(
+                        MockMvcRequestBuilders.post(
+                                        "/api/queue/update/workflowId/taskRefName/{status}",
+                                        TaskModel.Status.SKIPPED)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        new ObjectMapper()
+                                                .writeValueAsString(Collections.emptyMap())))
+                .andDo(print());
+
+        // must NOT be logged at ERROR (reserved for genuine 5xx server faults)
+        verify(logger, never()).error(any(), any(), any(), any());
+        // recorded at WARN instead
+        verify(logger, atLeastOnce())
+                .warn(
+                        eq(
+                                "Client disconnected before response was written. url: '{}', exception: {}"),
+                        eq("/api/queue/update/workflowId/taskRefName/SKIPPED"),
+                        eq("AsyncRequestNotUsableException"));
+    }
+
     private void assertLoggedAtWarn(Exception exception, ResultMatcher expectedStatus)
             throws Exception {
         // logger is a static mock reused across assertions; start each one clean.

--- a/rest/src/test/java/com/netflix/conductor/rest/controllers/MetadataResourceTest.java
+++ b/rest/src/test/java/com/netflix/conductor/rest/controllers/MetadataResourceTest.java
@@ -14,6 +14,7 @@ package com.netflix.conductor.rest.controllers;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,9 +22,12 @@ import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import com.netflix.conductor.common.metadata.tasks.TaskDef;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDef;
+import com.netflix.conductor.common.metadata.workflow.WorkflowDefListItem;
 import com.netflix.conductor.common.metadata.workflow.WorkflowDefSummary;
 import com.netflix.conductor.core.exception.ConflictException;
 import com.netflix.conductor.service.MetadataService;
@@ -34,11 +38,14 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class MetadataResourceTest {
 
@@ -160,6 +167,50 @@ public class MetadataResourceTest {
 
         when(mockMetadataService.getWorkflowDefsLatestVersions()).thenReturn(listOfWorkflowDef);
         assertEquals(listOfWorkflowDef, metadataResource.getAllWorkflowsWithLatestVersions());
+    }
+
+    @Test
+    public void testGetWorkflowListItems() {
+        WorkflowDefListItem item = new WorkflowDefListItem();
+        item.setName("wf");
+        item.setVersion(3);
+        when(mockMetadataService.getWorkflowDefListItems()).thenReturn(List.of(item));
+
+        List<WorkflowDefListItem> result = metadataResource.getWorkflowListItems(null);
+
+        assertEquals(1, result.size());
+        assertEquals("wf", result.get(0).getName());
+        verify(mockMetadataService, times(1)).getWorkflowDefListItems();
+    }
+
+    @Test
+    public void testGetWorkflowListItemsFiltersByClassifier() {
+        WorkflowDefListItem workflowItem = new WorkflowDefListItem();
+        workflowItem.setName("plain");
+        workflowItem.setClassifier("workflow");
+        WorkflowDefListItem agentItem = new WorkflowDefListItem();
+        agentItem.setName("bot");
+        agentItem.setClassifier("agent");
+        when(mockMetadataService.getWorkflowDefListItems())
+                .thenReturn(List.of(workflowItem, agentItem));
+
+        List<WorkflowDefListItem> filtered = metadataResource.getWorkflowListItems("workflow");
+        assertEquals(1, filtered.size());
+        assertEquals("plain", filtered.get(0).getName());
+
+        List<WorkflowDefListItem> all = metadataResource.getWorkflowListItems(null);
+        assertEquals(2, all.size());
+    }
+
+    @Test
+    public void testListPathDoesNotCollideWithNamePathVariable() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(metadataResource).build();
+        when(mockMetadataService.getWorkflowDefListItems()).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/api/metadata/workflow/list")).andExpect(status().isOk());
+
+        verify(mockMetadataService, never()).getWorkflowDef(eq("list"), any());
+        verify(mockMetadataService, times(1)).getWorkflowDefListItems();
     }
 
     @Test

--- a/ui-next/src/pages/definitions/Workflow.test.tsx
+++ b/ui-next/src/pages/definitions/Workflow.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from "@testing-library/react";
+import WorkflowDefinitions from "./Workflow";
+
+const navigate = vi.fn();
+
+vi.mock("react-router", () => ({
+  useNavigate: () => navigate,
+}));
+
+vi.mock("react-helmet", () => ({
+  Helmet: ({ children }: any) => <>{children}</>,
+}));
+
+vi.mock("utils/query", () => ({
+  useWorkflowDefListItems: () => ({
+    data: [
+      {
+        name: "order_fulfillment",
+        version: 3,
+        description: "Fulfills an order",
+        createTime: 1700000000000,
+      },
+    ],
+    isFetching: false,
+    refetch: vi.fn(),
+  }),
+  useActionWithPath: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("utils/hooks/useCustomPagination", () => ({
+  default: () => [
+    { filterParam: "", pageParam: "", searchParam: "" },
+    {
+      setFilterParam: vi.fn(),
+      setSearchParam: vi.fn(),
+      handlePageChange: vi.fn(),
+    },
+  ],
+}));
+
+vi.mock("utils/hooks/usePushHistory", () => ({
+  usePushHistory: () => vi.fn(),
+}));
+
+vi.mock("utils/flags", () => ({
+  featureFlags: { isEnabled: () => false },
+  FEATURES: {
+    PLAYGROUND: "PLAYGROUND",
+    TAG_VISIBILITY: "TAG_VISIBILITY",
+    HIDE_IMPORT_BPMN: "HIDE_IMPORT_BPMN",
+  },
+}));
+
+vi.mock("components/features/auth", () => ({
+  useAuth: () => ({ isTrialExpired: false }),
+}));
+
+vi.mock("components/providers/messageContext", () => ({
+  MessageContext: { Provider: ({ children }: any) => <>{children}</> },
+}));
+
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  return { ...actual, useContext: () => ({ setMessage: vi.fn() }) };
+});
+
+vi.mock("components", () => ({
+  Button: ({ children, onClick }: any) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+  DataTable: ({ columns, data }: any) => {
+    const nameColumn = columns.find(
+      (column: any) => column.id === "workflow_name",
+    );
+    return <>{nameColumn.renderer(data[0].name, data[0])}</>;
+  },
+  IconButton: ({ children, onClick }: any) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+  NavLink: ({ children, path }: any) => <a href={path}>{children}</a>,
+  Paper: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock("components/ui/Header", () => ({ default: () => null }));
+vi.mock("components/ui/NoDataComponent", () => ({ default: () => null }));
+vi.mock("components/ui/SnackbarMessage", () => ({
+  SnackbarMessage: () => null,
+}));
+vi.mock("components/ui/dialogs/ConfirmChoiceDialog", () => ({
+  default: () => null,
+}));
+vi.mock("components/features/tags/AddTagDialog", () => ({
+  default: () => null,
+}));
+vi.mock("components/ui/TagList", () => ({ default: () => null }));
+vi.mock("components/icons/PlayIcon", () => ({ default: () => null }));
+vi.mock("components/ui/layout/SectionContainer", () => ({
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock("components/layout/SectionHeader", () => ({
+  default: ({ actions }: any) => <div>{actions}</div>,
+}));
+vi.mock("components/ui/layout/SectionHeaderActions", () => ({
+  default: () => null,
+}));
+vi.mock(
+  "pages/executions/SplitWorkflowDefinitionButton/SplitWorkflowDefinitionButton",
+  () => ({ default: () => null }),
+);
+vi.mock("pages/executions/SplitWorkflowDefinitionButton/ImportBpmnButton", () => ({
+  default: () => null,
+}));
+vi.mock("pages/runWorkflow/runWorkflowUtils", () => ({
+  removeDeletedWorkflow: vi.fn(),
+}));
+vi.mock("./dialog/CloneWorkflowDialog", () => ({ default: () => null }));
+
+describe("WorkflowDefinitions", () => {
+  it("links a workflow name to its definition from the list endpoint", () => {
+    render(<WorkflowDefinitions />);
+
+    expect(
+      screen.getByRole("link", { name: "order_fulfillment" }),
+    ).toHaveAttribute("href", "/workflowDef/order_fulfillment");
+  });
+});

--- a/ui-next/src/pages/definitions/Workflow.tsx
+++ b/ui-next/src/pages/definitions/Workflow.tsx
@@ -41,7 +41,7 @@ import { featureFlags, FEATURES } from "utils/flags";
 import useCustomPagination from "utils/hooks/useCustomPagination";
 import { usePushHistory } from "utils/hooks/usePushHistory";
 import { logger } from "utils/logger";
-import { useActionWithPath, useWorkflowDefs } from "utils/query";
+import { useActionWithPath, useWorkflowDefListItems } from "utils/query";
 import { createSearchableTags, tryToJson } from "utils/utils";
 import { getUniqueWorkflows } from "utils/workflow";
 import CloneWorkflowDialog from "./dialog/CloneWorkflowDialog";
@@ -67,7 +67,7 @@ export default function WorkflowDefinitions() {
   const tagsEnabled = featureFlags.isEnabled(FEATURES.TAG_VISIBILITY);
   const isImportBpmnHidden = featureFlags.isEnabled(FEATURES.HIDE_IMPORT_BPMN);
   const { data, isFetching, refetch }: UseQueryResult<WorkflowDef[]> =
-    useWorkflowDefs({}, "workflow");
+    useWorkflowDefListItems({}, "workflow");
   const [showAddTagDialog, setShowAddTagDialog] = useState(false);
   const [addTagDialogData, setAddTagDialogData] =
     useState<TagDialogProps | null>(null);

--- a/ui-next/src/utils/constants/api.ts
+++ b/ui-next/src/utils/constants/api.ts
@@ -22,4 +22,5 @@ export const INTEGRATIONS_API_URL = {
 
 export const WORKFLOW_METADATA_SHORT_URL =
   "/metadata/workflow?short=true&metadata=true";
+export const WORKFLOW_METADATA_LIST_URL = "/metadata/workflow/list";
 export const ROLES_API_BASE_URL = "/roles";

--- a/ui-next/src/utils/query.ts
+++ b/ui-next/src/utils/query.ts
@@ -36,6 +36,7 @@ import {
 } from "utils/workflow";
 import {
   TASK_EXECUTIONS_SEARCH_URL,
+  WORKFLOW_METADATA_LIST_URL,
   WORKFLOW_METADATA_SHORT_URL,
 } from "./constants/api";
 import { HttpStatusCode } from "./constants/httpStatusCode";
@@ -468,6 +469,20 @@ export function useWorkflowDefs(
   const path = classifier
     ? `${WORKFLOW_METADATA_SHORT_URL}&classifier=${classifier}`
     : WORKFLOW_METADATA_SHORT_URL;
+  return useFetch<WorkflowDef[]>(path, {
+    staleTime: DEFAULT_STALE_TIME,
+    ...optionsOverride,
+  });
+}
+
+export function useWorkflowDefListItems(
+  optionsOverride: Partial<UseQueryOptions<WorkflowDef[], FetchError>> = {},
+  classifier?: "workflow" | "agent",
+): UseQueryResult<WorkflowDef[], FetchError> {
+  // New endpoint has no existing query string, so start with `?`
+  const path = classifier
+    ? `${WORKFLOW_METADATA_LIST_URL}?classifier=${classifier}`
+    : WORKFLOW_METADATA_LIST_URL;
   return useFetch<WorkflowDef[]>(path, {
     staleTime: DEFAULT_STALE_TIME,
     ...optionsOverride,


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

The Workflow Definitions page calls `GET /metadata/workflow`, which loads every version of every
workflow including complete task blueprints. In a real PostgreSQL deployment that response reached
104 MB / 16.65 s and the client disconnected mid-serialization, producing
`AsyncRequestNotUsableException` (`Broken pipe`). See the linked issue for the full trace.

This adds an additive, list-specific read model for the legacy UI and leaves every existing metadata
endpoint unchanged:

- **common**: `WorkflowDefListItem` read-only DTO + `fromWorkflowDef` factory. Returns latest version
  per name and every field the table displays or filters on (name, description, version, createTime,
  schemaVersion, restartable, workflowStatusListenerEnabled, ownerEmail, input/outputParameters,
  timeoutPolicy, timeoutSeconds), with task blueprints reduced to alphabetically-ordered distinct
  `taskTypes` + `taskCount` (TreeSet for deterministic, cross-backend order).
- **core**: `MetadataDAO.getWorkflowDefListItems()` default fallback + `MetadataService` wiring.
- **postgres-persistence**: PG11-compatible projection that parses `json_data` once via a LATERAL
  cast, strips the tasks blueprint in SQL, filters latest versions on the maintained
  `latest_version` column, and derives `taskCount`/`taskTypes` via a LATERAL aggregate; adds V20
  partial index `meta_workflow_def_latest_name_idx (name) WHERE version = latest_version`.
- **rest**: `GET /metadata/workflow/list` with an optional `classifier` filter (mirrors `getAll`),
  plus a dedicated `AsyncRequestNotUsableException` handler that logs at WARN, writes no body, and is
  not counted as a 5xx business error.
- **ui-next**: definitions page fetches `GET /metadata/workflow/list?classifier=workflow` via a new
  `useWorkflowDefListItems` hook instead of `/metadata/workflow?short=true&metadata=true`. Only the
  definitions page is switched; `useWorkflowDefsByVersions` (Scheduler, RunWorkflow),
  `useWorkflowNames`, and the generic `useWorkflowDefs` are untouched. Opening a row still loads the
  complete definition via `GET /metadata/workflow/{name}?version={version}`.

Existing metadata endpoints and their return types are unchanged (additive only). Registration,
execution, and historical-version access are unchanged. The old UI keeps working against a new
server, and rolling back the UI does not require a database rollback.

**Verified** on the deployed build, comparing the exact requests the page issues (uncompressed, 5
runs each, warm cache):

```text
                                    rows          payload      avg time
OLD  GET /metadata/workflow           2,924   47,684,709 B     7.40 s   (all versions)
     ?short=true&metadata=true                 (45.5 MiB)
NEW  GET /metadata/workflow/list      1,815      904,983 B     1.30 s   (latest per name)
     ?classifier=workflow                        (0.86 MiB)

response time:  5.7x faster   (82.4% reduction)
payload size:  52.7x smaller  (98.1% reduction)
per-row:       32.7x lighter  (~16 KB -> ~0.5 KB)
```

Two effects compound: latest-version-per-name (2,924 → 1,815 rows) and dropping the full `tasks`
blueprint (replaced by `taskCount` + `taskTypes`). The old call already used `short=true&metadata=true`
yet still carried complete blueprints, which is why "short" was still 45.5 MiB.

Tests: latest-version selection, every projected field, empty/null values, task type extraction and
count, PostgreSQL projection and non-PostgreSQL fallback, the exception mapper distinguishing client
disconnects from real 5xx, and UI coverage of the name column render via the new hook.

Issue #1611

Alternatives considered
----

- **Change `/metadata/workflow/latest-versions` to a paginated result** (per #843/#934): rejected —
  that is a breaking response-type change (`List<WorkflowDef>` → paginated) and still returns
  complete task blueprints. The additive list endpoint avoids both and keeps the legacy UI's
  complete client-side filtering and sorting.
- **Only switch the UI to `latest-versions`**: rejected — still ~57 MB because each item carries the
  full task blueprint.
