### PR TITLE
enh: add content and user-block slots to BaseLayout (sidebar)

### DIFF
--- a/ui-next/src/components/ui/layout/BaseLayout.slots.test.tsx
+++ b/ui-next/src/components/ui/layout/BaseLayout.slots.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * BaseLayout's extension points.
+ *
+ * The enterprise AgentLayout used to reproduce this entire shell — grid,
+ * banner, sidebar, app bar, content area — and that copy silently drifted:
+ * when BaseLayout moved onto the version query, the copy kept reading a
+ * localStorage key nothing wrote, so the sidebar showed a blank version.
+ * These slots exist so a wrapper can add to the shell instead of copying it.
+ */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("components/features/auth", () => ({
+  useAuth: () => ({
+    isTrialExpired: false,
+    trialExpiryDate: undefined,
+    isAnnouncementBannerDismissed: true,
+    dismissAnnouncementBanner: vi.fn(),
+  }),
+}));
+
+vi.mock("utils", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("utils");
+  return {
+    ...actual,
+    useAPIReleaseVersion: () => ({
+      data: "9.9.9",
+      isLoading: false,
+      isError: false,
+    }),
+  };
+});
+
+// Only the wiring matters here, not what the sidebar renders.
+const sidebarProps: Record<string, unknown>[] = [];
+vi.mock("components/providers/sidebar/UiSidebar", () => ({
+  UISidebar: (props: Record<string, unknown>) => {
+    sidebarProps.push(props);
+    return <div data-testid="ui-sidebar" />;
+  },
+}));
+
+vi.mock("components/layout/header/AnnouncementBanner", () => ({
+  default: () => null,
+}));
+vi.mock("components/features/search/SearchWrapper", () => ({
+  default: () => null,
+}));
+vi.mock("plugins/AppBarModules", () => ({ default: () => null }));
+
+import BaseLayout from "./BaseLayout";
+
+describe("BaseLayout slots", () => {
+  it("renders children in the content area", () => {
+    render(<BaseLayout>{<div>page content</div>}</BaseLayout>);
+
+    const content = document.querySelector("#main-content");
+    expect(content).toHaveTextContent("page content");
+  });
+
+  it("renders contentExtras alongside children in the content area", () => {
+    render(
+      <BaseLayout contentExtras={<div>assistant panel</div>}>
+        <div>page content</div>
+      </BaseLayout>,
+    );
+
+    const content = document.querySelector("#main-content");
+    // Both live in the content grid area — that is what lets AgentLayout put
+    // its panel here instead of rebuilding the grid.
+    expect(content).toHaveTextContent("page content");
+    expect(content).toHaveTextContent("assistant panel");
+  });
+
+  it("omits contentExtras when not supplied", () => {
+    render(<BaseLayout>{<div>page content</div>}</BaseLayout>);
+
+    expect(screen.queryByText("assistant panel")).not.toBeInTheDocument();
+  });
+
+  it("forwards customUserBlock to the sidebar", () => {
+    sidebarProps.length = 0;
+    const block = <div>enterprise footer</div>;
+    render(<BaseLayout customUserBlock={block}>{<div />}</BaseLayout>);
+
+    expect(sidebarProps).toHaveLength(1);
+    expect(sidebarProps[0].customUserBlock).toBe(block);
+  });
+
+  it("still owns the version it passes to the sidebar", () => {
+    sidebarProps.length = 0;
+    render(<BaseLayout>{<div />}</BaseLayout>);
+
+    // The whole point of the refactor: one place fetches this.
+    expect(sidebarProps[0].apiVersion).toBe("9.9.9");
+  });
+});

--- a/ui-next/src/components/ui/layout/BaseLayout.tsx
+++ b/ui-next/src/components/ui/layout/BaseLayout.tsx
@@ -20,9 +20,21 @@ const toolBarHeight = 60;
 
 type Props = {
   children: ReactNode;
+  /**
+   * Rendered inside the content area after {children}. Lets a wrapper add
+   * panels that share this shell — the enterprise agent layout puts its
+   * assistant here rather than reproducing the whole layout.
+   */
+  contentExtras?: ReactNode;
+  /** Replaces the sidebar footer's user block. See UISidebar. */
+  customUserBlock?: ReactNode;
 };
 
-export const BaseLayout = ({ children }: Props) => {
+export const BaseLayout = ({
+  children,
+  contentExtras,
+  customUserBlock,
+}: Props) => {
   const {
     data: apiVersion,
     isLoading: apiVersionLoading,
@@ -101,6 +113,7 @@ export const BaseLayout = ({ children }: Props) => {
           <UISidebar
             apiVersion={resolvedApiVersion}
             releaseVersion={releaseVersion}
+            customUserBlock={customUserBlock}
           />
         )}
 
@@ -153,6 +166,7 @@ export const BaseLayout = ({ children }: Props) => {
         id="main-content"
       >
         {children}
+        {contentExtras}
       </Box>
     </Box>
   );


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

Adds two optional props so a wrapper can extend this layout instead of copying it:

- `contentExtras` — rendered in the content area after `{children}`
- `customUserBlock` — forwarded to `UISidebar`

conductor-ui's AgentLayout reproduced ~90 lines of this shell, and that copy drifted: when BaseLayout moved onto the version query and the localStorage write was removed, the copy kept reading the dead key and the sidebar showed a blank version.

5 tests covering both slots.

Enterprise UI Playwright Tests
----
Every PR automatically triggers the enterprise UI Playwright E2E test suite.
Tests run against conductor-ui `main` by default. To test against a different
conductor-ui branch, add this line anywhere in the PR description:

```
conductor-ui-branch: my-feature-branch
```
