### PR TITLE
Scheduler Definitions list "Last Run Time" column never populates des…

### DIFF
--- a/ui-next/src/pages/definitions/Scheduler/Schedules.tsx
+++ b/ui-next/src/pages/definitions/Scheduler/Schedules.tsx
@@ -188,14 +188,6 @@ const columns = [
     tooltip: "The time the schedule was created",
   },
   {
-    id: "lastRunTimeInEpoch",
-    name: "lastRunTimeInEpoch",
-    label: "Last Run time",
-    type: ColumnCustomType.DATE,
-    sortable: false,
-    tooltip: "The last time the schedule ran",
-  },
-  {
     id: "createdBy",
     name: "createdBy",
     label: "Created by",

--- a/ui-next/src/types/Schedulers.ts
+++ b/ui-next/src/types/Schedulers.ts
@@ -21,7 +21,6 @@ export interface IScheduleDto {
   updatedTime?: number;
   createdBy?: string;
   updatedBy?: string;
-  lastRunTimeInEpoch?: number;
   nextRunTime?: number;
   tags?: TagDto[];
 }


### PR DESCRIPTION
…pite confirmed executions

https://orkes.atlassian.net/browse/CCOR-13402

Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
https://orkes.atlassian.net/browse/CCOR-13402
The definitions list API does not return last-run time, so that column was always empty. Last run is execution history, not part of the schedule definition; putting it on the list would mean persisting it (or querying executions on every load) and returning it from search. That is extra backend work for a value Scheduler query already shows

<img width="1800" height="874" alt="Screenshot 2026-09-10 at 2 20 38 PM" src="https://github.com/user-attachments/assets/4f15fcb2-9104-4dbc-adf3-608567e021dc" />
