### PR TITLE
Proposal: postgres+redis compose stack + a compose-matrix smoke test

### DIFF
--- a/docker/docker-compose-postgres-redis.yaml
+++ b/docker/docker-compose-postgres-redis.yaml
@@ -1,0 +1,86 @@
+version: '2.3'
+
+# Hybrid stack: Postgres for metadata/execution/payload/indexing, Redis (standalone)
+# for the workflow queue. Modeled on docker-compose-postgres.yaml; adds a redis
+# service borrowed from docker-compose.yaml.
+
+services:
+  conductor-server:
+    environment:
+      - CONFIG_PROP=config-postgres-redis.properties
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+    image: conductor:server
+    container_name: conductor-server
+    build:
+      context: ../
+      dockerfile: docker/server/Dockerfile
+      args:
+        YARN_OPTS: ${YARN_OPTS}
+    networks:
+      - internal
+    ports:
+      - 8000:8080
+      - 8127:5000
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:8080/health"]
+      interval: 60s
+      timeout: 30s
+      retries: 12
+    links:
+      - conductor-postgres:postgresdb
+      - conductor-redis:rs
+    depends_on:
+      conductor-postgres:
+        condition: service_healthy
+      conductor-redis:
+        condition: service_healthy
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1k"
+        max-file: "3"
+
+  conductor-postgres:
+    image: postgres:16
+    environment:
+      - POSTGRES_USER=conductor
+      - POSTGRES_PASSWORD=conductor
+    volumes:
+      - pgdata-conductor:/var/lib/postgresql/data
+    networks:
+      - internal
+    healthcheck:
+      test: timeout 5 bash -c 'cat < /dev/null > /dev/tcp/localhost/5432'
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1k"
+        max-file: "3"
+
+  conductor-redis:
+    image: redis:6.2.3-alpine
+    volumes:
+      - ../server/config/redis.conf:/usr/local/etc/redis/redis.conf
+    networks:
+      - internal
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1k"
+        max-file: "3"
+
+volumes:
+  pgdata-conductor:
+    driver: local
+
+networks:
+  internal:

--- a/docker/server/config/config-postgres-redis.properties
+++ b/docker/server/config/config-postgres-redis.properties
@@ -1,0 +1,33 @@
+# Hybrid persistence: PostgreSQL for metadata + execution + external payload + indexing;
+# Redis (standalone) for the workflow queue. Useful for deployments that want Postgres'
+# durability and SQL-queryability for workflow state while keeping Redis' speed for the
+# task/decision queue.
+
+# --- Persistence selection ---
+conductor.db.type=postgres
+conductor.queue.type=redis_standalone
+conductor.external-payload-storage.type=postgres
+
+# --- Postgres connectivity ---
+spring.datasource.url=jdbc:postgresql://postgresdb:5432/postgres
+spring.datasource.username=conductor
+spring.datasource.password=conductor
+
+# --- Indexing via Postgres (no Elasticsearch in this stack) ---
+conductor.indexing.enabled=true
+conductor.indexing.type=postgres
+conductor.elasticsearch.version=0
+
+# --- Redis connectivity (for queue) ---
+conductor.redis.hosts=rs:6379:us-east-1c
+conductor.redis.queueNamespacePrefix=conductor_queues
+conductor.redis.workflowNamespacePrefix=conductor
+conductor.redis.taskDefCacheRefreshInterval=1
+
+# --- Metrics / Prometheus (matches the single-backend configs) ---
+conductor.metrics-prometheus.enabled=true
+management.endpoints.web.exposure.include=prometheus
+
+# --- Sample workflows + test-friendly tuning (matches config-postgres.properties) ---
+loadSample=true
+conductor.app.taskExecutionPostponeDuration=10s

--- a/docker/test-configs.sh
+++ b/docker/test-configs.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# test-configs.sh — boot conductor against every docker-compose config and verify it
+# comes up healthy and serves the metadata API.
+#
+# This is a coverage smoke test for the docker/ compose matrix: each config selects a
+# different persistence/queue/indexing backend combination, and it's easy for one combo
+# to silently rot (missing config key, renamed property, backend image change) while the
+# others stay green. Running them all in one pass surfaces that quickly.
+#
+# Usage:  ./docker/test-configs.sh
+# Requires: a locally built `conductor:server` image (see docker/server/Dockerfile).
+set -euo pipefail
+
+DOCKER_DIR="$(cd "$(dirname "$0")" && pwd)"
+PASS=()
+FAIL=()
+
+wait_healthy() {
+  local name="$1" port="${2:-8080}" timeout=180 elapsed=0
+  echo "  waiting for http://localhost:$port/health ..."
+  while [ $elapsed -lt $timeout ]; do
+    local resp
+    resp=$(curl -sf "http://localhost:$port/health" 2>/dev/null || true)
+    if echo "$resp" | grep -q '"healthy":true'; then
+      echo "  healthy after ${elapsed}s"
+      return 0
+    fi
+    sleep 5; elapsed=$((elapsed + 5))
+  done
+  echo "  TIMEOUT after ${timeout}s"
+  return 1
+}
+
+smoke_test() {
+  local port="${1:-8080}"
+  local wf
+  wf=$(curl -sf "http://localhost:$port/api/metadata/workflow" 2>/dev/null || true)
+  if echo "$wf" | python3 -c "import json,sys; json.load(sys.stdin)" 2>/dev/null; then
+    echo "  /api/metadata/workflow: OK"
+    return 0
+  fi
+  echo "  /api/metadata/workflow: FAIL (got: ${wf:0:120})"
+  return 1
+}
+
+run_compose() {
+  local label="$1" file="$2" port="${3:-8000}"
+  echo ""
+  echo "========================================"
+  echo "  $label"
+  echo "  file: $file"
+  echo "========================================"
+
+  cd "$DOCKER_DIR"
+  docker compose -f "$file" down -v --remove-orphans 2>/dev/null || true
+
+  if ! docker compose -f "$file" up -d 2>&1 | tail -5; then
+    echo "  docker compose up FAILED"
+    FAIL+=("$label")
+    return
+  fi
+
+  if wait_healthy "$label" "$port" && smoke_test "$port"; then
+    PASS+=("$label")
+  else
+    docker compose -f "$file" logs conductor-server 2>&1 | tail -30
+    FAIL+=("$label")
+  fi
+
+  docker compose -f "$file" down -v --remove-orphans 2>&1 | tail -3
+}
+
+# ── 0. SQLite default (no compose, bare docker run) ─────────────────────────
+echo ""
+echo "========================================"
+echo "  0. SQLite default (no CONFIG_PROP)"
+echo "========================================"
+docker rm -f conductor-sqlite-test 2>/dev/null || true
+docker run -d --name conductor-sqlite-test -p 8080:8080 conductor:server
+if wait_healthy "sqlite" 8080 && smoke_test 8080; then
+  PASS+=("0. SQLite default")
+else
+  docker logs conductor-sqlite-test 2>&1 | tail -30
+  FAIL+=("0. SQLite default")
+fi
+docker rm -f conductor-sqlite-test 2>/dev/null || true
+
+# ── 1–9. Compose setups ──────────────────────────────────────────────────────
+run_compose "1. Redis + ES7"          docker-compose.yaml                  8000
+run_compose "2. Redis + ES8"          docker-compose-es8.yaml              8000
+run_compose "3. Redis + OpenSearch2"  docker-compose-redis-os.yaml         8000
+run_compose "4. Redis + OpenSearch3"  docker-compose-redis-os3.yaml        8000
+run_compose "5. Postgres"             docker-compose-postgres.yaml         8000
+run_compose "6. Postgres + ES7"       docker-compose-postgres-es7.yaml     8000
+run_compose "7. MySQL + Redis + ES7"  docker-compose-mysql.yaml            8000
+run_compose "8. Cassandra + ES7"      docker-compose-cassandra-es7.yaml    8000
+run_compose "9. Postgres + Redis"     docker-compose-postgres-redis.yaml   8000
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "========================================"
+echo "  RESULTS"
+echo "========================================"
+echo "PASS (${#PASS[@]}):"
+for s in "${PASS[@]}"; do echo "  ✓  $s"; done
+echo "FAIL (${#FAIL[@]}):"
+for s in "${FAIL[@]}"; do echo "  ✗  $s"; done
+[ ${#FAIL[@]} -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
**Draft / proposal — opening this to start a conversation, not to merge as-is.**

## What this adds

1. **`docker/docker-compose-postgres-redis.yaml`** + **`config-postgres-redis.properties`** — a hybrid stack: **Postgres** for metadata/execution/external-payload/indexing, **Redis (standalone)** for the workflow queue.
2. **`docker/test-configs.sh`** — a smoke test that boots conductor against *every* compose config and asserts it comes up healthy and serves `/api/metadata/workflow`.

## Why the postgres+redis combo

Mapping the existing tracked compose configs by backend:

| db | queue | indexing | needs Elasticsearch? |
|----|-------|----------|:--:|
| cassandra | redis | ES7 | yes |
| mysql | redis | ES7 | yes |
| postgres | postgres | ES7 | yes |
| postgres | postgres | postgres | no |
| redis | redis | ES8/OS2/OS3/ES7 | yes |
| **postgres** | **redis** | **postgres** | **no** ← *new* |

Every existing config either pays the Postgres-queue throughput tax (the all-Postgres stacks) or drags in a separate DB **plus** Elasticsearch. "Postgres persistence + Redis queue, no ES" is the one combination that's both operationally light and fast, and nothing covered it. It's also trivially derived from `config-postgres.properties` (flip `queue.type` to `redis_standalone`), so it's low-risk to support.

## Why the test harness — the real motivation

This started as local tooling to answer "do all our compose configs actually still boot?" — and the honest answer is that individual combos can silently rot (a missing config key, a renamed property, a backend image bump) while the rest stay green, because nothing exercises them together. `test-configs.sh` runs the whole matrix in one pass.

I'm putting it up as a **nudge toward a more comprehensive compose-level testing approach** — e.g. eventually running this (or something like it) in CI so the docker matrix is actually covered, not just assumed to work. The postgres+redis config is wired in as row 9 so the new topology is exercised by the same harness that motivated it.

## Open questions for discussion

- Do we want to **bless postgres+redis as a supported topology**, or keep the compose set to canonical single-backend + reference stacks?
- Is postgres-indexing + redis-queue exercised by any existing integration test, or would adding it to the matrix be its first real coverage?
- Is a host-driven bash matrix the right shape for CI, or should this be folded into the existing integration-test tooling? The script is a starting point, not a proposed final form.

## Orkes parity

Compose/config assets only — no Java, no `org.conductoross.*` code. No Orkes parallel applies.