### PR TITLE
fix(listener): set UTF-8 ContentType on status-notifier StringEntity (#1399)

### DIFF
--- a/task-status-listener/src/main/java/com/netflix/conductor/contribs/listener/RestClientManager.java
+++ b/task-status-listener/src/main/java/com/netflix/conductor/contribs/listener/RestClientManager.java
@@ -30,6 +30,7 @@ import org.apache.http.client.ServiceUnavailableRetryStrategy;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
@@ -232,10 +233,9 @@ public class RestClientManager {
     private HttpPost createPostRequest(String url, String data, Map<String, String> headers)
             throws IOException {
         HttpPost httpPost = new HttpPost(url);
-        StringEntity entity = new StringEntity(data);
+        StringEntity entity = new StringEntity(data, ContentType.APPLICATION_JSON);
         httpPost.setEntity(entity);
         httpPost.setHeader("Accept", "application/json");
-        httpPost.setHeader("Content-type", "application/json");
         headers.forEach(httpPost::setHeader);
         return httpPost;
     }

--- a/task-status-listener/src/test/java/com/netflix/conductor/contribs/listener/RestClientManagerTest.java
+++ b/task-status-listener/src/test/java/com/netflix/conductor/contribs/listener/RestClientManagerTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Conductor Authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.contribs.listener;
+
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.http.client.methods.HttpPost;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+/** Unit test for RestClientManager UTF-8 Content-Length entity initialization. */
+public class RestClientManagerTest {
+
+    @Test
+    public void testCreatePostRequest_withNonAsciiCharacters_setsUtf8ContentLength() throws Exception {
+        StatusNotifierNotificationProperties config = mock(StatusNotifierNotificationProperties.class);
+        RestClientManager clientManager = new RestClientManager(config);
+
+        String nonAsciiData = "{\"output\":\"Task finished with special chars: – — € 🚀\"}";
+        Map<String, String> headers = Collections.emptyMap();
+
+        Method createPostRequestMethod = RestClientManager.class.getDeclaredMethod("createPostRequest", String.class, String.class, Map.class);
+        createPostRequestMethod.setAccessible(true);
+
+        HttpPost request = (HttpPost) createPostRequestMethod.invoke(clientManager, "http://localhost:8080/webhook", nonAsciiData, headers);
+
+        assertNotNull(request.getEntity());
+        assertEquals("application/json; charset=UTF-8", request.getEntity().getContentType().getValue());
+        
+        long expectedUtf8ByteCount = nonAsciiData.getBytes(StandardCharsets.UTF_8).length;
+        assertEquals(expectedUtf8ByteCount, request.getEntity().getContentLength());
+    }
+}


### PR DESCRIPTION
### Summary
Enforces UTF-8 ContentType.APPLICATION_JSON on StringEntity initialization within RestClientManager in 	ask-status-listener.

### Problem
When RestClientManager.postNotification() generates HTTP POST webhook notifications containing non-ASCII characters (e.g., en-dashes –, non-Latin text or emojis in task outputs), the default single-argument 
ew StringEntity(data) defaults to ISO-8859-1. This causes entity.getContentLength() to miscalculate the total byte count relative to receivers expecting UTF-8 JSON payloads, leading to Content-Length header desync and payload truncation.

### Fix
- Updated 
ew StringEntity(data) to 
ew StringEntity(data, ContentType.APPLICATION_JSON) in RestClientManager.createPostRequest().
- Added RestClientManagerTest.java verifying that non-ASCII payload strings set Content-Type: application/json; charset=UTF-8 and produce matching UTF-8 byte Content-Length.

Fixes #1399